### PR TITLE
Ability to wake from .deepSleep

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The implementation supports the entire Arduino SPI API including transactions, e
 
 APIs related to deep sleep and watchdog timer are available in the ```ESP``` object.
 
-```ESP.deepSleep(microseconds, mode)``` will put the chip into deep sleep. ```mode``` is one of ```WAKE_DEFAULT```, ```WAKE_RFCAL```, ```WAKE_NO_RFCAL```, ```WAKE_RF_DISABLED```.
+```ESP.deepSleep(microseconds, mode)``` will put the chip into deep sleep. ```mode``` is one of ```WAKE_DEFAULT```, ```WAKE_RFCAL```, ```WAKE_NO_RFCAL```, ```WAKE_RF_DISABLED```. (GPIO16 needs to be tied to RST to wake from deepSleep.)
 
 ```ESP.wdtEnable()```, ```ESP.wdtDisable()```, and ```ESP.wdtFeed()``` provide some control over the watchdog timer.
 


### PR DESCRIPTION
This was not immediately apparent to me. I don't think it would be apparent to anyone else just playing around with ESP8266/Arduino either. GPIO16 and RST (REST) need to be tied together or you can "never wake from .deepSleep"

It must be GPIO16 and it must be RST, no other GPIO pin will wake it from deepSleep.