### PR TITLE
WifiClient example - Fix issue where not all lines are read from slow servers

### DIFF
--- a/libraries/ESP8266WiFi/examples/WiFiClient/WiFiClient.ino
+++ b/libraries/ESP8266WiFi/examples/WiFiClient/WiFiClient.ino
@@ -81,7 +81,7 @@ void loop() {
   }
   
   // Read all the lines of the reply from server and print them to Serial
-  while(client.available()){
+  while(client.available() || client.connected()){
     String line = client.readStringUntil('\r');
     Serial.print(line);
   }


### PR DESCRIPTION
The while loop which reads the response from the server can finish before all data has been sent by the server, if the server returns the data slower than the code is reading it from the buffer.

As in the example, the server is requested to close the connection after the data has been sent, the problem can be resolved by checking if the client is still connected to the server as well as checking if there is data in the client buffer using client.available()