### PR TITLE
allow global object instances be switch off with defines

### DIFF
--- a/cores/esp8266/FS.h
+++ b/cores/esp8266/FS.h
@@ -139,6 +139,8 @@ using fs::SeekEnd;
 using fs::FSInfo;
 #endif //FS_NO_GLOBALS
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SPIFFS)
 extern fs::FS SPIFFS;
+#endif
 
 #endif //FS_H

--- a/cores/esp8266/spiffs_api.cpp
+++ b/cores/esp8266/spiffs_api.cpp
@@ -124,11 +124,13 @@ extern "C" uint32_t _SPIFFS_block;
 #define SPIFFS_MAX_OPEN_FILES 5
 #endif
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SPIFFS)
 FS SPIFFS = FS(FSImplPtr(new SPIFFSImpl(
                              SPIFFS_PHYS_ADDR,
                              SPIFFS_PHYS_SIZE,
                              SPIFFS_PHYS_PAGE,
                              SPIFFS_PHYS_BLOCK,
                              SPIFFS_MAX_OPEN_FILES)));
+#endif
 
 #endif

--- a/libraries/ArduinoOTA/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/ArduinoOTA.cpp
@@ -334,4 +334,6 @@ int ArduinoOTAClass::getCommand() {
   return _cmd;
 }
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_ARDUINOOTA)
 ArduinoOTAClass ArduinoOTA;
+#endif

--- a/libraries/ArduinoOTA/ArduinoOTA.h
+++ b/libraries/ArduinoOTA/ArduinoOTA.h
@@ -68,6 +68,8 @@ class ArduinoOTAClass
     String readStringUntil(char end);
 };
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_ARDUINOOTA)
 extern ArduinoOTAClass ArduinoOTA;
+#endif
 
 #endif /* __ARDUINO_OTA_H */

--- a/libraries/EEPROM/EEPROM.cpp
+++ b/libraries/EEPROM/EEPROM.cpp
@@ -22,7 +22,7 @@
 #include "Arduino.h"
 #include "EEPROM.h"
 
- extern "C" {
+extern "C" {
 #include "c_types.h"
 #include "ets_sys.h"
 #include "os_type.h"
@@ -30,8 +30,18 @@
 #include "spi_flash.h"
 }
 
+extern "C" uint32_t _SPIFFS_end;
+
 EEPROMClass::EEPROMClass(uint32_t sector)
 : _sector(sector)
+, _data(0)
+, _size(0)
+, _dirty(false)
+{
+}
+
+EEPROMClass::EEPROMClass(void)
+: _sector((((uint32_t)&_SPIFFS_end - 0x40200000) / SPI_FLASH_SEC_SIZE))
 , _data(0)
 , _size(0)
 , _dirty(false)
@@ -121,5 +131,6 @@ uint8_t * EEPROMClass::getDataPtr() {
   return &_data[0];
 }
 
-extern "C" uint32_t _SPIFFS_end;
-EEPROMClass EEPROM((((uint32_t)&_SPIFFS_end - 0x40200000) / SPI_FLASH_SEC_SIZE));
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_EEPROM)
+EEPROMClass EEPROM;
+#endif

--- a/libraries/EEPROM/EEPROM.h
+++ b/libraries/EEPROM/EEPROM.h
@@ -29,6 +29,7 @@
 class EEPROMClass {
 public:
   EEPROMClass(uint32_t sector);
+  EEPROMClass(void);
 
   void begin(size_t size);
   uint8_t read(int address);
@@ -64,7 +65,9 @@ protected:
   bool _dirty;
 };
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_EEPROM)
 extern EEPROMClass EEPROM;
+#endif
 
 #endif
 

--- a/libraries/ESP8266NetBIOS/ESP8266NetBIOS.cpp
+++ b/libraries/ESP8266NetBIOS/ESP8266NetBIOS.cpp
@@ -261,5 +261,8 @@ void ESP8266NetBIOS::_s_recv(void *arg, udp_pcb *upcb, pbuf *p, struct ip_addr *
     reinterpret_cast<ESP8266NetBIOS*>(arg)->_recv(upcb, p, addr, port);
 }
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_NETBIOS)
 ESP8266NetBIOS NBNS;
+#endif
+
 // EOF

--- a/libraries/ESP8266NetBIOS/ESP8266NetBIOS.h
+++ b/libraries/ESP8266NetBIOS/ESP8266NetBIOS.h
@@ -33,6 +33,8 @@ public:
     void end();
 };
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_NETBIOS)
 extern ESP8266NetBIOS NBNS;
+#endif
 
 #endif

--- a/libraries/ESP8266SSDP/ESP8266SSDP.cpp
+++ b/libraries/ESP8266SSDP/ESP8266SSDP.cpp
@@ -431,4 +431,6 @@ void SSDPClass::_startTimer() {
   os_timer_arm(tm, interval, 1 /* repeat */);
 }
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SSDP)
 SSDPClass SSDP;
+#endif

--- a/libraries/ESP8266SSDP/ESP8266SSDP.h
+++ b/libraries/ESP8266SSDP/ESP8266SSDP.h
@@ -121,6 +121,8 @@ class SSDPClass{
     char _modelNumber[SSDP_MODEL_VERSION_SIZE];
 };
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SSDP)
 extern SSDPClass SSDP;
+#endif
 
 #endif

--- a/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.cpp
+++ b/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.cpp
@@ -383,6 +383,6 @@ bool ESP8266HTTPUpdate::runUpdate(Stream& in, uint32_t size, String md5, int com
     return true;
 }
 
-
-
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_HTTPUPDATE)
 ESP8266HTTPUpdate ESPhttpUpdate;
