### PR TITLE
Modify boards.txt for Sparkfun Thing Dev

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -433,7 +433,7 @@ thing.name=SparkFun ESP8266 Thing
 
 thing.upload.tool=esptool
 thing.upload.speed=921600
-thing.upload.resetmethod=ck
+thing.upload.resetmethod=nodemcu
 thing.upload.maximum_size=434160
 thing.upload.maximum_data_size=81920
 thing.upload.wait_for_upload_port=true


### PR DESCRIPTION
The Sparkfun ESP8266 Thing Dev board currently has the "upload.resetmethod" set to "ck" which is invalid for the hardware, which uses the "nodemcu" reset circuitry.  You can compare the reset circuits here: https://cdn.sparkfun.com/datasheets/Wireless/WiFi/ESP8266-Thing-Dev-v10.pdf and https://raw.githubusercontent.com/nodemcu/nodemcu-devkit/master/Documents/NODEMCU_DEVKIT_SCH.png

Sparkfun: 
![image](https://cloud.githubusercontent.com/assets/5554710/11818717/9348e52e-a321-11e5-87f4-7a51dca51702.png)

Node MCU:
![image](https://cloud.githubusercontent.com/assets/5554710/11818743/adfb32fa-a321-11e5-85e3-a45ddbe80f1a.png)

Without this change, the Thing Dev board will not program correctly unless it is power cycled with GPIO0 held to ground.  After this change, the board resets, programs, and runs correctly, without any manual jumper or reset operations.