### PR TITLE
Download tools without cd'ing in tools directory first

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Documentation: [http://esp8266.github.io/Arduino/versions/2.1.0-rc1/](http://esp
 - Clone this repository into hardware/esp8266com/esp8266 directory and download binary tools (you need Python 2.7)
 - Note: This has been tested on Linux; on other systems you might have to adjust the path to the `hardware` directory
 ```
-git clone https://github.com/esp8266/Arduino.git ~/Arduino/hardware/esp8266/git/ 
-python ~/Arduino/hardware/esp8266/git/tools/get.py
+git clone https://github.com/esp8266/Arduino.git ~/Arduino/hardware/esp8266/esp8266/ 
+python ~/Arduino/hardware/esp8266/esp8266/tools/get.py
 ```
 - Restart Arduino
 

--- a/README.md
+++ b/README.md
@@ -43,18 +43,11 @@ Documentation: [http://esp8266.github.io/Arduino/versions/2.1.0-rc1/](http://esp
 ### Using git version [![Linux build status](https://travis-ci.org/esp8266/Arduino.svg)](https://travis-ci.org/esp8266/Arduino)
 
 - Install Arduino 1.6.7
-- Go to Arduino directory
-- Clone this repository into hardware/esp8266com/esp8266 directory (or clone it elsewhere and create a symlink)
-```bash
-cd hardware
-mkdir esp8266com
-cd esp8266com
-git clone https://github.com/esp8266/Arduino.git esp8266
+- Clone this repository into hardware/esp8266com/esp8266 directory and download binary tools (you need Python 2.7)
+- Note: This has been tested on Linux; on other systems you might have to adjust the path to the `hardware` directory
 ```
-- Download binary tools (you need Python 2.7)
-```bash
-cd esp8266/tools
-python get.py
+git clone https://github.com/esp8266/Arduino.git ~/Arduino/hardware/esp8266/git/ 
+python ~/Arduino/hardware/esp8266/git/tools/get.py
 ```
 - Restart Arduino
 

--- a/tools/get.py
+++ b/tools/get.py
@@ -103,7 +103,7 @@ def identify_platform():
 
 if __name__ == '__main__':
     print('Platform: {0}'.format(identify_platform()))
-    tools_to_download = load_tools_list('../package/package_esp8266com_index.template.json', identify_platform())
+    tools_to_download = load_tools_list(os.path.abspath(os.path.join(__file__, '../../package/package_esp8266com_index.template.json')), identify_platform())
     mkdir_p(dist_dir)
     for tool in tools_to_download:
         get_tool(tool)


### PR DESCRIPTION
To install esp8266/Arduino from git, you currently have to run something like

```
git clone https://github.com/esp8266/Arduino.git ~/Arduino/hardware/esp8266/git/ 
cd ~/Arduino/hardware/esp8266/git/tools/ 
python ./get.py
cd -
```

With this patch, it boils down to

```
git clone https://github.com/esp8266/Arduino.git ~/Arduino/hardware/esp8266/git/ 
python ~/Arduino/hardware/esp8266/git/tools/get.py
```

If this is applied, we can adjust the documentation accordingly.