### PR TITLE
ESP8266WiFi extended functions

### DIFF
--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,7 @@
+*.zip
+linux/*tar.gz
+linux/dist/*tgz
+macosx/*tar.gz
+macosx/dist/*tgz
+windows/*zip
+windows/dist/*tgz

--- a/build/build_board_manager_package.sh
+++ b/build/build_board_manager_package.sh
@@ -5,6 +5,11 @@ outdir=esp8266-$ver
 srcdir=../hardware/esp8266com/esp8266/
 mkdir -p $outdir
 cp -R $srcdir/* $outdir/
+
+cp -R ../libraries/SD $outdir/libraries/
+cp -R ../libraries/Adafruit_ILI9341 $outdir/libraries/
+cp -R ../libraries/OneWire $outdir/libraries/
+
 cat $srcdir/platform.txt | \
 gsed 's/runtime.tools.xtensa-lx106-elf-gcc.path={runtime.platform.path}\/tools\/xtensa-lx106-elf//g' | \
 gsed 's/runtime.tools.esptool.path={runtime.platform.path}\/tools//g' | \
@@ -12,13 +17,17 @@ gsed 's/tools.esptool.path={runtime.platform.path}\/tools/tools.esptool.path=\{r
  > $outdir/platform.txt
 
 zip -r $outdir.zip $outdir
+rm -rf $outdir
 sha=`shasum -a 256 $outdir.zip | cut -f 1 -d ' '`
 size=`/bin/ls -l $outdir.zip | awk '{print $5}'`
 echo Size: $size
 echo SHA-256: $sha
 
-scp $outdir.zip dl:apps/download_files/download/
-
+if [ ! -z "$do_upload" ]; then
+    remote="http://arduino.esp8266.com"
+else
+    remote="http://localhost:8000"
+fi
 
 cat << EOF > package_esp8266com_index.json
 {
@@ -36,7 +45,7 @@ cat << EOF > package_esp8266com_index.json
       "architecture":"esp8266",
       "version":"$ver",
       "category":"ESP8266",
-      "url":"http://arduino.esp8266.com/$outdir.zip",
+      "url":"$remote/$outdir.zip",
       "archiveFileName":"$outdir.zip",
       "checksum":"SHA-256:$sha",
       "size":"$size",
@@ -85,11 +94,11 @@ cat << EOF > package_esp8266com_index.json
             "size":"12513"
         },
         {
-        	"host":"i686-pc-linux-gnu",
-        	"url":"https://github.com/igrr/esptool-ck/releases/download/0.4.4/esptool-0.4.4-linux32.tar.gz",
+            "host":"i686-pc-linux-gnu",
+            "url":"https://github.com/igrr/esptool-ck/releases/download/0.4.4/esptool-0.4.4-linux32.tar.gz",
             "archiveFileName":"esptool-0.4.4-linux32.tar.gz",
             "checksum":"SHA-256:4aa81b97a470641771cf371e5d470ac92d3b177adbe8263c4aae66e607b67755",
-            "size":"12044"	
+            "size":"12044"  
         }
       ]
     },
@@ -131,5 +140,12 @@ cat << EOF > package_esp8266com_index.json
 }
 EOF
 
-scp package_esp8266com_index.json dl:apps/download_files/download
+if [ ! -z "$do_upload" ]; then
+    scp $outdir.zip dl:apps/download_files/download/
+    scp package_esp8266com_index.json dl:apps/download_files/download
+else
+    python -m SimpleHTTPServer 
+fi
+
+
 

--- a/hardware/esp8266com/esp8266/changes.md
+++ b/hardware/esp8266com/esp8266/changes.md
@@ -1,0 +1,21 @@
+
+
+# Current version
+
+- Add 32-bit Linux toolchain
+- Better connection handling in ESP8266WebServer.
+  The server now sends Content-Length and Connection: close headers,
+  then waits for the client to disconnect. By not closing the connection
+  actively, server avoids TIME_WAIT TCP state, and the TCP stack is able to 
+  release the memory immediately, without waiting for 2xMSL period. 
+  If the client doesn't disconnect in 2000ms, the server closes the connection
+  actively.
+- Add Hash library, which has a function to calculate SHA1 hash.
+
+---
+
+# 1.6.4-g545ffde
+19 May, 2015
+
+- Initial release of board manager package
+

--- a/hardware/esp8266com/esp8266/libraries/EEPROM/EEPROM.h
+++ b/hardware/esp8266com/esp8266/libraries/EEPROM/EEPROM.h
@@ -26,43 +26,42 @@
 #include <stdint.h>
 #include <string.h>
 
-class EEPROMClass
-{
-  public:
-    EEPROMClass();
-    void begin(size_t size);
-    uint8_t read(int address);
-    void write(int address, uint8_t val);
-    bool commit();
-    void end();
+class EEPROMClass {
+public:
+  EEPROMClass(uint32_t sector);
 
-    uint8_t * getDataPtr();
+  void begin(size_t size);
+  uint8_t read(int address);
+  void write(int address, uint8_t val);
+  bool commit();
+  void end();
 
-    template<typename T> T &get(int address, T &t)
-    {
-        if (address < 0 || address + sizeof(T) > _size)
-            return t;
+  uint8_t * getDataPtr();
 
-        uint8_t *ptr = (uint8_t*) &t;
-        memcpy(ptr, _data + address, sizeof(T));
-        return t;
-    }
+  template<typename T> 
+  T &get(int address, T &t) {
+    if (address < 0 || address + sizeof(T) > _size)
+      return t;
 
-    template<typename T> const T &put(int address, const T &t)
-    {
-        if (address < 0 || address + sizeof(T) > _size)
-            return t;
+    memcpy((uint8_t*) &t, _data + address, sizeof(T));
+    return t;
+  }
 
-        const uint8_t *ptr = (const uint8_t*) &t;
-        memcpy(_data + address, ptr, sizeof(T));
-        _dirty = true;
-        return t;
-    }
+  template<typename T> 
+  const T &put(int address, const T &t) {
+    if (address < 0 || address + sizeof(T) > _size)
+      return t;
 
-  protected:
-    uint8_t* _data;
-    size_t _size;
-    bool _dirty;
+    memcpy(_data + address, (const uint8_t*) &t, sizeof(T));
+    _dirty = true;
+    return t;
+  }
+
+protected:
+  uint32_t _sector;
+  uint8_t* _data;
+  size_t _size;
+  bool _dirty;
 };
 
 extern EEPROMClass EEPROM;

--- a/hardware/esp8266com/esp8266/libraries/EEPROM/examples/eeprom_write/eeprom_write.ino
+++ b/hardware/esp8266com/esp8266/libraries/EEPROM/examples/eeprom_write/eeprom_write.ino
@@ -22,7 +22,7 @@ void loop()
   // need to divide by 4 because analog inputs range from
   // 0 to 1023 and each byte of the EEPROM can only hold a
   // value from 0 to 255.
-  int val = analogRead(0) / 4;
+  int val = analogRead(A0) / 4;
 
   // write the value to the appropriate byte of the EEPROM.
   // these values will remain there when the board is

--- a/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/ESP8266WiFi.h
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/ESP8266WiFi.h
@@ -42,21 +42,18 @@ public:
 
     void mode(WiFiMode);
         
-    
-    /* Start Wifi connection for OPEN networks
-     *
-     * param ssid: Pointer to the SSID string.
+    /**
+     * Start Wifi connection
+     * if passphrase is set the most secure supported mode will be automatically selected
+     * @param ssid const char*          Pointer to the SSID string.
+     * @param passphrase const char *   Optional. Passphrase. Valid characters in a passphrase must be between ASCII 32-126 (decimal).
+     * @param bssid uint8_t[6]          Optional. BSSID / MAC of AP
+     * @param channel                   Optional. Channel of AP
+     * @return
      */
