### PR TITLE
Add virtual destructor to WiFiServer class

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiServer.h
+++ b/libraries/ESP8266WiFi/src/WiFiServer.h
@@ -47,6 +47,7 @@ private:
 public:
   WiFiServer(IPAddress addr, uint16_t port);
   WiFiServer(uint16_t port);
+  virtual ~WiFiServer() {}
   WiFiClient available(uint8_t* status = NULL);
   bool hasClient();
   void begin();


### PR DESCRIPTION
Without this line compiler complains about :

Warning		22:9: warning: deleting object of polymorphic class type 'WiFiServer' which has non-virtual destructor might cause undefined behaviour [-Wdelete-non-virtual-dtor]		\\Mac\Home\Documents\Visual Studio 2015\Projects\BlinkESP8266_12\ActAsWiFi_server\SVServer.cpp	22

Reason for this is that I would like to init WiFiServer with port which can by dynamically chosen (for example by serial port)

internalServer = new WiFiServer(port);