### PR TITLE
Use the same DEBUG provisions as ESP8266WebServer

### DIFF
--- a/libraries/DNSServer/src/DNSServer.cpp
+++ b/libraries/DNSServer/src/DNSServer.cpp
@@ -2,6 +2,11 @@
 #include <lwip/def.h>
 #include <Arduino.h>
 
+#ifdef DEBUG_ESP_PORT
+#define DEBUG_OUTPUT DEBUG_ESP_PORT
+#else
+#define DEBUG_OUTPUT Serial
+#endif
 
 DNSServer::DNSServer()
 {
@@ -144,7 +149,7 @@ void DNSServer::replyWithIP()
 
 
 
-  #ifdef DEBUG
+  #ifdef DEBUG_ESP_DNS_SERVER
     DEBUG_OUTPUT.print("DNS responds: ");
     DEBUG_OUTPUT.print(_resolvedIP[0]);
     DEBUG_OUTPUT.print(".");


### PR DESCRIPTION
Since DEBUG is a generic flag used by other projects, and since DEBUG_OUTPUT was not defined in this case, I opted to set DEBUG_OUTPUT as part of this file (cfr. ESP8266WebServer) and changed the default DEBUG #ifdef to a more specific DEBUG_ESP_DNS_SERVER #ifdef, also cfr. ESP8266WebServer.

This ensure out project using WiFiManager does not fail to build with the error:

```
/home/dag/home-made/ADEM/arduino15/packages/esp8266/hardware/esp8266/2.3.0/libraries/DNSServer/src/DNSServer.cpp: In member function 'void DNSServer::replyWithIP()':
/home/dag/home-made/ADEM/arduino15/packages/esp8266/hardware/esp8266/2.3.0/libraries/DNSServer/src/DNSServer.cpp:148:5: error: 'DEBUG_OUTPUT' was not declared in this scope
     DEBUG_OUTPUT.print("DNS responds: ");
     ^
```
