### PR TITLE
CaptivePortalAdvanced fix #1718

### DIFF
--- a/libraries/DNSServer/examples/CaptivePortalAdvanced/handleHttp.ino
+++ b/libraries/DNSServer/examples/CaptivePortalAdvanced/handleHttp.ino
@@ -6,6 +6,7 @@ void handleRoot() {
   server.sendHeader("Cache-Control", "no-cache, no-store, must-revalidate");
   server.sendHeader("Pragma", "no-cache");
   server.sendHeader("Expires", "-1");
+  server.setContentLength(CONTENT_LENGTH_UNKNOWN);
   server.send(200, "text/html", ""); // Empty content inhibits Content-length header so we have to close the socket ourselves.
   server.sendContent(
     "<html><head></head><body>"
@@ -40,6 +41,7 @@ void handleWifi() {
   server.sendHeader("Cache-Control", "no-cache, no-store, must-revalidate");
   server.sendHeader("Pragma", "no-cache");
   server.sendHeader("Expires", "-1");
+  server.setContentLength(CONTENT_LENGTH_UNKNOWN);
   server.send(200, "text/html", ""); // Empty content inhibits Content-length header so we have to close the socket ourselves.
   server.sendContent(
     "<html><head></head><body>"


### PR DESCRIPTION
fix for #1718: CaptivePortalAdvanced example doesn't call setContentLength