### PR TITLE
Re-added lost function memcpy_P

### DIFF
--- a/hardware/esp8266com/esp8266/cores/esp8266/pgmspace.cpp
+++ b/hardware/esp8266com/esp8266/cores/esp8266/pgmspace.cpp
@@ -26,6 +26,18 @@ size_t strnlen_P(PGM_P s, size_t size) {
     return (size_t) (cp - s);
 }
 
+void* memcpy_P(void* dest, PGM_VOID_P src, size_t count) {
+    const uint8_t* read = reinterpret_cast<const uint8_t*>(src);
+    uint8_t* write = reinterpret_cast<uint8_t*>(dest);
+
+    while (count)
+    {
+        *write++ = pgm_read_byte(read++);
+        count--;
+    }
+
+    return dest;
+}
 
 int memcmp_P(const void* buf1, PGM_VOID_P buf2P, size_t size) {
     int result = 0;


### PR DESCRIPTION
This was lost in https://github.com/esp8266/Arduino/commit/80a5f29e89ebb48d2414edd75e1847c3f47798e4

I've also changed the type of src to PGM_VOID_P to match the other changes made in @Makuna 's PR.