### PR TITLE
Add pyesptool as a programmer option

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -933,6 +933,8 @@
     <move file="${staging_folder}/work/${staging_hardware_folder}/tools/esp8266/esptool-0.4.2-win32/esptool.exe" tofile="${staging_folder}/work/${staging_hardware_folder}/tools/esp8266/esptool.exe" />
     <delete dir="${staging_folder}/work/${staging_hardware_folder}/tools/esp8266/esptool-0.4.2-win32/" />
  
+    <!-- Retrieve pyesptool -->
+    <get src="https://raw.githubusercontent.com/themadinventor/esptool/master/esptool.py" dest="${staging_folder}/work/${staging_hardware_folder}/tools/esp8266/esptool.py" verbose="true" ignoreerrors="true" />
   </target>
 
   <target name="windows-run" depends="windows-build"

--- a/build/build.xml
+++ b/build/build.xml
@@ -388,6 +388,9 @@
     <move file="${staging_folder}/work/${staging_hardware_folder}/tools/esp8266/esptool-0.4.2-osx/esptool" tofile="${staging_folder}/work/${staging_hardware_folder}/tools/esp8266/esptool" />
     <delete dir="${staging_folder}/work/${staging_hardware_folder}/tools/esp8266/esptool-0.4.2-osx/" />
 
+	<!-- Retrieve pyesptool -->
+    <get src="https://raw.githubusercontent.com/themadinventor/esptool/master/esptool.py" dest="${staging_folder}/work/${staging_hardware_folder}/tools/esp8266/esptool.py" verbose="true" ignoreerrors="true" />
+
   </target>
 
   <target name="macosx-run" depends="macosx-build" description="Run Mac OS X version">
@@ -667,6 +670,9 @@
     </antcall>
     <move file="${staging_folder}/work/${staging_hardware_folder}/tools/esp8266/esptool-0.4.2-linux64/esptool" tofile="${staging_folder}/work/${staging_hardware_folder}/tools/esp8266/esptool" />
     <delete dir="${staging_folder}/work/${staging_hardware_folder}/tools/esp8266/esptool-0.4.2-linux64/" />
+    
+    <!-- Retrieve pyesptool -->
+    <get src="https://raw.githubusercontent.com/themadinventor/esptool/master/esptool.py" dest="${staging_folder}/work/${staging_hardware_folder}/tools/esp8266/esptool.py" verbose="true" ignoreerrors="true" />
 
   </target>
 

--- a/hardware/esp8266com/esp8266/platform.txt
+++ b/hardware/esp8266com/esp8266/platform.txt
@@ -93,7 +93,7 @@ tools.esptool.program.params.quiet=
 tools.esptool.program.pattern="{path}/{cmd}" -vvv {program.verbose} -cd {upload.resetmethod} -cb {upload.speed} -cp {serial.port} -ca 0x00000 -cf "{build.path}/{build.project_name}_00000.bin" -ca 0x40000 -cf "{build.path}/{build.project_name}_40000.bin"
 
 tools.pyesptool.cmd=esptool.py
-tools.pyesptool.cmd.windows=esptool.exe
+tools.pyesptool.cmd.windows=esptool.py
 tools.pyesptool.path={runtime.ide.path}/hardware/tools/esp8266
 tools.pyesptool.program.params.verbose=""
 tools.pyesptool.program.params.quiet="" 

--- a/hardware/esp8266com/esp8266/platform.txt
+++ b/hardware/esp8266com/esp8266/platform.txt
@@ -88,8 +88,14 @@ tools.esptool.cmd=esptool
 tools.esptool.cmd.windows=esptool.exe
 tools.esptool.path={runtime.ide.path}/hardware/tools/esp8266
 
-tools.esptool.upload.protocol=esp
-tools.esptool.upload.params.verbose=-vv
-tools.esptool.upload.params.quiet=
-tools.esptool.upload.pattern="{path}/{cmd}" {upload.verbose} -cd {upload.resetmethod} -cb {upload.speed} -cp "{serial.port}" -ca 0x00000 -cf "{build.path}/{build.project_name}_00000.bin" -ca 0x40000 -cf "{build.path}/{build.project_name}_40000.bin"
+tools.esptool.program.params.verbose=-vv
+tools.esptool.program.params.quiet= 
+tools.esptool.program.pattern="{path}/{cmd}" -vvv {program.verbose} -cd {upload.resetmethod} -cb {upload.speed} -cp {serial.port} -ca 0x00000 -cf "{build.path}/{build.project_name}_00000.bin" -ca 0x40000 -cf "{build.path}/{build.project_name}_40000.bin"
+
+tools.pyesptool.cmd=esptool.py
+tools.pyesptool.cmd.windows=esptool.exe
+tools.pyesptool.path={runtime.ide.path}/hardware/tools/esp8266
+tools.pyesptool.program.params.verbose=""
+tools.pyesptool.program.params.quiet="" 
+tools.pyesptool.program.pattern=python "{path}/{cmd}" {program.verbose} --port {serial.port} write_flash 0x00000 "{build.path}/{build.project_name}_00000.bin" 0x40000 "{build.path}/{build.project_name}_40000.bin"
 

--- a/hardware/esp8266com/esp8266/programmers.txt
+++ b/hardware/esp8266com/esp8266/programmers.txt
@@ -1,0 +1,13 @@
+esptool.name=esptool
+esptool.communication=serial
+esptool.protocol=esp
+esptool.program.protocol=esp
+esptool.program.tool=esptool
+esptool.program.extra_params=
+
+pyesptool.name=pyesptool
+pyesptool.communication=serial
+pyesptool.protocol=esp
+pyesptool.program.protocol=esp
+pyesptool.program.tool=pyesptool
+pyesptool.program.extra_params=


### PR DESCRIPTION
I found that esptool consistently failed to upload on macos, this adds the python esptool as a programmer option