### PR TITLE
Fixes for poor HardwareSerial performance/crashes exacerbated by SDK1.5

### DIFF
--- a/cores/esp8266/HardwareSerial.cpp
+++ b/cores/esp8266/HardwareSerial.cpp
@@ -485,7 +485,7 @@ int uart_get_debug() {
 // ####################################################################################################
 
 HardwareSerial::HardwareSerial(int uart_nr) :
-        _uart_nr(uart_nr), _uart(0), _tx_buffer(0), _rx_buffer(0), _written(false) {
+        _uart_nr(uart_nr), _uart(0), _tx_buffer(0), _rx_buffer(0) {
 }
 
 void HardwareSerial::begin(unsigned long baud, byte config, byte mode) {
@@ -519,7 +519,6 @@ void HardwareSerial::begin(unsigned long baud, byte config, byte mode) {
             _uart->txEnabled = false;
         }
     }
-    _written = false;
     delay(1);
 
     uart_finish_init(_uart);
@@ -626,8 +625,6 @@ void HardwareSerial::flush() {
         return;
     if(!_uart->txEnabled)
         return;
-    if(!_written)
-        return;
 
     const int uart_nr = _uart->uart_nr;
     while(true) {
@@ -643,13 +640,11 @@ void HardwareSerial::flush() {
         }
         yield();
     }
-    _written = false;
 }
 
 size_t HardwareSerial::write(uint8_t c) {
     if(_uart == 0 || !_uart->txEnabled)
         return 0;
-    _written = true;
 
     bool tx_now = false;
     const int uart_nr = _uart->uart_nr;

--- a/cores/esp8266/HardwareSerial.cpp
+++ b/cores/esp8266/HardwareSerial.cpp
@@ -636,6 +636,9 @@ void HardwareSerial::flush() {
             if(_tx_buffer->getSize() == 0 &&
                UART_GET_TX_FIFO_ROOM(uart_nr) >= UART_TX_FIFO_SIZE) {
                 break;
+            } else if(il.savedInterruptLevel() > 0) {
+                _tx_empty_irq();
+                continue;
             }
         }
         yield();
@@ -663,6 +666,9 @@ size_t HardwareSerial::write(uint8_t c) {
                 break;
             } else if(_tx_buffer->write(c)) {
                 break;
+            } else if(il.savedInterruptLevel() > 0) {
+                _tx_empty_irq();
+                continue;
             }
         }
         yield();

--- a/cores/esp8266/HardwareSerial.cpp
+++ b/cores/esp8266/HardwareSerial.cpp
@@ -133,13 +133,7 @@ void ICACHE_RAM_ATTR uart_interrupt_handler(uart_t* uart) {
     }
 
     // -------------- UART 1 --------------
-
-    if(Serial1.isRxEnabled()) {
-        while(U1IS & (1 << UIFF)) {
-            Serial1._rx_complete_irq((char) (U1F & 0xff));
-            U1IC = (1 << UIFF);
-        }
-    }
+    // Note: only TX is supported on UART 1.
     if(Serial1.isTxEnabled()) {
         if(U1IS & (1 << UIFE)) {
             U1IC = (1 << UIFE);
@@ -294,6 +288,7 @@ uart_t* uart_init(int uart_nr, int baudrate, byte config, byte mode) {
             IOSWAP &= ~(1 << IOSWAPU0);
             break;
         case UART1:
+            // Note: uart_interrupt_handler does not support RX on UART 1.
             uart->rxEnabled = false;
             uart->txEnabled = (mode != SERIAL_RX_ONLY);
             uart->rxPin = 255;

--- a/cores/esp8266/HardwareSerial.cpp
+++ b/cores/esp8266/HardwareSerial.cpp
@@ -627,12 +627,13 @@ size_t HardwareSerial::write(uint8_t c) {
         return 0;
     _written = true;
 
+    bool tx_now = false;
     while(true) {
         {
             InterruptLock il;
             if(_tx_buffer->empty()) {
                 if(uart_get_tx_fifo_room(_uart) > 0) {
-                    uart_transmit_char(_uart, c);
+                    tx_now = true;
                 } else {
                     _tx_buffer->write(c);
                     uart_arm_tx_interrupt(_uart);
@@ -643,6 +644,9 @@ size_t HardwareSerial::write(uint8_t c) {
             }
         }
         yield();
+    }
+    if (tx_now) {
+        uart_transmit_char(_uart, c);
     }
     return 1;
 }

--- a/cores/esp8266/HardwareSerial.h
+++ b/cores/esp8266/HardwareSerial.h
@@ -117,7 +117,6 @@ class HardwareSerial: public Stream {
         uart_t* _uart;
         cbuf* _tx_buffer;
         cbuf* _rx_buffer;
-        bool _written;
 };
 
 extern HardwareSerial Serial;

--- a/cores/esp8266/cbuf.cpp
+++ b/cores/esp8266/cbuf.cpp
@@ -1,0 +1,46 @@
+/* 
+ cbuf.cpp - Circular buffer implementation
+ Copyright (c) 2014 Ivan Grokhotkov. All rights reserved.
+ This file is part of the esp8266 core for Arduino environment.
+ 
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "cbuf.h"
+#include "c_types.h"
+
+size_t ICACHE_RAM_ATTR cbuf::getSize() const {
+    if(_end >= _begin) {
+        return _end - _begin;
+    }
+    return _size - (_begin - _end);
+}
+
+int ICACHE_RAM_ATTR cbuf::read() {
+    if(empty()) return -1;
+
+    char result = *_begin;
+    _begin = wrap_if_bufend(_begin + 1);
+    return result; 
+    return static_cast<int>(result);
+}
+
+size_t ICACHE_RAM_ATTR cbuf::write(char c) {
+     if(full()) return 0;
+
+     *_end = c;
+     _end = wrap_if_bufend(_end + 1);
+     return 1;
+}

--- a/cores/esp8266/cbuf.cpp
+++ b/cores/esp8266/cbuf.cpp
@@ -33,7 +33,6 @@ int ICACHE_RAM_ATTR cbuf::read() {
 
     char result = *_begin;
     _begin = wrap_if_bufend(_begin + 1);
-    return result; 
     return static_cast<int>(result);
 }
 

--- a/cores/esp8266/cbuf.h
+++ b/cores/esp8266/cbuf.h
@@ -21,7 +21,10 @@
 #ifndef __cbuf_h
 #define __cbuf_h
 
+#include <stddef.h>
 #include <stdint.h>
+#include <string.h>
+
 class cbuf {
     public:
         cbuf(size_t size) :
@@ -32,11 +35,7 @@ class cbuf {
             delete[] _buf;
         }
 
-        size_t getSize() const {
-            if(_end >= _begin) return _end - _begin;
-
-            return _size - (_begin - _end);
-        }
+        size_t getSize() const;
 
         size_t room() const {
             if(_end >= _begin) {
@@ -59,13 +58,7 @@ class cbuf {
             return static_cast<int>(*_begin);
         }
 
-        int read() {
-            if(empty()) return -1;
-
-            char result = *_begin;
-            _begin = wrap_if_bufend(_begin + 1);
-            return static_cast<int>(result);
-        }
+        int read();
 
         size_t read(char* dst, size_t size) {
             size_t bytes_available = getSize();
@@ -83,13 +76,7 @@ class cbuf {
             return size_read;
         }
 
-        size_t write(char c) {
-            if(full()) return 0;
-
-            *_end = c;
-            _end = wrap_if_bufend(_end + 1);
-            return 1;
-        }
+        size_t write(char c);
 
         size_t write(const char* src, size_t size) {
             size_t bytes_available = room();

--- a/cores/esp8266/cbuf.h
+++ b/cores/esp8266/cbuf.h
@@ -45,18 +45,22 @@ class cbuf {
             return _begin - _end - 1;
         }
 
-        bool empty() const {
+        inline bool empty() const {
             return _begin == _end;
         }
 
+        inline bool full() const {
+            return wrap_if_bufend(_end + 1) == _begin;
+        }
+
         int peek() {
-            if(_end == _begin) return -1;
+            if(empty()) return -1;
 
             return static_cast<int>(*_begin);
         }
 
         int read() {
-            if(getSize() == 0) return -1;
+            if(empty()) return -1;
 
             char result = *_begin;
             _begin = wrap_if_bufend(_begin + 1);
@@ -80,7 +84,7 @@ class cbuf {
         }
 
         size_t write(char c) {
-            if(room() == 0) return 0;
+            if(full()) return 0;
 
             *_end = c;
             _end = wrap_if_bufend(_end + 1);
@@ -109,7 +113,7 @@ class cbuf {
         }
 
     private:
-        inline char* wrap_if_bufend(char* ptr) {
+        inline char* wrap_if_bufend(char* ptr) const {
             return (ptr == _bufend) ? _buf : ptr;
         }
 

--- a/cores/esp8266/interrupts.h
+++ b/cores/esp8266/interrupts.h
@@ -31,6 +31,10 @@ public:
         xt_wsr_ps(_state);
     }
 
+    uint32_t savedInterruptLevel() const {
+        return _state & 0x0f;
+    }
+
 protected:
     uint32_t _state;
 };

--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -38,7 +38,6 @@ extern "C"
 #include "lwip/tcp.h"
 #include "lwip/inet.h"
 #include "lwip/netif.h"
-#include "cbuf.h"
 #include "include/ClientContext.h"
 #include "c_types.h"
 

--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
@@ -37,7 +37,6 @@ extern "C"
 #include "lwip/tcp.h"
 #include "lwip/inet.h"
 #include "lwip/netif.h"
-#include "cbuf.h"
 #include "include/ClientContext.h"
 #include "c_types.h"
 

--- a/libraries/ESP8266WiFi/src/WiFiServer.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiServer.cpp
@@ -35,7 +35,6 @@ extern "C" {
 #include "lwip/opt.h"
 #include "lwip/tcp.h"
 #include "lwip/inet.h"
-#include "cbuf.h"
 #include "include/ClientContext.h"
 
 WiFiServer::WiFiServer(IPAddress addr, uint16_t port)


### PR DESCRIPTION
After SDK 1.5, libraries like NeoPixelBus which use the UART to generate timing signals stopped working correctly (logic analyser shows large intercharacter delays) as well as experiencing crashes in the IRQ handler.  This series of commits should up many of these issues.