### PR TITLE
ESP8266mDNS using the provided IP in the begin method

### DIFF
--- a/libraries/ESP8266mDNS/ESP8266mDNS.cpp
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.cpp
@@ -142,26 +142,39 @@ MDNSResponder::~MDNSResponder() {
   _answers = 0;
 }
 
-bool MDNSResponder::begin(const char* hostname){
-  size_t n = strlen(hostname);
+bool MDNSResponder::begin(const char* hostName){
+  return _begin(hostName, 0, 120);
+}
+
+bool MDNSResponder::begin(const char* hostName, IPAddress ip, uint32_t ttl){
+  return _begin(hostName, ip, ttl);
+}
+
+bool MDNSResponder::_begin(const char *hostName, uint32_t ip, uint32_t ttl){
+  size_t n = strlen(hostName);
   if (n > 63) { // max size for a single label.
     return false;
   }
 
+  _ip = ip;
+
   // Copy in hostname characters as lowercase
-  _hostName = hostname;
+  _hostName = hostName;
   _hostName.toLowerCase();
 
   // If instance name is not already set copy hostname to instance name
-  if (_instanceName.equals("") ) _instanceName=hostname;
+  if (_instanceName.equals("") ) _instanceName=hostName;
 
-  _gotIPHandler = WiFi.onStationModeGotIP([this](const WiFiEventStationModeGotIP& event){
-    _restart();
-  });
+  //only if the IP hasn't been set manually, use the events
+  if (ip == 0) {
+    _gotIPHandler = WiFi.onStationModeGotIP([this](const WiFiEventStationModeGotIP& event){
+      _restart();
+    });
 
-  _disconnectedHandler = WiFi.onStationModeDisconnected([this](const WiFiEventStationModeDisconnected& event) {
-    _restart();
-  });
+    _disconnectedHandler = WiFi.onStationModeDisconnected([this](const WiFiEventStationModeDisconnected& event) {
+      _restart();
+    });
+  }
 
   return _listen();
 }
@@ -442,7 +455,11 @@ uint16_t MDNSResponder::_getServicePort(char *name, char *proto){
 
 uint32_t MDNSResponder::_getOurIp(){
   int mode = wifi_get_opmode();
-  if(mode & STATION_MODE){
+
+  //if has a manually set IP use this
+  if(_ip){
+    return _ip;
+  } else if(mode & STATION_MODE){
     struct ip_info staIpInfo;
     wifi_get_ip_info(STATION_IF, &staIpInfo);
     return staIpInfo.ip.addr;
@@ -532,7 +549,7 @@ void MDNSResponder::_parsePacket(){
           tmp8 = _conn_read8();
           break;
         }
-        if (tmp8 == 0x00) { // Énd of name
+        if (tmp8 == 0x00) { // End of name
           break;
         }
         _conn_readS(serviceName, tmp8);

--- a/libraries/ESP8266mDNS/ESP8266mDNS.h
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.h
@@ -63,9 +63,7 @@ public:
   ~MDNSResponder();
   bool begin(const char* hostName);
   //for compatibility
-  bool begin(const char* hostName, IPAddress ip, uint32_t ttl=120){
-    return begin(hostName);
-  }
+  bool begin(const char* hostName, IPAddress ip, uint32_t ttl=120);
   void update();
 
   void addService(char *service, char *proto, uint16_t port);
@@ -116,8 +114,9 @@ private:
   bool _waitingForAnswers;
   WiFiEventHandler _disconnectedHandler;
   WiFiEventHandler _gotIPHandler;
-  
+  uint32_t _ip;
 
+  bool _begin(const char* hostName, uint32_t ip, uint32_t ttl);
   uint32_t _getOurIp();
   uint16_t _getServicePort(char *service, char *proto);
   MDNSTxt * _getServiceTxt(char *name, char *proto);


### PR DESCRIPTION
this fix forces the mDNS to use the provided IP in the begin method
instead of the auto detected IP. this is required if the ESP8266 starts
in the AP_STA mode and activates only the AP initially.

because of the old behaviour of the begin method, and how the ip is retrieved, if the current mode is AP_STA, only the STA ip will be tried. the fix allows the usage of the explicitly provided IP. now  I can start the esp in AP_STA, with only AP active, and provide the AP ip. when STA will be connected the mDNS will continue to listen for connections on the AP IP, not disrupting the behaviour. 

there still might be a problem in how the mDNS behaves when using the begin method with only the hostname and the initial mode is AP, then esp moves to AP_STA and connects to a station, as it subscribes to station events even when started in AP.