### PR TITLE
ClientContext.h: Remove delay and force output of queued data.

### DIFF
--- a/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/include/ClientContext.h
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/include/ClientContext.h
@@ -170,7 +170,7 @@ class ClientContext {
             _size_sent = will_send;
             DEBUGV(":wr\r\n");
             _send_waiting = true;
-            delay(5000); // max send timeout
+            tcp_output( _pcb );
             _send_waiting = false;
             DEBUGV(":ww\r\n");
             return will_send - _size_sent;


### PR DESCRIPTION
This replaces a 5 second delay to an LWIP function `tcp_output()`. Rather than waiting for interrupts to handle sending, this will actively send the data.

I proposed this change on the esp8266 forum and it appears to solve a large latency issue: 
http://www.esp8266.com/viewtopic.php?f=28&t=2672