### PR TITLE
NodeMCU: BUILTIN_LED is on GPIO16

### DIFF
--- a/hardware/esp8266com/esp8266/variants/nodemcu/pins_arduino.h
+++ b/hardware/esp8266com/esp8266/variants/nodemcu/pins_arduino.h
@@ -42,7 +42,7 @@ static const uint8_t MOSI  = 13;
 static const uint8_t MISO  = 12;
 static const uint8_t SCK   = 14;
 
-static const uint8_t BUILTIN_LED = 1;
+static const uint8_t BUILTIN_LED = 16;
 
 static const uint8_t A0 = 17;
 


### PR DESCRIPTION
see: https://raw.githubusercontent.com/nodemcu/nodemcu-devkit/master/Documents/NODEMCU_DEVKIT_SCH.png