### PR TITLE
Remove Generated Warnings

### DIFF
--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -14,25 +14,6 @@ static scheduled_fn_t* sLastUnused = 0;
 
 static int sCount = 0;
 
-static void init_lists()
-{
-    if (sCount != 0) {
-        return;
-    }
-    while (sCount < SCHEDULED_FN_INITIAL_COUNT) {
-        scheduled_fn_t* it = new scheduled_fn_t;
-        if (sCount == 0) {
-            sFirstUnused = it;
-        }
-        else {
-            sLastUnused->mNext = it;
-        }
-        sLastUnused = it;
-        ++sCount;
-    }
-    sLastUnused->mNext = NULL;
-}
-
 static scheduled_fn_t* get_fn() {
     scheduled_fn_t* result = NULL;
     // try to get an item from unused items list

--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -132,7 +132,6 @@ bool HTTPClient::begin(String url)
 bool HTTPClient::beginInternal(String url, const char* expectedProtocol)
 {
     DEBUG_HTTPCLIENT("[HTTP-Client][begin] url: %s\n", url.c_str());
-    bool hasPort = false;
     clear();
 
     // check for : (http: or https:

--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
@@ -589,7 +589,7 @@ bool WiFiClientSecure::loadPrivateKey(Stream& stream, size_t size)
 extern "C" int __ax_port_read(int fd, uint8_t* buffer, size_t count)
 {
     ClientContext* _client = SSLContext::getIOContext(fd);
-    if (!_client || _client->state() != ESTABLISHED && !_client->getSize()) {
+    if (!_client || (_client->state() != ESTABLISHED && !_client->getSize())) {
         errno = EIO;
         return -1;
     }

--- a/libraries/ESP8266mDNS/ESP8266mDNS.cpp
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.cpp
@@ -588,8 +588,6 @@ void MDNSResponder::_parsePacket(){
       } while (true);
 
       uint16_t answerType = _conn_read16(); // Read type
-      uint16_t answerClass = _conn_read16(); // Read class
-      uint32_t answerTtl = _conn_read32(); // Read ttl
       uint16_t answerRdlength = _conn_read16(); // Read rdlength
 
       if(answerRdlength > 255){
@@ -638,8 +636,6 @@ void MDNSResponder::_parsePacket(){
 
       else if (answerType == MDNS_TYPE_SRV) {
         partsCollected |= 0x04;
-        uint16_t answerPrio = _conn_read16(); // Read priority
-        uint16_t answerWeight = _conn_read16(); // Read weight
         answerPort = _conn_read16(); // Read port
 
         // Read hostname


### PR DESCRIPTION
Updates to remove warnings I have come across in 2.3.0 builds. See issue #2183 

I have split into 3 separate commits;
- ef5182a Removes unused variables found within each respective single file
- 77f2492 Intent of pointer checking is made clearer using paren.
- ceb74ff Removed unused function entirely. Have checked (text based search) that no other occurrences found
