### PR TITLE
fix umm memory managment

### DIFF
--- a/cores/esp8266/memory_wrap.c
+++ b/cores/esp8266/memory_wrap.c
@@ -52,12 +52,24 @@ void * ICACHE_RAM_ATTR __wrap_mem_malloc(size_t size) {
     return malloc(size);
 }
 
+void * ICACHE_RAM_ATTR __wrap_mem_calloc(size_t num, size_t size) {
+    return calloc(num, size);
+}
+
 void * ICACHE_RAM_ATTR __wrap_mem_realloc(void *ptr, size_t size) {
     return realloc(ptr, size);
 }
 
 void * ICACHE_RAM_ATTR __wrap_mem_zalloc(size_t size) {
     return calloc(1, size);
+}
+
+void ICACHE_RAM_ATTR __wrap_mem_init(void) {
+    umm_init();
+}
+
+void * ICACHE_RAM_ATTR __wrap_mem_trim(void *ptr, size_t size) {
+    return ptr;
 }
 
 size_t ICACHE_RAM_ATTR __wrap_xPortGetFreeHeapSize(void) {

--- a/cores/esp8266/memory_wrap.c
+++ b/cores/esp8266/memory_wrap.c
@@ -1,0 +1,65 @@
+/**
+ memory_wrap.c
+
+ Copyright (c) 2015 Markus Sattler. All rights reserved.
+ This file is part of the esp8266 core for Arduino environment.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+*/
+
+#include <stdlib.h>
+#include <debug.h>
+#include <Arduino.h>
+
+void ICACHE_RAM_ATTR __wrap_vPortFree(void *ptr, const char* file, int line) {
+    free(ptr);
+}
+
+void * ICACHE_RAM_ATTR __wrap_pvPortMalloc(size_t size, const char* file, int line) {
+    return malloc(size);
+}
+
+void * ICACHE_RAM_ATTR __wrap_pvPortCalloc(size_t num, size_t size, const char* file, int line) {
+    return calloc(num, size);
+}
+
+void * ICACHE_RAM_ATTR __wrap_pvPortRealloc(void *ptr, size_t size, const char* file, int line) {
+    return realloc(ptr, size);
+}
+
+void * ICACHE_RAM_ATTR __wrap_pvPortZalloc(size_t size, const char* file, int line) {
+    return calloc(1, size);
+}
+
+void ICACHE_RAM_ATTR __wrap_mem_free(void *ptr) {
+    free(ptr);
+}
+
+void * ICACHE_RAM_ATTR __wrap_mem_malloc(size_t size) {
+    return malloc(size);
+}
+
+void * ICACHE_RAM_ATTR __wrap_mem_realloc(void *ptr, size_t size) {
+    return realloc(ptr, size);
+}
+
+void * ICACHE_RAM_ATTR __wrap_mem_zalloc(size_t size) {
+    return calloc(1, size);
+}
+
+size_t ICACHE_RAM_ATTR __wrap_xPortGetFreeHeapSize(void) {
+    return umm_free_heap_size();
+}

--- a/cores/esp8266/umm_malloc/umm_malloc.c
+++ b/cores/esp8266/umm_malloc/umm_malloc.c
@@ -498,6 +498,12 @@
 
 #include "umm_malloc_cfg.h"   /* user-dependent */
 
+#ifdef ESP8266
+#include "osapi.h"
+#define printf os_printf
+#endif
+
+
 #ifndef UMM_FIRST_FIT
 #  ifndef UMM_BEST_FIT
 #    define UMM_BEST_FIT

--- a/platform.txt
+++ b/platform.txt
@@ -27,7 +27,7 @@ compiler.c.flags=-c {compiler.warning_flags} -Os -g -Wpointer-arith -Wno-implici
 compiler.S.cmd=xtensa-lx106-elf-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp -MMD -mlongcalls
 
-compiler.c.elf.flags=-g {compiler.warning_flags} -Os -nostdlib -Wl,--no-check-sections -u call_user_start -Wl,-static "-L{compiler.sdk.path}/lib" "-L{compiler.sdk.path}/ld" "-T{build.flash_ld}" -Wl,--gc-sections -Wl,-wrap,system_restart_local -Wl,-wrap,register_chipv6_phy -Wl,-wrap,vPortFree -Wl,-wrap,pvPortMalloc -Wl,-wrap,pvPortCalloc -Wl,-wrap,pvPortRealloc -Wl,-wrap,pvPortZalloc -Wl,-wrap,mem_free -Wl,-wrap,mem_malloc -Wl,-wrap,mem_realloc -Wl,-wrap,mem_zalloc -Wl,-wrap,xPortGetFreeHeapSize
+compiler.c.elf.flags=-g {compiler.warning_flags} -Os -nostdlib -Wl,--no-check-sections -u call_user_start -Wl,-static "-L{compiler.sdk.path}/lib" "-L{compiler.sdk.path}/ld" "-T{build.flash_ld}" -Wl,--gc-sections -Wl,-wrap,system_restart_local -Wl,-wrap,register_chipv6_phy -Wl,-wrap,vPortFree -Wl,-wrap,pvPortMalloc -Wl,-wrap,pvPortCalloc -Wl,-wrap,pvPortRealloc -Wl,-wrap,pvPortZalloc -Wl,-wrap,mem_free -Wl,-wrap,mem_malloc -Wl,-wrap,mem_realloc -Wl,-wrap,mem_zalloc -Wl,-wrap,xPortGetFreeHeapSize -Wl,-wrap,mem_init -Wl,-wrap,mem_calloc -Wl,-wrap,mem_trim
 
 compiler.c.elf.cmd=xtensa-lx106-elf-gcc
 compiler.c.elf.libs=-lm -lgcc -lhal -lphy -lpp -lnet80211 -llwip -lwpa -lcrypto -lmain -lwps -laxtls -lsmartconfig -lmesh

--- a/platform.txt
+++ b/platform.txt
@@ -27,7 +27,7 @@ compiler.c.flags=-c {compiler.warning_flags} -Os -g -Wpointer-arith -Wno-implici
 compiler.S.cmd=xtensa-lx106-elf-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp -MMD -mlongcalls
 
-compiler.c.elf.flags=-g {compiler.warning_flags} -Os -nostdlib -Wl,--no-check-sections -u call_user_start -Wl,-static "-L{compiler.sdk.path}/lib" "-L{compiler.sdk.path}/ld" "-T{build.flash_ld}" -Wl,--gc-sections -Wl,-wrap,system_restart_local -Wl,-wrap,register_chipv6_phy
+compiler.c.elf.flags=-g {compiler.warning_flags} -Os -nostdlib -Wl,--no-check-sections -u call_user_start -Wl,-static "-L{compiler.sdk.path}/lib" "-L{compiler.sdk.path}/ld" "-T{build.flash_ld}" -Wl,--gc-sections -Wl,-wrap,system_restart_local -Wl,-wrap,register_chipv6_phy -Wl,-wrap,vPortFree -Wl,-wrap,pvPortMalloc -Wl,-wrap,pvPortCalloc -Wl,-wrap,pvPortRealloc -Wl,-wrap,pvPortZalloc -Wl,-wrap,mem_free -Wl,-wrap,mem_malloc -Wl,-wrap,mem_realloc -Wl,-wrap,mem_zalloc -Wl,-wrap,xPortGetFreeHeapSize
 
 compiler.c.elf.cmd=xtensa-lx106-elf-gcc
 compiler.c.elf.libs=-lm -lgcc -lhal -lphy -lpp -lnet80211 -llwip -lwpa -lcrypto -lmain -lwps -laxtls -lsmartconfig -lmesh


### PR DESCRIPTION
wrap all SDK memory functions in all libs, to get umm to work
fix umm_malloc.c:1708: undefined reference to `putchar'