### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ You need to put ESP8266 into bootloader mode before uploading code.
 For stable use of the ESP8266 a power supply with 3V3 and >= 250mA is required.
 
 * Note
- - using Power from USB to Serial is may unstable, they not deliver enough current.
+ - Using the Power available from the USB to Serial adapter is not reccomended, these adapters typically do not supply enough current to run the ESP8266 reliably in every situation, an external supply or regulator is preferred.
 
 #### Serial Adapter ####
 
@@ -257,16 +257,17 @@ ESPxx Hardware
 | TX or GPIO2*  |          | RX             |
 | RX            |          | TX             |
 | GPIO0         | PullUp   | DTR            |
-| Reset*        |          | RTS            |
+| Reset*        | PullUp   | RTS            |
 | GPIO15*       | PullDown |                |
 | CH_PD         | PullUp   |                |
 
 * Note
  - GPIO15 is also named MTDO
- - Reset is also named RSBT or REST (adding PullUp improves the stability of the Module)
+ - Reset is also named RSBT or REST (the PullUp improves the stability of the Module)
  - GPIO2 is alternative TX for the boot loader mode
+ - **Directly connecting a pin to 3.3v or Ground is not a substitute for a PullUp or PullDown resistor, doing this can break upload management and the serial console, instability has also been noted in some cases.**
 
-###### esp to Serial
+###### ESP to Serial
 ![ESP to Serial](https://raw.githubusercontent.com/Links2004/Arduino/esp8266/docs/ESP_to_serial.png)
 
 #### Minimal hardware Setup for Bootloading only ####
@@ -298,10 +299,10 @@ ESPxx Hardware
 | GPIO15        | PullDown |                 |
 | CH_PD         | PullUp   |                 |
 
-###### minimal
+###### Minimal
 ![ESP min](https://raw.githubusercontent.com/Links2004/Arduino/esp8266/docs/ESP_min.png)
 
-###### improved stability
+###### Improved Stability
 ![ESP improved stability](https://raw.githubusercontent.com/Links2004/Arduino/esp8266/docs/ESP_improved_stability.png)
 
 ### Issues and support ###


### PR DESCRIPTION
Corrected missing "PullUp" in the "Minimal hardware Setup for Bootloading and usage" table, now consistent with the "ESP to Serial" schematic just below it.

Corrected case of schematic titles, it just looks nicer.

Added a caveat about the potential issues of trying to take shortcuts with pull-down and pull-up resistors, there's a few people scratching their heads on the forums because of this often overlooked, self inflicted issue, much the same as people were scratching their heads regarding stability issues whilst trying to use their USB to Serial adapters as a power supply.

Rewording of USB to Serial Note.