### PR TITLE
Updated String library to use C++11 iterators.

### DIFF
--- a/cores/esp8266/WString.h
+++ b/cores/esp8266/WString.h
@@ -207,9 +207,11 @@ class String {
         void toCharArray(char *buf, unsigned int bufsize, unsigned int index = 0) const {
             getBytes((unsigned char *) buf, bufsize, index);
         }
-        const char * c_str() const {
-            return buffer;
-        }
+        const char* c_str() const { return buffer; }
+        char* begin() { return buffer; }
+        char* end() { return buffer + length(); }
+        const char* begin() const { return c_str(); }
+        const char* end() const { return c_str() + length(); }
 
         // search
         int indexOf(char ch) const;


### PR DESCRIPTION
This will allow using the String library in a ranged for loop:

```C++
String s("Hi, this is a test");

for (const char& ch : s) {
  Serial.print(ch);
}
```

and even modify

```C++
String s("Hi, this is another test");

for (char& ch : s) {
  ch++;
}
Serial.println(s);
```