### PR TITLE
Add support for EightByEight Blinky

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1892,3 +1892,39 @@ coredev.menu.DebugLevel.OTA2____=OTA + Updater
 coredev.menu.DebugLevel.OTA2____.build.debug_level=-DDEBUG_ESP_OTA -DDEBUG_ESP_UPDATER
 coredev.menu.DebugLevel.all_____=All
 coredev.menu.DebugLevel.all_____.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_SSL -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_SERVER -DDEBUG_ESP_UPDATER -DDEBUG_ESP_OTA -DDEBUG_TLS_MEM
+
+##############################################################
+eightbyeight.name=Blinkinlabs EightByEight Blinky
+
+eightbyeight.upload.tool=esptool
+eightbyeight.upload.speed.linux=460800
+eightbyeight.upload.speed.macosx=460800
+eightbyeight.upload.speed.windows=512000
+eightbyeight.upload.resetmethod=nodemcu
+eightbyeight.upload.maximum_size=1044464
+eightbyeight.upload.maximum_data_size=81920
+eightbyeight.upload.wait_for_upload_port=true
+eightbyeight.serial.disableDTR=true
+eightbyeight.serial.disableRTS=true
+
+eightbyeight.build.mcu=esp8266
+eightbyeight.build.f_cpu=80000000L
+eightbyeight.build.board=ESP8266_ESP12
+eightbyeight.build.core=esp8266
+eightbyeight.build.variant=generic
+eightbyeight.build.flash_mode=qio
+eightbyeight.build.flash_size=2M
+eightbyeight.build.flash_freq=40
+eightbyeight.build.flash_ld=eagle.flash.2m.ld
+eightbyeight.build.spiffs_start=0x100000
+eightbyeight.build.spiffs_end=0x1FB000
+eightbyeight.build.spiffs_blocksize=8192
+eightbyeight.upload.maximum_size=1044464
+
+eightbyeight.build.debug_port=
+eightbyeight.build.debug_level=
+
+eightbyeight.menu.CpuFrequency.80=80 MHz
+eightbyeight.menu.CpuFrequency.80.build.f_cpu=80000000L
+eightbyeight.menu.CpuFrequency.160=160 MHz
+eightbyeight.menu.CpuFrequency.160.build.f_cpu=160000000L

--- a/doc/boards.md
+++ b/doc/boards.md
@@ -33,6 +33,7 @@ title: Supported Hardware
   * [WeMos D1](#wemos-d1)
   * [WeMos D1 mini](#wemos-d1-mini)
   * [ESPino by ThaiEasyElec](#espinotee)
+  * [Blinkinlabs EightByEight Blinky](#eightbyeight-blinky)
 
 ## Adafruit HUZZAH ESP8266 (ESP-12)
 
@@ -303,6 +304,9 @@ We will update an English description soon.
 - Dimensions: http://thaieasyelec.com/downloads/ETEE052/ETEE052_ESPino_Dimension.pdf
 - Pinouts: http://thaieasyelec.com/downloads/ETEE052/ETEE052_ESPino_User_Manual_TH_v1_0_20160204.pdf (Please see pg. 8)
 
+
+## Blinkinlabs EightByEight Blinky
+Product page: https://blinkinlabs.com/eightbyeight
 
 
 

--- a/package/package_esp8266com_index.template.json
+++ b/package/package_esp8266com_index.template.json
@@ -70,8 +70,11 @@
             {
               "name": "WifInfo"
             },
-			{
+	    {
               "name": "ESPDuino"
+            },
+	    {
+              "name": "Blinkinlabs EightByEight Blinky"
             }
           ],
           "toolsDependencies": [


### PR DESCRIPTION
We'd like to add support for our EightByEight LED blinky, which is an LED necklace powered by an ESP-WROOM-20 module. The project is release under the CERN OHL and MIT licenses:

https://github.com/Blinkinlabs/EightByEight
