### PR TITLE
Set DHCP subnet correctly for softAP

### DIFF
--- a/tools/sdk/lwip/src/app/dhcpserver.c
+++ b/tools/sdk/lwip/src/app/dhcpserver.c
@@ -139,6 +139,8 @@ static uint8_t* ICACHE_FLASH_ATTR add_offer_options(uint8_t *optptr)
         os_bzero(&if_ip, sizeof(struct ip_info));
         wifi_get_ip_info(SOFTAP_IF, &if_ip);
 
+        *optptr++ = DHCP_OPTION_SUBNET_MASK;
+        *optptr++ = 4;
         *optptr++ = ip4_addr1( &if_ip.netmask);
         *optptr++ = ip4_addr2( &if_ip.netmask);
         *optptr++ = ip4_addr3( &if_ip.netmask);


### PR DESCRIPTION
Remove hardcoded subnet mask from add_offer_options()
Retrieve subnet mask using if_ip.netmask

Fixes issue [2578](https://github.com/esp8266/Arduino/issues/2578)