### PR TITLE
proposal for issue #1845 Scan networks don't work after WPS config failed

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
@@ -590,6 +590,12 @@ void wifi_wps_status_cb(wps_cb_status status) {
         case WPS_CB_ST_WEP:
             DEBUGV("wps WEP\n");
             break;
+        case WPS_CB_ST_UNK:
+            DEBUGV("wps UNKNOWN\n");
+            if(!wifi_wps_disable()) {
+                DEBUGV("wps disable failed\n");
+            }
+            break;
     }
     // TODO user function to get status
 
@@ -670,4 +676,3 @@ void ESP8266WiFiSTAClass::_smartConfigCallback(uint32_t st, void* result) {
         WiFi.stopSmartConfig();
     }
 }
-

--- a/tools/sdk/include/user_interface.h
+++ b/tools/sdk/include/user_interface.h
@@ -481,6 +481,7 @@ enum wps_cb_status {
 	WPS_CB_ST_FAILED,
 	WPS_CB_ST_TIMEOUT,
 	WPS_CB_ST_WEP,
+	WPS_CB_ST_UNK,
 };
 
 bool wifi_wps_enable(WPS_TYPE_t wps_type);


### PR DESCRIPTION
Thix fixes the issue for me as discussed here :
https://github.com/esp8266/Arduino/issues/1845

It seems like wifi_wps_status_cb gets an undefined status 4, I gave it a name and added the missing call to wifi_wps_disable.

here is a sketch for testing the case.

```
/*
 *  This sketch demonstrates how to scan WiFi networks. 
 *  The API is almost the same as with the WiFi Shield library, 
 *  the most obvious difference being the different file you need to include:
 */
#include "ESP8266WiFi.h"

void setup() {
  Serial.begin(74880);
  Serial.setDebugOutput(1);
  Serial.setDebugOutput(true);

  // Set WiFi to station mode and disconnect from an AP if it was previously connected
  WiFi.mode(WIFI_STA);
  WiFi.disconnect();
  delay(100);

  Serial.println("Setup done");
}

void loop() {

  // If not connected, run the WPS procedure.
  if(!connectWPS()) {
    Serial.println("WPS Failed");
  }
  
  Serial.println("scan start");

  // WiFi.scanNetworks will return the number of networks found
  int n = WiFi.scanNetworks();
  Serial.println("scan done");
  if (n == 0)
    Serial.println("no networks found");
  else
  {
    Serial.print(n);
    Serial.println(" networks found");
    for (int i = 0; i < n; ++i)
    {
      // Print SSID and RSSI for each network found
      Serial.print(i + 1);
      Serial.print(": ");
      Serial.print(WiFi.SSID(i));
      Serial.print(" (");
      Serial.print(WiFi.RSSI(i));
      Serial.print(")");
      Serial.println((WiFi.encryptionType(i) == ENC_TYPE_NONE)?" ":"*");
      delay(10);
    }
  }
  Serial.println("");

  // Wait a bit before scanning again
  delay(5000);
}

// https://gist.github.com/copa2/fcc718c6549721c210d614a325271389
bool connectWPS() {
  if (WiFi.status() != WL_CONNECTED) {
    Serial.println("\nAttempting WPS connection ...");
    bool wpsSuccess = WiFi.beginWPSConfig();
    if(wpsSuccess) {
      // Ckeck SSID
      String newSSID = WiFi.SSID();
      if(newSSID.length() > 0) {
        // WPSConfig has already connected in STA mode successfully to the new station.
        Serial.printf("WPS finished. Connected successfull to SSID '%s'\n", newSSID.c_str());
      } else {
        Serial.println("WiFi.beginWPSConfig() returns true BUT WiFi.SSID() is Empty");
        wpsSuccess = false;
      }
    }
    return wpsSuccess; 
  } 
}
```