### PR TITLE
Added extra method for reading current 'passphrase'

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFi.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFi.cpp
@@ -93,8 +93,8 @@ String ESP8266WiFiClass::passphrase()
 {
     struct station_config conf;
     wifi_station_get_config(&conf);
-    const char* ssid = reinterpret_cast<const char*>(conf.password);
-    return String(ssid);
+    const char* passphrase = reinterpret_cast<const char*>(conf.password);
+    return String(passphrase);
 }
 
 ESP8266WiFiClass WiFi;

--- a/libraries/ESP8266WiFi/src/ESP8266WiFi.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFi.cpp
@@ -89,4 +89,12 @@ void ESP8266WiFiClass::printDiag(Print& p) {
 
 }
 
+String ESP8266WiFiClass::passphrase()
+{
+    struct station_config conf;
+    wifi_station_get_config(&conf);
+    const char* ssid = reinterpret_cast<const char*>(conf.password);
+    return String(ssid);
+}
+
 ESP8266WiFiClass WiFi;

--- a/libraries/ESP8266WiFi/src/ESP8266WiFi.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFi.h
@@ -76,6 +76,8 @@ class ESP8266WiFiClass : public ESP8266WiFiGenericClass, public ESP8266WiFiSTACl
 
     public:
 
+        String passphrase();
+
         void printDiag(Print& dest);
 
         friend class WiFiClient;


### PR DESCRIPTION
Hi all,

Firstly, thanks for all the hard work you put into this library.

I added an extra method for reading currently stored SSID passphrase. The placement may not be the optimal but in the end it is functional. :)

This is useful for reading the password obtained from esp-touch and then storing it to the internal filesystem. SSID name reading has been already implemented. 

Someone else might find this useful too, so I'm sending this pull request.

Best,
ihsan.