### PR TITLE
Fix #2015 ESP8266mDNS doesn't accept queryService responses from avahi

### DIFF
--- a/libraries/ESP8266mDNS/ESP8266mDNS.cpp
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.cpp
@@ -470,8 +470,8 @@ void MDNSResponder::_parsePacket(){
     }
 
     int numAnswers = packetHeader[3];
-    // Assume that the PTR answer always comes first and that it is always accompanied by a TXT, SRV and A answer in the same packet.
-    if (numAnswers != 4) {
+    // Assume that the PTR answer always comes first and that it is always accompanied by a TXT, SRV, AAAA (optional) and A answer in the same packet.
+    if (numAnswers < 4) {
 #ifdef MDNS_DEBUG_RX
       Serial.println("Expected a packet with 4 answers, returning");
 #endif
@@ -550,7 +550,7 @@ void MDNSResponder::_parsePacket(){
 #endif
       }
 
-      if (answerType == MDNS_TYPE_TXT) {
+      else if (answerType == MDNS_TYPE_TXT) {
         partsCollected |= 0x02;
         _conn_readS(hostName, answerRdlength); // Read rdata
 #ifdef MDNS_DEBUG_RX
@@ -561,7 +561,7 @@ void MDNSResponder::_parsePacket(){
 #endif
       }
 
-      if (answerType == MDNS_TYPE_SRV) {
+      else if (answerType == MDNS_TYPE_SRV) {
         partsCollected |= 0x04;
         uint16_t answerPrio = _conn_read16(); // Read priority
         uint16_t answerWeight = _conn_read16(); // Read weight
@@ -589,11 +589,18 @@ void MDNSResponder::_parsePacket(){
         }
       }
 
-      if (answerType == MDNS_TYPE_A) {
+      else if (answerType == MDNS_TYPE_A) {
         partsCollected |= 0x08;
         for (int i = 0; i < 4; i++) {
           answerIp[i] = _conn_read8();
         }
+      }
+      else {
+#ifdef MDNS_DEBUG_RX
+          Serial.printf("Ignoring unsupported type\n", tmp8);
+#endif
+          for (int n = 0; n < answerRdlength; n++)
+		(void)_conn_read8();
       }
 
       if ((partsCollected == 0x0F) && serviceMatch) {


### PR DESCRIPTION
Ignore unknown records in the query response; this way we can extract
the IPv4 address and connect to the server.