### PR TITLE
Fix placement of code into RAM, enable gc-sections

### DIFF
--- a/hardware/esp8266com/esp8266/platform.txt
+++ b/hardware/esp8266com/esp8266/platform.txt
@@ -16,18 +16,18 @@ compiler.sdk.path={runtime.platform.path}/tools/sdk
 compiler.cpreprocessor.flags=-D__ets__ -DICACHE_FLASH -U__STRICT_ANSI__ "-I{compiler.sdk.path}/include"
 
 compiler.c.cmd=xtensa-lx106-elf-gcc
-compiler.c.flags=-c -Os -g -Wpointer-arith -Wno-implicit-function-declaration -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals -falign-functions=4 -MMD -std=gnu99
+compiler.c.flags=-c -Os -g -Wpointer-arith -Wno-implicit-function-declaration -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals -falign-functions=4 -MMD -std=gnu99 -ffunction-sections -fdata-sections
 
 compiler.S.cmd=xtensa-lx106-elf-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp -MMD
 
-compiler.c.elf.flags=-g -Os -nostdlib -Wl,--no-check-sections -u call_user_start -Wl,-static "-L{compiler.sdk.path}/lib" "-L{compiler.sdk.path}/ld" "-T{build.flash_ld}" -Wl,-wrap,system_restart_local -Wl,-wrap,register_chipv6_phy
+compiler.c.elf.flags=-g -Os -nostdlib -Wl,--no-check-sections -u call_user_start -Wl,-static "-L{compiler.sdk.path}/lib" "-L{compiler.sdk.path}/ld" "-T{build.flash_ld}" -Wl,--gc-sections -Wl,-wrap,system_restart_local -Wl,-wrap,register_chipv6_phy
 
 compiler.c.elf.cmd=xtensa-lx106-elf-gcc
 compiler.c.elf.libs=-lm -lgcc -lhal -lphy -lnet80211 -llwip -lwpa -lmain -lpp -lsmartconfig -lwps -lcrypto -laxtls
 
 compiler.cpp.cmd=xtensa-lx106-elf-g++
-compiler.cpp.flags=-c -Os -g -mlongcalls -mtext-section-literals -fno-exceptions -fno-rtti -falign-functions=4 -std=c++11 -MMD
+compiler.cpp.flags=-c -Os -g -mlongcalls -mtext-section-literals -fno-exceptions -fno-rtti -falign-functions=4 -std=c++11 -MMD -ffunction-sections -fdata-sections
 
 compiler.as.cmd=xtensa-lx106-elf-as
 

--- a/hardware/esp8266com/esp8266/tools/sdk/include/c_types.h
+++ b/hardware/esp8266com/esp8266/tools/sdk/include/c_types.h
@@ -67,7 +67,7 @@ typedef enum {
 
 #ifdef ICACHE_FLASH
 #define ICACHE_FLASH_ATTR   __attribute__((section(".irom0.text")))
-#define ICACHE_RAM_ATTR     __attribute__((section(".text")))
+#define ICACHE_RAM_ATTR     __attribute__((section(".iram.text")))
 #define ICACHE_RODATA_ATTR  __attribute__((section(".irom.text")))
 #else
 #define ICACHE_FLASH_ATTR

--- a/hardware/esp8266com/esp8266/tools/sdk/ld/eagle.app.v6.common.ld
+++ b/hardware/esp8266com/esp8266/tools/sdk/ld/eagle.app.v6.common.ld
@@ -150,12 +150,11 @@ SECTIONS
   .irom0.text : ALIGN(4)
   {
     _irom0_text_start = ABSOLUTE(.);
-    *core_esp8266_*.o(.literal*, .text*)
-    *spiffs*.o(.literal*, .text*)
+    *.c.o(.literal*, .text*)
     *.cpp.o(.literal*, .text*)
     *libm.a:(.literal .text .literal.* .text.*)
     *libsmartconfig.a:(.literal .text .literal.* .text.*)
-    *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text)
+    *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text .irom.text.*)
     _irom0_text_end = ABSOLUTE(.);
     _flash_code_end = ABSOLUTE(.);
   } >irom0_0_seg :irom0_0_phdr
@@ -192,6 +191,8 @@ SECTIONS
     *(.init.literal)
     *(.init)
     *(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+    *.cpp.o(.iram.text)
+    *.c.o(.iram.text)
     *(.fini.literal)
     *(.fini)
     *(.gnu.version)


### PR DESCRIPTION
Related to #856, #826, #803, #734.

- enable -gc-sections linker option (#734)
- enable -ffunction-sections -fdata-sections (in conjunction with the above, helps with #826)
- fix #856 by making ICACHE_RAM_ATTR place functions into `.iram.text` instead of `.text`. Place `.iram.text` into `.text` segment via linker script. This allows to (selectively) place code into RAM from .cpp files *and* moves code from .c files into `.irom.text` by default (#803).

Reduces size of the sketches somewhat.
Without this change (HelloServer sample sketch):

    Sketch uses 349,510 bytes (33%) of program storage space. Maximum is 1,044,464 bytes.
    Global variables use 45,674 bytes (55%) of dynamic memory, leaving 36,246 bytes for local variables. Maximum is 81,920 bytes.

With this change:

    Sketch uses 225,310 bytes (21%) of program storage space. Maximum is 1,044,464 bytes.
    Global variables use 36,506 bytes (44%) of dynamic memory, leaving 45,414 bytes for local variables. Maximum is 81,920 bytes.

Compile tests pass, but might break some sketches at run time. Needs testing.