### PR TITLE
Include Arduino.h AFTER memory.h

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClient.h
+++ b/libraries/ESP8266WiFi/src/WiFiClient.h
@@ -21,11 +21,11 @@
 
 #ifndef wificlient_h
 #define wificlient_h
+#include <memory>
 #include "Arduino.h"
 #include "Print.h"
 #include "Client.h"
 #include "IPAddress.h"
-#include <memory>
 #include "include/slist.h"
 
 #define WIFICLIENT_MAX_PACKET_SIZE 1460


### PR DESCRIPTION
Arduino.h defines min/max which are then redefined with templates in stl_algobase.h imported from memory.h.  This is the least impactful way I can find to get past this for now and unblock use of wificlient in more scenarios.

I haven't yet figured out how this is sometimes working just fine in simple scenarios, but very often any use of WifiClient.h will make it impossible to compile due to conflicting with the other definitions of min/max.

I'm using IDE 1.6.7.  This unblocks use of WifiClient and WifiSecureClient successfully for me and shouldn't have negative impacts.