### PR TITLE
reset I2C hangup #1025

### DIFF
--- a/cores/esp8266/twi.h
+++ b/cores/esp8266/twi.h
@@ -26,7 +26,7 @@
 extern "C" {
 #endif
 
-void twi_init(unsigned char sda, unsigned char scl);
+int twi_init(unsigned char sda, unsigned char scl);
 void twi_stop(void);
 void twi_setClock(unsigned int freq);
 void twi_setClockStretchLimit(uint32_t limit);


### PR DESCRIPTION
I2C slave might stil have something to send when ESP826 starts I2C, thus
keeping the bus stuck. Happens e.g. when power failure/reset during
transmission.Thanks to work of drmpf.