### PR TITLE
A content length of zero should also be sent

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -213,11 +213,10 @@ void ESP8266WebServer::_prepareHeader(String& response, int code, const char* co
         content_type = "text/html";
 
     sendHeader("Content-Type", content_type, true);
-    if (_contentLength != CONTENT_LENGTH_UNKNOWN && _contentLength != CONTENT_LENGTH_NOT_SET) {
-        sendHeader("Content-Length", String(_contentLength));
-    }
-    else if (contentLength > 0){
+    if (_contentLength == CONTENT_LENGTH_NOT_SET) {
         sendHeader("Content-Length", String(contentLength));
+    } else if (_contentLength != CONTENT_LENGTH_UNKNOWN) {
+        sendHeader("Content-Length", String(_contentLength));
     }
     sendHeader("Connection", "close");
     sendHeader("Access-Control-Allow-Origin", "*");


### PR DESCRIPTION
This is needed since when the content-length header is not sent the clients will
wait for data anyways. Sending a content length of zero will tell the client not
to expect any content and it will close the connection immediately.

Since size_t is unsigned, checking if the content-length is >=0 seems redundant.