### PR TITLE
Fixed crash bug with mDNS

### DIFF
--- a/libraries/ESP8266mDNS/ESP8266mDNS.cpp
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.cpp
@@ -495,7 +495,7 @@ void MDNSResponder::_reply(uint8_t replyMask, char * service, char *proto, uint1
   size_t hostNameLen = hostName.length();
 
   char underscore[]  = "_";
-
+ 
   // build service name with _
   char serviceName[os_strlen(service)+2];
   os_strcpy(serviceName,underscore);

--- a/libraries/ESP8266mDNS/ESP8266mDNS.cpp
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.cpp
@@ -290,7 +290,8 @@ void MDNSResponder::_parsePacket(){
   uint16_t servicePort = 0;
 
   char protoName[32];
-  uint8_t protoNameLen;
+  protoName[0] = 0;
+  uint8_t protoNameLen = 0;
 
   uint16_t packetHeader[6];
 
@@ -330,7 +331,7 @@ void MDNSResponder::_parsePacket(){
     serviceName[serviceNameLen] = '\0';
 
     if(serviceName[0] == '_'){
-      memcpy(serviceName, serviceName+1, serviceNameLen);
+      memmove(serviceName, serviceName+1, serviceNameLen);
       serviceNameLen--;
       serviceParsed = true;
     } else if(serviceNameLen == 5 && strcmp("local", serviceName) == 0){
@@ -362,7 +363,7 @@ void MDNSResponder::_parsePacket(){
     _conn_readS(protoName, protoNameLen);
     protoName[protoNameLen] = '\0';
     if(protoNameLen == 4 && protoName[0] == '_'){
-      memcpy(protoName, protoName+1, protoNameLen);
+      memmove(protoName, protoName+1, protoNameLen);
       protoNameLen--;
       protoParsed = true;
     } else {


### PR DESCRIPTION
The character buffer protoName, created on the stack in the function MDNSResponder::_parsePacket(), is uninitialized. It can remain uninitialized all the way to the bottom of that function, where it is passed to the function MDNSResponder::_reply. 

In MDNSResponder::_reply, the pointer passed in is named 'proto'.  You will will find these lines of code near the top of that function...

    //build proto name with _
    char protoName[5];
    os_strcpy(protoName,underscore);
    os_strcat(protoName, proto);
    size_t protoNameLen = 4; 

You can see there that if proto points to an uninitialized character buffer on the stack, the strcat call can blow way the stack.

I was getting random crashes when a client tried to connect to my esp8266 server using the 'server.local' host name. Those crashes have disappeared since I made this change.

Oh... one more thing... I changed a few memcpy to memmove calls where the source and destination overlap. Not sure that was causing a problem, but I believe memcpy does not guarantee correct results if the source and destination overlap. 