### PR TITLE
Improvements to ESP8266WebServer::sendContent

### DIFF
--- a/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -178,17 +178,18 @@ void ESP8266WebServer::send(int code, const String& content_type, const String& 
 }
 
 void ESP8266WebServer::sendContent(const String& content) {
+  const size_t unit_size = HTTP_DOWNLOAD_UNIT_SIZE;
   size_t size_to_send = content.length();
-  size_t size_sent = 0;
-  while(size_to_send) {
-    const size_t unit_size = HTTP_DOWNLOAD_UNIT_SIZE;
+  const char* send_start = content.c_str();
+  
+  while (size_to_send) {
     size_t will_send = (size_to_send < unit_size) ? size_to_send : unit_size;
-    size_t sent = _currentClient.write(content.c_str() + size_sent, will_send);
-    size_to_send -= sent;
-    size_sent += sent;
+    size_t sent = _currentClient.write(send_start, will_send);
     if (sent == 0) {
       break;
     }
+    size_to_send -= sent;
+    send_start += sent;
   }
 }
 


### PR DESCRIPTION
Minor mods:

Now makes only one call to .c_str() and using pointer tracking, rather that recalculating offset within the sending loop, to manage data window.

Moved invariant code out of the sending loop body.