### PR TITLE
Configurable I2C clock stretching limit

### DIFF
--- a/cores/esp8266/twi.h
+++ b/cores/esp8266/twi.h
@@ -29,6 +29,7 @@ extern "C" {
 void twi_init(unsigned char sda, unsigned char scl);
 void twi_stop(void);
 void twi_setClock(unsigned int freq);
+void twi_setClockStretchLimit(uint32_t limit);
 uint8_t twi_writeTo(unsigned char address, unsigned char * buf, unsigned int len, unsigned char sendStop);
 uint8_t twi_readFrom(unsigned char address, unsigned char * buf, unsigned int len, unsigned char sendStop);
 

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -85,6 +85,10 @@ void TwoWire::setClock(uint32_t frequency){
   twi_setClock(frequency);
 }
 
+void TwoWire::setClockStretchLimit(uint32_t limit){
+  twi_setClockStretchLimit(limit);
+}
+
 size_t TwoWire::requestFrom(uint8_t address, size_t size, bool sendStop){
   if(size > BUFFER_LENGTH){
     size = BUFFER_LENGTH;

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -56,6 +56,7 @@ class TwoWire : public Stream
     void begin(uint8_t);
     void begin(int);
     void setClock(uint32_t);
+    void setClockStretchLimit(uint32_t);
     void beginTransmission(uint8_t);
     void beginTransmission(int);
     uint8_t endTransmission(void);

--- a/libraries/Wire/keywords.txt
+++ b/libraries/Wire/keywords.txt
@@ -12,6 +12,7 @@
 
 begin	KEYWORD2
 setClock	KEYWORD2
+setClockStretchLimit	KEYWORD2
 beginTransmission	KEYWORD2
 endTransmission	KEYWORD2
 requestFrom	KEYWORD2


### PR DESCRIPTION
Use Wire.setClockStretchLimit(limit)
limit is in uSeconds