### PR TITLE
Fix handling of / to load index.htm

### DIFF
--- a/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
@@ -81,7 +81,7 @@ public:
 
         String path(_path); 
 
-        if(path.endsWith("/")) path += "index.htm";
+        if(requestUri.endsWith("/")) requestUri += "index.htm";
 
         if (!_isFile) { 
             // Base URI doesn't point to a file. Append whatever follows this


### PR DESCRIPTION
Recent changes broke the handling of / leading to index.htm.

Im not sure if changing the requestUri is the best / or valid way to do this.  but it works.  It will just change it on first call to the handle.  
If you prefer, I can make a local copy of the requestUri, append the index.htm if required, then use that throughout the rest of the function?