### PR TITLE
return true sketch size using ESP.getSketchSize() 

### DIFF
--- a/cores/esp8266/Esp.h
+++ b/cores/esp8266/Esp.h
@@ -133,6 +133,7 @@ class EspClass {
         bool flashRead(uint32_t offset, uint32_t *data, size_t size);
 
         uint32_t getSketchSize();
+        String getSketchMD5();
         uint32_t getFreeSketchSpace();
         bool updateSketch(Stream& in, uint32_t size, bool restartOnFail = false, bool restartOnSuccess = true);
 


### PR DESCRIPTION
return true sketch size using ESP.getSketchSize() 
https://github.com/esp8266/Arduino/issues/2153

add MD5 for current binary ESP.getSketchMD5()