### PR TITLE
Fix init array order

### DIFF
--- a/cores/esp8266/core_esp8266_main.cpp
+++ b/cores/esp8266/core_esp8266_main.cpp
@@ -119,9 +119,9 @@ static void loop_task(os_event_t *events) {
 }
 
 static void do_global_ctors(void) {
-    void (**p)(void);
-    for(p = &__init_array_start; p != &__init_array_end; ++p)
-        (*p)();
+    void (**p)(void) = &__init_array_end;
+    while (p != &__init_array_start)
+        (*--p)();
 }
 
 extern "C" void __gdb_init() {}


### PR DESCRIPTION
GCC for Xtensa LX106 generates constructor sections names in inverse order. 

The link script in tools/sdk/ld/eagle.app.v6.common.ld is also designed to create an __init_array in inverse order.

So we must traverse that array starting from the end.