### PR TITLE
Fix for undefined reference to strtok_r

### DIFF
--- a/hardware/esp8266com/esp8266/cores/esp8266/libc_replacements.c
+++ b/hardware/esp8266com/esp8266/cores/esp8266/libc_replacements.c
@@ -159,9 +159,6 @@ char* ICACHE_FLASH_ATTR strncat(char * dest, const char * src, size_t n) {
     return dest;
 }
 
-char* ICACHE_FLASH_ATTR strtok(char * str, const char * delimiters) {
-    return strtok_r(str, delimiters, NULL);
-}
 
 char* ICACHE_FLASH_ATTR strtok_r(char * str, const char * delimiters, char ** temp) {
     static char * ret = NULL;
@@ -203,6 +200,10 @@ char* ICACHE_FLASH_ATTR strtok_r(char * str, const char * delimiters, char ** te
     ret = (char *) malloc(size);
     strncpy(ret, start, size);
     return ret;
+}
+
+char* ICACHE_FLASH_ATTR strtok(char * str, const char * delimiters) {
+    return strtok_r(str, delimiters, NULL);
 }
 
 int strcasecmp(const char * str1, const char * str2) {


### PR DESCRIPTION
strtok_r is never prototyped and the function directly above it references it. 