### PR TITLE
use String return for both SSID functions

### DIFF
--- a/hardware/esp8266com/esp8266/libraries/DNSServer/examples/CaptivePortalAdvanced/handleHttp.ino
+++ b/hardware/esp8266com/esp8266/libraries/DNSServer/examples/CaptivePortalAdvanced/handleHttp.ino
@@ -73,7 +73,7 @@ void handleWifi() {
   Serial.println("scan done");
   if (n > 0) {
     for (int i = 0; i < n; i++) {
-      server.sendContent(String() + "\r\n<tr><td>SSID " + String(WiFi.SSID(i)) + String((WiFi.encryptionType(i) == ENC_TYPE_NONE)?" ":" *") + " (" + WiFi.RSSI(i) + ")</td></tr>");
+      server.sendContent(String() + "\r\n<tr><td>SSID " + WiFi.SSID(i) + String((WiFi.encryptionType(i) == ENC_TYPE_NONE)?" ":" *") + " (" + WiFi.RSSI(i) + ")</td></tr>");
     }
   } else {
     server.sendContent(String() + "<tr><td>No WLAN found</td></tr>");

--- a/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/ESP8266WiFi.cpp
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/ESP8266WiFi.cpp
@@ -536,13 +536,13 @@ void * ESP8266WiFiClass::_getScanInfoByIndex(int i)
     return reinterpret_cast<bss_info*>(ESP8266WiFiClass::_scanResult) + i;
 }
 
-const char* ESP8266WiFiClass::SSID(uint8_t i)
+String ESP8266WiFiClass::SSID(uint8_t i)
 {
     struct bss_info* it = reinterpret_cast<struct bss_info*>(_getScanInfoByIndex(i));
     if (!it)
-        return 0;
+        return "";
 
-    return reinterpret_cast<const char*>(it->ssid);
+    return String(reinterpret_cast<const char*>(it->ssid));
 }
 
 uint8_t * ESP8266WiFiClass::BSSID(uint8_t i)

--- a/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/ESP8266WiFi.h
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WiFi/src/ESP8266WiFi.h
@@ -239,7 +239,7 @@ public:
 	 *
      * return: ssid string of the specified item on the networks scanned list
      */
-    const char*	SSID(uint8_t networkItem);
+    String SSID(uint8_t networkItem);
 
     /*
      * Return the encryption type of the networks discovered during the scanNetworks


### PR DESCRIPTION
I changed the return type from SSID() last day.
Is it better to use the same return type for all overloaded functions?