### PR TITLE
libc_replacements: add strtol and strtoul from newlib, fix strtod

### DIFF
--- a/hardware/esp8266com/esp8266/cores/esp8266/libc_replacements.c
+++ b/hardware/esp8266com/esp8266/cores/esp8266/libc_replacements.c
@@ -483,7 +483,7 @@ size_t ICACHE_FLASH_ATTR strlcpy(char* dst, const char* src, size_t size) {
  * SUCH DAMAGE.
  */
 
-long strtol(const char *nptr, char **endptr, int base) {
+long ICACHE_FLASH_ATTR strtol(const char *nptr, char **endptr, int base) {
 	const unsigned char *s = (const unsigned char *)nptr;
 	unsigned long acc;
 	int c;
@@ -559,7 +559,7 @@ long strtol(const char *nptr, char **endptr, int base) {
 	return (acc);
 }
 
-unsigned long strtoul(const char *nptr, char **endptr, int base)
+unsigned long ICACHE_FLASH_ATTR strtoul(const char *nptr, char **endptr, int base)
 {
 	const unsigned char *s = (const unsigned char *)nptr;
 	unsigned long acc;

--- a/hardware/esp8266com/esp8266/cores/esp8266/libc_replacements.c
+++ b/hardware/esp8266com/esp8266/cores/esp8266/libc_replacements.c
@@ -215,57 +215,6 @@ char* ICACHE_FLASH_ATTR strdup(const char *str) {
     return cstr;
 }
 
-long int ICACHE_FLASH_ATTR strtol(const char* str, char** endptr, int base) {
-    long int result = 0;
-    int sign = 1;
-
-    while(isspace(*str)) {
-        str++;
-    }
-
-    if(*str == 0x00) {
-        // only space in str?
-        *endptr = (char*) str;
-        return result;
-    }
-
-    switch(base) {
-        case 10:
-
-            if(*str == '-') {
-                sign = -1;
-                str++;
-            } else if(*str == '+') {
-                str++;
-            }
-
-            for(uint8_t i = 0; *str; i++, str++) {
-                int x = *str - '0';
-                if(x < 0 || x > 9) {
-                    break;
-                }
-                result = result * 10 + x;
-            }
-            break;
-        case 2:
-            for(uint8_t i = 0; *str; i++, str++) {
-                int x = *str - '0';
-                if(x < 0 || x > 1) {
-                    break;
-                }
-                result = result * 2 + x;
-            }
-            break;
-        case 16:
-        default:
-            os_printf("fnk: strtol() only supports base 10 and 2 ATM!\n");
-            break;
-
-    }
-    *endptr = (char*) str;
-    return sign * result;
-}
-
 // based on Source:
 // https://github.com/anakod/Sming/blob/master/Sming/system/stringconversion.cpp#L93
 double ICACHE_FLASH_ATTR strtod(const char* str, char** endptr) {
@@ -479,16 +428,189 @@ size_t ICACHE_FLASH_ATTR strlcpy(char* dst, const char* src, size_t size) {
                 break;
         } while (--n != 0);
     }
-    
+
     if (n == 0) {
         if (size != 0)
             *dst = 0;
         while (*s++);
     }
-    
+
     return(s - src - 1);
 }
 /*
  * end of newlib/string/strlcpy.c
  */
 
+
+
+/**
+ * strtol() and strtoul() implementations borrowed from newlib:
+ * http://www.sourceware.org/newlib/
+ *      newlib/libc/stdlib/strtol.c
+ *      newlib/libc/stdlib/strtoul.c
+ *
+ * Adapted for ESP8266 by Kiril Zyapkov <kiril.zyapkov@gmail.com>
+ *
+ * Copyright (c) 1990 The Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+long strtol(const char *nptr, char **endptr, int base) {
+	const unsigned char *s = (const unsigned char *)nptr;
+	unsigned long acc;
+	int c;
+	unsigned long cutoff;
+	int neg = 0, any, cutlim;
+
+	/*
+	 * Skip white space and pick up leading +/- sign if any.
+	 * If base is 0, allow 0x for hex and 0 for octal, else
+	 * assume decimal; if base is already 16, allow 0x.
+	 */
+	do {
+		c = *s++;
+	} while (isspace(c));
+	if (c == '-') {
+		neg = 1;
+		c = *s++;
+	} else if (c == '+')
+		c = *s++;
+	if ((base == 0 || base == 16) &&
+	    c == '0' && (*s == 'x' || *s == 'X')) {
+		c = s[1];
+		s += 2;
+		base = 16;
+	}
+	if (base == 0)
+		base = c == '0' ? 8 : 10;
+
+	/*
+	 * Compute the cutoff value between legal numbers and illegal
+	 * numbers.  That is the largest legal value, divided by the
+	 * base.  An input number that is greater than this value, if
+	 * followed by a legal input character, is too big.  One that
+	 * is equal to this value may be valid or not; the limit
+	 * between valid and invalid numbers is then based on the last
+	 * digit.  For instance, if the range for longs is
+	 * [-2147483648..2147483647] and the input base is 10,
+	 * cutoff will be set to 214748364 and cutlim to either
+	 * 7 (neg==0) or 8 (neg==1), meaning that if we have accumulated
+	 * a value > 214748364, or equal but the next digit is > 7 (or 8),
+	 * the number is too big, and we will return a range error.
+	 *
+	 * Set any if any `digits' consumed; make it negative to indicate
+	 * overflow.
+	 */
+	cutoff = neg ? -(unsigned long)LONG_MIN : LONG_MAX;
+	cutlim = cutoff % (unsigned long)base;
+	cutoff /= (unsigned long)base;
+	for (acc = 0, any = 0;; c = *s++) {
+		if (isdigit(c))
+			c -= '0';
+		else if (isalpha(c))
+			c -= isupper(c) ? 'A' - 10 : 'a' - 10;
+		else
+			break;
+		if (c >= base)
+			break;
+               if (any < 0 || acc > cutoff || (acc == cutoff && c > cutlim))
+			any = -1;
+		else {
+			any = 1;
+			acc *= base;
+			acc += c;
+		}
+	}
+	if (any < 0) {
+		acc = neg ? LONG_MIN : LONG_MAX;
+		errno = ERANGE;
+	} else if (neg)
+		acc = -acc;
+	if (endptr != 0)
+		*endptr = (char *) (any ? (char *)s - 1 : nptr);
+	return (acc);
+}
+
+unsigned long strtoul(const char *nptr, char **endptr, int base)
+{
+	const unsigned char *s = (const unsigned char *)nptr;
+	unsigned long acc;
+	int c;
+	unsigned long cutoff;
+	int neg = 0, any, cutlim;
+
+	/*
+	 * See strtol for comments as to the logic used.
+	 */
+	do {
+		c = *s++;
+	} while (isspace(c));
+	if (c == '-') {
+		neg = 1;
+		c = *s++;
+	} else if (c == '+')
+		c = *s++;
+	if ((base == 0 || base == 16) &&
+	    c == '0' && (*s == 'x' || *s == 'X')) {
+		c = s[1];
+		s += 2;
+		base = 16;
+	}
+	if (base == 0)
+		base = c == '0' ? 8 : 10;
+	cutoff = (unsigned long)ULONG_MAX / (unsigned long)base;
+	cutlim = (unsigned long)ULONG_MAX % (unsigned long)base;
+	for (acc = 0, any = 0;; c = *s++) {
+		if (isdigit(c))
+			c -= '0';
+		else if (isalpha(c))
+			c -= isupper(c) ? 'A' - 10 : 'a' - 10;
+		else
+			break;
+		if (c >= base)
+			break;
+               if (any < 0 || acc > cutoff || (acc == cutoff && c > cutlim))
+			any = -1;
+		else {
+			any = 1;
+			acc *= base;
+			acc += c;
+		}
+	}
+	if (any < 0) {
+		acc = ULONG_MAX;
+		errno = ERANGE;
+	} else if (neg)
+		acc = -acc;
+	if (endptr != 0)
+		*endptr = (char *) (any ? (char *)s - 1 : nptr);
+	return (acc);
+}

--- a/hardware/esp8266com/esp8266/cores/esp8266/libc_replacements.c
+++ b/hardware/esp8266com/esp8266/cores/esp8266/libc_replacements.c
@@ -229,7 +229,7 @@ double ICACHE_FLASH_ATTR strtod(const char* str, char** endptr) {
 
     if(*str == 0x00) {
         // only space in str?
-        *endptr = (char*) str;
+        if (endptr) *endptr = (char*) str;
         return result;
     }
 
@@ -259,7 +259,7 @@ double ICACHE_FLASH_ATTR strtod(const char* str, char** endptr) {
 
         str++;
     }
-    *endptr = (char*) str;
+    if (endptr) *endptr = (char*) str;
     return result * factor;
 }
 


### PR DESCRIPTION
I've copied the `strtol()` and `strtoul()` functions from newlib, the only change is how we access `errno`.

`strtod()` will no longer cause a crash when callers don't care about `endptr`.