### PR TITLE
Changed timeout logic in wificlient example

### DIFF
--- a/libraries/ESP8266WiFi/examples/WiFiClient/WiFiClient.ino
+++ b/libraries/ESP8266WiFi/examples/WiFiClient/WiFiClient.ino
@@ -71,9 +71,9 @@ void loop() {
   client.print(String("GET ") + url + " HTTP/1.1\r\n" +
                "Host: " + host + "\r\n" + 
                "Connection: close\r\n\r\n");
-  int timeout = millis() + 5000;
+  unsigned long timeout = millis();
   while (client.available() == 0) {
-    if (timeout - millis() < 0) {
+    if (millis() - timeout < 5000) {
       Serial.println(">>> Client Timeout !");
       client.stop();
       return;

--- a/libraries/ESP8266WiFi/examples/WiFiClient/WiFiClient.ino
+++ b/libraries/ESP8266WiFi/examples/WiFiClient/WiFiClient.ino
@@ -73,7 +73,7 @@ void loop() {
                "Connection: close\r\n\r\n");
   unsigned long timeout = millis();
   while (client.available() == 0) {
-    if (millis() - timeout < 5000) {
+    if (millis() - timeout > 5000) {
       Serial.println(">>> Client Timeout !");
       client.stop();
       return;


### PR DESCRIPTION
Changed timeout to unsigned long. Using addition with millis() is not recommended. 
Source: http://www.gammon.com.au/millis