### PR TITLE
Speed up SPI.writePattern()

### DIFF
--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -75,7 +75,6 @@ public:
 private:
   bool useHwCs;
   void writeBytes_(uint8_t * data, uint8_t size);
-  void writePattern_(uint8_t * data, uint8_t size, uint8_t repeat);
   void transferBytes_(uint8_t * out, uint8_t * in, uint8_t size);
   inline void setDataBits(uint16_t bits);
 };


### PR DESCRIPTION
The old code kept re-writing fifo's contents over and over and over every iteration, both with data from MISO and then with the supplied data -- this new version writes fifo's contents only once, disables it from being overwritten by data from MISO and as such also skips on writing its contents over and over again with supplied data.

This results in major speed-ups in anything that uses writePattern(), like e.g. with @Links2004 's ILI9341-library there's about a 54% speed-up in fill-screen and anything from 30%-50% speed-up with anything else that uses writePattern() behind-the-scenes.