### PR TITLE
Support HTTP header without white space.

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -906,7 +906,8 @@ int HTTPClient::handleHeaderResponse()
                 _returnCode = headerLine.substring(9, headerLine.indexOf(' ', 9)).toInt();
             } else if(headerLine.indexOf(':')) {
                 String headerName = headerLine.substring(0, headerLine.indexOf(':'));
-                String headerValue = headerLine.substring(headerLine.indexOf(':') + 2);
+                String headerValue = headerLine.substring(headerLine.indexOf(':') + 1);
+                headerValue.trim();
 
                 if(headerName.equalsIgnoreCase("Content-Length")) {
                     _size = headerValue.toInt();


### PR DESCRIPTION
ESP8266HTTPClient can't process HTTP header which has no white space after `:`.

A header, `Content-Length:1234` makes `234`.

Some implementation of HTTP server returns HTTP header which has no white space.
