### PR TITLE
Update core_esp8266_phy.c

### DIFF
--- a/cores/esp8266/core_esp8266_phy.c
+++ b/cores/esp8266/core_esp8266_phy.c
@@ -23,8 +23,8 @@
  #include <stdint.h>
  #include <stddef.h>
  #include <stdbool.h>
-
-#include "c_types.h"
+ #include <string.h>
+ #include "c_types.h"
 
 static const uint8_t ICACHE_FLASH_ATTR phy_init_data[128] =
 {


### PR DESCRIPTION
add #include <string.h> to fix warning: incompatible implicit declaration of built-in function 'memcpy'