### PR TITLE
WiFiClient::write refactoring

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -241,6 +241,9 @@ void ESP8266WebServer::sendHeader(const String& name, const String& value, bool 
   }
 }
 
+void ESP8266WebServer::setContentLength(size_t contentLength) {
+    _contentLength = contentLength;
+}
 
 void ESP8266WebServer::_prepareHeader(String& response, int code, const char* content_type, size_t contentLength) {
     response = "HTTP/1.1 ";

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -307,67 +307,15 @@ void ESP8266WebServer::send(int code, const String& content_type, const String& 
 }
 
 void ESP8266WebServer::sendContent(const String& content) {
-  const size_t unit_size = HTTP_DOWNLOAD_UNIT_SIZE;
-  size_t size_to_send = content.length();
-  const char* send_start = content.c_str();
-
-  while (size_to_send) {
-    size_t will_send = (size_to_send < unit_size) ? size_to_send : unit_size;
-    size_t sent = _currentClient.write(send_start, will_send);
-    if (sent == 0) {
-      break;
-    }
-    size_to_send -= sent;
-    send_start += sent;
-  }
+  _currentClient.write(content.c_str(), content.length());
 }
 
 void ESP8266WebServer::sendContent_P(PGM_P content) {
-    char contentUnit[HTTP_DOWNLOAD_UNIT_SIZE + 1];
-
-    contentUnit[HTTP_DOWNLOAD_UNIT_SIZE] = '\0';
-
-    while (content != NULL) {
-        size_t contentUnitLen;
-        PGM_P contentNext;
-
-        // due to the memccpy signature, lots of casts are needed
-        contentNext = (PGM_P)memccpy_P((void*)contentUnit, (PGM_VOID_P)content, 0, HTTP_DOWNLOAD_UNIT_SIZE);
-
-        if (contentNext == NULL) {
-            // no terminator, more data available
-            content += HTTP_DOWNLOAD_UNIT_SIZE;
-            contentUnitLen = HTTP_DOWNLOAD_UNIT_SIZE;
-        }
-        else {
-            // reached terminator. Do not send the terminator
-            contentUnitLen = contentNext - contentUnit - 1;
-            content = NULL;
-        }
-
-        // write is so overloaded, had to use the cast to get it pick the right one
-        _currentClient.write((const char*)contentUnit, contentUnitLen);
-    }
+  _currentClient.write_P(content, strlen_P(content));
 }
 
 void ESP8266WebServer::sendContent_P(PGM_P content, size_t size) {
-    char contentUnit[HTTP_DOWNLOAD_UNIT_SIZE + 1];
-    contentUnit[HTTP_DOWNLOAD_UNIT_SIZE] = '\0';
-    size_t remaining_size = size;
-
-    while (content != NULL && remaining_size > 0) {
-        size_t contentUnitLen = HTTP_DOWNLOAD_UNIT_SIZE;
-
-        if (remaining_size < HTTP_DOWNLOAD_UNIT_SIZE) contentUnitLen = remaining_size;
-        // due to the memcpy signature, lots of casts are needed
-        memcpy_P((void*)contentUnit, (PGM_VOID_P)content, contentUnitLen);
-
-        content += contentUnitLen;
-        remaining_size -= contentUnitLen;
-
-        // write is so overloaded, had to use the cast to get it pick the right one
-        _currentClient.write((const char*)contentUnit, contentUnitLen);
-    }
+  _currentClient.write_P(content, size);
 }
 
 

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -193,7 +193,7 @@ void ESP8266WebServer::handleClient() {
       _currentStatus = HC_NONE;
       return;
     }
-
+    _currentClient.setTimeout(HTTP_MAX_SEND_WAIT);
     _contentLength = CONTENT_LENGTH_NOT_SET;
     _handleRequest();
 
@@ -270,7 +270,6 @@ void ESP8266WebServer::send(int code, const char* content_type, const String& co
     String header;
     _prepareHeader(header, code, content_type, content.length());
     sendContent(header);
-
     sendContent(content);
 }
 

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -112,7 +112,7 @@ public:
   void send_P(int code, PGM_P content_type, PGM_P content);
   void send_P(int code, PGM_P content_type, PGM_P content, size_t contentLength);
 
-  void setContentLength(size_t contentLength) { _contentLength = contentLength; }
+  void setContentLength(size_t contentLength);
   void sendHeader(const String& name, const String& value, bool first = false);
   void sendContent(const String& content);
   void sendContent_P(PGM_P content);

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -125,7 +125,7 @@ template<typename T> size_t streamFile(T &file, const String& contentType){
     sendHeader("Content-Encoding", "gzip");
   }
   send(200, contentType, "");
-  return _currentClient.write(file, HTTP_DOWNLOAD_UNIT_SIZE);
+  return _currentClient.write(file);
 }
 
 protected:

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -34,6 +34,7 @@ enum HTTPClientStatus { HC_NONE, HC_WAIT_READ, HC_WAIT_CLOSE };
 #define HTTP_DOWNLOAD_UNIT_SIZE 1460
 #define HTTP_UPLOAD_BUFLEN 2048
 #define HTTP_MAX_DATA_WAIT 1000 //ms to wait for the client to send the request
