### PR TITLE
fix warnings in ESP8266WiFi

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFi.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFi.cpp
@@ -725,7 +725,7 @@ wl_status_t ESP8266WiFiClass::status()
       return WL_DISCONNECTED;
 }
 
-void wifi_dns_found_callback(const char *name, ip_addr_t *ipaddr, void *callback_arg)
+static void wifi_dns_found_callback(const char *, ip_addr_t *ipaddr, void *callback_arg)
 {
     if (ipaddr)
         (*reinterpret_cast<IPAddress*>(callback_arg)) = ipaddr->addr;

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp
@@ -121,11 +121,11 @@ wl_status_t ESP8266WiFiMulti::run(void) {
                 }
 
                 IPAddress ip;
-                uint8_t * mac;
+                DEBUG_WIFI_MULTI(uint8_t * mac);
                 switch(status) {
                     case WL_CONNECTED:
                         ip = WiFi.localIP();
-                        mac = WiFi.BSSID();
+                        DEBUG_WIFI_MULTI(mac = WiFi.BSSID());
                         DEBUG_WIFI_MULTI("[WIFI] Connecting done.\n");
                         DEBUG_WIFI_MULTI("[WIFI] SSID: %s\n", WiFi.SSID());
                         DEBUG_WIFI_MULTI("[WIFI] IP: %d.%d.%d.%d\n", ip[0], ip[1], ip[2], ip[3]);

--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -134,7 +134,7 @@ int WiFiClient::connect(IPAddress ip, uint16_t port)
     return 0;
 }
 
-int8_t WiFiClient::_connected(void* pcb, int8_t err)
+int8_t WiFiClient::_connected(void* pcb, int8_t)
 {
     tcp_pcb* tpcb = reinterpret_cast<tcp_pcb*>(pcb);
     _client = new ClientContext(tpcb, 0, 0);
@@ -143,7 +143,7 @@ int8_t WiFiClient::_connected(void* pcb, int8_t err)
     return ERR_OK;
 }
 
-void WiFiClient::_err(int8_t err)
+void WiFiClient::_err(int8_t DEBUGV(err))
 {
     DEBUGV(":err %d\r\n", err);
     esp_schedule();

--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
@@ -474,7 +474,7 @@ extern "C" int ax_port_write(int fd, uint8_t* buffer, size_t count) {
     return cb;
 }
 
-extern "C" int ax_get_file(const char *filename, uint8_t **buf) {
+extern "C" int ax_get_file(const char *, uint8_t **buf) {
     *buf = 0;
     return 0;
 }
@@ -486,15 +486,16 @@ extern "C" int ax_get_file(const char *filename, uint8_t **buf) {
 #define DEBUG_TLS_MEM_PRINT(...)
 #endif
 
-extern "C" void* ax_port_malloc(size_t size, const char* file, int line) {
+extern "C" void* ax_port_malloc(size_t size, const char* DEBUG_TLS_MEM_PRINT(file), int DEBUG_TLS_MEM_PRINT(line)) {
     void* result = malloc(size);
 
     if (result == nullptr) {
         DEBUG_TLS_MEM_PRINT("%s:%d malloc %d failed, left %d\r\n", file, line, size, ESP.getFreeHeap());
         panic();
     }
-    if (size >= 1024)
+    if (size >= 1024) {
         DEBUG_TLS_MEM_PRINT("%s:%d malloc %d, left %d\r\n", file, line, size, ESP.getFreeHeap());
+    }
     return result;
 }
 
@@ -504,14 +505,15 @@ extern "C" void* ax_port_calloc(size_t size, size_t count, const char* file, int
     return result;
 }
 
-extern "C" void* ax_port_realloc(void* ptr, size_t size, const char* file, int line) {
+extern "C" void* ax_port_realloc(void* ptr, size_t size, const char* DEBUG_TLS_MEM_PRINT(file), int DEBUG_TLS_MEM_PRINT(line)) {
     void* result = realloc(ptr, size);
     if (result == nullptr) {
         DEBUG_TLS_MEM_PRINT("%s:%d realloc %d failed, left %d\r\n", file, line, size, ESP.getFreeHeap());
         panic();
     }
-    if (size >= 1024)
+    if (size >= 1024) {
         DEBUG_TLS_MEM_PRINT("%s:%d realloc %d, left %d\r\n", file, line, size, ESP.getFreeHeap());
+    }
     return result;
 }
 
@@ -519,6 +521,7 @@ extern "C" void ax_port_free(void* ptr) {
     free(ptr);
     uint32_t *p = (uint32_t*) ptr;
     size_t size = p[-3];
-    if (size >= 1024)
+    if (size >= 1024) {
         DEBUG_TLS_MEM_PRINT("free %d, left %d\r\n", p[-3], ESP.getFreeHeap());
+    }
 }

--- a/libraries/ESP8266WiFi/src/include/ClientContext.h
+++ b/libraries/ESP8266WiFi/src/include/ClientContext.h
@@ -241,7 +241,7 @@ class ClientContext {
 
     private:
 
-        err_t _sent(tcp_pcb* pcb, uint16_t len) {
+        err_t _sent(tcp_pcb*, uint16_t len) {
             DEBUGV(":sent %d\r\n", len);
             _size_sent -= len;
             if(_size_sent == 0 && _send_waiting) esp_schedule();
@@ -269,7 +269,7 @@ class ClientContext {
             }
         }
 
-        err_t _recv(tcp_pcb* pcb, pbuf* pb, err_t err) {
+        err_t _recv(tcp_pcb*, pbuf* pb, err_t DEBUGV(err)) {
 
             if(pb == 0) // connection closed
             {
@@ -290,7 +290,7 @@ class ClientContext {
             return ERR_OK;
         }
 
-        void _error(err_t err) {
+        void _error(err_t DEBUGV(err)) {
             DEBUGV(":er %d %d %d\r\n", err, _size_sent, _send_waiting);
             tcp_arg(_pcb, NULL);
             tcp_sent(_pcb, NULL);
@@ -302,7 +302,7 @@ class ClientContext {
             }
         }
 
-        err_t _poll(tcp_pcb* pcb) {
+        err_t _poll(tcp_pcb*) {
             return ERR_OK;
         }
 


### PR DESCRIPTION
Fixing some miscellaneous warnings in ESP8266WiFi.

I found that the functions with conditionals around DEBUG_TLS_MEM_PRINT were erroneous since they actually put an if statement around the final return of a function.