### PR TITLE
Update spiffs_api.cpp

### DIFF
--- a/cores/esp8266/spiffs_api.cpp
+++ b/cores/esp8266/spiffs_api.cpp
@@ -63,12 +63,14 @@ bool SPIFFSImpl::exists(const char* path)
     return rc == SPIFFS_OK;
 }
 
-DirImplPtr SPIFFSImpl::openDir(const char* path)
-{
-    if (!isSpiffsFilenameValid(path)) {
-        DEBUGV("SPIFFSImpl::openDir: invalid path=`%s` \r\n", path);
-        return DirImplPtr();
+DirImplPtr SPIFFSImpl::openDir(const char* path) {
+    if (strlen(path) > 0) {
+        if (!isSpiffsFilenameValid(path)) {
+            DEBUGV("SPIFFSImpl::openDir: invalid path=`%s` \r\n", path);
+            return DirImplPtr();
+        }
     }
+
     spiffs_DIR dir;
     spiffs_DIR* result = SPIFFS_opendir(&_fs, path, &dir);
     if (!result) {


### PR DESCRIPTION
Fixes a bug where un-prefixed files are irretrievable with openDir(""). Described: https://github.com/esp8266/Arduino/issues/1818.