### PR TITLE
Fix UDP send to not temporarily use connect()

### DIFF
--- a/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/WiFiUdp.cpp
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/WiFiUdp.cpp
@@ -132,14 +132,13 @@ int WiFiUDP::beginPacket(const char *host, uint16_t port)
 
 int WiFiUDP::beginPacket(IPAddress ip, uint16_t port)
 {
-    ip_addr_t addr;
-    addr.addr = ip;
-
     if (!_ctx) {
         _ctx = new UdpContext;
         _ctx->ref();
     }
-    return (_ctx->connect(addr, port)) ? 1 : 0;
+    begunIp_ = ip;
+    begunPort_= port;
+    return 1;
 }
 
 int WiFiUDP::beginPacketMulticast(IPAddress multicastAddress, uint16_t port, 
@@ -167,8 +166,9 @@ int WiFiUDP::endPacket()
     if (!_ctx)
         return 0;
 
-    _ctx->send();
-    _ctx->disconnect();
+    ip_addr_t addr;
+    addr.addr = begunIp_;
+    _ctx->send(&addr, begunPort_);
     return 1;
 }
 

--- a/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/WiFiUdp.h
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/WiFiUdp.h
@@ -31,6 +31,8 @@ class UdpContext;
 class WiFiUDP : public UDP {
 private:
   UdpContext* _ctx;
+  IPAddress begunIp_;
+  uint16_t begunPort_;
 
 public:
   WiFiUDP();  // Constructor

--- a/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/include/UdpContext.h
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/include/UdpContext.h
@@ -281,7 +281,7 @@ private:
 
     void _reserve(size_t size)
     {
-        const size_t pbuf_unit_size = 1024;
+        const size_t pbuf_unit_size = 512;
         if (!_tx_buf_head)
         {
             _tx_buf_head = pbuf_alloc(PBUF_TRANSPORT, pbuf_unit_size, PBUF_RAM);


### PR DESCRIPTION
Using connect() temporarily is incorrect, because any packet arriving for the listening port from another host while inside the beginPacket()/endPacket() bracket will be discarded.

Instead, remember the IP and port used in beginPacket(), and provide those as unicast destination when endPacket() calls send().

A better option would be to change beginPacket() to not take the destination, and make endPacket() take the destination, but this would break compatibility with the Arduino WiFi library.

This change also makes the size of each buffer created for buffering data 512 bytes instead of 1024. Most UDP datagrams are < 256 bytes in size, so this is a better trade-off for using on an embedded device.