### PR TITLE
millis() - wraparound fixes

### DIFF
--- a/cores/esp8266/Stream.cpp
+++ b/cores/esp8266/Stream.cpp
@@ -37,7 +37,7 @@ int ICACHE_FLASH_ATTR Stream::timedRead() {
         if(c >= 0)
             return c;
         yield();
-    } while(millis() - _startMillis < _timeout);
+    } while(((long)millis() - (long)_startMillis) < _timeout);
     return -1;     // -1 indicates timeout
 }
 
@@ -50,7 +50,7 @@ int ICACHE_FLASH_ATTR Stream::timedPeek() {
         if(c >= 0)
             return c;
         yield();
-    } while(millis() - _startMillis < _timeout);
+    } while(((long)millis() - (long)_startMillis) < _timeout);
     return -1;     // -1 indicates timeout
 }
 

--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -895,7 +895,7 @@ int HTTPClient::handleHeaderResponse() {
             }
 
         } else {
-            if((millis() - lastDataTime) > _tcpTimeout) {
+            if(((long)millis() - (long)lastDataTime) > _tcpTimeout) {
                 return HTTPC_ERROR_READ_TIMEOUT;
             }
             delay(0);

--- a/libraries/ESP8266SSDP/ESP8266SSDP.cpp
+++ b/libraries/ESP8266SSDP/ESP8266SSDP.cpp
@@ -354,7 +354,7 @@ void SSDPClass::_update(){
   if(_pending && ((long)millis() - (long)_process_time) > _delay){
     _pending = false; _delay = 0;
     _send(NONE);
-  } else if(_notify_time == 0 || ((long)millis() - (long)_process_time) > (SSDP_INTERVAL * 1000L)){
+  } else if(_notify_time == 0 || ((long)millis() - (long)_notify_time) > (SSDP_INTERVAL * 1000L)){
     _notify_time = millis();
     _send(NOTIFY);
   }

--- a/libraries/ESP8266SSDP/ESP8266SSDP.cpp
+++ b/libraries/ESP8266SSDP/ESP8266SSDP.cpp
@@ -351,10 +351,10 @@ void SSDPClass::_update(){
     }
   }
 
-  if(_pending && (millis() - _process_time) > _delay){
+  if(_pending && ((long)millis() - (long)_process_time) > _delay){
     _pending = false; _delay = 0;
     _send(NONE);
-  } else if(_notify_time == 0 || (millis() - _notify_time) > (SSDP_INTERVAL * 1000L)){
+  } else if(_notify_time == 0 || ((long)millis() - (long)_process_time) > (SSDP_INTERVAL * 1000L)){
     _notify_time = millis();
     _send(NOTIFY);
   }

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -180,7 +180,7 @@ void ESP8266WebServer::handleClient() {
   // Wait for data from client to become available
   if (_currentStatus == HC_WAIT_READ) {
     if (!_currentClient.available()) {
-      if (millis() - _statusChange > HTTP_MAX_DATA_WAIT) {
+      if (((long)millis() - (long)_statusChange) > HTTP_MAX_DATA_WAIT) {
         _currentClient = WiFiClient();
         _currentStatus = HC_NONE;
       }
@@ -209,7 +209,7 @@ void ESP8266WebServer::handleClient() {
   }
 
   if (_currentStatus == HC_WAIT_CLOSE) {
-    if (millis() - _statusChange > HTTP_MAX_CLOSE_WAIT) {
+    if (((long)millis() - (long)_statusChange) > HTTP_MAX_CLOSE_WAIT) {
       _currentClient = WiFiClient();
       _currentStatus = HC_NONE;
     } else {

--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -246,7 +246,7 @@ size_t WiFiClient::peekBytes(uint8_t *buffer, size_t length) {
     }
 
     _startMillis = millis();
-    while((available() < (int) length) && ((millis() - _startMillis) < _timeout)) {
+    while((available() < (int) length) && (((long)millis() - (long)_startMillis) < _timeout)) {
         yield();
     }
 

--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
@@ -298,7 +298,7 @@ size_t WiFiClientSecure::peekBytes(uint8_t *buffer, size_t length) {
     }
 
     _startMillis = millis();
-    while((available() < (int) length) && ((millis() - _startMillis) < _timeout)) {
+    while((available() < (int) length) && (((long)millis() - (long)_startMillis) < _timeout)) {
         yield();
     }
 

--- a/libraries/Ethernet/src/Dhcp.cpp
+++ b/libraries/Ethernet/src/Dhcp.cpp
@@ -62,12 +62,12 @@ int DhcpClass::request_DHCP_lease(){
         {
             _dhcpTransactionId++;
             
-            send_DHCP_MESSAGE(DHCP_DISCOVER, ((millis() - startTime) / 1000));
+            send_DHCP_MESSAGE(DHCP_DISCOVER, (((long)millis() - (long)startTime) / 1000));
             _dhcp_state = STATE_DHCP_DISCOVER;
         }
         else if(_dhcp_state == STATE_DHCP_REREQUEST){
             _dhcpTransactionId++;
-            send_DHCP_MESSAGE(DHCP_REQUEST, ((millis() - startTime)/1000));
+            send_DHCP_MESSAGE(DHCP_REQUEST, (((long)millis() - (long)startTime)/1000));
             _dhcp_state = STATE_DHCP_REQUEST;
         }
         else if(_dhcp_state == STATE_DHCP_DISCOVER)
@@ -79,7 +79,7 @@ int DhcpClass::request_DHCP_lease(){
                 // We'll use the transaction ID that the offer came with,
                 // rather than the one we were up to
                 _dhcpTransactionId = respId;
-                send_DHCP_MESSAGE(DHCP_REQUEST, ((millis() - startTime) / 1000));
+                send_DHCP_MESSAGE(DHCP_REQUEST, (((long)millis() - (long)startTime) / 1000));
                 _dhcp_state = STATE_DHCP_REQUEST;
             }
         }
@@ -117,7 +117,7 @@ int DhcpClass::request_DHCP_lease(){
             _dhcp_state = STATE_DHCP_START;
         }
         
-        if(result != 1 && ((millis() - startTime) > _timeout))
+        if(result != 1 && (((long)millis() - (long)startTime) > _timeout))
             break;
     }
     
@@ -259,7 +259,7 @@ uint8_t DhcpClass::parseDHCPResponse(unsigned long responseTimeout, uint32_t& tr
 
     while(_dhcpUdpSocket.parsePacket() <= 0)
     {
-        if((millis() - startTime) > responseTimeout)
+        if(((long)millis() - (long)startTime) > responseTimeout)
         {
             return 255;
         }

--- a/libraries/Ethernet/src/EthernetClient.cpp
+++ b/libraries/Ethernet/src/EthernetClient.cpp
@@ -138,7 +138,7 @@ void EthernetClient::stop() {
     if (s == SnSR::CLOSED)
       break; // exit the loop
     delay(1);
-  } while (millis() - start < 1000);
+  } while (((long)millis() - (long)start) < 1000);
 
   // if it hasn't closed, close it forcefully
   if (s != SnSR::CLOSED)


### PR DESCRIPTION
A lot of code in the libraries do not take wraparound of millis() into account, meaning that after 49 days of uptime they'd suddenly fail to work. I am using the signed/unsigned trick here to fix it and as far as I can tell everything works, but some more experienced code-wizard should double-check.