### PR TITLE
Exclude the terminator in sendContent_P

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -226,8 +226,8 @@ void ESP8266WebServer::sendContent_P(PGM_P content) {
             contentUnitLen = HTTP_DOWNLOAD_UNIT_SIZE;
         }
         else {
-            // reached terminator
-            contentUnitLen = contentNext - contentUnit;
+            // reached terminator. Do not send the terminator
+            contentUnitLen = contentNext - contentUnit - 1;
             content = NULL;
         }
 


### PR DESCRIPTION
The terminator should not be sent by sendContent_P. For example, if you
have a null-terminated string, the null itself should not be sent to the
client. This change decrements the number of bytes to send so it does
not include the termination character. This is for Issue #987