### PR TITLE
Update NTPClient.ino

### DIFF
--- a/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/examples/NTPClient/NTPClient.ino
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/examples/NTPClient/NTPClient.ino
@@ -27,7 +27,11 @@ char pass[] = "********";       // your network password
 
 unsigned int localPort = 2390;      // local port to listen for UDP packets
 
-IPAddress timeServer(129, 6, 15, 28); // time.nist.gov NTP server
+/* Don't hardwire the IP address or we won't get the benefits of the pool.
+ *  Lookup the IP address for the host name instead */
+//IPAddress timeServer(129, 6, 15, 28); // time.nist.gov NTP server
+IPAddress timeServerIP; // time.nist.gov NTP server address
+const char* ntpServerName = "time.nist.gov";
 
 const int NTP_PACKET_SIZE = 48; // NTP time stamp is in the first 48 bytes of the message
 
@@ -65,6 +69,9 @@ void setup()
 
 void loop()
 {
+  //get a random server from the pool
+  WiFi.hostByName(ntpServerName, timeServerIP); 
+
   sendNTPpacket(timeServer); // send an NTP packet to a time server
   // wait to see if a reply is available
   delay(1000);


### PR DESCRIPTION
Do not hardwire the NTP server IP address into the code.  Instead, look-up the IP address from the host name.  This way you will get a different random server from the pool each time you make a request.