### PR TITLE
Make pgm_read_byte() and pgm_read_word() usable from c.

### DIFF
--- a/cores/esp8266/pgmspace.h
+++ b/cores/esp8266/pgmspace.h
@@ -78,7 +78,7 @@ int	vsnprintf_P(char *str, size_t strSize, PGM_P formatP, va_list ap) __attribut
 (__extension__({                                                               \
     PGM_P __local = (PGM_P)(addr);  /* isolate varible for macro expansion */         \
     ptrdiff_t __offset = ((uint32_t)__local & 0x00000003); /* byte aligned mask */            \
-    const uint32_t* __addr32 = reinterpret_cast<const uint32_t*>(reinterpret_cast<const uint8_t*>(__local)-__offset);   \
+    const uint32_t* __addr32 = (const uint32_t*)((const uint8_t*)(__local)-__offset); \
     uint8_t __result = ((*__addr32) >> (__offset * 8));                        \
     __result;                                                                  \
 }))
@@ -87,7 +87,7 @@ int	vsnprintf_P(char *str, size_t strSize, PGM_P formatP, va_list ap) __attribut
 (__extension__({                                                               \
     PGM_P __local = (PGM_P)(addr); /* isolate varible for macro expansion */          \
     ptrdiff_t __offset = ((uint32_t)__local & 0x00000002);   /* word aligned mask */          \
-    const uint32_t* __addr32 = reinterpret_cast<const uint32_t*>(reinterpret_cast<const uint8_t*>(__local) - __offset); \
+    const uint32_t* __addr32 = (const uint32_t*)((const uint8_t*)(__local) - __offset); \
     uint16_t __result = ((*__addr32) >> (__offset * 8));                       \
     __result;                                                                  \
 }))	


### PR DESCRIPTION
The two defines used reinterpret_cast<> which is only available when
compiling with c++. Now using plain old c casts instead.