### PR TITLE
Size reports for CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,12 @@ addons:
 script:
   - set -e
   - export CXX="g++-4.8" CC="gcc-4.8" GCOV="gcov-4.8"
+  - echo -e "travis_fold:start:host_tests"
   - pushd $TRAVIS_BUILD_DIR/tests/host
   - make
   - make clean-objects
+  - echo -e "travis_fold:end:host_tests"
+  - echo -e "travis_fold:start:sketch_test_env_prepare"
   - popd
   - wget -O arduino.tar.xz https://www.arduino.cc/download.php?f=/arduino-nightly-linux64.tar.xz
   - tar xf arduino.tar.xz
@@ -31,7 +34,13 @@ script:
   - cd $TRAVIS_BUILD_DIR
   - source tests/common.sh
   - install_libraries
+  - echo -e "travis_fold:end:sketch_test_env_prepare"
+  - echo -e "travis_fold:start:sketch_test"
   - build_sketches $HOME/arduino_ide $TRAVIS_BUILD_DIR "-l $HOME/Arduino/libraries"
+  - echo -e "travis_fold:end:sketch_test"
+  - echo -e "travis_fold:start:size_report"
+  - cat size.log
+  - echo -e "travis_fold:end:size_report"
 
 after_success:
     - pushd $TRAVIS_BUILD_DIR/tests/host

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - ln -s $TRAVIS_BUILD_DIR esp8266
   - cd esp8266/tools
   - python get.py
-  - export PATH="$HOME/arduino_ide:$PATH"
+  - export PATH="$HOME/arduino_ide:$TRAVIS_BUILD_DIR/tools/xtensa-lx106-elf/bin:$PATH"
   - which arduino
   - cd $TRAVIS_BUILD_DIR
   - source tests/common.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,12 @@ script:
   - ln -s $TRAVIS_BUILD_DIR esp8266
   - cd esp8266/tools
   - python get.py
-  - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16
-  - sleep 3
-  - export DISPLAY=:1.0
   - export PATH="$HOME/arduino_ide:$PATH"
   - which arduino
   - cd $TRAVIS_BUILD_DIR
   - source tests/common.sh
   - install_libraries
-  - build_sketches $HOME/arduino_ide $TRAVIS_BUILD_DIR "python tools/build.py -l $HOME/Arduino/libraries -b generic -v"
+  - build_sketches $HOME/arduino_ide $TRAVIS_BUILD_DIR "-l $HOME/Arduino/libraries"
 
 after_success:
     - pushd $TRAVIS_BUILD_DIR/tests/host

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -1,13 +1,49 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+function print_size_info()
+{
+    elf_file=$1
+
+    if [ -z "$elf_file" ]; then
+        printf "sketch                       data     rodata   bss      text     irom0.text   dram     flash\n"
+        return 0
+    fi
+
+    elf_name=$(basename $elf_file)
+    sketch_name="${elf_name%.*}"
+    # echo $sketch_name
+    declare -A segments
+    while read -a tokens; do
+        seg=${tokens[0]}
+        seg=${seg//./}
+        size=${tokens[1]}
+        addr=${tokens[2]}
+        if [ "$addr" -eq "$addr" -a "$addr" -ne "0" ] 2>/dev/null; then
+            segments[$seg]=$size
+        fi
+
+
+    done < <(xtensa-lx106-elf-size --format=sysv $elf_file)
+
+    total_ram=$((${segments[data]} + ${segments[rodata]} + ${segments[bss]}))
+    total_flash=$((${segments[data]} + ${segments[rodata]} + ${segments[text]} + ${segments[irom0text]}))
+
+    printf "%-28s %-8d %-8d %-8d %-8d %-8d     %-8d %-8d\n" $sketch_name ${segments[data]} ${segments[rodata]} ${segments[bss]} ${segments[text]} ${segments[irom0text]} $total_ram $total_flash
+    return 0
+}
 
 function build_sketches()
 {
     set +e
     local arduino=$1
     local srcpath=$2
-    local build_cmd=$3
-    echo $build_cmd
+    local build_arg=$3
+    local build_dir=build.tmp
+    mkdir -p $build_dir
+    rm -rf $build_dir/*
+    local build_cmd="python tools/build.py -b generic -v -k -p $PWD/$build_dir $build_arg "
     local sketches=$(find $srcpath -name *.ino)
+    print_size_info >size.log
     export ARDUINO_IDE_PATH=$arduino
     for sketch in $sketches; do
         local sketchdir=$(dirname $sketch)
@@ -33,8 +69,12 @@ function build_sketches()
             return $result
         fi
         rm build.log
+        print_size_info $build_dir/*.elf >>size.log
     done
     set -e
+    echo -e "\n ------------ Size report ------------ \n"
+    cat size.log
+    echo -e "\n ------------------------------------- \n"
 }
 
 function install_libraries()

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -72,9 +72,6 @@ function build_sketches()
         print_size_info $build_dir/*.elf >>size.log
     done
     set -e
-    echo -e "\n ------------ Size report ------------ \n"
-    cat size.log
-    echo -e "\n ------------------------------------- \n"
 }
 
 function install_libraries()


### PR DESCRIPTION
This pull request adds sketch size reports at the end of CI build logs.
Intended use is to see how a given pull request affects flash/RAM usage.