### PR TITLE
Changes to static request handler

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -83,8 +83,8 @@ void ESP8266WebServer::_addRequestHandler(RequestHandler* handler) {
     }
 }
 
-void ESP8266WebServer::serveStatic(const char* uri, FS& fs, const char* path) {
-    _addRequestHandler(new StaticRequestHandler(fs, path, uri));
+void ESP8266WebServer::serveStatic(const char* uri, FS& fs, const char* path, const char* cache_header) {
+    _addRequestHandler(new StaticRequestHandler(fs, path, uri, cache_header));
 }
 
 void ESP8266WebServer::handleClient() {

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -69,7 +69,7 @@ public:
   void on(const char* uri, THandlerFunction handler);
   void on(const char* uri, HTTPMethod method, THandlerFunction fn);
   void addHandler(RequestHandler* handler);
-  void serveStatic(const char* uri, fs::FS& fs, const char* path);
+  void serveStatic(const char* uri, fs::FS& fs, const char* path, const char* cache_header = NULL );
   void onNotFound(THandlerFunction fn);  //called when handler is not assigned
   void onFileUpload(THandlerFunction fn); //handle file uploads
 


### PR DESCRIPTION
Try number two: 

As discussed in https://github.com/esp8266/Arduino/issues/999

Allow serving of static SPIFFS files with a cache-control header.  Defaults to nothing, so existing sketches are not broken.  Takes a const char * but is stored as string. 

Also added the ability to serve gz files, and directories.  The handler will serve the original file first if present, then the gzipped one.  Directories can also be served statically with the same rules.  

Examples
```
// serves all SPIFFS with 24hr max-age control
HTTP.serveStatic("", SPIFFS, "","max-age=86400"); 
```
```
// serves all of server directory with no-cache
HTTP.serveStatic("/server", SPIFFS, "/server", "no-cache"); 
```