### PR TITLE
Add libraries categories

### DIFF
--- a/libraries/EEPROM/library.properties
+++ b/libraries/EEPROM/library.properties
@@ -4,5 +4,6 @@ author=Ivan Grokhotkov
 maintainer=Ivan Grokhotkov <ivan@esp8266.com>
 sentence=Enables reading and writing data to the permanent FLASH storage, up to 4kb.
 paragraph=
+category=Data Storage
 url=http://arduino.cc/en/Reference/EEPROM
 architectures=esp8266

--- a/libraries/ESP8266httpUpdate/library.properties
+++ b/libraries/ESP8266httpUpdate/library.properties
@@ -4,5 +4,6 @@ author=Markus Sattler
 maintainer=Markus Sattler
 sentence=Http Update for ESP8266
 paragraph=
+category=Data Processing
 url=https://github.com/Links2004/Arduino/tree/esp8266/hardware/esp8266com/esp8266/libraries/ESP8266httpUpdate
 architectures=esp8266

--- a/libraries/Hash/library.properties
+++ b/libraries/Hash/library.properties
@@ -4,5 +4,6 @@ author=Markus Sattler
 maintainer=Markus Sattler 
 sentence=Generate Hash from data
 paragraph=
+category=Data Processing
 url=
 architectures=esp8266

--- a/libraries/SPI/library.properties
+++ b/libraries/SPI/library.properties
@@ -4,5 +4,6 @@ author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=Enables the communication with devices that use the Serial Peripheral Interface (SPI) Bus. For all Arduino boards, BUT Arduino DUE. 
 paragraph=
+category=Signal Input/Output
 url=http://arduino.cc/en/Reference/SPI
 architectures=esp8266

--- a/libraries/Ticker/library.properties
+++ b/libraries/Ticker/library.properties
@@ -4,5 +4,6 @@ author=Ivan Grokhtokov <ivan@esp8266.com>
 maintainer=Ivan Grokhtokov <ivan@esp8266.com>
 sentence=Allows to call functions with a given interval.
 paragraph=
+category=Timing
 url=
 architectures=esp8266

--- a/libraries/Wire/library.properties
+++ b/libraries/Wire/library.properties
@@ -4,5 +4,6 @@ author=Arduino
 maintainer=Ivan Grokhotkov <ivan@esp8266.com>
 sentence=Allows the communication between devices or sensors connected via Two Wire Interface Bus. For esp8266 boards. 
 paragraph=
+category=Signal Input/Output
 url=http://arduino.cc/en/Reference/Wire
 architectures=esp8266


### PR DESCRIPTION
Since Arduino 1.5.6, the `category` library metadata is implemented (see https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format).

Making the libraries 1.5 compliant removes the warnings generated for those of us who are using arduino-builder (e.g. `WARNING: Category '' in library EEPROM is not valid. Setting to 'Uncategorized'`).