### PR TITLE
Update platform.txt

### DIFF
--- a/hardware/esp8266com/esp8266/platform.txt
+++ b/hardware/esp8266com/esp8266/platform.txt
@@ -91,5 +91,5 @@ tools.esptool.path={runtime.ide.path}/hardware/tools/esp8266
 tools.esptool.upload.protocol=esp
 tools.esptool.upload.params.verbose=-vv
 tools.esptool.upload.params.quiet=
-tools.esptool.upload.pattern="{path}/{cmd}" {upload.verbose} -cd {upload.resetmethod} -cb {upload.speed} -cp {serial.port} -ca 0x00000 -cf "{build.path}/{build.project_name}_00000.bin" -ca 0x40000 -cf "{build.path}/{build.project_name}_40000.bin"
+tools.esptool.upload.pattern="{path}/{cmd}" {upload.verbose} -cd {upload.resetmethod} -cb {upload.speed} -cp "{serial.port}" -ca 0x00000 -cf "{build.path}/{build.project_name}_00000.bin" -ca 0x40000 -cf "{build.path}/{build.project_name}_40000.bin"
 


### PR DESCRIPTION
Quoting the serial.port will enable esptool to work for dev/tty devices with spaces in their name. Like in OSX: `/dev/tty.wch ch341 USB=>RS232 fa130`. Without quote the esptool fails silently since it only parses the `/dev/tty.wch`.