### PR TITLE
fix #1244 - MD5 handling

### DIFF
--- a/cores/esp8266/Updater.cpp
+++ b/cores/esp8266/Updater.cpp
@@ -57,7 +57,7 @@ bool UpdaterClass::begin(size_t size, int command) {
     return false;
   }
 
-  if(ESP.checkFlashConfig(false)) {
+  if(!ESP.checkFlashConfig(false)) {
     _error = UPDATE_ERROR_FLASH_CONFIG;
 #ifdef DEBUG_UPDATER
     printError(DEBUG_UPDATER);

--- a/cores/esp8266/Updater.cpp
+++ b/cores/esp8266/Updater.cpp
@@ -124,9 +124,13 @@ bool UpdaterClass::begin(size_t size, int command) {
   return true;
 }
 
-void UpdaterClass::setMD5(const char * expected_md5){
-  if(strlen(expected_md5) != 32) return;
+bool UpdaterClass::setMD5(const char * expected_md5){
+  if(strlen(expected_md5) != 32)
+  {
+    return false;
+  }
   _target_md5 = expected_md5;
+  return true;
 }
 
 bool UpdaterClass::end(bool evenIfRemaining){
@@ -160,6 +164,7 @@ bool UpdaterClass::end(bool evenIfRemaining){
 #ifdef DEBUG_UPDATER
       DEBUG_UPDATER.printf("MD5 Failed: expected:%s, calculated:%s\n", _target_md5.c_str(), _md5.toString().c_str());
 #endif
+      _reset();
       return false;
     }
 #ifdef DEBUG_UPDATER

--- a/cores/esp8266/Updater.h
+++ b/cores/esp8266/Updater.h
@@ -65,7 +65,7 @@ class UpdaterClass {
     /*
       sets the expected MD5 for the firmware (hexString)
     */
-    void setMD5(const char * expected_md5);
+    bool setMD5(const char * expected_md5);
 
     /*
       returns the MD5 String of the sucessfully ended firmware

--- a/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.cpp
+++ b/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.cpp
@@ -296,7 +296,11 @@ bool ESP8266HTTPUpdate::runUpdate(Stream& in, uint32_t size, String md5, int com
     }
 
     if(md5.length()) {
-        Update.setMD5(md5.c_str());
+        if(!Update.setMD5(md5.c_str())) {
+            lastError = HTTP_UE_SERVER_FAULTY_MD5;
+            DEBUG_HTTP_UPDATE("[httpUpdate] Update.setMD5 failed! (%s)\n", md5.c_str());
+            return false;
+        }
     }
 
     if(Update.writeStream(in) != size) {

--- a/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.h
+++ b/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.h
@@ -44,6 +44,7 @@
 #define HTTP_UE_SERVER_FILE_NOT_FOUND   (-102)
 #define HTTP_UE_SERVER_FORBIDDEN        (-103)
 #define HTTP_UE_SERVER_WRONG_HTTP_CODE  (-104)
+#define HTTP_UE_SERVER_FAULTY_MD5       (-105)
 
 typedef enum {
     HTTP_UPDATE_FAILED,


### PR DESCRIPTION
- setMD5 has now returns bool
- handle setMD5 failed in HTTP update
- reset UpdaterClass when MD5 check failed
see: #1244