### PR TITLE
WebServer: handle initial read/close timeouts asynchronously

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -80,6 +80,7 @@ ESP8266WebServer::~ESP8266WebServer() {
 }
 
 void ESP8266WebServer::begin() {
+  _currentStatus = HC_NONE;
   _server.begin();
   if(!_headerKeysCount)
     collectHeaders(0, 0);
@@ -155,28 +156,67 @@ void ESP8266WebServer::serveStatic(const char* uri, FS& fs, const char* path, co
 }
 
 void ESP8266WebServer::handleClient() {
-  WiFiClient client = _server.available();
-  if (!client) {
-    return;
-  }
+  if (_currentStatus == HC_NONE) {
+    WiFiClient client = _server.available();
+    if (!client) {
+      return;
+    }
 
 #ifdef DEBUG_ESP_HTTP_SERVER
-  DEBUG_OUTPUT.println("New client");
+    DEBUG_OUTPUT.println("New client");
 #endif
 
-  // Wait for data from client to become available
-  uint16_t maxWait = HTTP_MAX_DATA_WAIT;
-  while(client.connected() && !client.available() && maxWait--){
-    delay(1);
+    _currentClient = client;
+    _currentStatus = HC_WAIT_READ;
+    _statusChange = millis();
   }
 
-  if (!_parseRequest(client)) {
+  if (!_currentClient.connected()) {
+    _currentClient = WiFiClient();
+    _currentStatus = HC_NONE;
     return;
   }
 
-  _currentClient = client;
-  _contentLength = CONTENT_LENGTH_NOT_SET;
-  _handleRequest();
+  // Wait for data from client to become available
+  if (_currentStatus == HC_WAIT_READ) {
+    if (!_currentClient.available()) {
+      if (millis() - _statusChange > HTTP_MAX_DATA_WAIT) {
+        _currentClient = WiFiClient();
+        _currentStatus = HC_NONE;
+      }
+      yield();
+      return;
+    }
+
+    if (!_parseRequest(_currentClient)) {
+      _currentClient = WiFiClient();
+      _currentStatus = HC_NONE;
+      return;
+    }
+
+    _contentLength = CONTENT_LENGTH_NOT_SET;
+    _handleRequest();
+
+    if (!_currentClient.connected()) {
+      _currentClient = WiFiClient();
+      _currentStatus = HC_NONE;
+      return;
+    } else {
+      _currentStatus = HC_WAIT_CLOSE;
+      _statusChange = millis();
+      return;
+    }
+  }
+
+  if (_currentStatus == HC_WAIT_CLOSE) {
+    if (millis() - _statusChange > HTTP_MAX_CLOSE_WAIT) {
+      _currentClient = WiFiClient();
+      _currentStatus = HC_NONE;
+    } else {
+      yield();
+      return;
+    }
+  }
 }
 
 void ESP8266WebServer::close() {
@@ -443,12 +483,7 @@ void ESP8266WebServer::_handleRequest() {
     }
   }
 
-  uint16_t maxWait = HTTP_MAX_CLOSE_WAIT;
-  while(_currentClient.connected() && maxWait--) {
-    delay(1);
-  }
-  _currentClient   = WiFiClient();
-  _currentUri      = String();
+  _currentUri = String();
 }
 
 const char* ESP8266WebServer::_responseCodeToString(int code) {

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -29,6 +29,7 @@
 enum HTTPMethod { HTTP_ANY, HTTP_GET, HTTP_POST, HTTP_PUT, HTTP_PATCH, HTTP_DELETE, HTTP_OPTIONS };
 enum HTTPUploadStatus { UPLOAD_FILE_START, UPLOAD_FILE_WRITE, UPLOAD_FILE_END,
                         UPLOAD_FILE_ABORTED };
+enum HTTPClientStatus { HC_NONE, HC_WAIT_READ, HC_WAIT_CLOSE };
 
 #define HTTP_DOWNLOAD_UNIT_SIZE 1460
 #define HTTP_UPLOAD_BUFLEN 2048
@@ -151,6 +152,8 @@ protected:
   WiFiClient  _currentClient;
   HTTPMethod  _currentMethod;
   String      _currentUri;
+  HTTPClientStatus _currentStatus;
+  unsigned long _statusChange;
 
   RequestHandler*  _currentHandler;
   RequestHandler*  _firstHandler;


### PR DESCRIPTION
If there is a delay before data becomes available on a new connection
then the handler function blocks for up to 1 second, and there's another
wait on connection close for up to 2 seconds.

This doesn't make the whole server process asynchronous (there is another
delay between headers/data) but it helps when there are other events
that need attention while handling web requests.