### PR TITLE
Fix issue linking pgmspace.h functions in a sketch.

### DIFF
--- a/hardware/esp8266com/esp8266/cores/esp8266/pgmspace.h
+++ b/hardware/esp8266com/esp8266/cores/esp8266/pgmspace.h
@@ -8,9 +8,6 @@ extern "C" {
 #include <stdio.h>
 #include "ets_sys.h"
 #include "osapi.h"
-#ifdef __cplusplus
-}
-#endif
 
 #define PROGMEM     ICACHE_RODATA_ATTR
 #define PGM_P  		const char *
@@ -89,5 +86,9 @@ int	vsnprintf_P(char *str, size_t strSize, const char *formatP, va_list ap) __at
 #define pgm_read_word_far(addr) 	pgm_read_word(addr)
 #define pgm_read_dword_far(addr) 	pgm_read_dword(addr)
 #define pgm_read_float_far(addr) 	pgm_read_float(addr)
+
+#ifdef __cplusplus // End extern "C" wrapper.
+}
+#endif
 
 #endif //__PGMSPACE_H_


### PR DESCRIPTION
This pull fixes issue #401, that pgmspace.h functions like strcpy_P, strlen_P, etc. fail to link with an error they can't be found. The fix is to extend the extern "C" in pgmspace.h so it covers all the function declarations. To test it use the example sketch in #401 and you can see if fail before the fix and succeed after the fix (and work as expected when run on the hardware).