-    int begin(const char* ssid);
+    int begin(const char* ssid, const char *passphrase = NULL, int32_t channel = 0, uint8_t bssid[6] = NULL);
+    int begin(char* ssid, char *passphrase = NULL, int32_t channel = 0, uint8_t bssid[6] = NULL);
 
-    /* Start Wifi connection with passphrase
-     * the most secure supported mode will be automatically selected
-     *
-     * param ssid: Pointer to the SSID string.
-     * param passphrase: Passphrase. Valid characters in a passphrase
-     *        must be between ASCII 32-126 (decimal).
-     */
-    int begin(const char* ssid, const char *passphrase);
 
    /* Wait for Wifi connection to reach a result
     * returns the status reached or disconnect if STA is off
@@ -152,6 +149,20 @@ public:
     char* SSID();
 
     /*
+     * Return the current bssid / mac associated with the network if configured
+     *
+     * return: bssid string
+     */
+    uint8_t * BSSID(void);
+
+    /*
+     * Return the current channel associated with the network
+     *
+     * return: channel
+     */
+    int32_t Channel(void);
+
+    /*
      * Return the current network RSSI. Note: this is just a stub, there is no way to
      *  get the RSSI in the Espressif SDK yet.
      *
@@ -193,6 +204,42 @@ public:
      * return: signed value of RSSI of the specified item on the networks scanned list
      */
     int32_t RSSI(uint8_t networkItem);
