### PR TITLE
Avoid multiple instances of INADDR_NONE

### DIFF
--- a/cores/esp8266/IPAddress.cpp
+++ b/cores/esp8266/IPAddress.cpp
@@ -112,3 +112,4 @@ String IPAddress::toString()
     return String(szRet);
 }
 
+const IPAddress INADDR_NONE(0, 0, 0, 0);

--- a/cores/esp8266/IPAddress.h
+++ b/cores/esp8266/IPAddress.h
@@ -87,6 +87,6 @@ class IPAddress: public Printable {
         friend class DNSClient;
 };
 
-const IPAddress INADDR_NONE(0, 0, 0, 0);
+extern const IPAddress INADDR_NONE;
 
 #endif


### PR DESCRIPTION
By moving the definition from the header to the source we now only use
one instance for the entire app with a little saving in space.