### PR TITLE
Switch sprintf arguments in SSDPClass::_send around

### DIFF
--- a/libraries/ESP8266SSDP/ESP8266SSDP.cpp
+++ b/libraries/ESP8266SSDP/ESP8266SSDP.cpp
@@ -206,9 +206,9 @@ void SSDPClass::_send(ssdp_method_t method){
     (method == NONE)?_ssdp_response_template:_ssdp_notify_template,
     SSDP_INTERVAL,
     _modelName, _modelNumber,
+    _uuid,
     (method == NONE)?"ST":"NT",
     _deviceType,
-    _uuid,
     IP2STR(&ip), _port, _schemaURL
   );
 


### PR DESCRIPTION
They are in the wrong order - `_ssdp_packet_template` expects `_uuid` to be before the NT/ST header.