### PR TITLE
Fixed PUT(String) method, it called POST in error

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -349,7 +349,7 @@ int HTTPClient::PUT(uint8_t * payload, size_t size) {
 }
 
 int HTTPClient::PUT(String payload) {
-    return POST((uint8_t *) payload.c_str(), payload.length());
+    return PUT((uint8_t *) payload.c_str(), payload.length());
 }
 
 /**


### PR DESCRIPTION
About the simplest change possible, just delete two characters and add one. The PUT(String) convenience method called the full POST method instead of calling the PUT method
