### PR TITLE
added a way to disable SSL

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -142,11 +142,13 @@ void HTTPClient::begin(String url, String httpsFingerprint) {
             if(!hasPort) {
                 _port = 80;
             }
+#ifndef DISABLE_SSL
         } else if(protocol.equalsIgnoreCase("https")) {
             _https = true;
             if(!hasPort) {
                 _port = 443;
             }
+#endif /* DISABLE_SSL */
         } else {
             DEBUG_HTTPCLIENT("[HTTP-Client][begin] protocol: %s unknown?!\n", protocol.c_str());
             return;
@@ -714,6 +716,7 @@ bool HTTPClient::connect(void) {
         return true;
     }
 
+#ifndef DISABLE_SSL
     if(_https) {
         DEBUG_HTTPCLIENT("[HTTP-Client] connect https...\n");
         if(_tcps) {
@@ -724,13 +727,16 @@ bool HTTPClient::connect(void) {
         _tcps = new WiFiClientSecure();
         _tcp = _tcps;
     } else {
+#endif /* DISABLE_SSL */
         DEBUG_HTTPCLIENT("[HTTP-Client] connect http...\n");
         if(_tcp) {
             delete _tcp;
             _tcp = NULL;
         }
         _tcp = new WiFiClient();
+#ifndef DISABLE_SSL
     }
+#endif /* DISABLE_SSL */
 
     if(!_tcp->connect(_host.c_str(), _port)) {
         DEBUG_HTTPCLIENT("[HTTP-Client] failed connect to %s:%u\n", _host.c_str(), _port);
@@ -739,6 +745,7 @@ bool HTTPClient::connect(void) {
 
     DEBUG_HTTPCLIENT("[HTTP-Client] connected to %s:%u\n", _host.c_str(), _port);
 
+#ifndef DISABLE_SSL
     if(_https && _httpsFingerprint.length() > 0) {
         if(_tcps->verify(_httpsFingerprint.c_str(), _host.c_str())) {
             DEBUG_HTTPCLIENT("[HTTP-Client] https certificate matches\n");
@@ -748,6 +755,7 @@ bool HTTPClient::connect(void) {
             return false;
         }
     }
+#endif /* DISABLE_SSL */
 
     // set Timeout for readBytesUntil and readStringUntil
     _tcp->setTimeout(_tcpTimeout);

--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
@@ -50,6 +50,8 @@ extern "C"
 #define SSL_DEBUG_OPTS 0
 #endif
 
+#ifndef DISABLE_SSL
+
 uint8_t* default_private_key = 0;
 uint32_t default_private_key_len = 0;
 static bool default_private_key_dynamic = false;
@@ -526,3 +528,5 @@ extern "C" void ax_port_free(void* ptr) {
         DEBUG_TLS_MEM_PRINT("free %d, left %d\r\n", p[-3], ESP.getFreeHeap());
     }
 }
+
+#endif // DISABLE_SSL


### PR DESCRIPTION
Hi,

I was trying to slim down the binary size of one of my projects and saw that a lot of stuff is included in the binary even if it is never used (empty sketch needs >50% of my ESP module). This is particularly annoying since I want to use HTTP-OTA. 

This PR allows to disable SSL using a preprocessor definition (currently not configureable in the UI).

For me this saves ~14% sketch size (since axtls is ommited).

I have not yet figured how to inspect the contents of the binary image but i guess there are a lot of things I do not require in all of my sketches (e.g. WPS, ...). I'm happy about any pointers.

Wolfgang