### PR TITLE
More ESP8266-compatible libraries

### DIFF
--- a/doc/libraries.md
+++ b/doc/libraries.md
@@ -151,3 +151,5 @@ Libraries that don't rely on low-level access to AVR registers should work well.
 - [Task](https://github.com/Makuna/Task) - Arduino Nonpreemptive multitasking library.  While similiar to the included Ticker library in the functionality provided, this library was meant for cross Arduino compatibility.
 - [UTFT-ESP8266](https://github.com/gnulabis/UTFT-ESP8266) - UTFT display library with support for ESP8266. Only serial interface (SPI) displays are supported for now (no 8-bit parallel mode, etc). Also includes support for the hardware SPI controller of the ESP8266.
 - [WiFiManager](https://github.com/tzapu/WiFiManager) - WiFi Connection manager with web captive portal. If it can't connect, it starts AP mode and a configuration portal so you can choose and enter WiFi credentials.
+- [OneWire](https://github.com/PaulStoffregen/OneWire) - Library for Dallas/Maxim 1-Wire Chips.
+- [Adafruit-PCD8544-Nokia-5110-LCD-Library](https://github.com/WereCatf/Adafruit-PCD8544-Nokia-5110-LCD-library) - Port of the Adafruit PCD8544 - library for the ESP8266.


### PR DESCRIPTION
Add Paul Stoffregen's OneWire-library and (originally bbx10's) port of the Adafruit PCD8544 - lib to the collection of tested and compatible libraries.