### PR TITLE
Fix crash on client disconnect

### DIFF
--- a/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -106,6 +106,10 @@ void ESP8266WebServer::handleClient()
     delay(1);
   }
 
+  if (!client) {
+    return;
+  }
+
   if (!_parseRequest(client)) {
     return;
   }


### PR DESCRIPTION
APOLOGIES: This does not fix the issue. Still looking into this.

If a client connects, but then disconnects before the request is handled the server will crash. This seems to fix the issue.

Test this by putting a few second delay in your  loop() before handling the request (via server.handleClient()), connecting with, e.g. curl, and then cancel the request (control-C out of curl) before the request gets handled. Without the check the server crashes.