### PR TITLE
Remove DEBUG defined by default in library

### DIFF
--- a/hardware/esp8266com/esp8266/libraries/DNSServer/src/DNSServer.cpp
+++ b/hardware/esp8266com/esp8266/libraries/DNSServer/src/DNSServer.cpp
@@ -2,8 +2,6 @@
 #include <lwip/def.h>
 #include <Arduino.h>
 
-#define DEBUG
-#define DEBUG_OUTPUT Serial
 
 DNSServer::DNSServer()
 {


### PR DESCRIPTION
DEBUG should be defined outside the library to enable it  not enabled by
default in library itself