### PR TITLE
Allow PSK instead of passphrase in WiFiSTA::begin

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
@@ -106,7 +106,7 @@ wl_status_t ESP8266WiFiSTAClass::begin(const char* ssid, const char *passphrase,
         return WL_CONNECT_FAILED;
     }
 
-    if(passphrase && strlen(passphrase) > 63) {
+    if(passphrase && strlen(passphrase) > 64) {
         // fail passphrase too long!
         return WL_CONNECT_FAILED;
     }
@@ -115,7 +115,10 @@ wl_status_t ESP8266WiFiSTAClass::begin(const char* ssid, const char *passphrase,
     strcpy(reinterpret_cast<char*>(conf.ssid), ssid);
 
     if(passphrase) {
-        strcpy(reinterpret_cast<char*>(conf.password), passphrase);
+        if (strlen(passphrase) == 64) // it's not a passphrase, is the PSK
+            memcpy(reinterpret_cast<char*>(conf.password), passphrase, 64);
+        else
+            strcpy(reinterpret_cast<char*>(conf.password), passphrase);
     } else {
         *conf.password = 0;
     }


### PR DESCRIPTION
In WPA protocol, the maximum length of the passphrases is 64 characters in order to distinguish them from the actual PSK which is 64 ASCII characters long, so in most systems if a 64 chars string is passed, it is assumed to be a PSK, otherwise is treated as a passphrase and is used to compute the PSK.