### PR TITLE
espota: fixed remaining python 3.5 incompatibility

### DIFF
--- a/tools/espota.py
+++ b/tools/espota.py
@@ -104,10 +104,10 @@ def serve(remoteAddr, localAddr, remotePort, localPort, password, filename, comm
     if(data.startswith('AUTH')):
       nonce = data.split()[1]
       cnonce_text = '%s%u%s%s' % (filename, content_size, file_md5, remoteAddr)
-      cnonce = hashlib.md5(cnonce_text).hexdigest()
-      passmd5 = hashlib.md5(password).hexdigest()
+      cnonce = hashlib.md5(cnonce_text.encode()).hexdigest()
+      passmd5 = hashlib.md5(password.encode()).hexdigest()
       result_text = '%s:%s:%s' % (passmd5 ,nonce, cnonce)
-      result = hashlib.md5(result_text).hexdigest()
+      result = hashlib.md5(result_text.encode()).hexdigest()
       sys.stderr.write('Authenticating...')
       sys.stderr.flush()
       message = '%d %s %s\n' % (AUTH, cnonce, result)


### PR DESCRIPTION
Sadly I didn't use authentication for ArduinoOTA so far. When I tried it turned out that it doesn't work with python 3.5...
```
Traceback (most recent call last):
  File "/home/bitn/.arduino15/packages/esp8266/hardware/esp8266/2.0.0/tools/espota.py", line 318, in <module>
    sys.exit(main(sys.argv))
  File "/home/bitn/.arduino15/packages/esp8266/hardware/esp8266/2.0.0/tools/espota.py", line 313, in main
    return serve(options.esp_ip, options.host_ip, options.esp_port, options.host_port, options.auth, options.image, command)
  File "/home/bitn/.arduino15/packages/esp8266/hardware/esp8266/2.0.0/tools/espota.py", line 107, in serve
    cnonce = hashlib.md5(cnonce_text).hexdigest()
TypeError: Unicode-objects must be encoded before hashing
```
Fixed the error and tested with python 2.7.11 and 3.5.1 as before. Everything worked fine with all the parameters, so I hope these were the last ones.
Sorry for the double pull request.