### PR TITLE
Fix to Servo allowing write() to be called before attach()

### DIFF
--- a/hardware/esp8266com/esp8266/libraries/Servo/src/esp8266/Servo.cpp
+++ b/hardware/esp8266com/esp8266/libraries/Servo/src/esp8266/Servo.cpp
@@ -146,6 +146,10 @@ Servo::Servo()
         _servoIndex = s_servoCount++;
         // store default values
         s_servos[_servoIndex].usPulse = DEFAULT_PULSE_WIDTH;
+
+        // set default _minUs and _maxUs incase write() is called before attach()
+        _minUs = MIN_PULSE_WIDTH;
+        _maxUs = MAX_PULSE_WIDTH;
     }
     else {
         _servoIndex = INVALID_SERVO;  // too many servos


### PR DESCRIPTION
Fixes #839 by initializing the `_minUs` and `_maxUs` fields to the defaults in the constructor.