### PR TITLE
Enable WPA2-Enterprise

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -30,7 +30,7 @@ compiler.S.flags=-c -g -x assembler-with-cpp -MMD -mlongcalls
 compiler.c.elf.flags=-g {compiler.warning_flags} -Os -nostdlib -Wl,--no-check-sections -u call_user_start -Wl,-static "-L{compiler.sdk.path}/lib" "-L{compiler.sdk.path}/ld" "-T{build.flash_ld}" -Wl,--gc-sections -Wl,-wrap,system_restart_local -Wl,-wrap,register_chipv6_phy
 
 compiler.c.elf.cmd=xtensa-lx106-elf-gcc
-compiler.c.elf.libs=-lm -lgcc -lhal -lphy -lpp -lnet80211 -llwip -lwpa -lcrypto -lmain -lwps -laxtls -lsmartconfig -lmesh
+compiler.c.elf.libs=-lm -lgcc -lhal -lphy -lpp -lnet80211 -llwip -lwpa -lcrypto -lmain -lwps -laxtls -lsmartconfig -lmesh -lwpa2
 
 compiler.cpp.cmd=xtensa-lx106-elf-g++
 compiler.cpp.flags=-c {compiler.warning_flags} -Os -g -mlongcalls -mtext-section-literals -fno-exceptions -fno-rtti -falign-functions=4 -std=c++11 -MMD -ffunction-sections -fdata-sections

--- a/tools/sdk/include/user_interface.h
+++ b/tools/sdk/include/user_interface.h
@@ -255,6 +255,8 @@ int wifi_station_set_cert_key(uint8 *client_cert, int client_cert_len,
     uint8 *private_key, int private_key_len,
     uint8 *private_key_passwd, int private_key_passwd_len);
 void wifi_station_clear_cert_key(void);
+int wifi_station_set_username(unsigned char*, int);
+void wifi_station_clear_username(void);
 
 struct softap_config {
     uint8 ssid[32];


### PR DESCRIPTION
Include libwpa2 to enable WPA2-Enterprise (EAP-TLS only). Note that there are some function prototypes missing in the espressif sdk (v1.5.2), that need to be patched in order to overwrite the default identity ('espressif').

For testing, see https://github.com/joostd/esp8266-eduroam/tree/master/ansible. That project targets a specific Wifi network (eduroam), but the test setup is generic.

