### PR TITLE
Add a start callback for HTTP updater

### DIFF
--- a/libraries/ESP8266httpUpdate/examples/httpUpdate/httpUpdate.ino
+++ b/libraries/ESP8266httpUpdate/examples/httpUpdate/httpUpdate.ino
@@ -17,6 +17,10 @@
 
 ESP8266WiFiMulti WiFiMulti;
 
+void update_starting(void) {
+    Serial.println("Update starting");
+}
+
 void setup() {
 
     USE_SERIAL.begin(115200);
@@ -40,6 +44,7 @@ void loop() {
     // wait for WiFi connection
     if((WiFiMulti.run() == WL_CONNECTED)) {
 
+        ESPhttpUpdate.onStart(update_starting);
         t_httpUpdate_return ret = ESPhttpUpdate.update("http://server/file.bin");
         //t_httpUpdate_return  ret = ESPhttpUpdate.update("https://server/file.bin");
 

--- a/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.cpp
+++ b/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.cpp
@@ -173,7 +173,6 @@ t_httpUpdate_return ESP8266HTTPUpdate::handleUpdate(HTTPClient * http, const cha
     // track these headers
     http->collectHeaders(headerkeys, headerkeyssize);
 
-
     int code = http->GET();
     int len = http->getSize();
 
@@ -223,7 +222,7 @@ t_httpUpdate_return ESP8266HTTPUpdate::handleUpdate(HTTPClient * http, const cha
                     lastError = HTTP_UE_TOO_LESS_SPACE;
                     ret = HTTP_UPDATE_FAILED;
                 } else {
-
+                    http_update_start();
                     WiFiClient * tcp = http->getStreamPtr();
 
                     WiFiUDP::stopAll();

--- a/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.h
+++ b/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.h
@@ -52,6 +52,8 @@
 #define HTTP_UE_BIN_VERIFY_HEADER_FAILED    (-106)
 #define HTTP_UE_BIN_FOR_WRONG_FLASH         (-107)
 
+#define HTTP_UPDATE_START_CALLBACK(callback) void (*callback)()
+
 typedef enum {
     HTTP_UPDATE_FAILED,
     HTTP_UPDATE_NO_UPDATES,
@@ -71,12 +73,14 @@ class ESP8266HTTPUpdate {
 
         int getLastError(void);
         String getLastErrorString(void);
+        void onStart(HTTP_UPDATE_START_CALLBACK(callback)) { http_update_start = callback; }
 
     protected:
         t_httpUpdate_return handleUpdate(HTTPClient * http, const char * current_version, bool reboot = true, bool spiffs = false);
         bool runUpdate(Stream& in, uint32_t size, String md5, int command = U_FLASH);
 
         int lastError;
+        HTTP_UPDATE_START_CALLBACK(http_update_start);
 };
 
 extern ESP8266HTTPUpdate ESPhttpUpdate;


### PR DESCRIPTION
The callback is called when the upgrade actually starts rather than just
the initial query so that the user can know that it will not take longer
and can also prepare for the upgrade by shutting down other works.
