### PR TITLE
DNSServer can now be configured to reply to all requests with one IP address (e.g. for captive portal)

### DIFF
--- a/hardware/esp8266com/esp8266/libraries/DNSServer/examples/CaptivePortal/CaptivePortal.ino
+++ b/hardware/esp8266com/esp8266/libraries/DNSServer/examples/CaptivePortal/CaptivePortal.ino
@@ -1,0 +1,34 @@
+#include <ESP8266WiFi.h>
+#include <DNSServer.h>
+#include <ESP8266WebServer.h>
+
+const byte DNS_PORT = 53;
+IPAddress apIP(192, 168, 1, 1);
+DNSServer dnsServer;
+ESP8266WebServer webServer(80);
+
+String responseHTML = ""
+  "<!DOCTYPE html><html><head><title>CaptivePortal</title></head><body>"
+  "<h1>Hello World!</h1><p>This is a captive portal example. All requests will "
+  "be redirected here.</p></body></html>";
+
+void setup() {
+  WiFi.mode(WIFI_AP);
+  WiFi.softAPConfig(apIP, apIP, IPAddress(255, 255, 255, 0));
+  WiFi.softAP("DNSServer CaptivePortal example");
+
+  // if DNSServer is started with "*" for domain name, it will reply with
+  // provided IP to all DNS request
+  dnsServer.start(DNS_PORT, "*", apIP);
+
+  // replay to all requests with same HTML
+  webServer.onNotFound([]() {
+    webServer.send(200, "text/html", responseHTML);
+  });
+  webServer.begin();
+}
+
+void loop() {
+  dnsServer.processNextRequest();
+  webServer.handleClient();
+}

--- a/hardware/esp8266com/esp8266/libraries/DNSServer/examples/DNSServer/DNSServer.ino
+++ b/hardware/esp8266com/esp8266/libraries/DNSServer/examples/DNSServer/DNSServer.ino
@@ -21,10 +21,10 @@ void setup() {
   // default is DNSReplyCode::NonExistentDomain
   dnsServer.setErrorReplyCode(DNSReplyCode::ServerFailure);
 
-  //start DNS server for a specific domain name
+  // start DNS server for a specific domain name
   dnsServer.start(DNS_PORT, "www.example.com", apIP);
 
-  //simple HTTP server to see that DNS server is working
+  // simple HTTP server to see that DNS server is working
   webServer.onNotFound([]() {
     String message = "Hello World!\n\n";
     message += "URI: ";

--- a/hardware/esp8266com/esp8266/libraries/DNSServer/examples/DNSServer/DNSServer.ino
+++ b/hardware/esp8266com/esp8266/libraries/DNSServer/examples/DNSServer/DNSServer.ino
@@ -1,9 +1,11 @@
 #include <ESP8266WiFi.h>
 #include <DNSServer.h>
+#include <ESP8266WebServer.h>
 
 const byte DNS_PORT = 53;
 IPAddress apIP(192, 168, 1, 1);
 DNSServer dnsServer;
+ESP8266WebServer webServer(80);
 
 void setup() {
   WiFi.mode(WIFI_AP);
@@ -21,8 +23,19 @@ void setup() {
 
   //start DNS server for a specific domain name
   dnsServer.start(DNS_PORT, "www.example.com", apIP);
+
+  //simple HTTP server to see that DNS server is working
+  webServer.onNotFound([]() {
+    String message = "Hello World!\n\n";
+    message += "URI: ";
+    message += webServer.uri();
+
+    webServer.send(200, "text/plain", message);
+  });
+  webServer.begin();
 }
 
 void loop() {
   dnsServer.processNextRequest();
+  webServer.handleClient();
 }

--- a/hardware/esp8266com/esp8266/libraries/DNSServer/library.properties
+++ b/hardware/esp8266com/esp8266/libraries/DNSServer/library.properties
@@ -1,5 +1,5 @@
 name=DNSServer
-version=1.0.0
+version=1.1.0
 author=Kristijan Novoselić
 maintainer=Kristijan Novoselić, <kristijan.novoselic@gmail.com>
 sentence=A simple DNS server for ESP8266.

--- a/hardware/esp8266com/esp8266/libraries/DNSServer/src/DNSServer.cpp
+++ b/hardware/esp8266com/esp8266/libraries/DNSServer/src/DNSServer.cpp
@@ -54,7 +54,8 @@ void DNSServer::processNextRequest()
     if (_dnsHeader->QR == DNS_QR_QUERY &&
         _dnsHeader->OPCode == DNS_OPCODE_QUERY &&
         requestIncludesOnlyOneQuestion() &&
-        getDomainNameWithoutWwwPrefix() == _domainName)
+        (_domainName == "*" || getDomainNameWithoutWwwPrefix() == _domainName)
+       )
     {
       replyWithIP();
     }

--- a/hardware/esp8266com/esp8266/libraries/DNSServer/src/DNSServer.h
+++ b/hardware/esp8266com/esp8266/libraries/DNSServer/src/DNSServer.h
@@ -27,7 +27,7 @@ struct DNSHeader
   unsigned char AA : 1;      // authoritive answer
   unsigned char OPCode : 4;  // message_type
   unsigned char QR : 1;      // query/response flag
-  unsigned char RCode : 4;    // response code
+  unsigned char RCode : 4;   // response code
   unsigned char Z : 3;       // its z! reserved
   unsigned char RA : 1;      // recursion available
   uint16_t QDCount;          // number of question entries
@@ -61,7 +61,6 @@ class DNSServer
     DNSHeader* _dnsHeader;
     uint32_t _ttl;
     DNSReplyCode _errorReplyCode;
-
 
     void downcaseAndRemoveWwwPrefix(String &domainName);
     String getDomainNameWithoutWwwPrefix();


### PR DESCRIPTION
Added new feature - DNSServer can now be configured to reply to all requests with one IP address (e.g. for captive portal).
Improved initial example and added CaptivePortal example.