### PR TITLE
Add OTA type to onStart callback

### DIFF
--- a/libraries/ArduinoOTA/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/ArduinoOTA.cpp
@@ -180,7 +180,7 @@ void ArduinoOTAClass::_onRx(){
       nonce_md5.add(String(micros()));
       nonce_md5.calculate();
       _nonce = nonce_md5.toString();
-      
+
       char auth_req[38];
       sprintf(auth_req, "AUTH %s", _nonce.c_str());
       _udp_ota->append((const char *)auth_req, strlen(auth_req));
@@ -324,6 +324,10 @@ void ArduinoOTAClass::handle() {
     _runUpdate();
     _state = OTA_IDLE;
   }
+}
+
+int ArduinoOTAClass::getCommand() {
+  return _cmd;
 }
 
 ArduinoOTAClass ArduinoOTA;

--- a/libraries/ArduinoOTA/ArduinoOTA.h
+++ b/libraries/ArduinoOTA/ArduinoOTA.h
@@ -40,6 +40,7 @@ class ArduinoOTAClass
     void onProgress(THandlerFunction_Progress fn);
     void begin();
     void handle();
+    int getCommand(); // get update command type after OTA started- either U_FLASH or U_SPIFFS
 
   private:
     int _port;

--- a/libraries/ArduinoOTA/examples/BasicOTA/BasicOTA.ino
+++ b/libraries/ArduinoOTA/examples/BasicOTA/BasicOTA.ino
@@ -27,7 +27,14 @@ void setup() {
   // ArduinoOTA.setPassword((const char *)"123");
 
   ArduinoOTA.onStart([]() {
-    Serial.println("Start");
+    String type;
+    if (ArduinoOTA.getCommand() == U_FLASH)
+      type = "sketch";
+    else // U_SPIFFS
+      type = "filesystem";
+
+    // NOTE: if updating SPIFFS this would be the place to unmount SPIFFS using SPIFFS.end()
+    Serial.println("Start updating " + type);
   });
   ArduinoOTA.onEnd([]() {
     Serial.println("\nEnd");


### PR DESCRIPTION
Allows to decide if unmounting SPIFFS and potentially writing config files to SPIFFS is necessary.

Mentioned this on gitter- right now none of the examples show use of `SPIFFS.end()` nor is it possible to decide if thats even needed. Idea of this PR is to tell the handler what type of spiffs update is actually doing on. 

If updating the handler is undesired I could also a `getOTAType` function or similar that would expose the `_cmd` value.
