### PR TITLE
Add boot loader compatible speed of 74880 to serial

### DIFF
--- a/app/src/processing/app/AbstractMonitor.java
+++ b/app/src/processing/app/AbstractMonitor.java
@@ -135,7 +135,7 @@ public abstract class AbstractMonitor extends JFrame implements ActionListener {
 
     String[] serialRateStrings = {
             "300", "1200", "2400", "4800", "9600",
-            "19200", "38400", "57600", "115200"
+            "19200", "38400", "57600", "74880", "115200"
     };
 
     serialRates = new JComboBox();


### PR DESCRIPTION
This would be handy for those of us who wish to see the boot loader information in the IDE.