### PR TITLE
fix upload size for gerneric 4m1m

### DIFF
--- a/hardware/esp8266com/esp8266/boards.txt
+++ b/hardware/esp8266com/esp8266/boards.txt
@@ -119,7 +119,7 @@ generic.menu.FlashSize.4M1M.build.spiffs_start=0x300000
 generic.menu.FlashSize.4M1M.build.spiffs_end=0x3FB000
 generic.menu.FlashSize.4M1M.build.spiffs_blocksize=8192
 generic.menu.FlashSize.4M1M.build.spiffs_pagesize=256
-generic.menu.FlashSize.4M1M.upload.maximum_size=3044464
+generic.menu.FlashSize.4M1M.upload.maximum_size=1044464
 
 generic.menu.FlashSize.4M=4M (3M SPIFFS)
 generic.menu.FlashSize.4M.build.flash_size=4M


### PR DESCRIPTION
It have to be updated because of igrr's commit [9ae85d4](https://github.com/esp8266/Arduino/commit/9ae85d4a59ee15795bfc34817fe15eb11ded9b36).
I didn't know that the rest of the flash have to be empty.