### PR TITLE
Add PIN defines, so the pins can easily be used by external libraries

### DIFF
--- a/variants/ESPDuino/pins_arduino.h
+++ b/variants/ESPDuino/pins_arduino.h
@@ -27,8 +27,11 @@
 
 #include "../generic/common.h"
 
-static const uint8_t SDA = 4;
-static const uint8_t SCL = 5;
+#define PIN_WIRE_SDA (4)
+#define PIN_WIRE_SCL (5)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
 
 static const uint8_t LED_BUILTIN = 16;
 static const uint8_t BUILTIN_LED = 16;

--- a/variants/adafruit/pins_arduino.h
+++ b/variants/adafruit/pins_arduino.h
@@ -28,8 +28,11 @@
 
 #include "../generic/common.h"
 
-static const uint8_t SDA = 4;
-static const uint8_t SCL = 5;
+#define PIN_WIRE_SDA (4)
+#define PIN_WIRE_SCL (5)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
 
 static const uint8_t LED_BUILTIN = 0;
 static const uint8_t BUILTIN_LED = 0;

--- a/variants/d1/pins_arduino.h
+++ b/variants/d1/pins_arduino.h
@@ -28,8 +28,11 @@
 
 #include "../generic/common.h"
 
-static const uint8_t SDA = 4;
-static const uint8_t SCL = 5;
+#define PIN_WIRE_SDA (4)
+#define PIN_WIRE_SCL (5)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
 
 static const uint8_t LED_BUILTIN = 2;//new ESP-12E GPIO2
 static const uint8_t BUILTIN_LED = 2;//new ESP-12E GPIO2

--- a/variants/d1_mini/pins_arduino.h
+++ b/variants/d1_mini/pins_arduino.h
@@ -28,8 +28,11 @@
 
 #include "../generic/common.h"
 
-static const uint8_t SDA = 4;
-static const uint8_t SCL = 5;
+#define PIN_WIRE_SDA (4)
+#define PIN_WIRE_SCL (5)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
 
 static const uint8_t LED_BUILTIN = 2;
 static const uint8_t BUILTIN_LED = 2;

--- a/variants/espino/pins_arduino.h
+++ b/variants/espino/pins_arduino.h
@@ -28,8 +28,11 @@
 
 #include "../generic/common.h"
 
-static const uint8_t SDA = 4;
-static const uint8_t SCL = 5;
+#define PIN_WIRE_SDA (4)
+#define PIN_WIRE_SCL (5)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
 
 static const uint8_t LED_BUILTIN = 2;
 static const uint8_t LED_BUILTIN_R = 2;

--- a/variants/espinotee/pins_arduino.h
+++ b/variants/espinotee/pins_arduino.h
@@ -28,8 +28,11 @@
 
 #include "../generic/common.h"
 
-static const uint8_t SDA = 4;
-static const uint8_t SCL = 5;
+#define PIN_WIRE_SDA (4)
+#define PIN_WIRE_SCL (5)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
 
 static const uint8_t BUILTIN_LED = 16;
 static const uint8_t LED_BUILTIN = 16;

--- a/variants/espresso_lite_v1/pins_arduino.h
+++ b/variants/espresso_lite_v1/pins_arduino.h
@@ -30,8 +30,11 @@
 
 #define ESPRESSO_LITE_VERSION   1
 
-static const uint8_t SDA = 4;
-static const uint8_t SCL = 5;
+#define PIN_WIRE_SDA (4)
+#define PIN_WIRE_SCL (5)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
 
 static const uint8_t LED_BUILTIN = 16;
 static const uint8_t BUILTIN_LED = 16;

--- a/variants/espresso_lite_v2/pins_arduino.h
+++ b/variants/espresso_lite_v2/pins_arduino.h
@@ -30,8 +30,11 @@
 
 #define ESPRESSO_LITE_VERSION   2
 
-static const uint8_t SDA = 4;
-static const uint8_t SCL = 5;
+#define PIN_WIRE_SDA (4)
+#define PIN_WIRE_SCL (5)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
 
 static const uint8_t LED_BUILTIN = 2;
 static const uint8_t BUILTIN_LED = 2;

--- a/variants/generic/common.h
+++ b/variants/generic/common.h
@@ -37,12 +37,19 @@
 #define digitalPinToInterrupt(p)    (((p) < EXTERNAL_NUM_INTERRUPTS)? (p) : NOT_AN_INTERRUPT)
 #define digitalPinHasPWM(p)         (((p) < NUM_DIGITAL_PINS && !isFlashInterfacePin(p))? 1 : 0)
 
-static const uint8_t SS    = 15;
-static const uint8_t MOSI  = 13;
-static const uint8_t MISO  = 12;
-static const uint8_t SCK   = 14;
+#define PIN_SPI_SS   (15)
+#define PIN_SPI_MOSI (13)
+#define PIN_SPI_MISO (12)
+#define PIN_SPI_SCK  (14)
 
-static const uint8_t A0 = 17;
+static const uint8_t SS    = PIN_SPI_SS;
+static const uint8_t MOSI  = PIN_SPI_MOSI;
+static const uint8_t MISO  = PIN_SPI_MISO;
+static const uint8_t SCK   = PIN_SPI_SCK;
+
+#define PIN_A0 (17)
+
+static const uint8_t A0 = PIN_A0;
 
 // These serial port names are intended to allow libraries and architecture-neutral
 // sketches to automatically default to the correct port name for a particular type

