### PR TITLE
Add get and put functions to EEPROM

### DIFF
--- a/hardware/esp8266com/esp8266/libraries/EEPROM/EEPROM.h
+++ b/hardware/esp8266com/esp8266/libraries/EEPROM/EEPROM.h
@@ -37,7 +37,7 @@ class EEPROMClass
 
     template<typename T> T &get(int address, T &t)
     {
-        if (address < 0 || address >= _size)
+        if (address < 0 || address + sizeof(T) > _size)
             return t;
 
         uint8_t *ptr = (uint8_t*) &t;
@@ -47,7 +47,7 @@ class EEPROMClass
 
     template<typename T> const T &put(int address, const T &t)
     {
-        if (address < 0 || address >= _size)
+        if (address < 0 || address + sizeof(T) > _size)
             return t;
 
         const uint8_t *ptr = (const uint8_t*) &t;

--- a/hardware/esp8266com/esp8266/libraries/EEPROM/EEPROM.h
+++ b/hardware/esp8266com/esp8266/libraries/EEPROM/EEPROM.h
@@ -35,6 +35,27 @@ class EEPROMClass
     void commit();
     void end();
 
+    template<typename T> T &get(int address, T &t)
+    {
+        if (address < 0 || address >= _size)
+            return t;
+
+        uint8_t *ptr = (uint8_t*) &t;
+        for(int count = 0; count < sizeof(T); ++count) *ptr++ = _data[address + count];
+        return t;
+    }
+
+    template<typename T> const T &put(int address, const T &t)
+    {
+        if (address < 0 || address >= _size)
+            return t;
+
+        const uint8_t *ptr = (const uint8_t*) &t;
+        for(int count = 0; count < sizeof(T); ++count) _data[address + count] = *ptr++;
+        _dirty = true;
+        return t;
+    }
+
   protected:
     uint8_t* _data;
     size_t _size;

--- a/hardware/esp8266com/esp8266/libraries/EEPROM/EEPROM.h
+++ b/hardware/esp8266com/esp8266/libraries/EEPROM/EEPROM.h
@@ -24,6 +24,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 class EEPROMClass
 {
@@ -41,7 +42,7 @@ class EEPROMClass
             return t;
 
         uint8_t *ptr = (uint8_t*) &t;
-        for(int count = 0; count < sizeof(T); ++count) *ptr++ = _data[address + count];
+        memcpy(ptr, _data + address, sizeof(T));
         return t;
     }
 
@@ -51,7 +52,7 @@ class EEPROMClass
             return t;
 
         const uint8_t *ptr = (const uint8_t*) &t;
-        for(int count = 0; count < sizeof(T); ++count) _data[address + count] = *ptr++;
+        memcpy(_data + address, ptr, sizeof(T));
         _dirty = true;
         return t;
     }


### PR DESCRIPTION
As available in http://www.arduino.cc/en/Reference/EEPROM
https://github.com/arduino/Arduino/tree/master/hardware/arduino/avr/libraries/EEPROM

EEPROM.get(address, data)
Read any data type or object from the EEPROM.

EEPROM.put(address, data)
Write any data type or object to the EEPROM.

Both functions return a reference to the object passed in.