### PR TITLE
Add Adafruit HUZZAH ESP8266 (ESP-12 breakout) to Board Manager Package

### DIFF
--- a/build/build_board_manager_package.sh
+++ b/build/build_board_manager_package.sh
@@ -64,8 +64,10 @@ cat << EOF > package_esp8266com_index.json
         },
         {
           "name":"NodeMCU 1.0 (ESP-12E Module)"
+        },
+        {
+          "name":"Adafruit HUZZAH ESP8266 (ESP-12)"
         }
-
       ],
       "toolsDependencies":[ {
         "packager":"esp8266",

--- a/hardware/esp8266com/esp8266/boards.txt
+++ b/hardware/esp8266com/esp8266/boards.txt
@@ -283,6 +283,48 @@ nodemcuv2.menu.UploadSpeed.921600=921600
 nodemcuv2.menu.UploadSpeed.921600.upload.speed=921600
 
 ##############################################################
+huzzah.name=Adafruit HUZZAH ESP8266
+
+huzzah.upload.tool=esptool
+huzzah.upload.speed=115200
+huzzah.upload.resetmethod=ck
+huzzah.upload.maximum_size=983040
+huzzah.upload.maximum_data_size=81920
+huzzah.upload.wait_for_upload_port=true
+huzzah.serial.disableDTR=true
+huzzah.serial.disableRTS=true
+
+huzzah.build.mcu=esp8266
+huzzah.build.f_cpu=80000000L
+huzzah.build.board=ESP8266_ESP12
+huzzah.build.core=esp8266
+huzzah.build.variant=adafruit
+huzzah.build.flash_mode=qio
+huzzah.build.flash_size=4M
+huzzah.build.flash_freq=40
+huzzah.build.flash_ld=eagle.flash.4m.ld
+huzzah.build.spiffs_start=0x100000
+huzzah.build.spiffs_end=0x3FB000
+huzzah.build.spiffs_pagesize=256
+huzzah.build.spiffs_blocksize=8192
+
+huzzah.menu.CpuFrequency.80=80 MHz
+huzzah.menu.CpuFrequency.80.build.f_cpu=80000000L
+huzzah.menu.CpuFrequency.160=160 MHz
+huzzah.menu.CpuFrequency.160.build.f_cpu=160000000L
+
+huzzah.menu.UploadSpeed.115200=115200
+huzzah.menu.UploadSpeed.115200.upload.speed=115200
+huzzah.menu.UploadSpeed.9600=9600
+huzzah.menu.UploadSpeed.9600.upload.speed=9600
+huzzah.menu.UploadSpeed.57600=57600
+huzzah.menu.UploadSpeed.57600.upload.speed=57600
+huzzah.menu.UploadSpeed.256000=256000
+huzzah.menu.UploadSpeed.256000.upload.speed=256000
+huzzah.menu.UploadSpeed.921600=921600
+huzzah.menu.UploadSpeed.921600.upload.speed=921600
+
+##############################################################
 # wifio.name=Wifio
 #
 # wifio.upload.tool=esptool

--- a/hardware/esp8266com/esp8266/variants/adafruit/pins_arduino.h
+++ b/hardware/esp8266com/esp8266/variants/adafruit/pins_arduino.h
@@ -1,0 +1,70 @@
+/*
+  pins_arduino.h - Pin definition functions for Arduino
+  Part of Arduino - http://www.arduino.cc/
+
+  Copyright (c) 2007 David A. Mellis
+  Modified for ESP8266 platform by Ivan Grokhotkov, 2014-2015.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General
+  Public License along with this library; if not, write to the
+  Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+  Boston, MA  02111-1307  USA
+
+  $Id: wiring.h 249 2007-02-03 16:52:51Z mellis $
+*/
+
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#define EXTERNAL_NUM_INTERRUPTS 16
+#define NUM_DIGITAL_PINS        17
+#define NUM_ANALOG_INPUTS       1
+
+#define analogInputToDigitalPin(p)  ((p > 0)?NOT_A_PIN:0)
+#define digitalPinToInterrupt(p)  	(((p) < EXTERNAL_NUM_INTERRUPTS)?p:NOT_A_PIN)
+#define digitalPinHasPWM(p)         (((p) < NUM_DIGITAL_PINS)?p:NOT_A_PIN)
+
+static const uint8_t SDA = 4;
+static const uint8_t SCL = 5;
+
+static const uint8_t SS    = 15;
+static const uint8_t MOSI  = 13;
+static const uint8_t MISO  = 12;
+static const uint8_t SCK   = 14;
+
+static const uint8_t BUILTIN_LED = 0;
+
+static const uint8_t A0 = 17;
+
+// These serial port names are intended to allow libraries and architecture-neutral
+// sketches to automatically default to the correct port name for a particular type
+// of use.  For example, a GPS module would normally connect to SERIAL_PORT_HARDWARE_OPEN,
+// the first hardware serial port whose RX/TX pins are not dedicated to another use.
+//
+// SERIAL_PORT_MONITOR        Port which normally prints to the Arduino Serial Monitor
+//
+// SERIAL_PORT_USBVIRTUAL     Port which is USB virtual serial
+//
+// SERIAL_PORT_LINUXBRIDGE    Port which connects to a Linux system via Bridge library
+//
+// SERIAL_PORT_HARDWARE       Hardware serial port, physical RX & TX pins.
+//
+// SERIAL_PORT_HARDWARE_OPEN  Hardware serial ports which are open for use.  Their RX & TX
+//                            pins are NOT connected to anything by default.
+#define SERIAL_PORT_MONITOR        Serial
+#define SERIAL_PORT_USBVIRTUAL     Serial
+#define SERIAL_PORT_HARDWARE       Serial
+#define SERIAL_PORT_HARDWARE_OPEN  Serial
+
+#endif /* Pins_Arduino_h */
+


### PR DESCRIPTION
In an attempt to reduce confusion about how to install support for ESP8266 boards, I was hoping to add the Adafruit HUZZAH ESP-12 breakout to the official ESP8266 community package index. That way we can drop the ESP8266 board from the Adafruit package and point people to the official version.

Let me know if that sounds good, and we can change documentation to point to your package index and drop the ESP package from our package index once these changes are deployed.

Thanks!