### PR TITLE
Prevent exception by detaching Timer0 interrupt when updating

### DIFF
--- a/libraries/ESP8266HTTPUpdateServer/src/ESP8266HTTPUpdateServer.cpp
+++ b/libraries/ESP8266HTTPUpdateServer/src/ESP8266HTTPUpdateServer.cpp
@@ -43,6 +43,7 @@ void ESP8266HTTPUpdateServer::setup(ESP8266WebServer *server)
       if(upload.status == UPLOAD_FILE_START){
         if (_serial_output)
           Serial.setDebugOutput(true);
+        timer0_detachInterrupt();
         WiFiUDP::stopAll();
         if (_serial_output)
           Serial.printf("Update: %s\n", upload.filename.c_str());


### PR DESCRIPTION
I use Timer0 for my encoder. When the timer is active and being reloaded after firing, updates fail with an exception. Detaching the timer fixes this problem. (Verified on bare ESP-12)