+#endif

--- a/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.h
+++ b/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.h
@@ -105,6 +105,8 @@ protected:
     bool _rebootOnUpdate = true;
 };
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_HTTPUPDATE)
 extern ESP8266HTTPUpdate ESPhttpUpdate;
+#endif
 
 #endif /* ESP8266HTTPUPDATE_H_ */

--- a/libraries/ESP8266mDNS/ESP8266mDNS.cpp
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.cpp
@@ -1046,4 +1046,6 @@ void MDNSResponder::_reply(uint8_t replyMask, char * service, char *proto, uint1
  _conn->send();
 }
 
-MDNSResponder MDNS = MDNSResponder();
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_MDNS)
+MDNSResponder MDNS;
+#endif

--- a/libraries/ESP8266mDNS/ESP8266mDNS.h
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.h
@@ -131,6 +131,8 @@ private:
   void _restart();
 };
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_MDNS)
 extern MDNSResponder MDNS;
+#endif
 
 #endif //ESP8266MDNS_H

--- a/libraries/Ethernet/src/Ethernet.cpp
+++ b/libraries/Ethernet/src/Ethernet.cpp
@@ -139,4 +139,6 @@ IPAddress EthernetClass::dnsServerIP()
   return _dnsServerAddress;
 }
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_ETHERNET)
 EthernetClass Ethernet;
+#endif

--- a/libraries/Ethernet/src/Ethernet.h
+++ b/libraries/Ethernet/src/Ethernet.h
@@ -36,6 +36,8 @@ public:
   friend class EthernetServer;
 };
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_ETHERNET)
 extern EthernetClass Ethernet;
+#endif
 
 #endif

--- a/libraries/SD/src/SD.cpp
+++ b/libraries/SD/src/SD.cpp
@@ -611,4 +611,6 @@ void File::rewindDirectory(void) {
     _file->rewind();
 }
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SD)
 SDClass SD;
+#endif

--- a/libraries/SD/src/SD.h
+++ b/libraries/SD/src/SD.h
@@ -132,6 +132,8 @@ private:
   friend boolean callback_openPath(SdFile&, char *, boolean, void *); 
 };
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SD)
 extern SDClass SD;
+#endif
 
 #endif

--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -33,8 +33,6 @@ typedef union {
         };
 } spiClk_t;
 
-SPIClass SPI;
-
 SPIClass::SPIClass() {
     useHwCs = false;
 }
@@ -486,3 +484,6 @@ void SPIClass::transferBytes_(uint8_t * out, uint8_t * in, uint8_t size) {
     }
 }
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SPI)
+SPIClass SPI;
+#endif

--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -79,6 +79,8 @@ private:
   inline void setDataBits(uint16_t bits);
 };
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SPI)
 extern SPIClass SPI;
+#endif
 
 #endif

--- a/libraries/SPISlave/src/SPISlave.cpp
+++ b/libraries/SPISlave/src/SPISlave.cpp
@@ -100,4 +100,6 @@ void SPISlaveClass::onStatusSent(SpiSlaveSentHandler cb)
     _status_sent_cb = cb;
 }
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SPISLAVE)
 SPISlaveClass SPISlave;
+#endif

--- a/libraries/SPISlave/src/SPISlave.h
+++ b/libraries/SPISlave/src/SPISlave.h
@@ -64,6 +64,8 @@ public:
     void onStatusSent(SpiSlaveSentHandler cb);
 };
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SPISLAVE)
 extern SPISlaveClass SPISlave;
+#endif
 
 #endif

--- a/libraries/TFT_Touch_Shield_V2/TFTv2.cpp
+++ b/libraries/TFT_Touch_Shield_V2/TFTv2.cpp
@@ -567,7 +567,10 @@ INT8U TFT::drawFloat(float floatNumber,INT16U poX, INT16U poY,INT16U size,INT16U
     return f;
 }
 
-TFT Tft=TFT();
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_TFT)
+TFT Tft;
+#endif
+
 /*********************************************************************************************************
   END FILE
 *********************************************************************************************************/

--- a/libraries/TFT_Touch_Shield_V2/TFTv2.h
+++ b/libraries/TFT_Touch_Shield_V2/TFTv2.h
@@ -213,7 +213,9 @@ public:
 
 };
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_TFT)
 extern TFT Tft;
+#endif
 
 #endif
 

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -251,4 +251,6 @@ void TwoWire::onRequest( void (*function)(void) ){
 
 // Preinstantiate Objects //////////////////////////////////////////////////////
 
-TwoWire Wire = TwoWire();
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_TWOWIRE)
+TwoWire Wire;
+#endif

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -85,7 +85,9 @@ class TwoWire : public Stream
     using Print::write;
 };
 
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_TWOWIRE)
 extern TwoWire Wire;
+#endif
 
 #endif
 


### PR DESCRIPTION
creating global objects can be switched off by the following defines:

globally:

NO_GLOBAL_INSTANCES

locally:

NO_GLOBAL_SPIFFS
NO_GLOBAL_NETBIOS
NO_GLOBAL_SD
NO_GLOBAL_SPI
NO_GLOBAL_TWOWIRE
NO_GLOBAL_EEPROM
NO_GLOBAL_ETHERNET
NO_GLOBAL_ARDUINOOTA
NO_GLOBAL_MDNS
NO_GLOBAL_TFT
NO_GLOBAL_SPISLAVE
NO_GLOBAL_HTTPUPDATE
NO_GLOBAL_SSDP

i tried to find the most logical name for the define derived from the class name. creation of the global objects have been unified on the go.

EEPROM class got a new constructor, to allow 'external' instantiation of the class the same way es the global one (without knowing the location in flash).