### PR TITLE
MD5Builder::addStream: fixed falsy calculated hash for len > filelength

### DIFF
--- a/cores/esp8266/MD5Builder.h
+++ b/cores/esp8266/MD5Builder.h
@@ -37,7 +37,7 @@ class MD5Builder {
     void addHexString(const char * data);
     void addHexString(char * data){ addHexString((const char*)data); }
     void addHexString(String data){ addHexString(data.c_str()); }
-    bool addStream(Stream & stream, const size_t total_len);
+    bool addStream(Stream & stream, const size_t maxLen);
     void calculate(void);
     void getBytes(uint8_t * output);
     void getChars(char * output);


### PR DESCRIPTION
We found an issue with the MD5Builder::addStream method. 
If len > filelength handled a false hash was calculated. Refactored for better readability.  

Tested with a filestream resulted in calculating the correct hash. 

