### PR TITLE
Avoid redefining printf

### DIFF
--- a/cores/esp8266/umm_malloc/umm_malloc.c
+++ b/cores/esp8266/umm_malloc/umm_malloc.c
@@ -493,6 +493,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include "ets_sys.h"
 
 #include "umm_malloc.h"
 
@@ -552,42 +553,42 @@
 /* ------------------------------------------------------------------------- */
 
 #if DBG_LOG_LEVEL >= 6
-#  define DBG_LOG_TRACE( format, ... ) printf( format, ## __VA_ARGS__ )
+#  define DBG_LOG_TRACE( format, ... ) ets_printf( format, ## __VA_ARGS__ )
 #else
 #  define DBG_LOG_TRACE( format, ... )
 #endif
 
 #if DBG_LOG_LEVEL >= 5
-#  define DBG_LOG_DEBUG( format, ... ) printf( format, ## __VA_ARGS__ )
+#  define DBG_LOG_DEBUG( format, ... ) ets_printf( format, ## __VA_ARGS__ )
 #else
 #  define DBG_LOG_DEBUG( format, ... )
 #endif
 
 #if DBG_LOG_LEVEL >= 4
-#  define DBG_LOG_CRITICAL( format, ... ) printf( format, ## __VA_ARGS__ )
+#  define DBG_LOG_CRITICAL( format, ... ) ets_printf( format, ## __VA_ARGS__ )
 #else
 #  define DBG_LOG_CRITICAL( format, ... )
 #endif
 
 #if DBG_LOG_LEVEL >= 3
-#  define DBG_LOG_ERROR( format, ... ) printf( format, ## __VA_ARGS__ )
+#  define DBG_LOG_ERROR( format, ... ) ets_printf( format, ## __VA_ARGS__ )
 #else
 #  define DBG_LOG_ERROR( format, ... )
 #endif
 
 #if DBG_LOG_LEVEL >= 2
-#  define DBG_LOG_WARNING( format, ... ) printf( format, ## __VA_ARGS__ )
+#  define DBG_LOG_WARNING( format, ... ) ets_printf( format, ## __VA_ARGS__ )
 #else
 #  define DBG_LOG_WARNING( format, ... )
 #endif
 
 #if DBG_LOG_LEVEL >= 1
-#  define DBG_LOG_INFO( format, ... ) printf( format, ## __VA_ARGS__ )
+#  define DBG_LOG_INFO( format, ... ) ets_printf( format, ## __VA_ARGS__ )
 #else
 #  define DBG_LOG_INFO( format, ... )
 #endif
 
-#define DBG_LOG_FORCE( force, format, ... ) {if(force) {printf( format, ## __VA_ARGS__  );}}
+#define DBG_LOG_FORCE( force, format, ... ) {if(force) {ets_printf( format, ## __VA_ARGS__  );}}
 
 /* }}} */
 
@@ -676,7 +677,7 @@ static int integrity_check(void) {
 
     /* Check that next free block number is valid */
     if (cur >= UMM_NUMBLOCKS) {
-      printf("heap integrity broken: too large next free num: %d "
+      ets_printf("heap integrity broken: too large next free num: %d "
           "(in block %d, addr 0x%lx)\n", cur, prev,
           (unsigned long)&UMM_NBLOCK(prev));
       ok = 0;
@@ -689,7 +690,7 @@ static int integrity_check(void) {
 
     /* Check if prev free block number matches */
     if (UMM_PFREE(cur) != prev) {
-      printf("heap integrity broken: free links don't match: "
+      ets_printf("heap integrity broken: free links don't match: "
           "%d -> %d, but %d -> %d\n",
           prev, cur, cur, UMM_PFREE(cur));
       ok = 0;
@@ -708,7 +709,7 @@ static int integrity_check(void) {
 
     /* Check that next block number is valid */
     if (cur >= UMM_NUMBLOCKS) {
-      printf("heap integrity broken: too large next block num: %d "
+      ets_printf("heap integrity broken: too large next block num: %d "
           "(in block %d, addr 0x%lx)\n", cur, prev,
           (unsigned long)&UMM_NBLOCK(prev));
       ok = 0;
@@ -723,7 +724,7 @@ static int integrity_check(void) {
     if ((UMM_NBLOCK(cur) & UMM_FREELIST_MASK)
         != (UMM_PBLOCK(cur) & UMM_FREELIST_MASK))
     {
-      printf("heap integrity broken: mask wrong at addr 0x%lx: n=0x%x, p=0x%x\n",
+      ets_printf("heap integrity broken: mask wrong at addr 0x%lx: n=0x%x, p=0x%x\n",
           (unsigned long)&UMM_NBLOCK(cur),
           (UMM_NBLOCK(cur) & UMM_FREELIST_MASK),
           (UMM_PBLOCK(cur) & UMM_FREELIST_MASK)
@@ -737,7 +738,7 @@ static int integrity_check(void) {
 
     /* Check if prev block number matches */
     if (UMM_PBLOCK(cur) != prev) {
-      printf("heap integrity broken: block links don't match: "
+      ets_printf("heap integrity broken: block links don't match: "
           "%d -> %d, but %d -> %d\n",
           prev, cur, cur, UMM_PBLOCK(cur));
       ok = 0;
@@ -783,7 +784,7 @@ clean:
  */
 static void dump_mem ( const unsigned char *ptr, size_t len ) {
   while (len--) {
-    printf(" 0x%.2x", (unsigned int)(*ptr++));
+    ets_printf(" 0x%.2x", (unsigned int)(*ptr++));
   }
 }
 
@@ -814,11 +815,11 @@ static int check_poison( const unsigned char *ptr, size_t poison_size,
   }
 
   if (!ok) {
-    printf("there is no poison %s the block. "
+    ets_printf("there is no poison %s the block. "
         "Expected poison address: 0x%lx, actual data:",
         where, (unsigned long)ptr);
     dump_mem(ptr, poison_size);
-    printf("\n");
+    ets_printf("\n");
   }
 
   return ok;
@@ -832,7 +833,7 @@ static int check_poison_block( umm_block *pblock ) {
   int ok = 1;
 
   if (pblock->header.used.next & UMM_FREELIST_MASK) {
-    printf("check_poison_block is called for free block 0x%lx\n",
+    ets_printf("check_poison_block is called for free block 0x%lx\n",
         (unsigned long)pblock);
   } else {
     /* the block is used; let's check poison */

--- a/cores/esp8266/umm_malloc/umm_malloc_cfg.h
+++ b/cores/esp8266/umm_malloc/umm_malloc_cfg.h
@@ -6,8 +6,6 @@
 #define _UMM_MALLOC_CFG_H
 
 #include <debug.h>
-#include <ets_sys.h>
-#define printf ets_printf
 /*
  * There are a number of defines you can set at compile time that affect how
  * the memory allocator will operate.


### PR DESCRIPTION
Needed to avoid userland error when including `umm_malloc.h` for heap diagnosis.