### PR TITLE
Added support for querying host IP numbers with the new method

### DIFF
--- a/libraries/ESP8266mDNS/ESP8266mDNS.cpp
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.cpp
@@ -38,7 +38,7 @@ License (MIT license):
 #define LWIP_OPEN_SRC
 #endif
 
-#include "ESP8266mDNShost.h"
+#include "ESP8266mDNS.h"
 #include <functional>
 
 #include "debug.h"

--- a/libraries/ESP8266mDNS/ESP8266mDNS.cpp
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.cpp
@@ -388,8 +388,8 @@ IPAddress MDNSResponder::queryHost(const char *host)
     _query = 0;
   }
   _query = (struct MDNSQuery*)(os_malloc(sizeof(struct MDNSQuery)));
-  os_strncpy(_query->_service, host, sizeof( _query->service) - 1);
-  _query->_service[ sizeof( _query->service ) - 1 ] = '\0';
+  os_strncpy(_query->_service, host, sizeof( _query->_service) - 1);
+  _query->_service[ sizeof( _query->_service ) - 1 ] = '\0';
 
   _newQuery = true;
   

--- a/libraries/ESP8266mDNS/ESP8266mDNS.h
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.h
@@ -4,6 +4,7 @@ Version 1.1
 Copyright (c) 2013 Tony DiCola (tony@tonydicola.com)
 ESP8266 port (c) 2015 Ivan Grokhotkov (ivan@esp8266.com)
 Extended MDNS-SD support 2016 Lars Englund (lars.englund@gmail.com)
+Host query support 2016 Erland Lewin (erland@lewin.nu)
 
 This is a simple implementation of multicast DNS query support for an Arduino
 running on ESP8266 chip. Only support for resolving address queries is currently
@@ -89,6 +90,9 @@ public:
   int queryService(String service, String proto){
     return queryService(service.c_str(), proto.c_str());
   }
+
+  IPAddress queryHost(const char *host);
+
   String hostname(int idx);
   IPAddress IP(int idx);
   uint16_t port(int idx);

--- a/libraries/ESP8266mDNS/keywords.txt
+++ b/libraries/ESP8266mDNS/keywords.txt
@@ -18,6 +18,8 @@ begin	KEYWORD2
 update	KEYWORD2
 addService	KEYWORD2
 enableArduino	KEYWORD2
+queryService    KEYWORD2
+queryHost       KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Fix for issue #2584 

Introduces new method:

`IPAddress queryHost( const chat *host );`

Please review the consequences for service queries, I've made some changes to the parsePacket code.
