### PR TITLE
ESP8266WiFi: made connected() return true if data is available

### DIFF
--- a/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -197,7 +197,7 @@ uint8_t ICACHE_FLASH_ATTR WiFiClient::connected()
     if (!_client)
         return 0;
 
-    return _client->state() == ESTABLISHED;
+    return _client->state() == ESTABLISHED || available();
 }
 
 uint8_t ICACHE_FLASH_ATTR WiFiClient::status() 


### PR DESCRIPTION
I found an slight incompatibility with the Arduino documentation for `WiFiClient::connected()`: http://www.arduino.cc/en/Reference/WiFiClientConnected

`WiFiClient::connected()` should return true if the connection is disconnected, but there is still data available.
Before this patch `WiFiClient::connected()` returned true when the connection was still there. I found this more intuitive, but the documentation sadly said otherwise.