### PR TITLE
Mode missed

### DIFF
--- a/hardware/esp8266com/esp8266/libraries/EEPROM/examples/eeprom_clear/eeprom_clear.ino
+++ b/hardware/esp8266com/esp8266/libraries/EEPROM/examples/eeprom_clear/eeprom_clear.ino
@@ -16,6 +16,7 @@ void setup()
     EEPROM.write(i, 0);
 
   // turn the LED on when we're done
+  pinMode(13, OUTPUT);
   digitalWrite(13, HIGH);
   EEPROM.end();
 }


### PR DESCRIPTION
pinMode was missed in eeprom_clear example.