### PR TITLE
Add header access using same method as arguments

### DIFF
--- a/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -41,6 +41,10 @@ ESP8266WebServer::ESP8266WebServer(int port)
 }
 
 ESP8266WebServer::~ESP8266WebServer() {
+  if (_headerKeys) {
+    free(_headerKeys);
+    _headerKeys = 0;
+  }
   if (!_firstHandler)
     return;
   RequestHandler* handler = _firstHandler;
@@ -289,6 +293,14 @@ String ESP8266WebServer::header(const char* name) {
       return _currentHeaders[i].value;
   }
   return String();
+}
+
+void ESP8266WebServer::collectHeaders(const char* headerKeys[], const size_t headerKeysCount) {
+  _headerKeysCount = headerKeysCount;
+  _headerKeys = (const char**)malloc(_headerKeysCount*sizeof(char*));
+  for (int i = 0; i < _headerKeysCount; i++){
+    _headerKeys[i] = headerKeys[i];
+  }
 }
 
 String ESP8266WebServer::header(int i) {

--- a/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -283,6 +283,38 @@ bool ESP8266WebServer::hasArg(const char* name) {
   return false;
 }
 
+String ESP8266WebServer::header(const char* name) {
+  for (int i = 0; i < _currentHeaderCount; ++i) {
+    if (_currentHeaders[i].key == name)
+      return _currentHeaders[i].value;
+  }
+  return String();
+}
+
+String ESP8266WebServer::header(int i) {
+  if (i < _currentHeaderCount)
+    return _currentHeaders[i].value;
+  return String();
+}
+
+String ESP8266WebServer::headerName(int i) {
+  if (i < _currentHeaderCount)
+    return _currentHeaders[i].key;
+  return String();
+}
+
+int ESP8266WebServer::headers() {
+  return _currentHeaderCount;
+}
+
+bool ESP8266WebServer::hasHeader(const char* name) {
+  for (int i = 0; i < _currentHeaderCount; ++i) {
+    if (_currentHeaders[i].key == name)
+      return true;
+  }
+  return false;
+}
+
 String ESP8266WebServer::hostHeader() {
   return _hostHeader;
 }

--- a/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -41,10 +41,10 @@ ESP8266WebServer::ESP8266WebServer(int port)
 }
 
 ESP8266WebServer::~ESP8266WebServer() {
-  if (_headerKeys) {
+  if (_headerKeys)
     free(_headerKeys);
-    _headerKeys = 0;
-  }
+  _headerKeys = 0;
+  _headerKeysCount = 0;
   if (!_firstHandler)
     return;
   RequestHandler* handler = _firstHandler;

--- a/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -84,6 +84,7 @@ public:
   int args();                     // get arguments count
   bool hasArg(const char* name);  // check if argument exists
   
+  void collectHeaders(const char* headerKeys[], const size_t headerKeysCount); // set the request headers to collect
   String header(const char* name);   // get request header value by name
   String header(int i);              // get request header value by number
   String headerName(int i);          // get request header name by number
@@ -130,6 +131,7 @@ protected:
   void _uploadWriteByte(uint8_t b);
   uint8_t _uploadReadByte(WiFiClient& client);
   void _prepareHeader(String& response, int code, const char* content_type, size_t contentLength);
+  bool _collectHeader(const char* headerName);
 
   struct RequestArgument {
     String key;
@@ -148,6 +150,8 @@ protected:
   
   size_t           _currentHeaderCount;
   RequestArgument* _currentHeaders;
+  size_t           _headerKeysCount;
+  const char**     _headerKeys;
 
   size_t           _contentLength;
   String           _responseHeaders;

--- a/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -83,6 +83,12 @@ public:
   String argName(int i);          // get request argument name by number
   int args();                     // get arguments count
   bool hasArg(const char* name);  // check if argument exists
+  
+  String header(const char* name);   // get request header value by name
+  String header(int i);              // get request header value by number
+  String headerName(int i);          // get request header name by number
+  int headers();                     // get header count
+  bool hasHeader(const char* name);  // check if header exists
 
   String hostHeader();            // get request host header if available or empty String if not
 
@@ -139,6 +145,9 @@ protected:
   size_t           _currentArgCount;
   RequestArgument* _currentArgs;
   HTTPUpload       _currentUpload;
+  
+  size_t           _currentHeaderCount;
+  RequestArgument* _currentHeaders;
 
   size_t           _contentLength;
   String           _responseHeaders;

--- a/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/Parsing.cpp
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/Parsing.cpp
@@ -34,7 +34,7 @@ bool ESP8266WebServer::_parseRequest(WiFiClient& client) {
   
   if (_currentHeaders)
     delete[] _currentHeaders;
-  _currentHeaders = 0;
+  _currentHeaders = new RequestArgument[_headerKeysCount];
   _currentHeaderCount = 0;
   
   // First line of HTTP request looks like "GET /path HTTP/1.1"
@@ -102,16 +102,12 @@ bool ESP8266WebServer::_parseRequest(WiFiClient& client) {
       headerName = req.substring(0, headerDiv);
       headerValue = req.substring(headerDiv + 2);
       
-      RequestArgument* _newHeaders = new RequestArgument[_currentHeaderCount+1];
-      for (int i = 0; i < _currentHeaderCount; i++) {
-        _newHeaders[i] = _currentHeaders[i];
+      if (_collectHeader(headerName.c_str())) {
+        RequestArgument& arg = _currentHeaders[_currentHeaderCount];
+        arg.key = headerName;
+        arg.value = headerValue;
+        _currentHeaderCount++;
       }
-      RequestArgument& arg = _newHeaders[_currentHeaderCount];
-      arg.key = headerName;
-      arg.value = headerValue;
-      _currentHeaderCount++;
-      if (_currentHeaders) delete[] _currentHeaders;
-      _currentHeaders = _newHeaders;
 	  
 	  #ifdef DEBUG
 	  DEBUG_OUTPUT.print("headerName: ");
@@ -178,16 +174,12 @@ bool ESP8266WebServer::_parseRequest(WiFiClient& client) {
       headerName = req.substring(0, headerDiv);
       headerValue = req.substring(headerDiv + 2);
       
-      RequestArgument* _newHeaders = new RequestArgument[_currentHeaderCount+1];
-      for (int i = 0; i < _currentHeaderCount; i++) {
-        _newHeaders[i] = _currentHeaders[i];
+      if (_collectHeader(headerName.c_str())) {
+        RequestArgument& arg = _currentHeaders[_currentHeaderCount];
+        arg.key = headerName;
+        arg.value = headerValue;
+        _currentHeaderCount++;
       }
-      RequestArgument& arg = _newHeaders[_currentHeaderCount];
-      arg.key = headerName;
-      arg.value = headerValue;
-      _currentHeaderCount++;
-      if (_currentHeaders) delete[] _currentHeaders;
-      _currentHeaders = _newHeaders;
 	  
 	  #ifdef DEBUG
 	  DEBUG_OUTPUT.print("headerName: ");
@@ -214,6 +206,12 @@ bool ESP8266WebServer::_parseRequest(WiFiClient& client) {
   return true;
 }
 
+bool ESP8266WebServer::_collectHeader(const char* headerName) {
+  for (size_t i = 0; i < _headerKeysCount; i++) {
+    if (strcmp(headerName, _headerKeys[i]) == 0) return true;
+  }
+  return false;
+}
 
 void ESP8266WebServer::_parseArguments(String data) {
 #ifdef DEBUG

--- a/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/Parsing.cpp
+++ b/hardware/esp8266com/esp8266/libraries/ESP8266WebServer/src/Parsing.cpp
@@ -31,7 +31,12 @@ bool ESP8266WebServer::_parseRequest(WiFiClient& client) {
   // Read the first line of HTTP request
   String req = client.readStringUntil('\r');
   client.readStringUntil('\n');
-
+  
+  if (_currentHeaders)
+    delete[] _currentHeaders;
+  _currentHeaders = 0;
+  _currentHeaderCount = 0;
+  
   // First line of HTTP request looks like "GET /path HTTP/1.1"
   // Retrieve the "/path" part by finding the spaces
   int addr_start = req.indexOf(' ');
@@ -96,6 +101,17 @@ bool ESP8266WebServer::_parseRequest(WiFiClient& client) {
       }
       headerName = req.substring(0, headerDiv);
       headerValue = req.substring(headerDiv + 2);
+      
+      RequestArgument* _newHeaders = new RequestArgument[_currentHeaderCount+1];
+      for (int i = 0; i < _currentHeaderCount; i++) {
+        _newHeaders[i] = _currentHeaders[i];
+      }
+      RequestArgument& arg = _newHeaders[_currentHeaderCount];
+      arg.key = headerName;
+      arg.value = headerValue;
+      _currentHeaderCount++;
+      if (_currentHeaders) delete[] _currentHeaders;
+      _currentHeaders = _newHeaders;
 	  
 	  #ifdef DEBUG
 	  DEBUG_OUTPUT.print("headerName: ");
@@ -161,6 +177,17 @@ bool ESP8266WebServer::_parseRequest(WiFiClient& client) {
       }
       headerName = req.substring(0, headerDiv);
       headerValue = req.substring(headerDiv + 2);
+      
+      RequestArgument* _newHeaders = new RequestArgument[_currentHeaderCount+1];
+      for (int i = 0; i < _currentHeaderCount; i++) {
+        _newHeaders[i] = _currentHeaders[i];
+      }
+      RequestArgument& arg = _newHeaders[_currentHeaderCount];
+      arg.key = headerName;
+      arg.value = headerValue;
+      _currentHeaderCount++;
+      if (_currentHeaders) delete[] _currentHeaders;
+      _currentHeaders = _newHeaders;
 	  
 	  #ifdef DEBUG
 	  DEBUG_OUTPUT.print("headerName: ");


### PR DESCRIPTION
Here's my fix for issue #795 which adds access to request headers by the same method that arguments are accessed. I needed to access the Cookie header and now I can do that like this.

```C
if (server.hasHeader("Cookie")) {
    String cookieValue = server.header("Cookie");
}
```