### PR TITLE
PgmSpace working

### DIFF
--- a/hardware/esp8266com/esp8266/cores/esp8266/Print.cpp
+++ b/hardware/esp8266com/esp8266/cores/esp8266/Print.cpp
@@ -18,6 +18,7 @@
  
  Modified 23 November 2006 by David A. Mellis
  Modified December 2014 by Ivan Grokhotkov
+ Modified May 2015 by Michael C. Miller - esp8266 progmem support
  */
 
 #include <stdlib.h>
@@ -38,6 +39,18 @@ size_t ICACHE_FLASH_ATTR Print::write(const uint8_t *buffer, size_t size) {
     size_t n = 0;
     while(size--) {
         n += write(*buffer++);
+    }
+    return n;
+}
+
+size_t ICACHE_FLASH_ATTR Print::print(const __FlashStringHelper *ifsh) {
+    PGM_P p = reinterpret_cast<PGM_P>(ifsh);
+
+    size_t n = 0;
+    while (1) {
+        uint8_t c = pgm_read_byte(p++);
+        if (c == 0) break;
+        n += write(c);
     }
     return n;
 }
@@ -90,6 +103,12 @@ size_t ICACHE_FLASH_ATTR Print::print(unsigned long n, int base) {
 
 size_t ICACHE_FLASH_ATTR Print::print(double n, int digits) {
     return printFloat(n, digits);
+}
+
+size_t ICACHE_FLASH_ATTR Print::println(const __FlashStringHelper *ifsh) {
+    size_t n = print(ifsh);
+    n += println();
+    return n;
 }
 
 size_t ICACHE_FLASH_ATTR Print::print(const Printable& x) {

--- a/hardware/esp8266com/esp8266/cores/esp8266/Print.h
+++ b/hardware/esp8266com/esp8266/cores/esp8266/Print.h
@@ -63,6 +63,7 @@ class Print {
             return write((const uint8_t *) buffer, size);
         }
 
+        size_t print(const __FlashStringHelper *);
         size_t print(const String &);
         size_t print(const char[]);
         size_t print(char);
@@ -74,6 +75,7 @@ class Print {
         size_t print(double, int = 2);
         size_t print(const Printable&);
 
+        size_t println(const __FlashStringHelper *);
         size_t println(const String &s);
         size_t println(const char[]);
         size_t println(char);

--- a/hardware/esp8266com/esp8266/cores/esp8266/WString.h
+++ b/hardware/esp8266com/esp8266/cores/esp8266/WString.h
@@ -26,15 +26,17 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
-#define PROGMEM
+#include <pgmspace.h>
 
 // An inherited class for holding the result of a concatenation.  These
 // result objects are assumed to be writable by subsequent concatenations.
 class StringSumHelper;
 
-typedef char* __FlashStringHelper;
-//#define F(str)  []() -> const char * { static const char tmp[] ICACHE_RODATA_ATTR = str; return &tmp[0]; }()
-#define F(str) str
+// an abstract class used as a means to proide a unique pointer type
+// but really has no body
+class __FlashStringHelper;
+#define F(string_literal) (reinterpret_cast<const __FlashStringHelper *>(PSTR(string_literal)))
+
 
 // The string class
 class String {
@@ -53,6 +55,7 @@ class String {
         // be false).
         String(const char *cstr = "");
         String(const String &str);
+        String(const __FlashStringHelper *str);
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
         String(String &&rval);
         String(StringSumHelper &&rval);
@@ -81,6 +84,7 @@ class String {
         // marked as invalid ("if (s)" will be false).
         String & operator =(const String &rhs);
         String & operator =(const char *cstr);
+        String & operator = (const __FlashStringHelper *str);
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
         String & operator =(String &&rval);
         String & operator =(StringSumHelper &&rval);
@@ -101,6 +105,7 @@ class String {
         unsigned char concat(unsigned long num);
         unsigned char concat(float num);
         unsigned char concat(double num);
+        unsigned char concat(const __FlashStringHelper * str);
 
         // if there's not enough memory for the concatenated value, the string
         // will be left unchanged (but this isn't signalled in any way)
@@ -144,6 +149,10 @@ class String {
             concat(num);
             return (*this);
         }
+        String & operator += (const __FlashStringHelper *str){
+            concat(str);
+            return (*this);
+        }
 
         friend StringSumHelper & operator +(const StringSumHelper &lhs, const String &rhs);
         friend StringSumHelper & operator +(const StringSumHelper &lhs, const char *cstr);
@@ -155,6 +164,7 @@ class String {
         friend StringSumHelper & operator +(const StringSumHelper &lhs, unsigned long num);
         friend StringSumHelper & operator +(const StringSumHelper &lhs, float num);
         friend StringSumHelper & operator +(const StringSumHelper &lhs, double num);
+        friend StringSumHelper & operator +(const StringSumHelper &lhs, const __FlashStringHelper *rhs);
 
         // comparison (only works w/ Strings and "strings")
         operator StringIfHelperType() const {
@@ -237,6 +247,7 @@ class String {
 
         // copy and move
         String & copy(const char *cstr, unsigned int length);
+        String & copy(const __FlashStringHelper *pstr, unsigned int length);
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
         void move(String &rhs);
 #endif

--- a/hardware/esp8266com/esp8266/cores/esp8266/libc_replacements.c
+++ b/hardware/esp8266com/esp8266/cores/esp8266/libc_replacements.c
@@ -116,7 +116,7 @@ char* strncpy(char * dest, const char * src, size_t n) {
     return ets_strncpy(dest, src, n);
 }
 
-size_t strnlen(const char *s, size_t len) {
+size_t ICACHE_FLASH_ATTR strnlen(const char *s, size_t len) {
     // there is no ets_strnlen
     const char *cp;
     for (cp = s; len != 0 && *cp != '\0'; cp++, len--);
@@ -127,7 +127,7 @@ char* strstr(const char *haystack, const char *needle) {
     return ets_strstr(haystack, needle);
 }
 
-char* strchr(const char * str, int character) {
+char* ICACHE_FLASH_ATTR strchr(const char * str, int character) {
     while(1) {
         if(*str == 0x00) {
             return NULL;
@@ -139,7 +139,7 @@ char* strchr(const char * str, int character) {
     }
 }
 
-char * strrchr(const char * str, int character) {
+char * ICACHE_FLASH_ATTR strrchr(const char * str, int character) {
     char * ret = NULL;
     while(1) {
         if(*str == 0x00) {
@@ -223,7 +223,7 @@ char* ICACHE_FLASH_ATTR strtok(char * str, const char * delimiters) {
     return ret;
 }
 
-int strcasecmp(const char * str1, const char * str2) {
+int ICACHE_FLASH_ATTR strcasecmp(const char * str1, const char * str2) {
     int d = 0;
     while(1) {
         int c1 = tolower(*str1++);

--- a/hardware/esp8266com/esp8266/cores/esp8266/pgmspace.cpp
+++ b/hardware/esp8266com/esp8266/cores/esp8266/pgmspace.cpp
@@ -1,0 +1,161 @@
+/*
+pgmspace.cpp - string functions that support PROGMEM
+Copyright (c) 2015 Michael C. Miller.  All right reserved.
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include <ctype.h>
+#include "pgmspace.h"
+
+size_t ICACHE_FLASH_ATTR strnlen_P(const char* s, size_t size) {
+    const char* cp;
+    for (cp = s; size != 0 && pgm_read_byte(cp) != '\0'; cp++, size--);
+    return (size_t)(cp - s);
+}
+
+void* ICACHE_FLASH_ATTR memcpy_P(void* dest, const void* src, size_t count) {
+    const uint8_t* read = reinterpret_cast<const uint8_t*>(src);
+    uint8_t* write = reinterpret_cast<uint8_t*>(dest);
+
+    while (count)
+    {
+        *write++ = pgm_read_byte(read++);
+        count--;
+    }
+
+    return dest;
+}
+
+char* ICACHE_FLASH_ATTR strncpy_P(char* dest, const char* src, size_t size) {
+    const char* read = src;
+    char* write = dest;
+    char ch = '.';
+    while (size > 0 && ch != '\0')
+    {
+        ch = pgm_read_byte(read++);
+        *write++ = ch;
+        size--;
+    } 
+
+    return dest;
+}
+
+char* ICACHE_FLASH_ATTR strncat_P(char* dest, const char* src, size_t size) {
+    char* write = dest;
+
+    while (*write != '\0')
+    {
+        write++;
+    }
+    
+    const char* read = src;
+    char ch = '.';
+
+    while (size > 0 && ch != '\0')
+    {
+        ch = pgm_read_byte(read++);
+        *write++ = ch;
+
+        size--;
+    }
+
+    if (ch != '\0')
+    {
+        *write = '\0';
+    }
+
+    return dest;
+}
+
+int ICACHE_FLASH_ATTR strncmp_P(const char* str1, const char* str2P, size_t size) {
+    int result = 0;
+
+    while (size > 0)
+    {
+        char ch1 = *str1++;
+        char ch2 = pgm_read_byte(str2P++);
+        result = ch1 - ch2;
+        if (result != 0 || ch2 == '\0')
+        {
+            break;
+        }
+
+        size--;
+    }
+
+    return result;
+}
+
+int ICACHE_FLASH_ATTR strncasecmp_P(const char* str1, const char* str2P, size_t size) {
+    int result = 0;
+
+    while (size > 0)
+    {
+        char ch1 = tolower(*str1++);
+        char ch2 = tolower(pgm_read_byte(str2P++));
+        result = ch1 - ch2;
+        if (result != 0 || ch2 == '\0')
+        {
+            break;
+        }
+
+        size--;
+    }
+
+    return result;
+}
+
+int	ICACHE_FLASH_ATTR printf_P(const char* formatP, ...) {
+    int ret;
+    va_list arglist;
+    va_start(arglist, formatP);
+
+    size_t fmtLen = strlen_P(formatP);
+    char* format = new char[fmtLen + 1];
+    strcpy_P(format, formatP);
+
+    ret = os_printf(format, arglist);
+
+    delete [] format;
+
+    va_end(arglist);
+    return ret;
+}
+
+int	ICACHE_FLASH_ATTR snprintf_P(char* str, size_t strSize, const char* formatP, ...) {
+    int ret;
+    va_list arglist;
+    va_start(arglist, formatP);
+
+    ret = vsnprintf_P(str, strSize, formatP, arglist);
+
+    va_end(arglist);
+    return ret;
+}
+
+int	ICACHE_FLASH_ATTR vsnprintf_P(char* str, size_t strSize, const char* formatP, va_list ap) {
+    int ret;
+
+    size_t fmtLen = strlen_P(formatP);
+    char* format = new char[fmtLen + 1];
+    strcpy_P(format, formatP);
+
+    ret = ets_vsnprintf(str, strSize, format, ap);
+
+    delete [] format;
+
+    return ret;
+}


### PR DESCRIPTION
PSTR() and F() macros correctly place string into flash memory relying
on PROGMEM
PROGMEM uses ICACHE_RODATA_ATTR
Print and String classes fixed up
str* classes fixed up