### PR TITLE
Unique Built-In libraries library.properties name

### DIFF
--- a/libraries/Ethernet/library.properties
+++ b/libraries/Ethernet/library.properties
@@ -1,4 +1,4 @@
-name=Ethernet
+name=Ethernet(esp8266)
 version=1.0.4
 author=Arduino
 maintainer=Arduino <info@arduino.cc>

--- a/libraries/OneWire/library.properties
+++ b/libraries/OneWire/library.properties
@@ -1,0 +1,10 @@
+name=OneWire(esp8266)
+version=2.2
+author=Jim Studt, Tom Pollard, Robin James, Glenn Trewitt, Jason Dangel, Guillermo Lovato, Paul Stoffregen, Scott Roberts, Bertrik Sikken, Mark Tillotson, Ken Butcher, Roger Clark, Love Nystrom
+maintainer=
+sentence=Access 1-wire temperature sensors, memory and other chips. ESP8266 compatible version.
+paragraph=
+category=Communication
+url=
+architectures=esp8266
+

--- a/libraries/SD/library.properties
+++ b/libraries/SD/library.properties
@@ -1,4 +1,4 @@
-name=SD
+name=SD(esp8266)
 version=1.0.5
 author=Arduino, SparkFun
 maintainer=Arduino <info@arduino.cc>

--- a/libraries/Servo/library.properties
+++ b/libraries/Servo/library.properties
@@ -1,4 +1,4 @@
-name=Servo
+name=Servo(esp8266)
 version=1.0.2
 author=Michael C. Miller
 maintainer=GitHub/esp8266/arduino


### PR DESCRIPTION
Use unique name values in library.properties for the esp8266 libraries
that are also Arduino IDE Built-In libraries. This solves the issue of
SD and Servo libraries always appearing as Type: Updatable in the
Arduino IDE 1.6.6 Library Manager when an esp8266 board is selected.