### PR TITLE
true noInterrupts() interrupts() support

### DIFF
--- a/hardware/esp8266com/esp8266/cores/esp8266/Arduino.h
+++ b/hardware/esp8266com/esp8266/cores/esp8266/Arduino.h
@@ -124,11 +124,17 @@ void timer1_write(uint32_t ticks); //maximum ticks 8388607
 void ets_intr_lock();
 void ets_intr_unlock();
 
-void xt_enable_interrupts();
-void xt_disable_interrupts();
+// level (0-15), 
+// level 15 will disable ALL interrupts, 
+// level 0 will disable most software interrupts
+//
+#define xt_disable_interrupts(state, level) __asm__ __volatile__("rsil %0," __STRINGIFY(level) "; esync; isync; dsync" : "=a" (state))
+#define xt_enable_interrupts(state)  __asm__ __volatile__("wsr %0,ps; esync" :: "a" (state) : "memory")
 
-#define interrupts() xt_enable_interrupts();
-#define noInterrupts() xt_disable_interrupts();
+extern uint32_t interruptsState;
+
+#define interrupts() xt_enable_interrupts(interruptsState)
+#define noInterrupts() xt_disable_interrupts(interruptsState, 15)
 
 #define clockCyclesPerMicrosecond() ( F_CPU / 1000000L )
 #define clockCyclesToMicroseconds(a) ( (a) / clockCyclesPerMicrosecond() )

--- a/hardware/esp8266com/esp8266/cores/esp8266/Arduino.h
+++ b/hardware/esp8266com/esp8266/cores/esp8266/Arduino.h
@@ -124,8 +124,11 @@ void timer1_write(uint32_t ticks); //maximum ticks 8388607
 void ets_intr_lock();
 void ets_intr_unlock();
 
-#define interrupts() ets_intr_unlock();
-#define noInterrupts() ets_intr_lock();
+void xt_enable_interrupts();
+void xt_disable_interrupts();
+
+#define interrupts() xt_enable_interrupts();
+#define noInterrupts() xt_disable_interrupts();
 
 #define clockCyclesPerMicrosecond() ( F_CPU / 1000000L )
 #define clockCyclesToMicroseconds(a) ( (a) / clockCyclesPerMicrosecond() )

--- a/hardware/esp8266com/esp8266/cores/esp8266/Esp.h
+++ b/hardware/esp8266com/esp8266/cores/esp8266/Esp.h
@@ -95,7 +95,15 @@ class EspClass {
         FlashMode_t getFlashChipMode(void);
         uint32_t getFlashChipSizeByChipId(void);
 
+        inline uint32_t getCycleCount(void);
 };
+
+uint32_t EspClass::getCycleCount(void)
+{
+    uint32_t ccount;
+    __asm__ __volatile__("rsr %0,ccount":"=a" (ccount));
+    return ccount;
+}
 
 extern EspClass ESP;
 

--- a/hardware/esp8266com/esp8266/cores/esp8266/core_esp8266_wiring_digital.c
+++ b/hardware/esp8266com/esp8266/cores/esp8266/core_esp8266_wiring_digital.c
@@ -139,20 +139,8 @@ extern void __detachInterrupt(uint8_t pin) {
   }
 }
 
-static uint32_t interruptState = 0;
-
-void xt_disable_interrupts()
-{
-    __asm__ __volatile__("rsil %0,15":"=a" (interruptState));
-    __asm__("esync");
-    __asm__("isync");
-    __asm__("dsync");
-}
-void xt_enable_interrupts()
-{
-    __asm__ __volatile__("wsr %0,ps"::"a" (interruptState) : "memory");
-    __asm__("esync");
-}
+// stored state for the noInterrupts/interrupts methods
+uint32_t interruptsState = 0;
 
 void initPins() {
   //Disable UART interrupts

--- a/hardware/esp8266com/esp8266/cores/esp8266/core_esp8266_wiring_digital.c
+++ b/hardware/esp8266com/esp8266/cores/esp8266/core_esp8266_wiring_digital.c
@@ -139,6 +139,21 @@ extern void __detachInterrupt(uint8_t pin) {
   }
 }
 
+static uint32_t interruptState = 0;
+
+void xt_disable_interrupts()
+{
+    __asm__ __volatile__("rsil %0,15":"=a" (interruptState));
+    __asm__("esync");
+    __asm__("isync");
+    __asm__("dsync");
+}
+void xt_enable_interrupts()
+{
+    __asm__ __volatile__("wsr %0,ps"::"a" (interruptState) : "memory");
+    __asm__("esync");
+}
+
 void initPins() {
   //Disable UART interrupts
   system_set_os_print(0);


### PR DESCRIPTION
This will expose the inherent cpu instruction cycle count, which is handy for bit bang timing.
Further, this fixes the interrupts() and noInterrupts() routines to honor original intent.

Due to the priority interrupt system on the chip, it supports the ability to suppress interrupts at different levels. The levels are from 0 to 14, where most are on 0, but some of the WiFi is done on 14.

The current implementation of noInterrupts() doesn't block level 14 interrupts, causing routines that rely on not being interrupted to malfunction. This change will honor the original intent of noInterrupts().
