### PR TITLE
Use WIFI_STA in WiFiClient-examples

### DIFF
--- a/libraries/ESP8266WiFi/examples/WiFiClient/WiFiClient.ino
+++ b/libraries/ESP8266WiFi/examples/WiFiClient/WiFiClient.ino
@@ -26,6 +26,10 @@ void setup() {
   Serial.print("Connecting to ");
   Serial.println(ssid);
   
+  /* Explicitly set the ESP8266 to be a WiFi-client, otherwise, it by default,
+     would try to act as both a client and an access-point and could cause
+     network-issues with your other WiFi-devices on your WiFi-network. */
+  WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
   
   while (WiFi.status() != WL_CONNECTED) {

--- a/libraries/ESP8266WiFi/examples/WiFiClientEvents/WiFiClientEvents.ino
+++ b/libraries/ESP8266WiFi/examples/WiFiClientEvents/WiFiClientEvents.ino
@@ -34,6 +34,10 @@ void setup() {
 
     WiFi.onEvent(WiFiEvent);
 
+    /* Explicitly set the ESP8266 to be a WiFi-client, otherwise, it by default,
+       would try to act as both a client and an access-point and could cause
+       network-issues with your other WiFi-devices on your WiFi-network. */
+    WiFi.mode(WIFI_STA);
     WiFi.begin(ssid, password);
 
     Serial.println();


### PR DESCRIPTION
Many people have problems with using ESP8266 as WiFi-client due to
none of the examples mentioning that you should use WIFI_STA if you
only want the ESP8266 to act as a WiFi-client. Many WiFi-devices
will randomly try to connect to the ESP8266 if used as STA+AP and
complain about not being able to access the Internet or other devices
on the network.
