### PR TITLE
Allow indefinite duration for `tone()`

### DIFF
--- a/cores/esp8266/Tone.cpp
+++ b/cores/esp8266/Tone.cpp
@@ -113,7 +113,7 @@ void noTone(uint8_t _pin) {
   digitalWrite(_pin, LOW);
 }
 
-void t1IntHandler() {
+ICACHE_RAM_ATTR void t1IntHandler() {
   if (toggle_counts[T1INDEX] != 0){
     // toggle the pin
     digitalWrite(tone_pins[T1INDEX], toggle_counts[T1INDEX] % 2);

--- a/cores/esp8266/Tone.cpp
+++ b/cores/esp8266/Tone.cpp
@@ -114,10 +114,14 @@ void noTone(uint8_t _pin) {
 }
 
 void t1IntHandler() {
-  if (toggle_counts[T1INDEX] > 0){
+  if (toggle_counts[T1INDEX] != 0){
     // toggle the pin
     digitalWrite(tone_pins[T1INDEX], toggle_counts[T1INDEX] % 2);
     toggle_counts[T1INDEX]--;
+    // handle the case of indefinite duration
+    if (toggle_counts[T1INDEX] < -2){
+      toggle_counts[T1INDEX] = -1;
+    }
   }else{
     disableTimer(T1INDEX);
     digitalWrite(tone_pins[T1INDEX], LOW);


### PR DESCRIPTION
Bugfix: the `duration` parameter should be optional, per [`tone()`](https://www.arduino.cc/en/Reference/Tone) docs.