### PR TITLE
Re-enable old behaviour if passphrase string is empty

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiAP.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiAP.cpp
@@ -89,13 +89,13 @@ bool ESP8266WiFiAPClass::softAP(const char* ssid, const char* passphrase, int ch
         return false;
     }
 
-    if(!ssid || *ssid == 0 || strlen(ssid) > 31) {
+    if(!ssid || strlen(ssid) == 0 || strlen(ssid) > 31) {
         // fail SSID too long or missing!
         DEBUG_WIFI("[AP] SSID too long or missing!\n");
         return false;
     }
 
-    if(passphrase && (strlen(passphrase) > 63 || strlen(passphrase) < 8)) {
+    if(passphrase && strlen(passphrase) > 0 && (strlen(passphrase) > 63 || strlen(passphrase) < 8)) {
         // fail passphrase to long or short!
         DEBUG_WIFI("[AP] fail passphrase to long or short!\n");
         return false;


### PR DESCRIPTION
An empty passphrase string should enable AUTH_OPEN mode of softAP.
This was the behaviour before commit 293e55c.
Additionally make the type of checking for empty strings consistent.
Fixes #1861