### PR TITLE
Fixed error: unknown type name 'size_t' and added support for ESPD-12 4 Mbyte flash model

### DIFF
--- a/hardware/esp8266com/esp8266/boards.txt
+++ b/hardware/esp8266com/esp8266/boards.txt
@@ -1,5 +1,7 @@
 menu.UploadSpeed=Upload Speed
 menu.CpuFrequency=CPU Frequency
+
+
 ##############################################################
 generic.name=Generic ESP8266 Module
 
@@ -32,6 +34,41 @@ generic.menu.UploadSpeed.256000=256000
 generic.menu.UploadSpeed.256000.upload.speed=256000
 generic.menu.UploadSpeed.921600=921600
 generic.menu.UploadSpeed.921600.upload.speed=921600
+
+
+##############################################################
+espd12.name=ESPD-12
+
+espd12.upload.tool=esptool
+espd12.upload.speed=115200
+espd12.upload.resetmethod=ck
+espd12.upload.maximum_size=4194304
+espd12.upload.wait_for_upload_port=true
+espd12.serial.disableDTR=true
+espd12.serial.disableRTS=true
+
+espd12.build.mcu=esp8266
+espd12.build.f_cpu=80000000L
+espd12.build.board=ESP8266_ESP01
+espd12.build.core=esp8266
+espd12.build.variant=espd12
+
+espd12.menu.CpuFrequency.80=80 MHz
+espd12.menu.CpuFrequency.80.build.f_cpu=80000000L
+espd12.menu.CpuFrequency.160=160 MHz
+espd12.menu.CpuFrequency.160.build.f_cpu=160000000L
+
+espd12.menu.UploadSpeed.115200=115200
+espd12.menu.UploadSpeed.115200.upload.speed=115200
+espd12.menu.UploadSpeed.9600=9600
+espd12.menu.UploadSpeed.9600.upload.speed=9600
+espd12.menu.UploadSpeed.57600=57600
+espd12.menu.UploadSpeed.57600.upload.speed=57600
+espd12.menu.UploadSpeed.256000=256000
+espd12.menu.UploadSpeed.256000.upload.speed=256000
+espd12.menu.UploadSpeed.921600=921600
+espd12.menu.UploadSpeed.921600.upload.speed=921600
+
 
 ##############################################################
 wifio.name=Wifio

--- a/hardware/esp8266com/esp8266/variants/espd12/pins_arduino.h
+++ b/hardware/esp8266com/esp8266/variants/espd12/pins_arduino.h
@@ -1,0 +1,78 @@
+/*
+  pins_arduino.h - Pin definition functions for Arduino
+  Part of Arduino - http://www.arduino.cc/
+
+  Copyright (c) 2007 David A. Mellis
+  Modified for ESP8266 platform by Ivan Grokhotkov, 2014-2015.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General
+  Public License along with this library; if not, write to the
+  Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+  Boston, MA  02111-1307  USA
+
+  $Id: wiring.h 249 2007-02-03 16:52:51Z mellis $
+*/
+
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#define NUM_DIGITAL_PINS  16
+#define NUM_ANALOG_INPUTS 1
+#define ESP_PINS_OFFSET   0 
+
+static const uint8_t SDA = 0;
+static const uint8_t SCL = 2;
+
+static const uint8_t SS   = 12;
+static const uint8_t MOSI = 13;
+static const uint8_t MISO = 14;
+static const uint8_t SCK  = 15;
+
+static const uint8_t BUILTIN_LED = 1;
+
+static const uint8_t A0 = 0;
+
+static const uint8_t E0 = ESP_PINS_OFFSET + 0;
+static const uint8_t E1 = ESP_PINS_OFFSET + 1;
+static const uint8_t E2 = ESP_PINS_OFFSET + 2;
+static const uint8_t E3 = ESP_PINS_OFFSET + 3;
+static const uint8_t E4 = ESP_PINS_OFFSET + 4;
+static const uint8_t E5 = ESP_PINS_OFFSET + 5;
+static const uint8_t E11 = ESP_PINS_OFFSET + 11;
+static const uint8_t E12 = ESP_PINS_OFFSET + 12;
+static const uint8_t E13 = ESP_PINS_OFFSET + 13;
+static const uint8_t E14 = ESP_PINS_OFFSET + 14;
+static const uint8_t E15 = ESP_PINS_OFFSET + 15;
+static const uint8_t E16 = ESP_PINS_OFFSET + 16;
+
+// These serial port names are intended to allow libraries and architecture-neutral
+// sketches to automatically default to the correct port name for a particular type
+// of use.  For example, a GPS module would normally connect to SERIAL_PORT_HARDWARE_OPEN,
+// the first hardware serial port whose RX/TX pins are not dedicated to another use.
+//
+// SERIAL_PORT_MONITOR        Port which normally prints to the Arduino Serial Monitor
+//
+// SERIAL_PORT_USBVIRTUAL     Port which is USB virtual serial
+//
+// SERIAL_PORT_LINUXBRIDGE    Port which connects to a Linux system via Bridge library
+//
+// SERIAL_PORT_HARDWARE       Hardware serial port, physical RX & TX pins.
+//
+// SERIAL_PORT_HARDWARE_OPEN  Hardware serial ports which are open for use.  Their RX & TX
+//                            pins are NOT connected to anything by default.
+#define SERIAL_PORT_MONITOR        Serial
+#define SERIAL_PORT_USBVIRTUAL     Serial
+#define SERIAL_PORT_HARDWARE       Serial
+#define SERIAL_PORT_HARDWARE_OPEN  Serial
+
+#endif /* Pins_Arduino_h */

--- a/hardware/tools/esp8266/sdk/include/c_types.h
+++ b/hardware/tools/esp8266/sdk/include/c_types.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+typedef __SIZE_TYPE__       size_t;
 typedef signed char         sint8_t;
 typedef signed short        sint16_t;
 typedef signed long         sint32_t;


### PR DESCRIPTION
Currently trying to adapt https://github.com/cnlohr/ws2812esp8266 for the Arduino IDE and ran into this compile error. Adding the definition to c_types.h fixed it.

Also, I added an option for the new ESPD-12 model to make the full 4 megabytes of flash available. Afaik all EDP-12 boards currently being sold are the new 4 megabyte models unless they're old stock. My supplier confirmed that the 512 kilobyte models are no longer available.