### PR TITLE
optimistic_yield()

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Libraries that don't rely on low-level access to AVR registers should work well.
 - [PubSubClient](https://github.com/Imroy/pubsubclient) MQTT library by @Imroy.
 - [RTC](https://github.com/Makuna/Rtc) - Arduino Library for Ds1307 & Ds3231 compatible with esp8266.
 - [Souliss, Smart Home](https://github.com/souliss/souliss) - Framework for Smart Home based on Arduino, Android and openHAB.
+- [ST7735](https://github.com/nzmichaelh/Adafruit-ST7735-Library) - Adafruit's ST7735 library modified to be compatible with esp8266.  Just make sure to modify the pins in the examples as they are still AVR specific.
 
 #### Upload via serial port ####
 Pick the correct serial port.

--- a/hardware/esp8266com/esp8266/cores/esp8266/Arduino.h
+++ b/hardware/esp8266com/esp8266/cores/esp8266/Arduino.h
@@ -39,6 +39,7 @@ extern "C" {
 #include "twi.h"
 
 void yield(void);
+void optimistic_yield(void);
 
 #define HIGH 0x1
 #define LOW  0x0

--- a/hardware/esp8266com/esp8266/cores/esp8266/HardwareSerial.cpp
+++ b/hardware/esp8266com/esp8266/cores/esp8266/HardwareSerial.cpp
@@ -551,14 +551,20 @@ bool HardwareSerial::isRxEnabled(void) {
     return _uart->rxEnabled;
 }
 
+extern "C" void optimistic_yield();
+
 int HardwareSerial::available(void) {
-    if(_uart == 0)
-        return 0;
-    if(_uart->rxEnabled) {
-        return static_cast<int>(_rx_buffer->getSize());
-    } else {
-        return 0;
+    int result = 0;
+
+    if (_uart != NULL && _uart->rxEnabled) {
+        result = static_cast<int>(_rx_buffer->getSize());
     }
+
+    if (!result) {
+        optimistic_yield();
+    }
+
+    return result;
 }
 
 int HardwareSerial::peek(void) {

--- a/hardware/esp8266com/esp8266/cores/esp8266/HardwareSerial.cpp
+++ b/hardware/esp8266com/esp8266/cores/esp8266/HardwareSerial.cpp
@@ -551,8 +551,6 @@ bool HardwareSerial::isRxEnabled(void) {
     return _uart->rxEnabled;
 }
 
-extern "C" void optimistic_yield();
-
 int HardwareSerial::available(void) {
     int result = 0;
 

--- a/hardware/esp8266com/esp8266/cores/esp8266/core_esp8266_main.cpp
+++ b/hardware/esp8266com/esp8266/cores/esp8266/core_esp8266_main.cpp
@@ -88,7 +88,8 @@ extern "C" void __yield() {
 extern "C" void yield(void) __attribute__ ((weak, alias("__yield")));
 
 extern "C" void optimistic_yield() {
-    if (system_get_time() - g_micros_at_last_task_yield > OPTIMISTIC_YIELD_TIME_US)
+    if (!ETS_INTR_WITHINISR() && 
+        (system_get_time() - g_micros_at_last_task_yield) > OPTIMISTIC_YIELD_TIME_US)
     {
         __yield();
     }

--- a/hardware/esp8266com/esp8266/cores/esp8266/core_esp8266_main.cpp
+++ b/hardware/esp8266com/esp8266/cores/esp8266/core_esp8266_main.cpp
@@ -87,7 +87,7 @@ extern "C" void __yield() {
 }
 extern "C" void yield(void) __attribute__ ((weak, alias("__yield")));
 
-extern "C" void optimistic_yield() {
+extern "C" void optimistic_yield(void) {
     if (!ETS_INTR_WITHINISR() && 
         (system_get_time() - g_micros_at_last_task_yield) > OPTIMISTIC_YIELD_TIME_US)
     {

--- a/hardware/esp8266com/esp8266/cores/esp8266/core_esp8266_main.cpp
+++ b/hardware/esp8266com/esp8266/cores/esp8266/core_esp8266_main.cpp
@@ -34,6 +34,8 @@ extern "C" {
 #define LOOP_TASK_PRIORITY 0
 #define LOOP_QUEUE_SIZE    1
 
+#define OPTIMISTIC_YIELD_TIME_US 16000
+
 struct rst_info resetInfo;
 
 int atexit(void (*func)()) {
@@ -62,11 +64,8 @@ extern void (*__init_array_end)(void);
 cont_t g_cont __attribute__ ((aligned (16)));
 static os_event_t g_loop_queue[LOOP_QUEUE_SIZE];
 
-static uint32_t g_micros_at_task_start;
+static uint32_t g_micros_at_last_task_yield;
 
-extern "C" uint32_t esp_micros_at_task_start() {
-    return g_micros_at_task_start;
-}
 
 extern "C" void abort() {
     while(1) {
@@ -74,6 +73,7 @@ extern "C" void abort() {
 }
 
 extern "C" void esp_yield() {
+    g_micros_at_last_task_yield = system_get_time();
     cont_yield(&g_cont);
 }
 
@@ -87,6 +87,13 @@ extern "C" void __yield() {
 }
 extern "C" void yield(void) __attribute__ ((weak, alias("__yield")));
 
+extern "C" void optimistic_yield() {
+    if (system_get_time() - g_micros_at_last_task_yield > OPTIMISTIC_YIELD_TIME_US)
+    {
+        __yield();
+    }
+}
+
 static void loop_wrapper() {
     static bool setup_done = false;
     if(!setup_done) {
@@ -99,7 +106,7 @@ static void loop_wrapper() {
 }
 
 static void loop_task(os_event_t *events) {
-    g_micros_at_task_start = system_get_time();
+    g_micros_at_last_task_yield = system_get_time();
     cont_run(&g_cont, &loop_wrapper);
     if(cont_check(&g_cont) != 0) {
         ets_printf("\r\nheap collided with sketch stack\r\n");

--- a/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -177,8 +177,6 @@ size_t WiFiClient::write(const uint8_t *buf, size_t size)
     return _client->write(reinterpret_cast<const char*>(buf), size);
 }
 
-extern "C" void optimistic_yield();
-
 int WiFiClient::available()
 {
     int result = 0;

--- a/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -177,20 +177,19 @@ size_t WiFiClient::write(const uint8_t *buf, size_t size)
     return _client->write(reinterpret_cast<const char*>(buf), size);
 }
 
-extern "C" uint32_t esp_micros_at_task_start();
+extern "C" void optimistic_yield();
 
 int WiFiClient::available()
 {
-    static uint32_t lastPollTime = 0;
-    if (!_client)
-        return 0;
+    int result = 0;
 
-    if (lastPollTime > esp_micros_at_task_start())
-        yield();
+    if (_client) {
+        result = _client->getSize();
+    }
 
-    lastPollTime = micros();
-
-    int result = _client->getSize();
+    if (!result) {
+        optimistic_yield();
+    }
     return result;
 }
 

--- a/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/WiFiServer.cpp
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/WiFiServer.cpp
@@ -84,17 +84,15 @@ bool WiFiServer::getNoDelay(){
   return tcp_nagle_disabled(_pcb);
 }
 
-extern "C" uint32_t esp_micros_at_task_start();
-
 bool WiFiServer::hasClient(){
   if (_unclaimed) return true;
   return false;
 }
 
+extern "C" void optimistic_yield();
+
 WiFiClient WiFiServer::available(byte* status)
 {
-    static uint32_t lastPollTime = 0;
-
     if (_unclaimed)
     {
         WiFiClient result(_unclaimed);
@@ -103,9 +101,7 @@ WiFiClient WiFiServer::available(byte* status)
         return result;
     }
 
-    if (lastPollTime > esp_micros_at_task_start())
-        yield();
-    lastPollTime = micros();
+    optimistic_yield();
 
     return WiFiClient();
 }

--- a/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/WiFiServer.cpp
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/WiFiServer.cpp
@@ -89,8 +89,6 @@ bool WiFiServer::hasClient(){
   return false;
 }
 
-extern "C" void optimistic_yield();
-
 WiFiClient WiFiServer::available(byte* status)
 {
     if (_unclaimed)

--- a/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/WiFiUdp.cpp
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/WiFiUdp.cpp
@@ -113,12 +113,22 @@ uint8_t WiFiUDP::beginMulticast(IPAddress interfaceAddr, IPAddress multicast, ui
     return 1;
 }
 
+extern "C" void optimistic_yield();
+
 /* return number of bytes available in the current packet,
    will return zero if parsePacket hasn't been called yet */
 int WiFiUDP::available() {
-    if (!_ctx)
-        return 0;
-    return static_cast<int>(_ctx->getSize());
+    int result = 0;
+
+    if (_ctx) {
+        result = static_cast<int>(_ctx->getSize());
+    }
+
+    if (!result) {
+        optimistic_yield();
+    }
+
+    return result;
 }
 
 /* Release any resources being used by this WiFiUDP instance */

--- a/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/WiFiUdp.cpp
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/WiFiUdp.cpp
@@ -113,8 +113,6 @@ uint8_t WiFiUDP::beginMulticast(IPAddress interfaceAddr, IPAddress multicast, ui
     return 1;
 }
 
-extern "C" void optimistic_yield();
-
 /* return number of bytes available in the current packet,
    will return zero if parsePacket hasn't been called yet */
 int WiFiUDP::available() {

--- a/hardware/esp8266com/esp8266/libraries/Wire/Wire.cpp
+++ b/hardware/esp8266com/esp8266/libraries/Wire/Wire.cpp
@@ -160,8 +160,6 @@ size_t TwoWire::write(const uint8_t *data, size_t quantity){
   return quantity;
 }
 
-extern "C" void optimistic_yield();
-
 int TwoWire::available(void){
     int result = rxBufferLength - rxBufferIndex;
 

--- a/hardware/esp8266com/esp8266/libraries/Wire/Wire.cpp
+++ b/hardware/esp8266com/esp8266/libraries/Wire/Wire.cpp
@@ -160,8 +160,16 @@ size_t TwoWire::write(const uint8_t *data, size_t quantity){
   return quantity;
 }
 
+extern "C" void optimistic_yield();
+
 int TwoWire::available(void){
-  return rxBufferLength - rxBufferIndex;
+    int result = rxBufferLength - rxBufferIndex;
+
+    if (!result) {
+        optimistic_yield();
+    }
+
+    return result;
 }
 
 int TwoWire::read(void){

--- a/hardware/esp8266com/esp8266/tools/sdk/include/ets_sys.h
+++ b/hardware/esp8266com/esp8266/tools/sdk/include/ets_sys.h
@@ -61,6 +61,14 @@ typedef void (*int_handler_t)(void*);
 #define ETS_INTR_DISABLE(inum) \
     ets_isr_mask((1<<inum))
 
+inline bool ETS_INTR_WITHINISR()
+{
+    uint32_t ps;
+    __asm__ __volatile__("rsr %0,ps":"=a" (ps));
+    // PS.EXCM and PS.UM bit checks
+    return ((ps & ((1 << 4) | (1 << 5))) > 0);
+}
+
 inline uint32_t ETS_INTR_ENABLED(void)
 {
     uint32_t enabled;


### PR DESCRIPTION
this introduces optimistic_yield() used for when standard library
methods are normally used in tight loops waiting for something to
happen, like available().

this replaces https://github.com/esp8266/Arduino/pull/545