--- a/variants/generic/pins_arduino.h
+++ b/variants/generic/pins_arduino.h
@@ -28,8 +28,11 @@
 
 #include "common.h"
 
-static const uint8_t SDA = 4;
-static const uint8_t SCL = 5;
+#define PIN_WIRE_SDA (4)
+#define PIN_WIRE_SCL (5)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
 
 static const uint8_t BUILTIN_LED = 1;
 static const uint8_t LED_BUILTIN = 1;

--- a/variants/nodemcu/pins_arduino.h
+++ b/variants/nodemcu/pins_arduino.h
@@ -28,8 +28,11 @@
 
 #include "../generic/common.h"
 
-static const uint8_t SDA = 4;
-static const uint8_t SCL = 5;
+#define PIN_WIRE_SDA (4)
+#define PIN_WIRE_SCL (5)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
 
 static const uint8_t LED_BUILTIN = 16;
 static const uint8_t BUILTIN_LED = 16;

--- a/variants/phoenix_v1/pins_arduino.h
+++ b/variants/phoenix_v1/pins_arduino.h
@@ -30,8 +30,11 @@
 
 #define PHOENIX_VERSION   1
 
-static const uint8_t SDA = 4;
-static const uint8_t SCL = 5;
+#define PIN_WIRE_SDA (4)
+#define PIN_WIRE_SCL (5)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
 
 static const uint8_t LED_BUILTIN = 16;
 static const uint8_t BUILTIN_LED = 16;

--- a/variants/phoenix_v2/pins_arduino.h
+++ b/variants/phoenix_v2/pins_arduino.h
@@ -30,8 +30,11 @@
 
 #define PHOENIX_VERSION   2
 
-static const uint8_t SDA = 4;
-static const uint8_t SCL = 5;
+#define PIN_WIRE_SDA (4)
+#define PIN_WIRE_SCL (5)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
 
 static const uint8_t LED_BUILTIN = 2;
 static const uint8_t BUILTIN_LED = 2;

--- a/variants/thing/pins_arduino.h
+++ b/variants/thing/pins_arduino.h
@@ -28,8 +28,11 @@
 
 #include "../generic/common.h"
 
-static const uint8_t SDA = 2;
-static const uint8_t SCL = 14;
+#define PIN_WIRE_SDA (2)
+#define PIN_WIRE_SCL (14)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
 
 static const uint8_t LED_BUILTIN = 5;
 static const uint8_t BUILTIN_LED = 5;

--- a/variants/wifinfo/pins_arduino.h
+++ b/variants/wifinfo/pins_arduino.h
@@ -33,8 +33,11 @@
 
 #include "../generic/common.h"
 
-static const uint8_t SDA = 4;
-static const uint8_t SCL = 5;
+#define PIN_WIRE_SDA (4)
+#define PIN_WIRE_SCL (5)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
 
 static const uint8_t LED_BUILTIN = 12;
 static const uint8_t BUILTIN_LED = 12;

--- a/variants/wifio/pins_arduino.h
+++ b/variants/wifio/pins_arduino.h
@@ -30,22 +30,39 @@
 #define NUM_ANALOG_INPUTS 1
 #define ESP_PINS_OFFSET 20
 
-static const uint8_t SDA = 4;
-static const uint8_t SCL = 5;
+#define PIN_WIRE_SDA (4)
+#define PIN_WIRE_SCL (5)
 
-static const uint8_t SS   = 12;
-static const uint8_t MOSI = 13;
-static const uint8_t MISO = 14;
-static const uint8_t SCK  = 15;
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
 
-static const uint8_t A0 = 14;
-static const uint8_t A1 = 15;
-static const uint8_t A2 = 16;
-static const uint8_t A3 = 17;
-static const uint8_t A4 = 18;
-static const uint8_t A5 = 19;
-static const uint8_t A6 = 20;
-static const uint8_t A7 = 21;
+#define PIN_SPI_SS   (12)
+#define PIN_SPI_MOSI (13)
+#define PIN_SPI_MISO (14)
+#define PIN_SPI_SCK  (15)
+
+static const uint8_t SS   = PIN_SPI_SS;
+static const uint8_t MOSI = PIN_SPI_MOSI;
+static const uint8_t MISO = PIN_SPI_MISO;
+static const uint8_t SCK  = PIN_SPI_SCK;
+
+#define PIN_A0 (14)
+#define PIN_A1 (15)
+#define PIN_A2 (16)
+#define PIN_A3 (17)
+#define PIN_A4 (18)
+#define PIN_A5 (19)
+#define PIN_A6 (20)
+#define PIN_A7 (21)
+
+static const uint8_t A0 = PIN_A0;
+static const uint8_t A1 = PIN_A1;
+static const uint8_t A2 = PIN_A2;
+static const uint8_t A3 = PIN_A3;
+static const uint8_t A4 = PIN_A4;
+static const uint8_t A5 = PIN_A5;
+static const uint8_t A6 = PIN_A6;
+static const uint8_t A7 = PIN_A7;
 
 static const uint8_t E0 = ESP_PINS_OFFSET + 0;
 static const uint8_t E1 = ESP_PINS_OFFSET + 1;


### PR DESCRIPTION
See: arduino/Arduino#4814.

For instance this is used by the USB Host library: https://github.com/felis/USB_Host_Shield_2.0/commit/231fb542a8f42d5ada6325bdb5a3a2e1d8d37348.
