### PR TITLE
true interrupt enable and disable

### DIFF
--- a/hardware/esp8266com/esp8266/cores/esp8266/Arduino.h
+++ b/hardware/esp8266com/esp8266/cores/esp8266/Arduino.h
@@ -124,8 +124,11 @@ void timer1_write(uint32_t ticks); //maximum ticks 8388607
 void ets_intr_lock();
 void ets_intr_unlock();
 
-#define interrupts() ets_intr_unlock();
-#define noInterrupts() ets_intr_lock();
+void xt_enable_interrupts();
+void xt_disable_interrupts();
+
+#define interrupts() xt_enable_interrupts();
+#define noInterrupts() xt_disable_interrupts();
 
 #define clockCyclesPerMicrosecond() ( F_CPU / 1000000L )
 #define clockCyclesToMicroseconds(a) ( (a) / clockCyclesPerMicrosecond() )

--- a/hardware/esp8266com/esp8266/cores/esp8266/Esp.h
+++ b/hardware/esp8266com/esp8266/cores/esp8266/Esp.h
@@ -95,7 +95,15 @@ class EspClass {
         FlashMode_t getFlashChipMode(void);
         uint32_t getFlashChipSizeByChipId(void);
 
+        inline uint32_t getCycleCount(void);
 };
+
+uint32_t EspClass::getCycleCount(void)
+{
+    uint32_t ccount;
+    __asm__ __volatile__("rsr %0,ccount":"=a" (ccount));
+    return ccount;
+}
 
 extern EspClass ESP;
 


### PR DESCRIPTION
This will expose the inherent cpu instruction cycle count, which is handy for bit bang timing.
Further, this fixes the interrupts() and noInterrupts() routines to honor original intent.

Due to the priority interrupt system on the chip, it supports the ability to suppress interrupts at different levels.  The levels are from 0 to 14, where most are on 0, but some of the WiFi is done on 14.

The current implementation of noInterrupts() doesn't block level 14 interrupts, causing routines that rely on not being interrupted to malfunction.  This change will honor the original intent of noInterrupts().