### PR TITLE
avoid to dereference a NULL pointer if update is called before begin

### DIFF
--- a/hardware/esp8266com/esp8266/libraries/ESP8266mDNS/ESP8266mDNS.cpp
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266mDNS/ESP8266mDNS.cpp
@@ -134,7 +134,7 @@ bool MDNSResponder::begin(const char* domain){
 }
 
 void MDNSResponder::update() {
-  if (!_conn->next()) {
+  if (!_conn || !_conn->next()) {
     return;
   }
   _parsePacket();


### PR DESCRIPTION
Hi,
This pull request is about ESP8266mDNS, it add in the `update` method a check that _conn is not NULL before using it.
It allows to have a loop that always call it even when ESP8266mDNS is not still initialized.
Regards,
Michel.