### PR TITLE
Update boards.txt for ThaiEasyElec's ESPino

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1002,6 +1002,8 @@ espinotee.build.variant=espinotee
 espinotee.build.flash_mode=qio
 espinotee.build.flash_size=4M
 espinotee.build.flash_freq=40
+espinotee.build.debug_port=
+espinotee.build.debug_level=
 
 espinotee.menu.CpuFrequency.80=80 MHz
 espinotee.menu.CpuFrequency.80.build.f_cpu=80000000L


### PR DESCRIPTION
Error during compilation on Arduino IDE require debug port and debug level.
So, set both parameter to <ิblank> to solve that problem.