### PR TITLE
Fix windows build

### DIFF
--- a/.codenvy/project.json
+++ b/.codenvy/project.json
@@ -1,0 +1,1 @@
+{"mixinTypes":["contribution"],"builders":{"configs":{}},"runners":{"configs":{}},"description":"Arduino IDE for ESP8266","type":"blank","attributes":{"contribute_branch":["esp8266"],"contribute_mode":["contribute"]}}

--- a/build/build.xml
+++ b/build/build.xml
@@ -952,7 +952,7 @@
    <target name="source-dist" depends="revision-check"
 	  description="Build .tar.gz of source code">
     <input message="Enter version number:"
-	   addproperty="vreersion"
+	   addproperty="version"
 	   defaultvalue="${revision}" />
 
     <tar compression="gzip" destfile="arduino-${version}-src.tar.gz">

--- a/build/build.xml
+++ b/build/build.xml
@@ -47,6 +47,9 @@
   <condition property="launch4j-download-unpack-target-name" value="launch4j-windows"><os family="windows" /></condition>
   <property name="launch4j-download-unpack-target-name" value="launch4j-linux"/>
 
+  <property name="MACOSX_BUNDLED_JVM" value="${java.home}/../"/>
+  <property name="WINDOWS_BUNDLED_JVM" value="${java.home}"/>
+
   <!-- Libraries required for running arduino -->
   <fileset dir=".." id="runtime.jars">
     <include name="arduino-core/arduino-core.jar" />
@@ -729,30 +732,6 @@
   <target name="linux-dist" depends="build"
 	  description="Build .tar.xz of linux version">
 
-    <!--get src="http://dev.processing.org/build/jre-tools-6u18-linux-i586.tgz" 
-	 dest="linux/jre.tgz" 
-	 usetimestamp="true" />    
-    <untar compression="gzip" 
-	   dest="linux/work" 
-	   src="linux/jre.tgz" 
-	   overwrite="false"/-->
-
-<!--
-    <tar compression="gzip" basedir="linux/work"
-	 destfile="linux/arduino-${version}.tgz" />
-
-    <tar compression="gzip" destfile="linux/arduino-${version}-linux.tgz">
-      <tarfileset dir="linux/work"
-		  prefix="arduino-${version}"
-		  excludes="arduino,
-			    hardware/tools/avrdude,
-			    java/**"
-		  />
-      <tarfileset file="linux/work/arduino" filemode="755" prefix="arduino-${version}" />
-      <tarfileset file="linux/work/hardware/tools/avrdude" filemode="755"
-		  prefix="arduino-${version}/hardware/tools" />
-    </tar>
--->
     <move file="linux/work" tofile="linux/arduino-${version}" />
 
     <exec executable="tar" dir="linux">
@@ -935,15 +914,21 @@
 	  dir="windows/work" spawn="true"/>
   </target>
 
-  <target name="windows-dist" depends="windows-build"
-	  description="Create .zip files of windows version">
+  <target name="windows-dist" depends="windows-build" description="Create .zip files of windows version">
 
-    <antcall target="unzip">
-      <param name="archive_file" value="windows/jre-8u31.zip" />
-      <param name="archive_url" value="http://arduino.cc/download.php?f=/jre-8u31.zip" />
-      <param name="final_folder" value="${staging_folder}/work/java" />
-      <param name="dest_folder" value="${staging_folder}/work/" />
-    </antcall>
+    <loadproperties srcfile="${WINDOWS_BUNDLED_JVM}/../release" prefix="windows"/>
+
+    <fail message="It looks like ${WINDOWS_BUNDLED_JVM} does not contain a Windows JVM">
+      <condition>
+        <not>
+          <equals arg1="${windows.OS_NAME}" arg2="&quot;Windows&quot;"/>
+        </not>
+      </condition>
+    </fail>
+
+    <copy todir="${staging_folder}/work/java" includeemptydirs="true" preservelastmodified="true" overwrite="true" failonerror="true">
+      <fileset dir="${WINDOWS_BUNDLED_JVM}" includes="*/**"/>
+    </copy>
 
     <zip destfile="windows/arduino-${version}-${platform}.zip" level="9">
       <zipfileset dir="windows/work"
@@ -967,7 +952,7 @@
    <target name="source-dist" depends="revision-check"
 	  description="Build .tar.gz of source code">
     <input message="Enter version number:"
-	   addproperty="version"
+	   addproperty="vreersion"
 	   defaultvalue="${revision}" />
 
     <tar compression="gzip" destfile="arduino-${version}-src.tar.gz">

--- a/build/windows/jre-8u31.zip.sha
+++ b/build/windows/jre-8u31.zip.sha
@@ -1,1 +1,0 @@
-17bf4f25babaf70bdb68fd3464be163eb769c074


### PR DESCRIPTION
Fix Windows build according to official Arduino build process
Now it is required to install JDK and point JAVA_HOME to it's location