### PR TITLE
Remove unused include time.h from ssl.h

### DIFF
--- a/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/include/ssl.h
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/include/ssl.h
@@ -67,8 +67,6 @@
 extern "C" {
 #endif
 
-#include <time.h>
-
 /* need to predefine before ssl_lib.h gets to it */
 #define SSL_SESSION_ID_SIZE                     32
 


### PR DESCRIPTION
This include is not used by ssl.h but can be annoying.
If there is need for time.h it should be located in the esp8266 tree.