### PR TITLE
Leverage realloc() in String::changeBuffer()

### DIFF
--- a/cores/esp8266/WString.cpp
+++ b/cores/esp8266/WString.cpp
@@ -153,13 +153,12 @@ unsigned char ICACHE_FLASH_ATTR String::reserve(unsigned int size) {
 
 unsigned char ICACHE_FLASH_ATTR String::changeBuffer(unsigned int maxStrLen) {
     size_t newSize = (maxStrLen + 16) & (~0xf);
-    char *newbuffer = (char *) malloc(newSize);
+    char *newbuffer = (char *) realloc(buffer, newSize);
     if(newbuffer) {
-        memset(newbuffer, 0, newSize);
-        if (buffer)
+        size_t oldSize = capacity + 1; // include NULL.
+        if (newSize > oldSize)
         {
-            memcpy(newbuffer, buffer, len);
-            free(buffer);
+            memset(newbuffer + oldSize, 0, newSize - oldSize);
         }
         capacity = newSize - 1;
         buffer = newbuffer;


### PR DESCRIPTION
realloc() can be a better alternative to doing malloc() followed by strcpy(). It may reduce memory footprint of concatination operation (when consecutive memory blocks are available for allocation extension).