### PR TITLE
httpUpdate: fix case sensitivity issues

### DIFF
--- a/hardware/esp8266com/esp8266/libraries/ESP8266httpUpdate/library.properties
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266httpUpdate/library.properties
@@ -1,8 +1,8 @@
 name=ESP8266httpUpdate
 version=1.0
 author=Markus Sattler
-maintainer=Markus Sattler 
+maintainer=Markus Sattler
 sentence=Http Update for ESP8266
 paragraph=
 url=https://github.com/Links2004/Arduino/tree/esp8266/hardware/esp8266com/esp8266/libraries/ESP8266httpUpdate
-architectures=ESP8266
+architectures=esp8266

--- a/hardware/esp8266com/esp8266/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.cpp
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.cpp
@@ -23,7 +23,7 @@
  *
  */
 
-#include "ESP8266HTTPUpdate.h"
+#include "ESP8266httpUpdate.h"
 
 ESP8266HTTPUpdate::ESP8266HTTPUpdate(void) {
 


### PR DESCRIPTION
On Linux (presumably Mac too), the header of the library
could not be included, caps changed to match the filename.

The line 'architectures=ESP8266' in library.properties caused:
WARNING: library ESP8266httpUpdate claims to run on [ESP8266] architecture(s) and may be incompatible with your current board which runs on [esp8266] architecture(s).