### PR TITLE
Fix a crash in String::changeBuffer()

### DIFF
--- a/cores/esp8266/WString.cpp
+++ b/cores/esp8266/WString.cpp
@@ -156,9 +156,11 @@ unsigned char ICACHE_FLASH_ATTR String::changeBuffer(unsigned int maxStrLen) {
     char *newbuffer = (char *) malloc(newSize);
     if(newbuffer) {
         memset(newbuffer, 0, newSize);
-        memcpy(newbuffer, buffer, len);
         if (buffer)
+        {
+            memcpy(newbuffer, buffer, len);
             free(buffer);
+        }
         capacity = newSize - 1;
         buffer = newbuffer;
         return 1;


### PR DESCRIPTION
Calling `String::reserve(0)` causes a crash if String object is in invalidated state. Per the comment on the method's declaration in WString.h, `reserve(0)` would validate the string object but in fact it just causes a crash instead of recovering from invalidated strings.

This change fixes the edge case bug in `String::changeBuffer()` which is the root cause of the crash exposed from `String::reserve()`.

Following test code was used to reproduce the problem and also to validate the fix:

```c++
String result;
while(true){ // suppose this is a loop which reads data from a web page.
  char c = 'A'; // suppose this is a byte read from client.
  result += c; // the loop will eventually cause malloc() to fail here
  if (result.c_str()==0) // even if we detect this
  {
    Serial.println("String INVALIDATED!!!!!");
    // attempt to validate string object so we can use it.
    result.reserve(0);   // before fix, this would crash.
    // if reserve(0) worked, the object is validated, i.e. available for use again.
    Serial.println("Trying to empty...."); // try to make use of object to see.
    result=""; 
    Serial.println("Emptied!!!!"); // works!
    break;
  } 
}
```