### PR TITLE
Allow setting TCP timeout

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -50,6 +50,7 @@ HTTPClient::HTTPClient() {
     _returnCode = 0;
     _size = -1;
     _canReuse = false;
+	_tcpTimeout = HTTPCLIENT_DEFAULT_TCP_TIMEOUT;
 
 }
 
@@ -250,6 +251,14 @@ void HTTPClient::setAuthorization(const char * auth) {
     if(auth) {
         _base64Authorization = auth;
     }
+}
+
+/**
+ * set the timeout for the TCP connection
+  * @param timeout unsigned int
+ */
+void HTTPClient::setTimeout(uint16_t timeout) {
+    _tcpTimeout = timeout;
 }
 
 /**
@@ -673,7 +682,7 @@ bool HTTPClient::connect(void) {
     }
 
     // set Timeout for readBytesUntil and readStringUntil
-    _tcp->setTimeout(HTTPCLIENT_TCP_TIMEOUT);
+    _tcp->setTimeout(_tcpTimeout);
 
 #ifdef ESP8266
     _tcp->setNoDelay(true);

--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -259,6 +259,9 @@ void HTTPClient::setAuthorization(const char * auth) {
  */
 void HTTPClient::setTimeout(uint16_t timeout) {
     _tcpTimeout = timeout;
+    if(connected()) {
+        _tcp->setTimeout(timeout);
+    }
 }
 
 /**

--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.h
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.h
@@ -31,7 +31,7 @@
 #define DEBUG_HTTPCLIENT(...)
 #endif
 
-#define HTTPCLIENT_TCP_TIMEOUT (1000)
+#define HTTPCLIENT_DEFAULT_TCP_TIMEOUT (1000)
 
 /// HTTP client errors
 #define HTTPC_ERROR_CONNECTION_REFUSED  (-1)
@@ -127,6 +127,7 @@ class HTTPClient {
         void setUserAgent(const char * userAgent);
         void setAuthorization(const char * user, const char * password);
         void setAuthorization(const char * auth);
+        void setTimeout(uint16_t timeout);
 
         /// request handling
         int GET();
@@ -170,7 +171,7 @@ class HTTPClient {
         String _host;
         uint16_t _port;
         bool _reuse;
-
+        uint16_t _tcpTimeout;
 
         String _url;
         bool _https;


### PR DESCRIPTION
Added method to set TCP timeout for connect on HTTP requests. Not sure if its worth allowing this to be set at runtime though, but it was useful in one of my own projects.