+#define HTTP_MAX_SEND_WAIT 5000 //ms to wait for data chunk to be ACKed
 #define HTTP_MAX_CLOSE_WAIT 2000 //ms to wait for the client to close the connection
 
 #define CONTENT_LENGTH_UNKNOWN ((size_t) -1)

--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
@@ -39,6 +39,7 @@ extern "C"
 #include "lwip/netif.h"
 #include "include/ClientContext.h"
 #include "c_types.h"
+#include "include/DataStrategyImpl.h"
 
 #ifdef DEBUG_ESP_SSL
 #define DEBUG_SSL
@@ -468,7 +469,10 @@ extern "C" int ax_port_write(int fd, uint8_t* buffer, size_t count) {
         errno = EIO;
         return -1;
     }
-    size_t cb = _client->write((const char*) buffer, count);
+
+    // TODO: add a way to pass timeout here (e.g. through ClientContext?)
+    BufferStrategy strategy(buffer, count, 5000);
+    size_t cb = _client->write(strategy);
     if (cb != count) {
         errno = EAGAIN;
     }

--- a/libraries/ESP8266WiFi/src/include/ClientContext.h
+++ b/libraries/ESP8266WiFi/src/include/ClientContext.h
@@ -31,315 +31,378 @@ extern "C" void esp_schedule();
 
 #include "DataStrategy.h"
 
