### PR TITLE
Added __throw_out_of_range

### DIFF
--- a/cores/esp8266/abi.cpp
+++ b/cores/esp8266/abi.cpp
@@ -106,6 +106,11 @@ void __throw_logic_error(const char* str)
 {
     panic();
 }
+
+void __throw_out_of_range(const ohar* str)
+{
+    panic();
+}
 }
 
 // TODO: rebuild windows toolchain to make this unnecessary:

--- a/cores/esp8266/abi.cpp
+++ b/cores/esp8266/abi.cpp
@@ -107,7 +107,7 @@ void __throw_logic_error(const char* str)
     panic();
 }
 
-void __throw_out_of_range(const ohar* str)
+void __throw_out_of_range(const char* str)
 {
     panic();
 }


### PR DESCRIPTION
I am having trouble using std::string in a library on esp8266. Following the advice here: https://github.com/esp8266/Arduino/issues/1136#issuecomment-162331360 I got most of the way but I am still getting linking issues looking for this function.