### PR TITLE
Real board name available in Sketch/MDNS/OTA

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -944,7 +944,7 @@ d1_mini.serial.disableRTS=true
 
 d1_mini.build.mcu=esp8266
 d1_mini.build.f_cpu=80000000L
-d1_mini.build.board=WEMOS_D1_MINI
+d1_mini.build.board=ESP8266_WEMOS_D1MINI
 d1_mini.build.core=esp8266
 d1_mini.build.variant=d1_mini
 d1_mini.build.flash_mode=dio
@@ -1009,7 +1009,7 @@ d1.serial.disableRTS=true
 
 d1.build.mcu=esp8266
 d1.build.f_cpu=80000000L
-d1.build.board=WEMOS_D1
+d1.build.board=ESP8266_WEMOS_D1MINI
 d1.build.core=esp8266
 d1.build.variant=d1
 d1.build.flash_mode=dio

--- a/boards.txt
+++ b/boards.txt
@@ -944,7 +944,7 @@ d1_mini.serial.disableRTS=true
 
 d1_mini.build.mcu=esp8266
 d1_mini.build.f_cpu=80000000L
-d1_mini.build.board=ESP8266_NODEMCU
+d1_mini.build.board=WEMOS_D1_MINI
 d1_mini.build.core=esp8266
 d1_mini.build.variant=d1_mini
 d1_mini.build.flash_mode=dio
@@ -995,7 +995,6 @@ d1_mini.menu.FlashSize.4M1M.build.spiffs_end=0x3FB000
 d1_mini.menu.FlashSize.4M1M.build.spiffs_blocksize=8192
 d1_mini.menu.FlashSize.4M1M.build.spiffs_pagesize=256
 
-
 ##############################################################
 d1.name=WeMos D1(Retired)
 
@@ -1010,7 +1009,7 @@ d1.serial.disableRTS=true
 
 d1.build.mcu=esp8266
 d1.build.f_cpu=80000000L
-d1.build.board=ESP8266_NODEMCU
+d1.build.board=WEMOS_D1
 d1.build.core=esp8266
 d1.build.variant=d1
 d1.build.flash_mode=dio
@@ -1215,11 +1214,9 @@ wifinfo.serial.disableDTR=true
 wifinfo.serial.disableRTS=true
 
 wifinfo.build.mcu=esp8266
-wifinfo.build.f_cpu=160000000L
 wifinfo.build.core=esp8266
 wifinfo.build.variant=wifinfo
-wifinfo.build.flash_mode=qio
-wifinfo.build.board=ESP8266_NODEMCU
+wifinfo.build.board=WIFINFO
 wifinfo.build.spiffs_pagesize=256
 wifinfo.build.debug_port=Serial1
 wifinfo.build.debug_level=Wifinfo
@@ -1300,20 +1297,20 @@ wifinfo.menu.ESPModule.ESP12.build.spiffs_blocksize=8192
 wifinfo.menu.ESPModule.ESP12.build.spiffs_pagesize=256
 wifinfo.menu.ESPModule.ESP12.upload.maximum_size=1044464
 
-wifinfo.menu.CpuFrequency.80=80 MHz
-wifinfo.menu.CpuFrequency.80.build.f_cpu=80000000L
 wifinfo.menu.CpuFrequency.160=160 MHz
 wifinfo.menu.CpuFrequency.160.build.f_cpu=160000000L
+wifinfo.menu.CpuFrequency.80=80 MHz
+wifinfo.menu.CpuFrequency.80.build.f_cpu=80000000L
 
 wifinfo.menu.FlashFreq.40=40MHz
 wifinfo.menu.FlashFreq.40.build.flash_freq=40
 wifinfo.menu.FlashFreq.80=80MHz
 wifinfo.menu.FlashFreq.80.build.flash_freq=80
 
-wifinfo.menu.FlashMode.dio=DIO
-wifinfo.menu.FlashMode.dio.build.flash_mode=dio
 wifinfo.menu.FlashMode.qio=QIO
 wifinfo.menu.FlashMode.qio.build.flash_mode=qio
+wifinfo.menu.FlashMode.dio=DIO
+wifinfo.menu.FlashMode.dio.build.flash_mode=dio
 
 wifinfo.menu.UploadSpeed.115200=115200
 wifinfo.menu.UploadSpeed.115200.upload.speed=115200

--- a/platform.txt
+++ b/platform.txt
@@ -64,13 +64,13 @@ compiler.objcopy.eep.extra_flags=
 compiler.elf2hex.extra_flags=
 
 ## Compile c files
-recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.cpreprocessor.flags} {compiler.c.flags} -DF_CPU={build.f_cpu} {build.lwip_flags} {build.debug_port} {build.debug_level} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.cpreprocessor.flags} {compiler.c.flags} -DF_CPU={build.f_cpu} {build.lwip_flags} {build.debug_port} {build.debug_level} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DARDUINO_BOARD="{build.board}" {compiler.c.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile c++ files
-recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpreprocessor.flags} {compiler.cpp.flags} -DF_CPU={build.f_cpu} {build.lwip_flags} {build.debug_port} {build.debug_level} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpreprocessor.flags} {compiler.cpp.flags} -DF_CPU={build.f_cpu} {build.lwip_flags} {build.debug_port} {build.debug_level} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DARDUINO_BOARD="{build.board}" {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile S files
-recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.cpreprocessor.flags} {compiler.S.flags} -DF_CPU={build.f_cpu} {build.lwip_flags} {build.debug_port} {build.debug_level} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.cpreprocessor.flags} {compiler.S.flags} -DF_CPU={build.f_cpu} {build.lwip_flags} {build.debug_port} {build.debug_level} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DARDUINO_BOARD="{build.board}" {compiler.c.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Create archives
 recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{build.path}/arduino.ar" "{object_file}"


### PR DESCRIPTION
- Changed WifInfo defaults settings
- Changed WeMos defined board name not to be ESP8266_NODEMCU but WEMOS_D1_MINI and WEMOS_D1
- Added board name defined symbol at compilation stage to have it available in sketch, MDNS and OTA using ARDUINO_BOARD (like in [ESP8266mDNS.h](https://github.com/esp8266/Arduino/blob/master/libraries/ESP8266mDNS/ESP8266mDNS.h#L51))
This avoid board name to be "generic" in case of known board