### PR TITLE
digitalWrite cleanup and more compliant with behavior on AVR

### DIFF
--- a/hardware/esp8266com/esp8266/cores/esp8266/core_esp8266_wiring_digital.c
+++ b/hardware/esp8266com/esp8266/cores/esp8266/core_esp8266_wiring_digital.c
@@ -77,11 +77,13 @@ extern void __pinMode(uint8_t pin, uint8_t mode) {
 }
 
 extern void ICACHE_RAM_ATTR __digitalWrite(uint8_t pin, uint8_t val) {
+  if (pin == 16) {
     if(val == LOW) {
 	  GP16O &= ~1;
 	} else {
 	  GP16O |= 1;
 	}
+  } else if ((pin >= 0) && (pin <= 15)) {
     if(val == LOW) {
       GPOC = digitalPinToBitMask(pin);
 	} else {

--- a/hardware/esp8266com/esp8266/cores/esp8266/core_esp8266_wiring_digital.c
+++ b/hardware/esp8266com/esp8266/cores/esp8266/core_esp8266_wiring_digital.c
@@ -77,13 +77,16 @@ extern void __pinMode(uint8_t pin, uint8_t mode) {
 }
 
 extern void ICACHE_RAM_ATTR __digitalWrite(uint8_t pin, uint8_t val) {
-  val &= 0x01;
-  if(pin < 16){
-    if(val) GPOS = (1 << pin);
-    else GPOC = (1 << pin);
-  } else if(pin == 16){
-    if(val) GP16O |= 1;
-    else GP16O &= ~1;
+    if(val == LOW) {
+	  GP16O &= ~1;
+	} else {
+	  GP16O |= 1;
+	}
+    if(val == LOW) {
+      GPOC = digitalPinToBitMask(pin);
+	} else {
+	  GPOS = digitalPinToBitMask(pin);
+	}
   }
 }
 

--- a/hardware/esp8266com/esp8266/cores/esp8266/core_esp8266_wiring_digital.c
+++ b/hardware/esp8266com/esp8266/cores/esp8266/core_esp8266_wiring_digital.c
@@ -77,18 +77,12 @@ extern void __pinMode(uint8_t pin, uint8_t mode) {
 }
 
 extern void ICACHE_RAM_ATTR __digitalWrite(uint8_t pin, uint8_t val) {
-  if (pin == 16) {
-    if(val == LOW) {
-	  GP16O &= ~1;
-	} else {
-	  GP16O |= 1;
-	}
-  } else if ((pin >= 0) && (pin <= 15)) {
-    if(val == LOW) {
-      GPOC = digitalPinToBitMask(pin);
-	} else {
-	  GPOS = digitalPinToBitMask(pin);
-	}
+  if(pin < 16){
+    if(val) GPOS = (1 << pin);
+    else GPOC = (1 << pin);
+  } else if(pin == 16){
+    if(val) GP16O |= 1;
+    else GP16O &= ~1;
   }
 }
 


### PR DESCRIPTION
I rewrote digitalWrite because the existing version was breaking
functionality as compared to how it behaves on the AVR.
Specifically, I could not use digitalWrite for a library that works fine on the AVR.

Instead I had to resort to fiddling with GPOC and GPOS and bit masks,
but this rewrite made all of that unnecessary, for whatever reason it
just works better.

This version borrows a little from the AVR library in the sense that the
same logic is applied to determine whether a pin should be high or low
as the AVR version, and yes, it does appear to make a difference, at least as far as my testing on hardware has shown.