### PR TITLE
fix umm_malloc null ptr.

### DIFF
--- a/cores/esp8266/umm_malloc/umm_malloc.c
+++ b/cores/esp8266/umm_malloc/umm_malloc.c
@@ -971,6 +971,10 @@ void ICACHE_FLASH_ATTR *umm_info( void *ptr, int force ) {
 
   unsigned short int blockNo = 0;
 
+  if (umm_heap == NULL) {
+      umm_init();
+  }
+
   /* Protect the critical section... */
   UMM_CRITICAL_ENTRY();
 


### PR DESCRIPTION
(endless reboot) like:
```
Fatal exception (28):
epc1=0x402097e8, epc2=0x00000000, epc3=0x00000000, excvaddr=0x00000001, depc=0x00000000
Fatal exception (28):
epc1=0x402097e8, epc2=0x00000000, epc3=0x00000000, excvaddr=0x00000001, depc=0x00000000
Fatal exception (28):
epc1=0x402097e8, epc2=0x00000000, epc3=0x00000000, excvaddr=0x00000001, depc=0x00000000
```

```
0x402097e8: umm_info at umm_malloc/umm_malloc.c line 1000
```