### PR TITLE
Prevent returning a pointer in a previous stack

### DIFF
--- a/cores/esp8266/time.c
+++ b/cores/esp8266/time.c
@@ -112,7 +112,7 @@ struct tm* localtime(const time_t *clock)
 char* ctime(const time_t *t)
 {
     struct tm* p_tm = localtime(t);
-    char* result = asctime(p_tm);
+    static char* result = asctime(p_tm);
     return result;
 }
 

--- a/cores/esp8266/time.c
+++ b/cores/esp8266/time.c
@@ -111,8 +111,9 @@ struct tm* localtime(const time_t *clock)
 
 char* ctime(const time_t *t)
 {
+    static char *result = NULL;
     struct tm* p_tm = localtime(t);
-    static char* result = asctime(p_tm);
+    result = asctime(p_tm);
     return result;
 }
 


### PR DESCRIPTION
This fixes a possible of data corruption and crashes due to using an overwritten pointer.