### PR TITLE
Protect transactions with flag

### DIFF
--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -37,6 +37,7 @@ SPIClass SPI;
 
 SPIClass::SPIClass() {
     useHwCs = false;
+    inTransaction = false;
 }
 
 void SPIClass::begin() {
@@ -74,13 +75,17 @@ void SPIClass::setHwCs(bool use) {
 }
 
 void SPIClass::beginTransaction(SPISettings settings) {
-    while(SPI1CMD & SPIBUSY) {}
+    while(inTransaction || SPI1CMD & SPIBUSY) {
+        yield();
+    }
+    inTransaction = true;
     setFrequency(settings._clock);
     setBitOrder(settings._bitOrder);
     setDataMode(settings._dataMode);
 }
 
 void SPIClass::endTransaction() {
+    inTransaction = false;
 }
 
 void SPIClass::setDataMode(uint8_t dataMode) {

--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -74,6 +74,7 @@ public:
   void endTransaction(void);
 private:
   bool useHwCs;
+  bool inTransaction;
   void writeBytes_(uint8_t * data, uint8_t size);
   void writePattern_(uint8_t * data, uint8_t size, uint8_t repeat);
   void transferBytes_(uint8_t * out, uint8_t * in, uint8_t size);


### PR DESCRIPTION
With soft CS and when called from interrupt, to protect the transaction it is not enough to just wait for the transfer to end.
Added a flag and allow other tasks to run while we wait to begin transaction