### PR TITLE
added NOT_ON_TIMER and digitalPinToTimer defines

### DIFF
--- a/hardware/esp8266com/esp8266/cores/esp8266/Arduino.h
+++ b/hardware/esp8266com/esp8266/cores/esp8266/Arduino.h
@@ -209,6 +209,7 @@ void loop(void);
 // This comes from the pins_*.c file for the active board configuration.
 #define digitalPinToPort(pin)       (0)
 #define digitalPinToBitMask(pin)    (1UL << (pin))
+#define digitalPinToTimer(pin)      (0)
 #define portOutputRegister(port)    ((volatile uint32_t*) GPO)
 #define portInputRegister(port)     ((volatile uint32_t*) GPI)
 #define portModeRegister(port)      ((volatile uint32_t*) GPE)
@@ -216,6 +217,7 @@ void loop(void);
 #define NOT_A_PIN -1
 #define NOT_A_PORT -1
 #define NOT_AN_INTERRUPT -1
+#define NOT_ON_TIMER 0
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
added these defines because (for as far as i needed) the i2c liquid-crystal library needs these to function.

after adding the defines, the display could be spoken to using gpio-0 and gpio-2 (the bit-banged i2c :) )

library in question:
https://bitbucket.org/fmalpartida/new-liquidcrystal/downloads

sketch is:
https://github.com/Duality4Y/Sketchbook/blob/master/sketchbook/HelloWorld_i2c_esp/HelloWorld_i2c_esp.ino