### PR TITLE
Improvements for MD5Builder with Stream

### DIFF
--- a/cores/esp8266/FS.h
+++ b/cores/esp8266/FS.h
@@ -59,7 +59,9 @@ public:
     int read() override;
     int peek() override;
     void flush() override;
-
+    size_t readBytes(char *buffer, size_t length)  override {
+        return read((uint8_t*)buffer, length);
+    }
     size_t read(uint8_t* buf, size_t size);
     bool seek(uint32_t pos, SeekMode mode);
     size_t position() const;

--- a/cores/esp8266/MD5Builder.cpp
+++ b/cores/esp8266/MD5Builder.cpp
@@ -23,6 +23,46 @@ void MD5Builder::addHexString(const char * data){
   free(tmp);
 }
 
+bool MD5Builder::addStream(Stream & stream, const int total_len) {
+    const int buf_size = 512;
+    int bytesleft = total_len;
+    uint8_t * buf = (uint8_t*) malloc(buf_size);
+    if(buf) {
+        while((stream.available() > -1) && (bytesleft > 0)) {
+
+            // get available data size
+            int sizeAvailable = stream.available();
+            if(sizeAvailable) {
+                int readBytes = sizeAvailable;
+
+                // read only the asked bytes
+                if(readBytes > bytesleft) {
+                    readBytes = bytesleft ;
+                }
+
+                // not read more the buffer can handle
+                if(readBytes > buf_size) {
+                    readBytes = buf_size;
+                }
+
+                // read data  
+                int bytesread = stream.readBytes(buf, readBytes);
+                bytesleft -= bytesread;
+                if(bytesread > 0) {
+                    MD5Update(&_ctx, buf, bytesread);
+                }
+            }
+            // time for network streams
+            delay(0);
+        }
+        // not free null ptr
+        free(buf);
+        return (bytesleft == 0);
+    } else {
+        return false;
+    }
+}
+
 void MD5Builder::calculate(void){
   MD5Final(_buf, &_ctx);
 }

--- a/cores/esp8266/MD5Builder.h
+++ b/cores/esp8266/MD5Builder.h
@@ -37,6 +37,7 @@ class MD5Builder {
     void addHexString(const char * data);
     void addHexString(char * data){ addHexString((const char*)data); }
     void addHexString(String data){ addHexString(data.c_str()); }
+    void addStream(Stream & stream, size_t len);
     void calculate(void);
     void getBytes(uint8_t * output);
     void getChars(char * output);

--- a/cores/esp8266/Stream.h
+++ b/cores/esp8266/Stream.h
@@ -87,8 +87,8 @@ class Stream: public Print {
 
         float parseFloat();               // float version of parseInt
 
-        size_t readBytes(char *buffer, size_t length); // read chars from stream into buffer
-        size_t readBytes(uint8_t *buffer, size_t length) {
+        virtual size_t readBytes(char *buffer, size_t length); // read chars from stream into buffer
+        virtual size_t readBytes(uint8_t *buffer, size_t length) {
             return readBytes((char *) buffer, length);
         }
         // terminates if length characters have been read or timeout (see setTimeout)


### PR DESCRIPTION
Addition of addStream(Stream, length) to MD5 builder
Changes to FS to allow super fast readBytes.  
These changes drop ReadBytes of a 20K file from 1400ms to 63ms, so worth having. 

Sorry for the new pull request, couldn't squash commits i'd pushed... tried... 