### PR TITLE
Support for multiple I2C buses

### DIFF
--- a/hardware/esp8266com/esp8266/cores/esp8266/twi.h
+++ b/hardware/esp8266com/esp8266/cores/esp8266/twi.h
@@ -25,12 +25,16 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+    
+typedef struct {
+    unsigned char dcount, sda, scl;
+} TwiConfig;
 
-void twi_init(unsigned char sda, unsigned char scl);
-void twi_stop(void);
-void twi_setClock(unsigned int freq);
-uint8_t twi_writeTo(unsigned char address, unsigned char * buf, unsigned int len, unsigned char sendStop);
-uint8_t twi_readFrom(unsigned char address, unsigned char * buf, unsigned int len, unsigned char sendStop);
+void twi_init(TwiConfig* twi, unsigned char sda, unsigned char scl);
+void twi_stop(TwiConfig* twi);
+void twi_setClock(TwiConfig* twi, unsigned int freq);
+uint8_t twi_writeTo(TwiConfig* twi, unsigned char address, unsigned char * buf, unsigned int len, unsigned char sendStop);
+uint8_t twi_readFrom(TwiConfig* twi, unsigned char address, unsigned char * buf, unsigned int len, unsigned char sendStop);
 
 #ifdef __cplusplus
 }

--- a/hardware/esp8266com/esp8266/libraries/Wire/Wire.cpp
+++ b/hardware/esp8266com/esp8266/libraries/Wire/Wire.cpp
@@ -45,9 +45,6 @@ uint8_t TwoWire::transmitting = 0;
 void (*TwoWire::user_onRequest)(void);
 void (*TwoWire::user_onReceive)(int);
 
-static int default_sda_pin = SDA;
-static int default_scl_pin = SCL;
-
 // Constructors ////////////////////////////////////////////////////////////////
 
 TwoWire::TwoWire(){}
@@ -55,19 +52,17 @@ TwoWire::TwoWire(){}
 // Public Methods //////////////////////////////////////////////////////////////
 
 void TwoWire::begin(int sda, int scl){
-  default_sda_pin = sda;
-  default_scl_pin = scl;
-  twi_init(sda, scl);
+  twi_init(&twi, sda, scl);
   flush();
 }
 
 void TwoWire::pins(int sda, int scl){
-  default_sda_pin = sda;
-  default_scl_pin = scl;
+  twi.sda = sda;
+  twi.scl = scl;
 }
 
 void TwoWire::begin(void){
-  begin(default_sda_pin, default_scl_pin);
+  begin(twi.sda, twi.scl);
 }
 
 void TwoWire::begin(uint8_t address){
@@ -82,14 +77,14 @@ void TwoWire::begin(int address){
 }
 
 void TwoWire::setClock(uint32_t frequency){
-  twi_setClock(frequency);
+  twi_setClock(&twi, frequency);
 }
 
 size_t TwoWire::requestFrom(uint8_t address, size_t size, bool sendStop){
   if(size > BUFFER_LENGTH){
     size = BUFFER_LENGTH;
   }
-  size_t read = (twi_readFrom(address, rxBuffer, size, sendStop) == 0)?size:0;
+  size_t read = (twi_readFrom(&twi, address, rxBuffer, size, sendStop) == 0)?size:0;
   rxBufferIndex = 0;
   rxBufferLength = read;
   return read;
@@ -123,7 +118,7 @@ void TwoWire::beginTransmission(int address){
 }
 
 uint8_t TwoWire::endTransmission(uint8_t sendStop){
-  int8_t ret = twi_writeTo(txAddress, txBuffer, txBufferLength, sendStop);
+  int8_t ret = twi_writeTo(&twi, txAddress, txBuffer, txBufferLength, sendStop);
   txBufferIndex = 0;
   txBufferLength = 0;
   transmitting = 0;

--- a/hardware/esp8266com/esp8266/libraries/Wire/Wire.h
+++ b/hardware/esp8266com/esp8266/libraries/Wire/Wire.h
@@ -26,6 +26,7 @@
 
 #include <inttypes.h>
 #include "Stream.h"
+#include "twi.h"
 
 
 
@@ -34,6 +35,8 @@
 class TwoWire : public Stream
 {
   private:
+    TwiConfig twi;
+      
     static uint8_t rxBuffer[];
     static uint8_t rxBufferIndex;
     static uint8_t rxBufferLength;


### PR DESCRIPTION
The ESP8266 doesn't have "actual" I2C hardware, and relies on bit-banging instead.

Since this is a sotware implementation, there is no reason we cannot bit-bang a bunch of I2C ports, right?

My use-case: I need to talk to 2 devices with the same address (Same chip - PN532). AFAIK, the only way is to put them in different buses.