### PR TITLE
core_esp8266_features.h to detect the features and library

### DIFF
--- a/cores/esp8266/core_esp8266_features.h
+++ b/cores/esp8266/core_esp8266_features.h
@@ -1,0 +1,32 @@
+/*
+ core_esp8266_features.h - list of features integrated in to ESP8266 core
+
+ Copyright (c) 2014 Ivan Grokhotkov. All rights reserved.
+ This file is part of the esp8266 core for Arduino environment.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+ */
+
+
+#ifndef CORE_ESP8266_FEATURES_H
+#define CORE_ESP8266_FEATURES_H
+
+
+#define CORE_HAS_LIBB64
+
+
+#endif
+


### PR DESCRIPTION
add core_esp8266_features.h to be able to detect the features and librarys included in the ESP core