### PR TITLE
allow F() to be used for uri parameter

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -128,15 +128,15 @@ void ESP8266WebServer::requestAuthentication(){
   send(401);
 }
 
-void ESP8266WebServer::on(const char* uri, ESP8266WebServer::THandlerFunction handler) {
+void ESP8266WebServer::on(const String &uri, ESP8266WebServer::THandlerFunction handler) {
   on(uri, HTTP_ANY, handler);
 }
 
-void ESP8266WebServer::on(const char* uri, HTTPMethod method, ESP8266WebServer::THandlerFunction fn) {
+void ESP8266WebServer::on(const String &uri, HTTPMethod method, ESP8266WebServer::THandlerFunction fn) {
   on(uri, method, fn, _fileUploadHandler);
 }
 
-void ESP8266WebServer::on(const char* uri, HTTPMethod method, ESP8266WebServer::THandlerFunction fn, ESP8266WebServer::THandlerFunction ufn) {
+void ESP8266WebServer::on(const String &uri, HTTPMethod method, ESP8266WebServer::THandlerFunction fn, ESP8266WebServer::THandlerFunction ufn) {
   _addRequestHandler(new FunctionRequestHandler(fn, ufn, uri, method));
 }
 

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -77,9 +77,9 @@ public:
   void requestAuthentication();
 
   typedef std::function<void(void)> THandlerFunction;
-  void on(const char* uri, THandlerFunction handler);
-  void on(const char* uri, HTTPMethod method, THandlerFunction fn);
-  void on(const char* uri, HTTPMethod method, THandlerFunction fn, THandlerFunction ufn);
+  void on(const String &uri, THandlerFunction handler);
+  void on(const String &uri, HTTPMethod method, THandlerFunction fn);
+  void on(const String &uri, HTTPMethod method, THandlerFunction fn, THandlerFunction ufn);
   void addHandler(RequestHandler* handler);
   void serveStatic(const char* uri, fs::FS& fs, const char* path, const char* cache_header = NULL );
   void onNotFound(THandlerFunction fn);  //called when handler is not assigned

--- a/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
@@ -5,7 +5,7 @@
 
 class FunctionRequestHandler : public RequestHandler {
 public:
-    FunctionRequestHandler(ESP8266WebServer::THandlerFunction fn, ESP8266WebServer::THandlerFunction ufn, const char* uri, HTTPMethod method)
+    FunctionRequestHandler(ESP8266WebServer::THandlerFunction fn, ESP8266WebServer::THandlerFunction ufn, const String &uri, HTTPMethod method)
     : _fn(fn)
     , _ufn(ufn)
     , _uri(uri)


### PR DESCRIPTION
currently we can only pass const char * ("foo") as uri parameter to the on() method of the webserver. in more complex sketches with many uri handlers those strings use significant amount of RAM (in my case 250+ bytes). changing the uri parameter from const char * to const String &, allows strings to be moved to flash by wrapping them in the F() macro. example:

webserver->on(F("/files"), HTTP_GET,  handle_file_page_cb);