### PR TITLE
Documenting of ESP.getFlashChipRealSize()

### DIFF
--- a/doc/libraries.md
+++ b/doc/libraries.md
@@ -99,6 +99,8 @@ Several APIs may be used to get flash chip info:
 
 `ESP.getFlashChipSize()` returns the flash chip size, in bytes, as seen by the SDK (may be less than actual size).
 
+`ESP.getFlashChipRealSize()` returns the real chip size, in bytes, based on the flash chip ID.
+
 `ESP.getFlashChipSpeed(void)` returns the flash chip frequency, in Hz.
 
 `ESP.getCycleCount()` returns the cpu instruction cycle count since start as an unsigned 32-bit.  This is useful for accurate timing of very short actions like bit banging.


### PR DESCRIPTION
Hi, 
I added ESP.getFlashChipRealSize() function to the documentation. I couldn't determine flash size of my ESP based on getFlashChipSize function, so I was googling and found this: https://github.com/esp8266/Arduino/issues/785
I tested functionality and now adding here to official documentation.
Cheers!