### PR TITLE
Update ESP8266HTTPClient.cpp

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -865,6 +865,7 @@ bool HTTPClient::sendHeader(const char * type)
     }
 
     if(_base64Authorization.length()) {
+        _base64Authorization.replace("\n", "");
         header += F("Authorization: Basic ");
         header += _base64Authorization;
         header += "\r\n";


### PR DESCRIPTION
The libb64 base64 library adds newlines to the base64 encoding of the encoded _base64Authorization String if the encoded string every 72 characters.  This causes problems with the Authorization: Basic http header when the username and password are long.  The change strips out newlines from _base64Authorization right before the header is sent.