### PR TITLE
Fix typo causing crash on missing uri scheme

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -107,7 +107,7 @@ void HTTPClient::begin(String url, String httpsFingerprint) {
     int index = url.indexOf(':');
     //int index2;
     bool hasPort = false;
-    if(index) {
+    if(index >= 0) {
         protocol = url.substring(0, index);
         url.remove(0, (index + 3)); // remove http:// or https://
 


### PR DESCRIPTION
Http Client isn't appropriately validating the presence of an uri scheme.