### PR TITLE
move libm to flash (.irom0.text)

### DIFF
--- a/hardware/tools/esp8266/sdk/ld/eagle.app.v6.ld
+++ b/hardware/tools/esp8266/sdk/ld/eagle.app.v6.ld
@@ -153,6 +153,7 @@ SECTIONS
     _irom0_text_start = ABSOLUTE(.);
     *core_esp8266_*.o(.literal*, .text*)
     *.cpp.o(.literal*, .text*)
+	*libm.a:(.literal .text .literal.* .text.*)
     *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text)
     _irom0_text_end = ABSOLUTE(.);
   } >irom0_0_seg :irom0_0_phdr


### PR DESCRIPTION
saves 3544 Byte in ram
see #104