### PR TITLE
Add ESP8266 build extra flag

### DIFF
--- a/hardware/esp8266com/esp8266/platform.txt
+++ b/hardware/esp8266com/esp8266/platform.txt
@@ -42,7 +42,7 @@ compiler.size.cmd=xtensa-lx106-elf-size
 compiler.esptool.cmd=esptool
 
 # This can be overriden in boards.txt
-build.extra_flags=
+build.extra_flags=-DESP8266
 
 # These can be overridden in platform.local.txt
 compiler.c.extra_flags=

--- a/hardware/esp8266com/esp8266/platform.txt
+++ b/hardware/esp8266com/esp8266/platform.txt
@@ -26,7 +26,7 @@ compiler.c.elf.cmd=xtensa-lx106-elf-gcc
 compiler.c.elf.libs=-lc -lgcc -lhal -lphy -lnet80211 -llwip -lwpa -lmain -lpp
 
 compiler.cpp.cmd=xtensa-lx106-elf-g++
-compiler.cpp.flags=-c -Os -mlongcalls -mtext-section-literals -fno-exceptions -fno-rtti -std=c++11 -MMD 
+compiler.cpp.flags=-c -Os -mlongcalls -mtext-section-literals -fno-exceptions -fno-rtti -std=c++11 -MMD
 
 compiler.as.cmd=xtensa-lx106-elf-as
 
@@ -66,7 +66,7 @@ recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.cpreprocessor.fla
 recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{build.path}/{archive_file}" "{object_file}"
 
 ## Combine gc-sections, archives, and objects
-recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" -Wl,--start-group {object_files} "{build.path}/{archive_file}" {compiler.c.elf.libs} -Wl,--end-group "-L{build.path}" 
+recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" -Wl,--start-group {object_files} "{build.path}/{archive_file}" {compiler.c.elf.libs} -Wl,--end-group "-L{build.path}"
 
 ## Create eeprom
 recipe.objcopy.eep.pattern=
@@ -89,6 +89,6 @@ tools.esptool.cmd.windows=esptool.exe
 tools.esptool.path={runtime.ide.path}/hardware/tools/esp8266
 
 tools.esptool.program.params.verbose=-vv
-tools.esptool.program.params.quiet= 
+tools.esptool.program.params.quiet=
 tools.esptool.program.pattern="{path}/{cmd}" {program.verbose} -cd {upload.resetmethod} -cb {upload.speed} -cp {serial.port} -ca 0x00000 -cf "{build.path}/{build.project_name}_00000.bin" -ca 0x40000 -cf "{build.path}/{build.project_name}_40000.bin"
 


### PR DESCRIPTION
Defines ```ESP8266```, useful for libraries that need to do ESP8266 specific things.