### PR TITLE
const-correctness `IPAddress::toString()`

### DIFF
--- a/cores/esp8266/IPAddress.cpp
+++ b/cores/esp8266/IPAddress.cpp
@@ -105,7 +105,7 @@ size_t IPAddress::printTo(Print& p) const {
     return n;
 }
 
-String IPAddress::toString()
+String IPAddress::toString() const
 {
     char szRet[16];
     sprintf(szRet,"%u.%u.%u.%u", _address.bytes[0], _address.bytes[1], _address.bytes[2], _address.bytes[3]);

--- a/cores/esp8266/IPAddress.h
+++ b/cores/esp8266/IPAddress.h
@@ -77,7 +77,7 @@ class IPAddress: public Printable {
         IPAddress& operator=(uint32_t address);
 
         virtual size_t printTo(Print& p) const;
-        String toString();
+        String toString() const;
 
         friend class EthernetClass;
         friend class UDP;


### PR DESCRIPTION
it doesn't modify any member variables, should be safe to be const.