+
+
+    /**
+     * return MAC / BSSID of scanned wifi
+     * @param networkItem specify from which network item want to get the information
+     * @return uint8_t * to MAC / BSSID of scanned wifi
+     */
+    uint8_t * BSSID(uint8_t networkItem);
+
+    /**
+     * return Channel of scanned wifi
+     * @param networkItem specify from which network item want to get the information
+     * @return uint32_t Channel of scanned wifi
+     */
+    int32_t Channel(uint8_t networkItem);
+
+    /**
+     * return if the scanned wifi is Hidden (no SSID)
+     * @param networkItem specify from which network item want to get the information
+     * @return bool (true == hidden)
+     */
+    bool isHidden(uint8_t networkItem);
+
+    /**
+     * loads all infos from a scanned wifi in to the ptr parameters
+     * @param networkItem uint8_t
+     * @param ssid  const char**
+     * @param encryptionType uint8_t *
+     * @param RSSI int32_t *
+     * @param BSSID uint8_t **
+     * @param channel int32_t *
+     * @param isHidden bool *
+     * @return (true if ok)
+     */
+    bool getNetworkInfo(uint8_t networkItem, const char** ssid, uint8_t * encryptionType, int32_t * RSSI, uint8_t ** BSSID, int32_t * channel, bool * isHidden);
+
 
     /*
      * Return Connection status.
@@ -242,6 +289,9 @@ protected:
     void * _getScanInfoByIndex(int i);
     static void _smartConfigDone(void* result);
     bool _smartConfigStarted = false;
+
+    bool useApMode;
+    bool useClientMode;
 
     static size_t _scanCount;
     static void* _scanResult;


### PR DESCRIPTION
ESP8266WiFi extended functions

begin changes
allow setting BSSID/MAC and Channel of an AP for faster connection (#261)
now checks if ssid and passphrase to big
selecting Wifi mode in better way (fix for #28)

ESP8266WiFiMulti uses the new functions to auto select best AP even in a multi AP WiFi network (more the one AP has same SSID)

add new functions to get current Connected AP:
uint8_t * BSSID(void);
int32_t Channel(void);

add new functions to get infos from scanned networks:
uint8_t * BSSID(uint8_t networkItem);
int32_t Channel(uint8_t networkItem);
bool isHidden(uint8_t networkItem);
bool getNetworkInfo(uint8_t networkItem, const char** ssid, uint8_t * encryptionType, int32_t * RSSI, uint8_t ** BSSID, int32_t * channel, bool * isHidden);