### PR TITLE
Fix esptool version field to 0.4.4

### DIFF
--- a/build/build_board_manager_package.sh
+++ b/build/build_board_manager_package.sh
@@ -50,7 +50,7 @@ cat << EOF > package_esp8266com_index.json
       "toolsDependencies":[ {
         "packager":"esp8266",
         "name":"esptool",
-        "version":"0.4.3"
+        "version":"0.4.4"
       },
       {
         "packager":"esp8266",
@@ -61,7 +61,7 @@ cat << EOF > package_esp8266com_index.json
 
     "tools": [ {
       "name":"esptool",
-      "version":"0.4.3",
+      "version":"0.4.4",
       "systems": [
         {
            "host":"i686-mingw32",


### PR DESCRIPTION
A tiny fix and not a big deal, but the esptool `version` doesn't match to the real one.