### PR TITLE
Static initialization guards implementation

### DIFF
--- a/cores/esp8266/abi.cpp
+++ b/cores/esp8266/abi.cpp
@@ -25,7 +25,10 @@ extern "C" {
 #include "osapi.h"
 #include "mem.h"
 }
+#include <Arduino.h>
+#include <cxxabi.h>
 
+using __cxxabiv1::__guard;
 
 void *operator new(size_t size) {
     size = ((size + 3) & ~((size_t)0x3));
@@ -55,6 +58,34 @@ void __cxa_pure_virtual(void) {
 void __cxa_deleted_virtual(void) {
     panic();
 }
+
+typedef struct {
+    uint8_t guard;
+    uint8_t ps;
+} guard_t;
+
+extern "C" int __cxa_guard_acquire(__guard* pg)
+{
+    uint8_t ps = xt_rsil(15);
+    if (reinterpret_cast<guard_t*>(pg)->guard) {
+        xt_wsr_ps(ps);
+        return 0;
+    }
+    reinterpret_cast<guard_t*>(pg)->ps = ps;
+    return 1;
+}
+
+extern "C" void __cxa_guard_release(__guard* pg)
+{
+    reinterpret_cast<guard_t*>(pg)->guard = 1;
+    xt_wsr_ps(reinterpret_cast<guard_t*>(pg)->ps);
+}
+
+extern "C" void __cxa_guard_abort(__guard* pg)
+{
+    xt_wsr_ps(reinterpret_cast<guard_t*>(pg)->ps);
+}
+
 
 namespace std {
 void __throw_bad_function_call() {

--- a/cores/esp8266/abi.cpp
+++ b/cores/esp8266/abi.cpp
@@ -19,43 +19,41 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <debug.h>
-extern "C" {
-#include "ets_sys.h"
-#include "os_type.h"
-#include "osapi.h"
-#include "mem.h"
-}
 #include <Arduino.h>
 #include <cxxabi.h>
 
 using __cxxabiv1::__guard;
 
-void *operator new(size_t size) {
-    size = ((size + 3) & ~((size_t)0x3));
-    return os_malloc(size);
+void *operator new(size_t size)
+{
+    return malloc(size);
 }
 
-void *operator new[](size_t size) {
-    size = ((size + 3) & ~((size_t)0x3));
-    return os_malloc(size);
+void *operator new[](size_t size)
+{
+    return malloc(size);
 }
 
-void operator delete(void * ptr) {
-    os_free(ptr);
+void operator delete(void * ptr)
+{
+    free(ptr);
 }
 
-void operator delete[](void * ptr) {
-    os_free(ptr);
+void operator delete[](void * ptr)
+{
+    free(ptr);
 }
 
 extern "C" void __cxa_pure_virtual(void) __attribute__ ((__noreturn__));
 extern "C" void __cxa_deleted_virtual(void) __attribute__ ((__noreturn__));
 
-void __cxa_pure_virtual(void) {
+void __cxa_pure_virtual(void)
+{
     panic();
 }
 
-void __cxa_deleted_virtual(void) {
+void __cxa_deleted_virtual(void)
+{
     panic();
 }
 
@@ -87,20 +85,25 @@ extern "C" void __cxa_guard_abort(__guard* pg)
 }
 
 
-namespace std {
-void __throw_bad_function_call() {
+namespace std
+{
+void __throw_bad_function_call()
+{
     panic();
 }
 
-void __throw_length_error(char const*) {
+void __throw_length_error(char const*)
+{
     panic();
 }
 
-void __throw_bad_alloc() {
+void __throw_bad_alloc()
+{
     panic();
 }
 
-void __throw_logic_error(const char* str) {
+void __throw_logic_error(const char* str)
+{
     panic();
 }
 }


### PR DESCRIPTION
This pull request adds implementation of libsupc++ functions which are used by gcc to protect local static initializers.

Interrupts are disabled for the duration of static initialization. This is not ideal, but i don't see a way to implement this without disabling interrupts. Imagine the following scenario:

```c++
int first_millis() {
  static int x = millis();
  return x; 
}

void isr_handler() {
  first_millis();
}

void setup() {
  Serial.begin(115200);
  attachInterrupt(0, &isr_handler, CHANGE);
  delay(10);
  Serial.println(millis() - first_millis());
}

void loop() {
}
```

Let's consider the case when `first_millis` is called from `setup` first, and GPIO interrupt happens at the point when `millis` is being executed. Execution context is switched to `isr_handler`, which calls `first_millis` again. C++ standard requires static initialization to be finished before execution is allowed to proceed further, but since we are now inside an interrupt, there is no way of doing that. ISR has higher priority and `millis` will proceed only when ISR is finished.

Therefore I think we have to live with interrupts disabled for the duration of static initialization.
