### PR TITLE
make espota compatible with python 3.5

### DIFF
--- a/tools/espota.py
+++ b/tools/espota.py
@@ -92,10 +92,10 @@ def serve(remoteAddr, localAddr, remotePort, localPort, password, filename, comm
   logging.info('Sending invitation to: %s', remoteAddr)
   sock2 = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
   remote_address = (remoteAddr, int(remotePort))
-  sent = sock2.sendto(message, remote_address)
+  sent = sock2.sendto(message.encode(), remote_address)
   sock2.settimeout(10)
   try:
-    data = sock2.recv(37)
+    data = sock2.recv(37).decode()
   except:
     logging.error('No Answer')
     sock2.close()
@@ -111,10 +111,10 @@ def serve(remoteAddr, localAddr, remotePort, localPort, password, filename, comm
       sys.stderr.write('Authenticating...')
       sys.stderr.flush()
       message = '%d %s %s\n' % (AUTH, cnonce, result)
-      sock2.sendto(message, remote_address)
+      sock2.sendto(message.encode(), remote_address)
       sock2.settimeout(10)
       try:
-        data = sock2.recv(32)
+        data = sock2.recv(32).decode()
       except:
         sys.stderr.write('FAIL\n')
         logging.error('No Answer to our Authentication')
@@ -173,7 +173,7 @@ def serve(remoteAddr, localAddr, remotePort, localPort, password, filename, comm
     logging.info('Waiting for result...')
     try:
       connection.settimeout(60)
-      data = connection.recv(32)
+      data = connection.recv(32).decode()
       logging.info('Result: %s' ,data)
       connection.close()
       f.close()


### PR DESCRIPTION
With python 3.5 (default on Arch linux) I got the following:
```
Traceback (most recent call last):
  File "espota.py", line 318, in <module>
    sys.exit(main(sys.argv))
  File "espota.py", line 313, in main
    return serve(options.esp_ip, options.host_ip, options.esp_port, options.host_port, options.auth, options.image, command)
  File "espota.py", line 95, in serve
    sent = sock2.sendto(message, remote_address)
TypeError: a bytes-like object is required, not 'str'
```

This patch will fix the error. Tested with python 2.7.11 and 3.5.1.