### PR TITLE
fix bug: wrong file path from request uri

### DIFF
--- a/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/detail/RequestHandler.h
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/detail/RequestHandler.h
@@ -62,8 +62,7 @@ public:
         if (!requestUri.startsWith(uri))
             return false;
 
-        auto prefixLength = uri.length();
-        String path = requestUri.substring(0, prefixLength);
+        String path = uri;
         DEBUGV("StaticRequestHandler::handle: %d %s\r\n", prefixLength, path.c_str());
         File f = fs.open(path, "r");
         if (!f)

--- a/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/detail/RequestHandler.h
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/detail/RequestHandler.h
@@ -62,8 +62,8 @@ public:
         if (!requestUri.startsWith(uri))
             return false;
 
-        auto prefixLength = uri.length() - 1;
-        String path = requestUri.substring(prefixLength);
+        auto prefixLength = uri.length();
+        String path = requestUri.substring(0, prefixLength);
         DEBUGV("StaticRequestHandler::handle: %d %s\r\n", prefixLength, path.c_str());
         File f = fs.open(path, "r");
         if (!f)


### PR DESCRIPTION
We don't need the extra `path` parameter for `ESP8266WebServer::serveStatic` anymore, do we?