### PR TITLE
Documentation update: Clarify DHT sensor usage for latest DHT sensor library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ ADC_MODE(ADC_VCC);
 ```
 TOUT pin has to be disconnected in this mode.
 
-Note that by default ADC is configured to read from TOUT pin using ```analogRead(A0)```, and 
+Note that by default ADC is configured to read from TOUT pin using ```analogRead(A0)```, and
 ```ESP.getVCC()``` is not available.
 
 #### OneWire (from https://www.pjrc.com/teensy/td_libs_OneWire.html) ####
@@ -210,7 +210,7 @@ Libraries that don't rely on low-level access to AVR registers should work well.
 - [aREST](https://github.com/marcoschwartz/aREST) REST API handler library.
 - [Blynk](https://github.com/blynkkk/blynk-library) - easy IoT framework for Makers (check out the [Kickstarter page](http://tiny.cc/blynk-kick)).
 - [DallasTemperature](https://github.com/milesburton/Arduino-Temperature-Control-Library.git)
-- [DHT11](https://github.com/adafruit/DHT-sensor-library) - initialize DHT as follows: ```DHT dht(DHTPIN, DHTTYPE, 15);```
+- [DHT11](https://github.com/adafruit/DHT-sensor-library) - Download latest v1.1.0 library and no changes are necessary.  Older versions should initialize DHT as follows: ```DHT dht(DHTPIN, DHTTYPE, 15);```
 - [NeoPixelBus](https://github.com/Makuna/NeoPixelBus) - Arduino NeoPixel library compatible with esp8266.
 - [PubSubClient](https://github.com/Imroy/pubsubclient) MQTT library by @Imroy.
 - [RTC](https://github.com/Makuna/Rtc) - Arduino Library for Ds1307 & Ds3231 compatible with esp8266.


### PR DESCRIPTION
We've refactored the DHT sensor library so that it can run on faster processors like the ESP8266 automatically without any need to adjust cycle counts, etc.  This pull updates the README.md to note the latest library works as is, or to add the adjusted cycle count for the older library.

And sorry I'm using a new text editor that for some reason decided to remove a trailing space elsewhere.  I guess it's technically a fix to the docs too. :)