### PR TITLE
Always arm the "TX FIFO Empty" interrupt after we write into _tx_buffer.

### DIFF
--- a/cores/esp8266/HardwareSerial.cpp
+++ b/cores/esp8266/HardwareSerial.cpp
@@ -617,18 +617,15 @@ size_t HardwareSerial::write(uint8_t c) {
     size_t room = uart_get_tx_fifo_room(_uart);
     if(room > 0 && _tx_buffer->empty()) {
         uart_transmit_char(_uart, c);
-        if(room < 10) {
-            uart_arm_tx_interrupt(_uart);
-        }
         return 1;
     }
 
     while(_tx_buffer->room() == 0) {
         yield();
-        uart_arm_tx_interrupt(_uart);
     }
 
     _tx_buffer->write(c);
+    uart_arm_tx_interrupt(_uart);
     return 1;
 }
 

--- a/cores/esp8266/cbuf.h
+++ b/cores/esp8266/cbuf.h
@@ -62,7 +62,7 @@ class cbuf {
             if(getSize() == 0) return -1;
 
             char result = *_begin;
-            if(++_begin == _bufend) _begin = _buf;
+            _begin = wrap_if_bufend(_begin + 1);
             return static_cast<int>(result);
         }
 
@@ -78,8 +78,7 @@ class cbuf {
                 dst += top_size;
             }
             memcpy(dst, _begin, size_to_read);
-            _begin += size_to_read;
-            if(_begin == _bufend) _begin = _buf;
+            _begin = wrap_if_bufend(_begin + size_to_read);
             return size_read;
         }
 
@@ -87,7 +86,7 @@ class cbuf {
             if(room() == 0) return 0;
 
             *_end = c;
-            if(++_end == _bufend) _end = _buf;
+            _end = wrap_if_bufend(_end + 1);
             return 1;
         }
 
@@ -103,8 +102,7 @@ class cbuf {
                 src += top_size;
             }
             memcpy(_end, src, size_to_write);
-            _end += size_to_write;
-            if(_end == _bufend) _end = _buf;
+            _end = wrap_if_bufend(_end + size_to_write);
             return size_written;
         }
 
@@ -114,6 +112,10 @@ class cbuf {
         }
 
     private:
+        inline char* wrap_if_bufend(char* ptr) {
+            return (ptr == _bufend) ? _buf : ptr;
+        }
+
         size_t _size;
         char* _buf;
         char* _bufend;

--- a/cores/esp8266/cbuf.h
+++ b/cores/esp8266/cbuf.h
@@ -42,9 +42,6 @@ class cbuf {
             if(_end >= _begin) {
                 return _size - (_end - _begin) - 1;
             }
-            if(_begin == _end) {
-                return _size;
-            }
             return _begin - _end - 1;
         }
 


### PR DESCRIPTION
This avoids a race where the interrupt handler detects an empty _tx_buffer just before we write data into it.

Note that commit d6f62943d4b511e7d5fe6147096c8979890416f5 works around this race when data is continually added to _tx_buffer in the hung state (but is not helpful when there is not new data being added).  This reverts that change here as the race should no longer occur.

Testing performed:
 - set UART_CONF1.txfifo_empty_thrhd=0x70 (which exacerbates the issue)
 - generate a ~240 byte burst of data, sent in back-to-back Serial1.write(, 4) calls, optionally followed by a Serial1.flush()

Test results:
 - before this change, observe occasional unsent data and hang in flush() (when called).
 - after this change, data is sent as expected.