### PR TITLE
Added Fast LED library to the list of supported libraries

### DIFF
--- a/doc/libraries.md
+++ b/doc/libraries.md
@@ -163,3 +163,4 @@ Libraries that don't rely on low-level access to AVR registers should work well.
 - [Adafruit-PCD8544-Nokia-5110-LCD-Library](https://github.com/WereCatf/Adafruit-PCD8544-Nokia-5110-LCD-library) - Port of the Adafruit PCD8544 - library for the ESP8266.
 - [PCF8574_ESP](https://github.com/WereCatf/PCF8574_ESP) - A very simplistic library for using the PCF8574/PCF8574A I2C 8-pin GPIO-expander.
 - [Dot Matrix Display Library 2](https://github.com/freetronics/DMD2) - Freetronics DMD & Generic 16 x 32 P10 style Dot Matrix Display Library
+- [FastLED](https://github.com/FastLED/FastLED) - a library for easily & efficiently controlling a wide variety of LED chipsets, like the Neopixel (WS2812B), DotStar, LPD8806 and many more. Includes fading, gradient, color conversion functions.


### PR DESCRIPTION
This library has been working well with Arduino for ESP8266 and it deserves to be added here.