-class ClientContext {
-    public:
-        ClientContext(tcp_pcb* pcb, discard_cb_t discard_cb, void* discard_cb_arg) :
-                _pcb(pcb), _rx_buf(0), _rx_buf_offset(0), _discard_cb(discard_cb), _discard_cb_arg(discard_cb_arg), _refcnt(0), _next(0) {
-            tcp_setprio(pcb, TCP_PRIO_MIN);
-            tcp_arg(pcb, this);
-            tcp_recv(pcb, (tcp_recv_fn) &_s_recv);
-            tcp_sent(pcb, &_s_sent);
-            tcp_err(pcb, &_s_error);
-            tcp_poll(pcb, &_s_poll, 1);
-        }
+class ClientContext
+{
+public:
+    ClientContext(tcp_pcb* pcb, discard_cb_t discard_cb, void* discard_cb_arg) :
+        _pcb(pcb), _rx_buf(0), _rx_buf_offset(0), _discard_cb(discard_cb), _discard_cb_arg(discard_cb_arg), _refcnt(0), _next(0)
+    {
+        tcp_setprio(pcb, TCP_PRIO_MIN);
+        tcp_arg(pcb, this);
+        tcp_recv(pcb, (tcp_recv_fn) &_s_recv);
+        tcp_sent(pcb, &_s_sent);
+        tcp_err(pcb, &_s_error);
+        tcp_poll(pcb, &_s_poll, 1);
+    }
 
-        err_t abort(){
-          if(_pcb) {
-              DEBUGV(":abort\r\n");
-              tcp_arg(_pcb, NULL);
-              tcp_sent(_pcb, NULL);
-              tcp_recv(_pcb, NULL);
-              tcp_err(_pcb, NULL);
-              tcp_poll(_pcb, NULL, 0);
-              tcp_abort(_pcb);
-              _pcb = 0;
-          }
-          return ERR_ABRT;
-        }
-
-        err_t close(){
-          err_t err = ERR_OK;
-          if(_pcb) {
-              DEBUGV(":close\r\n");
-              tcp_arg(_pcb, NULL);
-              tcp_sent(_pcb, NULL);
-              tcp_recv(_pcb, NULL);
-              tcp_err(_pcb, NULL);
-              tcp_poll(_pcb, NULL, 0);
-              err = tcp_close(_pcb);
-              if(err != ERR_OK) {
-                  DEBUGV(":tc err %d\r\n", err);
-                  tcp_abort(_pcb);
-                  err = ERR_ABRT;
-              }
-              _pcb = 0;
-          }
-          return err;
-        }
-
-        ~ClientContext() {
-        }
-
-        ClientContext* next() const {
-            return _next;
-        }
-
-        ClientContext* next(ClientContext* new_next) {
-            _next = new_next;
-            return _next;
-        }
-
-        void ref() {
-            ++_refcnt;
-            DEBUGV(":ref %d\r\n", _refcnt);
-        }
-
-        void unref() {
-            if(this != 0) {
-                DEBUGV(":ur %d\r\n", _refcnt);
-                if(--_refcnt == 0) {
-                    flush();
-                    close();
-                    if(_discard_cb)
-                        _discard_cb(_discard_cb_arg, this);
-                    DEBUGV(":del\r\n");
-                    delete this;
-                }
-            }
-        }
-
-        void setNoDelay(bool nodelay){
-          if(!_pcb) return;
-          if(nodelay) tcp_nagle_disable(_pcb);
-          else tcp_nagle_enable(_pcb);
-        }
-
-        bool getNoDelay(){
-          if(!_pcb) return false;
-          return tcp_nagle_disabled(_pcb);
-        }
-
-        uint32_t getRemoteAddress() {
-            if(!_pcb) return 0;
-
-            return _pcb->remote_ip.addr;
-        }
-
-        uint16_t getRemotePort() {
-            if(!_pcb) return 0;
-
-            return _pcb->remote_port;
-        }
-
-        uint32_t getLocalAddress() {
-            if(!_pcb) return 0;
-
-            return _pcb->local_ip.addr;
-        }
-
-        uint16_t getLocalPort() {
-            if(!_pcb) return 0;
-
-            return _pcb->local_port;
-        }
-
-        size_t getSize() const {
-            if(!_rx_buf) return 0;
-
-            return _rx_buf->tot_len - _rx_buf_offset;
-        }
-
-        char read() {
-            if(!_rx_buf) return 0;
-
-            char c = reinterpret_cast<char*>(_rx_buf->payload)[_rx_buf_offset];
-            _consume(1);
-            return c;
-        }
-
-        size_t read(char* dst, size_t size) {
-            if(!_rx_buf) return 0;
-
-            size_t max_size = _rx_buf->tot_len - _rx_buf_offset;
-            size = (size < max_size) ? size : max_size;
-
-            DEBUGV(":rd %d, %d, %d\r\n", size, _rx_buf->tot_len, _rx_buf_offset);
-            size_t size_read = 0;
-            while(size) {
-                size_t buf_size = _rx_buf->len - _rx_buf_offset;
-                size_t copy_size = (size < buf_size) ? size : buf_size;
-                DEBUGV(":rdi %d, %d\r\n", buf_size, copy_size);
-                os_memcpy(dst, reinterpret_cast<char*>(_rx_buf->payload) + _rx_buf_offset, copy_size);
-                dst += copy_size;
-                _consume(copy_size);
-                size -= copy_size;
-                size_read += copy_size;
-            }
-            return size_read;
-        }
-
-        char peek() {
-            if(!_rx_buf) return 0;
-
-            return reinterpret_cast<char*>(_rx_buf->payload)[_rx_buf_offset];
-        }
-
-        size_t peekBytes(char *dst, size_t size) {
-            if(!_rx_buf) return 0;
-
-            size_t max_size = _rx_buf->tot_len - _rx_buf_offset;
-            size = (size < max_size) ? size : max_size;
-
-            DEBUGV(":pd %d, %d, %d\r\n", size, _rx_buf->tot_len, _rx_buf_offset);
-            size_t buf_size = _rx_buf->len - _rx_buf_offset;
-            size_t copy_size = (size < buf_size) ? size : buf_size;
-            DEBUGV(":rpi %d, %d\r\n", buf_size, copy_size);
-            os_memcpy(dst, reinterpret_cast<char*>(_rx_buf->payload) + _rx_buf_offset, copy_size);
-            return copy_size;
-        }
-
-        void flush() {
-            if(!_rx_buf) {
-                return;
-            }
-            if(_pcb) {
-                tcp_recved(_pcb, (size_t) _rx_buf->tot_len);
-            }
-            pbuf_free(_rx_buf);
-            _rx_buf = 0;
-            _rx_buf_offset = 0;
-        }
-
-        uint8_t state() const {
-            if(!_pcb) return CLOSED;
-
-            return _pcb->state;
-        }
-
-        size_t getSendBufferSize()
-        {
-            if (!_pcb) {
-                return 0;
-            }
-            return tcp_sndbuf(_pcb);
-        }
-
-        bool write(const uint8_t* data, size_t size)
-        {
-            if (!_pcb) {
-                return false;
-            }
-            err_t err = tcp_write(_pcb, data, size, 0);
-            tcp_output(_pcb);
-            return err == ERR_OK;
-        }
-
-        size_t write(DataStrategy& strategy) {
-            _strategy = &strategy;
-            auto ret = strategy.write(*this);
-            _strategy = nullptr;
-            return ret;
-        }
-
-    private:
-
-        err_t _sent(tcp_pcb* pcb, uint16_t len) {
-            DEBUGV(":sent %d\r\n", len);
-            if (_strategy) {
-                _strategy->on_sent(*this, len);
-            }
-            return ERR_OK;
-        }
-
-        void _consume(size_t size) {
-            ptrdiff_t left = _rx_buf->len - _rx_buf_offset - size;
-            if(left > 0) {
-                _rx_buf_offset += size;
-            } else if(!_rx_buf->next) {
-                DEBUGV(":c0 %d, %d\r\n", size, _rx_buf->tot_len);
-                if(_pcb) tcp_recved(_pcb, _rx_buf->len);
-                pbuf_free(_rx_buf);
-                _rx_buf = 0;
-                _rx_buf_offset = 0;
-            } else {
-                DEBUGV(":c %d, %d, %d\r\n", size, _rx_buf->len, _rx_buf->tot_len);
-                auto head = _rx_buf;
-                _rx_buf = _rx_buf->next;
-                _rx_buf_offset = 0;
-                pbuf_ref(_rx_buf);
-                if(_pcb) tcp_recved(_pcb, head->len);
-                pbuf_free(head);
-            }
-        }
-
-        int32_t _recv(tcp_pcb* pcb, pbuf* pb, err_t err) {
-
-            if(pb == 0) // connection closed
-            {
-                DEBUGV(":rcl\r\n");
-                abort();
-                return ERR_ABRT;
-            }
-
-            if(_rx_buf) {
-                DEBUGV(":rch %d, %d\r\n", _rx_buf->tot_len, pb->tot_len);
-                pbuf_cat(_rx_buf, pb);
-            } else {
-                DEBUGV(":rn %d\r\n", pb->tot_len);
-                _rx_buf = pb;
-                _rx_buf_offset = 0;
-            }
-            return ERR_OK;
-        }
-
-        void _error(err_t err) {
-            DEBUGV(":er %d %08x\r\n", err, (uint32_t) _strategy);
+    err_t abort()
+    {
+        if(_pcb) {
+            DEBUGV(":abort\r\n");
             tcp_arg(_pcb, NULL);
             tcp_sent(_pcb, NULL);
             tcp_recv(_pcb, NULL);
             tcp_err(_pcb, NULL);
-            _pcb = NULL;
-            if (_strategy) {
-                _strategy->on_error(*this);
+            tcp_poll(_pcb, NULL, 0);
+            tcp_abort(_pcb);
+            _pcb = 0;
+        }
+        return ERR_ABRT;
+    }
+
+    err_t close()
+    {
+        err_t err = ERR_OK;
+        if(_pcb) {
+            DEBUGV(":close\r\n");
+            tcp_arg(_pcb, NULL);
+            tcp_sent(_pcb, NULL);
+            tcp_recv(_pcb, NULL);
+            tcp_err(_pcb, NULL);
+            tcp_poll(_pcb, NULL, 0);
+            err = tcp_close(_pcb);
+            if(err != ERR_OK) {
+                DEBUGV(":tc err %d\r\n", err);
+                tcp_abort(_pcb);
+                err = ERR_ABRT;
+            }
+            _pcb = 0;
+        }
+        return err;
+    }
+
+    ~ClientContext()
+    {
+    }
+
+    ClientContext* next() const
+    {
+        return _next;
+    }
+
+    ClientContext* next(ClientContext* new_next)
+    {
+        _next = new_next;
+        return _next;
+    }
+
+    void ref()
+    {
+        ++_refcnt;
+        DEBUGV(":ref %d\r\n", _refcnt);
+    }
+
+    void unref()
+    {
+        if(this != 0) {
+            DEBUGV(":ur %d\r\n", _refcnt);
+            if(--_refcnt == 0) {
+                flush();
+                close();
+                if(_discard_cb) {
+                    _discard_cb(_discard_cb_arg, this);
+                }
+                DEBUGV(":del\r\n");
+                delete this;
             }
         }
+    }
 
-        err_t _poll(tcp_pcb* pcb) {
-            if (_strategy) {
-                _strategy->on_poll(*this);
+    void setNoDelay(bool nodelay)
+    {
+        if(!_pcb) {
+            return;
+        }
+        if(nodelay) {
+            tcp_nagle_disable(_pcb);
+        } else {
+            tcp_nagle_enable(_pcb);
+        }
+    }
+
+    bool getNoDelay()
+    {
+        if(!_pcb) {
+            return false;
+        }
+        return tcp_nagle_disabled(_pcb);
+    }
+
+    uint32_t getRemoteAddress()
+    {
+        if(!_pcb) {
+            return 0;
+        }
+
+        return _pcb->remote_ip.addr;
+    }
+
+    uint16_t getRemotePort()
+    {
+        if(!_pcb) {
+            return 0;
+        }
+
+        return _pcb->remote_port;
+    }
+
+    uint32_t getLocalAddress()
+    {
+        if(!_pcb) {
+            return 0;
+        }
+
+        return _pcb->local_ip.addr;
+    }
+
+    uint16_t getLocalPort()
+    {
+        if(!_pcb) {
+            return 0;
+        }
+
+        return _pcb->local_port;
+    }
+
+    size_t getSize() const
+    {
+        if(!_rx_buf) {
+            return 0;
+        }
+
+        return _rx_buf->tot_len - _rx_buf_offset;
+    }
+
+    char read()
+    {
+        if(!_rx_buf) {
+            return 0;
+        }
+
+        char c = reinterpret_cast<char*>(_rx_buf->payload)[_rx_buf_offset];
+        _consume(1);
+        return c;
+    }
+
+    size_t read(char* dst, size_t size)
+    {
+        if(!_rx_buf) {
+            return 0;
+        }
+
+        size_t max_size = _rx_buf->tot_len - _rx_buf_offset;
+        size = (size < max_size) ? size : max_size;
+
+        DEBUGV(":rd %d, %d, %d\r\n", size, _rx_buf->tot_len, _rx_buf_offset);
+        size_t size_read = 0;
+        while(size) {
+            size_t buf_size = _rx_buf->len - _rx_buf_offset;
+            size_t copy_size = (size < buf_size) ? size : buf_size;
+            DEBUGV(":rdi %d, %d\r\n", buf_size, copy_size);
+            os_memcpy(dst, reinterpret_cast<char*>(_rx_buf->payload) + _rx_buf_offset, copy_size);
+            dst += copy_size;
+            _consume(copy_size);
+            size -= copy_size;
+            size_read += copy_size;
+        }
+        return size_read;
+    }
+
+    char peek()
+    {
+        if(!_rx_buf) {
+            return 0;
+        }
+
+        return reinterpret_cast<char*>(_rx_buf->payload)[_rx_buf_offset];
+    }
+
+    size_t peekBytes(char *dst, size_t size)
+    {
+        if(!_rx_buf) {
+            return 0;
+        }
+
+        size_t max_size = _rx_buf->tot_len - _rx_buf_offset;
+        size = (size < max_size) ? size : max_size;
+
+        DEBUGV(":pd %d, %d, %d\r\n", size, _rx_buf->tot_len, _rx_buf_offset);
+        size_t buf_size = _rx_buf->len - _rx_buf_offset;
+        size_t copy_size = (size < buf_size) ? size : buf_size;
+        DEBUGV(":rpi %d, %d\r\n", buf_size, copy_size);
+        os_memcpy(dst, reinterpret_cast<char*>(_rx_buf->payload) + _rx_buf_offset, copy_size);
+        return copy_size;
+    }
+
+    void flush()
+    {
+        if(!_rx_buf) {
+            return;
+        }
+        if(_pcb) {
+            tcp_recved(_pcb, (size_t) _rx_buf->tot_len);
+        }
+        pbuf_free(_rx_buf);
+        _rx_buf = 0;
+        _rx_buf_offset = 0;
+    }
+
+    uint8_t state() const
+    {
+        if(!_pcb) {
+            return CLOSED;
+        }
+
+        return _pcb->state;
+    }
+
+    size_t getSendBufferSize()
+    {
+        if (!_pcb) {
+            return 0;
+        }
+        return tcp_sndbuf(_pcb);
+    }
+
+    bool write(const uint8_t* data, size_t size)
+    {
+        if (!_pcb) {
+            return false;
+        }
+        err_t err = tcp_write(_pcb, data, size, 0);
+        tcp_output(_pcb);
+        return err == ERR_OK;
+    }
+
+    size_t write(DataStrategy& strategy)
+    {
+        _strategy = &strategy;
+        auto ret = strategy.write(*this);
+        _strategy = nullptr;
+        return ret;
+    }
+
+private:
+
+    err_t _sent(tcp_pcb* pcb, uint16_t len)
+    {
+        DEBUGV(":sent %d\r\n", len);
+        if (_strategy) {
+            _strategy->on_sent(*this, len);
+        }
+        return ERR_OK;
+    }
+
+    void _consume(size_t size)
+    {
+        ptrdiff_t left = _rx_buf->len - _rx_buf_offset - size;
+        if(left > 0) {
+            _rx_buf_offset += size;
+        } else if(!_rx_buf->next) {
+            DEBUGV(":c0 %d, %d\r\n", size, _rx_buf->tot_len);
+            if(_pcb) {
+                tcp_recved(_pcb, _rx_buf->len);
             }
-            return ERR_OK;
+            pbuf_free(_rx_buf);
+            _rx_buf = 0;
+            _rx_buf_offset = 0;
+        } else {
+            DEBUGV(":c %d, %d, %d\r\n", size, _rx_buf->len, _rx_buf->tot_len);
+            auto head = _rx_buf;
+            _rx_buf = _rx_buf->next;
+            _rx_buf_offset = 0;
+            pbuf_ref(_rx_buf);
+            if(_pcb) {
+                tcp_recved(_pcb, head->len);
+            }
+            pbuf_free(head);
+        }
+    }
+
+    int32_t _recv(tcp_pcb* pcb, pbuf* pb, err_t err)
+    {
+
+        if(pb == 0) { // connection closed
+            DEBUGV(":rcl\r\n");
+            abort();
+            return ERR_ABRT;
         }
 
-        static int32_t _s_recv(void *arg, struct tcp_pcb *tpcb, struct pbuf *pb, err_t err) {
-            return reinterpret_cast<ClientContext*>(arg)->_recv(tpcb, pb, err);
+        if(_rx_buf) {
+            DEBUGV(":rch %d, %d\r\n", _rx_buf->tot_len, pb->tot_len);
+            pbuf_cat(_rx_buf, pb);
+        } else {
+            DEBUGV(":rn %d\r\n", pb->tot_len);
+            _rx_buf = pb;
+            _rx_buf_offset = 0;
         }
+        return ERR_OK;
+    }
 
-        static void _s_error(void *arg, err_t err) {
-            reinterpret_cast<ClientContext*>(arg)->_error(err);
+    void _error(err_t err)
+    {
+        DEBUGV(":er %d %08x\r\n", err, (uint32_t) _strategy);
+        tcp_arg(_pcb, NULL);
+        tcp_sent(_pcb, NULL);
+        tcp_recv(_pcb, NULL);
+        tcp_err(_pcb, NULL);
+        _pcb = NULL;
+        if (_strategy) {
+            _strategy->on_error(*this);
         }
+    }
 
-        static err_t _s_poll(void *arg, struct tcp_pcb *tpcb) {
-            return reinterpret_cast<ClientContext*>(arg)->_poll(tpcb);
+    err_t _poll(tcp_pcb* pcb)
+    {
+        if (_strategy) {
+            _strategy->on_poll(*this);
         }
+        return ERR_OK;
+    }
 
-        static err_t _s_sent(void *arg, struct tcp_pcb *tpcb, uint16_t len) {
-            return reinterpret_cast<ClientContext*>(arg)->_sent(tpcb, len);
-        }
+    static int32_t _s_recv(void *arg, struct tcp_pcb *tpcb, struct pbuf *pb, err_t err)
+    {
+        return reinterpret_cast<ClientContext*>(arg)->_recv(tpcb, pb, err);
+    }
 
-    private:
-        tcp_pcb* _pcb;
+    static void _s_error(void *arg, err_t err)
+    {
+        reinterpret_cast<ClientContext*>(arg)->_error(err);
+    }
 
-        pbuf* _rx_buf;
-        size_t _rx_buf_offset;
+    static err_t _s_poll(void *arg, struct tcp_pcb *tpcb)
+    {
+        return reinterpret_cast<ClientContext*>(arg)->_poll(tpcb);
+    }
 
-        discard_cb_t _discard_cb;
-        void* _discard_cb_arg;
+    static err_t _s_sent(void *arg, struct tcp_pcb *tpcb, uint16_t len)
+    {
+        return reinterpret_cast<ClientContext*>(arg)->_sent(tpcb, len);
+    }
 
-        int _refcnt;
-        ClientContext* _next;
+private:
+    tcp_pcb* _pcb;
 
-        DataStrategy* _strategy = nullptr;
+    pbuf* _rx_buf;
+    size_t _rx_buf_offset;
+
+    discard_cb_t _discard_cb;
+    void* _discard_cb_arg;
+
+    int _refcnt;
+    ClientContext* _next;
+
+    DataStrategy* _strategy = nullptr;
 };
 
 #endif//CLIENTCONTEXT_H

--- a/libraries/ESP8266WiFi/src/include/DataStrategy.h
+++ b/libraries/ESP8266WiFi/src/include/DataStrategy.h
@@ -1,0 +1,25 @@
+/* DataStrategy.h - interface for writing data to ClientContext
+ * Copyright (c) 2016 Ivan Grokhotkov. All rights reserved.
+ * This file is distributed under MIT license.
+ */
+
+#ifndef DATASTRATEGY_H
+#define DATASTRATEGY_H
+
+
+#include "ClientContext.h"
+
+class DataStrategy
+{
+public:
+    virtual ~DataStrategy() {}
+    virtual size_t write(ClientContext& ctx) = 0;
+    virtual void on_sent(ClientContext& ctx, size_t size) = 0;
+    virtual void on_error(ClientContext& ctx) = 0;
+    virtual void on_poll(ClientContext& ctx) = 0;
+};
+
+/// in DataStrategyImpl.h
+
+
+#endif//DATASTRATEGY_H

--- a/libraries/ESP8266WiFi/src/include/DataStrategy.h
+++ b/libraries/ESP8266WiFi/src/include/DataStrategy.h
@@ -19,7 +19,4 @@ public:
     virtual void on_poll(ClientContext& ctx) = 0;
 };
 
-/// in DataStrategyImpl.h
-
-
 #endif//DATASTRATEGY_H

--- a/libraries/ESP8266WiFi/src/include/DataStrategyImpl.h
+++ b/libraries/ESP8266WiFi/src/include/DataStrategyImpl.h
@@ -1,0 +1,261 @@
+/* DataStrategyImpl.h - a few strategies for writing data to ClientContext,
+                        plus some helper classes
+ * Copyright (c) 2016 Ivan Grokhotkov. All rights reserved.
+ * This file is distributed under MIT license.
+ */
+
+#ifndef DATASTRATEGYIMPL_H
+#define DATASTRATEGYIMPL_H
+
+#include "DataStrategy.h"
+#include <assert.h>
+
+class BufferStrategy : public DataStrategy
+{
+public:
+    BufferStrategy(const uint8_t* buf, size_t size, uint32_t timeout)
+        : _buf(buf),
+          _size(size),
+          _timeout(timeout + millis())
+    {
+    }
+
+    size_t write(ClientContext& ctx) override
+    {
+        write_some(ctx);
+        while (!_done) {
+            esp_yield();
+        }
+        return _written;
+    }
+
+    void write_some(ClientContext& ctx)
+    {
+        size_t can_write = ctx.getSendBufferSize();
+        size_t will_write = (can_write < _size) ? can_write : _size;
+        if (!ctx.write(_buf, will_write)) {
+            end();
+            return;
+        }
+        _buf += will_write;
+        _size -= will_write;
+        _queued += will_write;
+    }
+
+    void on_sent(ClientContext& ctx, size_t size) override
+    {
+        if (_size > 0) {
+            write_some(ctx);
+        }
+        _queued -= size;
+        _written += size;
+        if (_queued == 0) {
+            end();
+        }
+    }
+
+    void on_error(ClientContext& ctx) override
+    {
+        if (_queued > 0) {
+            end();
+        }
+    }
+
+    void on_poll(ClientContext& ctx) override
+    {
+        if (millis() > _timeout && _queued > 0) {
+            end();
+        }
+    }
+
+    void end()
+    {
+        if (!_done) {
+            _done = true;
+            esp_schedule();
+        }
+    }
+
+protected:
+    const uint8_t * _buf;
+    size_t _size;
+    size_t _written = 0;
+    size_t _queued = 0;
+    uint32_t _timeout = 0;
+    bool _done = false;
+};
+
+class BufferLink
+{
+public:
+    BufferLink(size_t size, BufferLink* prev) :
+        _size(size),
+        _data(new uint8_t[size])
+    {
+        if (prev) {
+            prev->_next = this;
+        }
+    }
+
+    ~BufferLink()
+    {
+        delete[] _data;
+    }
+
+    uint8_t* data() const
+    {
+        return _data;
+    }
+
+    size_t size() const
+    {
+        return _size;
+    }
+
+    BufferLink* next() const
+    {
+        return _next;
+    }
+
+protected:
+    size_t _size;
+    uint8_t* _data;
+    BufferLink* _next = nullptr;
+};
+
+class ProgmemSource
+{
+public:
+    ProgmemSource(PGM_P buf, size_t size) :
+        _buf(buf),
+        _left(size)
+    {
+    }
+
+    size_t readBytes(char* dst, size_t size)
+    {
+        size_t will_read = (_left < size) ? _left : size;
+        memcpy_P((void*)dst, (PGM_VOID_P)_buf, will_read);
+        return will_read;
+    }
+
+protected:
+    PGM_P _buf;
+    size_t _left;
+};
+
+template<typename TSource>
+class ChunkedStrategy : public DataStrategy
+{
+public:
+    ChunkedStrategy(TSource& source, size_t size, unsigned timeout) :
+        _source(source),
+        _size(size),
+        _timeout(timeout)
+    {
+    }
+
+    ~ChunkedStrategy() override
+    {
+        while (_buffers_head) {
+            auto tmp = _buffers_head;
+            _buffers_head = _buffers_head->next();
+            delete tmp;
+        }
+    }
+
+    size_t write(ClientContext& ctx) override
+    {
+        write_some(ctx);
+        while (!_done) {
+            esp_yield();
+        }
+        return _written;
+    }
+
+    void write_some(ClientContext& ctx)
+    {
+        size_t can_write = ctx.getSendBufferSize();
+        size_t will_write = (can_write < _size) ? can_write : _size;
+
+        BufferLink* new_buf = new BufferLink(will_write, _buffers_tail);
+        if (!_buffers_head) {
+            _buffers_head = new_buf;
+        }
+        _buffers_tail = new_buf;
+        size_t cb = _source.readBytes((char*) new_buf->data(), will_write);
+        if (cb < will_write) {
+            end();
+            return;
+        }
+        if (!ctx.write(new_buf->data(), will_write)) {
+            end();
+            return;
+        }
+        _size -= will_write;
+        _last_write_time = millis();
+    }
+
+    void on_sent(ClientContext& ctx, size_t size) override
+    {
+        if (_size > 0) {
+            write_some(ctx);
+        }
+        auto size_to_remove = size;
+        while (size_to_remove) {
+            assert(_buffers_head != nullptr);
+            size_t buf_size = _buffers_head->size() - _offset;
+            if (buf_size > size_to_remove) {
+                _offset += size_to_remove;
+                break;
+            }
+            auto tmp = _buffers_head;
+            _buffers_head = _buffers_head->next();
+            delete tmp;
+            _offset = 0;
+            size_to_remove -= buf_size;
+        }
+        _written += size;
+        if (_buffers_head == nullptr) {
+            end();
+        }
+    }
+
+    void on_error(ClientContext& ctx) override
+    {
+        if (_buffers_head != nullptr) {
+            end();
+        }
+    }
+
+    void on_poll(ClientContext& ctx) override
+    {
+        if (_last_write_time != 0 &&
+                millis() - _last_write_time > _timeout &&
+                _buffers_head != nullptr) {
+            end();
+        }
+    }
+
+    void end()
+    {
+        if (!_done) {
+            _done = true;
+            esp_schedule();
+        }
+    }
+
+protected:
+    TSource& _source;
+    BufferLink* _buffers_head = nullptr;
+    BufferLink* _buffers_tail = nullptr;
+    size_t _size;
+    size_t _written = 0;
+    uint32_t _timeout = 0;
+    size_t _offset = 0;
+    bool _done = false;
+    uint32_t _last_write_time = 0;
+};
+
+
+#endif//DATASTRATEGYIMPL_H

--- a/libraries/ESP8266WiFi/src/include/DataStrategyImpl.h
+++ b/libraries/ESP8266WiFi/src/include/DataStrategyImpl.h
@@ -136,6 +136,8 @@ public:
     {
         size_t will_read = (_left < size) ? _left : size;
         memcpy_P((void*)dst, (PGM_VOID_P)_buf, will_read);
+        _left -= will_read;
+        _buf  += will_read;
         return will_read;
     }
 


### PR DESCRIPTION
- Moved write behaviour (splitting payload into chunks, waiting for ACKs to arrive) from ClientContext into strategies.
- Implemented `BufferStrategy` for payloads already present in RAM, and `ChunkedStrategy` for payloads which need to be copied to RAM on the fly.
- WiFiClient::write(Stream&) will now send as much data as possible, as soon as possible. Previously it would send 1460 byte chunks, and would wait for each chunk to be ACKed before sending new one. Depending on network latency, this gives transfer speed increase within 25% — 100%.
- WiFiClient will now get write timeout from `_timeout` member (1 second by default). Previously timeout was hard-coded to 5 seconds
- ESP8266WebServer sets client timeout of 5 seconds before writing data. This is done to preserve old behaviour of WebServer.
- `WiFiClientSecure` still has 5 seconds timeout hardcoded, some refactoring is necessary to expose `_timeout` member at the point when write function is called by axTLS.
- ESP8266WebServer sendContent (_P) will now rely on WiFiClient::write (_P) to deliver the data