### PR TITLE
Changes to StaticRequestHandler

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -83,8 +83,8 @@ void ESP8266WebServer::_addRequestHandler(RequestHandler* handler) {
     }
 }
 
-void ESP8266WebServer::serveStatic(const char* uri, FS& fs, const char* path) {
-    _addRequestHandler(new StaticRequestHandler(fs, path, uri));
+void ESP8266WebServer::serveStatic(const char* uri, FS& fs, const char* path, const char* cache_header) {
+    _addRequestHandler(new StaticRequestHandler(fs, path, uri, cache_header));
 }
 
 void ESP8266WebServer::handleClient() {

--- a/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
@@ -31,39 +31,59 @@ protected:
 
 class StaticRequestHandler : public RequestHandler {
 public:
-    StaticRequestHandler(FS& fs, const char* path, const char* uri)
+    StaticRequestHandler(FS& fs, const char* path, const char* uri, const char* cache_header)
     : _fs(fs)
     , _uri(uri)
     , _path(path)
+    , _cache_header(cache_header)
     {
         _isFile = fs.exists(path);
-        DEBUGV("StaticRequestHandler: path=%s uri=%s isFile=%d\r\n", path, uri, _isFile);
-        _baseUriLength = _uri.length();
+        DEBUGV("StaticRequestHandler: path=%s uri=%s isFile=%d, cache_header=%s\r\n", path, uri, _isFile, cache_header);
+        _baseUriLength = _uri.length(); 
     }
-
     bool handle(ESP8266WebServer& server, HTTPMethod requestMethod, String requestUri) override {
         if (requestMethod != HTTP_GET)
             return false;
         DEBUGV("StaticRequestHandler::handle: request=%s _uri=%s\r\n", requestUri.c_str(), _uri.c_str());
         if (!requestUri.startsWith(_uri))
-            return false;
+            return false; 
 
-        String path(_path);
-        if (!_isFile) {
+        String path(_path); 
+
+        if(path.endsWith("/")) path += "index.htm";
+
+        if (!_isFile) { 
             // Base URI doesn't point to a file. Append whatever follows this
             // URI in request to get the file path.
-            path += requestUri.substring(_baseUriLength);
+            path += requestUri.substring(_baseUriLength); 
         }
+
         else if (requestUri != _uri) {
             // Base URI points to a file but request doesn't match this URI exactly
             return false;
         }
         DEBUGV("StaticRequestHandler::handle: path=%s, isFile=%d\r\n", path.c_str(), _isFile);
+
+        String contentType = getContentType(path);
+        
+        // look for gz file, only if the original specified path is not a gz.  So part only works to send gzip via content encoding when a non compressed is asked for
+        // if you point the the path to gzip you will serve the gzip as content type "application/x-gzip", not text or javascript etc... 
+        if (!path.endsWith(".gz") && !SPIFFS.exists(path))  { 
+            String pathWithGz = path + ".gz";
+            if(SPIFFS.exists(pathWithGz)) { 
+                path += ".gz";
+                DEBUGV("StaticRequestHandler::handle: Served gz path=%s",path.c_str() ); 
+            }
+        }
+
         File f = _fs.open(path, "r");
         if (!f)
             return false;
 
-        server.streamFile(f, getContentType(path));
+        if (_cache_header.length() != 0) 
+            server.sendHeader("Cache-Control", _cache_header);
+        
+        server.streamFile(f, contentType);
         return true;
     }
 
@@ -81,6 +101,7 @@ public:
         else if (path.endsWith(".xml")) return "text/xml";
         else if (path.endsWith(".pdf")) return "application/pdf";
         else if (path.endsWith(".zip")) return "application/zip";
+        else if(path.endsWith(".gz")) return "application/x-gzip";
         return "application/octet-stream";
     }
 
@@ -88,6 +109,7 @@ protected:
     FS _fs;
     String _uri;
     String _path;
+    String _cache_header; 
     bool _isFile;
     size_t _baseUriLength;
 };

--- a/libraries/ESP8266WiFi/examples/HTTPSRequest/HTTPSRequest.ino
+++ b/libraries/ESP8266WiFi/examples/HTTPSRequest/HTTPSRequest.ino
@@ -14,15 +14,23 @@
 #include <ESP8266WiFi.h>
 #include <WiFiClientSecure.h>
 
-const char* ssid = "........";
-const char* password = "........";
+const char* ssid = "SKY";
+const char* password = "wellcometrust";
 
-const char* host = "api.github.com";
-const int httpsPort = 443;
+//const char* host = "api.github.com";
+//const char* host = "raw.githubusercontent.com";
+//const char * host = "www.google.co.uk";
+const char * host = "test2.tls-o-matic.com"; 
+
+const int httpsPort = 402;
 
 // Use web browser to view and copy
 // SHA1 fingerprint of the certificate
-const char* fingerprint = "CF 05 98 89 CA FF 8E D8 5E 5C E0 C2 E4 F7 E6 C3 C7 50 DD 5C";
+// const char* fingerprint = "CF 05 98 89 CA FF 8E D8 5E 5C E0 C2 E4 F7 E6 C3 C7 50 DD 5C"; // git api
+//const char * fingerprint = "E2 11 20 48 85 00 92 5B F9 56 EE 20 41 AF FC 52 D4 CC 39 1E"; // google
+//const char * fingerprint = "B0 74 BB EF 10 C2 DD 70 89 C8 EA 58 A2 F9 E1 41 00 D3 38 82"; //git raw
+  const char * fingerprint = "B9 1D 9E A7 57 8A 43 BF 8E 15 26 93 09 09 8F E9 3A 5D EE 52";
+
 
 void setup() {
   Serial.begin(115200);
@@ -54,7 +62,10 @@ void setup() {
     Serial.println("certificate doesn't match");
   }
 
-  String url = "/repos/esp8266/Arduino/commits/esp8266/status";
+  //String url = "/repos/esp8266/Arduino/commits/esp8266/status";
+  //String url = "/sticilface/ESPmanager/fixcrashing/examples/Settingsmanager-example/data/jquery.mobile-1.4.5.min.js.gz";
+    String url = ""; 
+  
   Serial.print("requesting URL: ");
   Serial.println(url);
 
@@ -64,22 +75,41 @@ void setup() {
                "Connection: close\r\n\r\n");
 
   Serial.println("request sent");
-  while (client.connected()) {
-    String line = client.readStringUntil('\n');
-    if (line == "\r") {
-      Serial.println("headers received");
-      break;
-    }
-  }
-  String line = client.readStringUntil('\n');
-  if (line.startsWith("{\"state\":\"success\"")) {
-    Serial.println("esp8266/Arduino CI successfull!");
-  } else {
-    Serial.println("esp8266/Arduino CI has failed");
-  }
+
+  
+//  while (client.connected()) {
+//    String line = client.readStringUntil('\n');
+//    if (line == "\r") {
+//      Serial.println("headers received");
+//      break;
+//    }
+//  }
+
+    size_t buf_size = 1024; 
+    uint8_t buf[buf_size];
+    
   Serial.println("reply was:");
   Serial.println("==========");
-  Serial.println(line);
+  
+  
+  
+     String line = client.readStringUntil('\r\n\r\n');
+
+     Serial.print(line);
+     
+//            while (client.available()) {
+//              Serial.print(client.read()); 
+//    
+//            }
+
+//  String line = client.readStringUntil('\n');
+//  if (line.startsWith("{\"state\":\"success\"")) {
+//    Serial.println("esp8266/Arduino CI successfull!");
+//  } else {
+//    Serial.println("esp8266/Arduino CI has failed");
+//  }
+
+  //Serial.println(line);
   Serial.println("==========");
   Serial.println("closing connection");
 }


### PR DESCRIPTION
- Set a Cache Header as const char *, defaults to current behaviour and does not send header.

`  void serveStatic(const char* uri, fs::FS& fs, const char* path, const char* cache_header = NULL );`

- Will serve .gz file if present, but not if a matching unzipped file is present.

- handles root by serving index.htm (not .html files) 
example

`HTTP.serveStatic("/123.htm", SPIFFS, "/123.htm","86400"); ` will serve 123.htm.gz with 24hr cache control

 `HTTP.serveStatic("/123", SPIFFS, "/123","86400"); ` will serve all files in 123 folder, including .gz files if present, with 24hrs cache control. 

 `_HTTP->serveStatic("", SPIFFS, "","86400"); ` will serve everything in SPIFFS with 24hrs cache control 
