### PR TITLE
handle short writes

### DIFF
--- a/cores/esp8266/StreamString.cpp
+++ b/cores/esp8266/StreamString.cpp
@@ -25,14 +25,10 @@
 
 size_t StreamString::write(const uint8_t *buffer, size_t size) {
     if(reserve(length() + size + 1)) {
-        for(size_t i = 0; i < size; i++) {
-            if(write(*buffer)) {
-                buffer++;
-            } else {
-                return i;
-            }
-        }
-
+        const uint8_t *s = buffer;
+        const uint8_t *end = buffer + size;
+        while(write(*s++) && s < end);
+        return s - buffer;
     }
     return 0;
 }

--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -363,7 +363,12 @@ int HTTPClient::sendRequest(const char * type, Stream * stream, size_t size) {
                 int c = stream->readBytes(buff, ((s > buff_size) ? buff_size : s));
 
                 // write it to Stream
-                bytesWritten += _tcp->write((const uint8_t *) buff, c);
+                int w = _tcp->write((const uint8_t *) buff, c);
+                if(w != c) {
+                    DEBUG_HTTPCLIENT("[HTTP-Client][sendRequest] short write asked for %d but got %d\n", c, w);
+                    break;
+                }
+                bytesWritten += c;
 
                 if(len > 0) {
                     len -= c;
@@ -470,7 +475,12 @@ int HTTPClient::writeToStream(Stream * stream) {
                 int c = _tcp->readBytes(buff, ((size > buff_size) ? buff_size : size));
 
                 // write it to Stream
-                bytesWritten += stream->write(buff, c);
+                int w = stream->write(buff, c);
+                if(w != c) {
+                    DEBUG_HTTPCLIENT("[HTTP-Client][writeToStream] short write asked for %d but got %d\n", c, w);
+                    break;
+                }
+                bytesWritten += c;
 
                 if(len > 0) {
                     len -= c;


### PR DESCRIPTION
Calling HTTPClient->getString() would call writeStream and this report back a short write on success because StreamString returns 0 on success.