### PR TITLE
HardwareSerial: add other configs than 8N1

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ more than 20 milliseconds is not recommended.
 
 ```Serial``` object works much the same way as on a regular Arduino. Apart from hardware FIFO (128 bytes for TX and RX) HardwareSerial has additional 256-byte TX and RX buffers. Both transmit and receive is interrupt-driven. Write and read functions only block the sketch execution when the respective FIFO/buffers are full/empty.
 
-Only 8n1 mode is supported right now.
-
 By default the diagnostic output from WiFi libraries is disabled when you call ```Serial.begin```. To enable debug output again, call ```Serial.setDebugOutput(true);```
 
 #### WiFi(ESP8266WiFi library) ####

--- a/hardware/esp8266com/esp8266/cores/esp8266/HardwareSerial.cpp
+++ b/hardware/esp8266com/esp8266/cores/esp8266/HardwareSerial.cpp
@@ -19,7 +19,7 @@
  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
  Modified 31 March 2015 by Markus Sattler (rewrite the code for UART0 + UART1 support in ESP8266)
-
+ Modified 25 April 2015 by Thomas Flayols (add configuration different from 8N1 in ESP8266)
  */
 
 #include <stdlib.h>
@@ -86,7 +86,7 @@ void uart_disarm_tx_interrupt(uart_t* uart);
 void uart_set_baudrate(uart_t* uart, int baud_rate);
 int uart_get_baudrate(uart_t* uart);
 
-uart_t* uart_init(UARTnr_t uart_nr, int baudrate);
+uart_t* uart_init(UARTnr_t uart_nr, int baudrate, byte config);
 void uart_uninit(uart_t* uart);
 void uart_swap(uart_t* uart);
 
@@ -278,7 +278,7 @@ int ICACHE_FLASH_ATTR uart_get_baudrate(uart_t* uart) {
     return uart->baud_rate;
 }
 
-uart_t* ICACHE_FLASH_ATTR uart_init(UARTnr_t uart_nr, int baudrate) {
+uart_t* ICACHE_FLASH_ATTR uart_init(UARTnr_t uart_nr, int baudrate, byte config) {
 
     uint32_t conf1 = 0x00000000;
     uart_t* uart = (uart_t*) os_malloc(sizeof(uart_t));
@@ -314,7 +314,7 @@ uart_t* ICACHE_FLASH_ATTR uart_init(UARTnr_t uart_nr, int baudrate) {
             break;
     }
     uart_set_baudrate(uart, baudrate);
-    WRITE_PERI_REG(UART_CONF0(uart->uart_nr), 0x3 << UART_BIT_NUM_S);   // 8n1
+    WRITE_PERI_REG(UART_CONF0(uart->uart_nr), config);
 
     uart_flush(uart);
     uart_interrupt_enable(uart);
@@ -493,7 +493,7 @@ void ICACHE_FLASH_ATTR HardwareSerial::begin(unsigned long baud, byte config) {
         uart_set_debug(UART_NO);
     }
 
-    _uart = uart_init(_uart_nr, baud);
+    _uart = uart_init(_uart_nr, baud, config);
 
     if(_uart == 0) {
         return;

--- a/hardware/esp8266com/esp8266/cores/esp8266/HardwareSerial.h
+++ b/hardware/esp8266com/esp8266/cores/esp8266/HardwareSerial.h
@@ -21,6 +21,7 @@
  Modified 3 December 2013 by Matthijs Kooijman
  Modified 18 December 2014 by Ivan Grokhotkov (esp8266 platform support)
  Modified 31 March 2015 by Markus Sattler (rewrite the code for UART0 + UART1 support in ESP8266)
+ Modified 25 April 2015 by Thomas Flayols (add configuration different from 8N1 in ESP8266)
  */
 
 #ifndef HardwareSerial_h
@@ -33,31 +34,31 @@
 #define SERIAL_TX_BUFFER_SIZE 256
 #define SERIAL_RX_BUFFER_SIZE 256
 
-// // Define config for Serial.begin(baud, config);
-// #define SERIAL_5N1 0x00
-// #define SERIAL_6N1 0x02
-// #define SERIAL_7N1 0x04
-// #define SERIAL_8N1 0x06
-// #define SERIAL_5N2 0x08
-// #define SERIAL_6N2 0x0A
-// #define SERIAL_7N2 0x0C
-// #define SERIAL_8N2 0x0E
-// #define SERIAL_5E1 0x20
-// #define SERIAL_6E1 0x22
-// #define SERIAL_7E1 0x24
-// #define SERIAL_8E1 0x26
-// #define SERIAL_5E2 0x28
-// #define SERIAL_6E2 0x2A
-// #define SERIAL_7E2 0x2C
-// #define SERIAL_8E2 0x2E
-// #define SERIAL_5O1 0x30
-// #define SERIAL_6O1 0x32
-// #define SERIAL_7O1 0x34
-// #define SERIAL_8O1 0x36
-// #define SERIAL_5O2 0x38
-// #define SERIAL_6O2 0x3A
-// #define SERIAL_7O2 0x3C
-// #define SERIAL_8O2 0x3E
+// Define config for Serial.begin(baud, config);
+#define SERIAL_5N1 0x10
+#define SERIAL_6N1 0x14
+#define SERIAL_7N1 0x18
+#define SERIAL_8N1 0x1c
+#define SERIAL_5N2 0x30
+#define SERIAL_6N2 0x34
+#define SERIAL_7N2 0x38
+#define SERIAL_8N2 0x3c
+#define SERIAL_5E1 0x12
+#define SERIAL_6E1 0x16
+#define SERIAL_7E1 0x1a
+#define SERIAL_8E1 0x1e
+#define SERIAL_5E2 0x32
+#define SERIAL_6E2 0x36
+#define SERIAL_7E2 0x3a
+#define SERIAL_8E2 0x3e
+#define SERIAL_5O1 0x13
+#define SERIAL_6O1 0x17
+#define SERIAL_7O1 0x1b
+#define SERIAL_8O1 0x1f
+#define SERIAL_5O2 0x33
+#define SERIAL_6O2 0x37
+#define SERIAL_7O2 0x3b
+#define SERIAL_8O2 0x3f
 
 class cbuf;
 
@@ -79,7 +80,7 @@ class HardwareSerial: public Stream {
         HardwareSerial(UARTnr_t uart_nr);
 
         void begin(unsigned long baud) {
-            begin(baud, 0);
+            begin(baud, SERIAL_8N1);
         }
         void begin(unsigned long, uint8_t);
         void end();


### PR DESCRIPTION
the register configurations has been computed like this:
```
#include <stdio.h>
int main(int argc, char **argv)
{
	char t[24][4]={"5N1","6N1","7N1","8N1","5N2","6N2","7N2","8N2","5E1","6E1","7E1","8E1","5E2","6E2","7E2","8E2","5O1","6O1","7O1","8O1","5O2","6O2","7O2","8O2"};
	char c;
	int i;
	for (i=0;i<24;i++)
	{
		c=0;
		if (t[i][0]=='5') c+=0<<2;
		if (t[i][0]=='6') c+=1<<2;
		if (t[i][0]=='7') c+=2<<2;
		if (t[i][0]=='8') c+=3<<2;
		
		if (t[i][1]=='E') c+=2<<0;
		if (t[i][1]=='O') c+=3<<0;
		if (t[i][1]=='N') c+=0<<0;
	
		if (t[i][2]=='1') c+=1<<4;
		if (t[i][2]=='2') c+=3<<4;
			
		printf("#define SERIAL_%s 0x%x\n", t[i],c);
	}
	return 0;
}
```