### PR TITLE
Fix GPIO Interrupt

### DIFF
--- a/hardware/esp8266com/esp8266/cores/esp8266/core_esp8266_wiring_digital.c
+++ b/hardware/esp8266com/esp8266/cores/esp8266/core_esp8266_wiring_digital.c
@@ -113,7 +113,7 @@ void interrupt_handler(void *arg) {
   uint32_t status = GPIE;
   GPIEC = status;//clear them interrupts
   if(status == 0 || interrupt_reg == 0) return;
-  ETS_GPIO_INTR_DISABLE();
+  noInterrupts();
   int i = 0;
   uint32_t changedbits = status & interrupt_reg;
   while(changedbits){
@@ -126,7 +126,7 @@ void interrupt_handler(void *arg) {
       handler->fn();
     }
   }
-  ETS_GPIO_INTR_ENABLE();
+  interrupts();
 }
 
 extern void __attachInterrupt(uint8_t pin, voidFuncPtr userFunc, int mode) {

--- a/hardware/esp8266com/esp8266/tools/sdk/include/ets_sys.h
+++ b/hardware/esp8266com/esp8266/tools/sdk/include/ets_sys.h
@@ -64,9 +64,9 @@ typedef void (*int_handler_t)(void*);
 inline bool ETS_INTR_WITHINISR()
 {
     uint32_t ps;
-    __asm__ __volatile__("rsr %0,ps":"=a" (ps));
-    // PS.EXCM and PS.UM bit checks
-    return ((ps & ((1 << 4) | (1 << 5))) > 0);
+    __asm__ __volatile__("rsync; rsr %0,ps":"=a" (ps));
+    // PS.INTLEVEL check
+    return ((ps & 0x0f) != 0);
 }
 
 inline uint32_t ETS_INTR_ENABLED(void)


### PR DESCRIPTION
GPIO interrupt was not restricting the level correctly, the ISR itself
could be interrupted by another ISR.  This will currently make it act
more inline with AVR Arduino and thus stopping ALL other interrupts
from triggering.

@igrr Further, this will fix the WithinISR and the issue with it using int level you found with GPIO interrupts.