### PR TITLE
Adding onBefore()

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -450,6 +450,10 @@ void ESP8266WebServer::onNotFound(THandlerFunction fn) {
   _notFoundHandler = fn;
 }
 
+void ESP8266WebServer::onBefore(TCheckHandlerFunction fn) {
+  _onBeforeHandler = fn;
+}
+
 void ESP8266WebServer::_handleRequest() {
   bool handled = false;
   if (!_currentHandler){
@@ -458,12 +462,19 @@ void ESP8266WebServer::_handleRequest() {
 #endif
   }
   else {
-    handled = _currentHandler->handle(*this, _currentMethod, _currentUri);
+	bool canhandle = true;
+	if (_onBeforeHandler) {
+  	  canhandle = _onBeforeHandler();
+	}
+
+    if (canhandle) {	
+      handled = _currentHandler->handle(*this, _currentMethod, _currentUri);
 #ifdef DEBUG_ESP_HTTP_SERVER
-    if (!handled) {
-      DEBUG_OUTPUT.println("request handler failed to handle request");
-    }
+      if (!handled) {
+        DEBUG_OUTPUT.println("request handler failed to handle request");
+      }
 #endif
+    }
   }
 
   if (!handled) {
@@ -523,3 +534,4 @@ String ESP8266WebServer::_responseCodeToString(int code) {
     default:  return "";
   }
 }
+

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -85,6 +85,9 @@ public:
   void onNotFound(THandlerFunction fn);  //called when handler is not assigned
   void onFileUpload(THandlerFunction fn); //handle file uploads
 
+  typedef std::function<bool(void)> TCheckHandlerFunction;
+  void onBefore(TCheckHandlerFunction fn); //called before a .on is executed, if returns false, .on is not handled
+  
   String uri() { return _currentUri; }
   HTTPMethod method() { return _currentMethod; }
   WiFiClient client() { return _currentClient; }
@@ -166,6 +169,8 @@ protected:
   THandlerFunction _notFoundHandler;
   THandlerFunction _fileUploadHandler;
 
+  TCheckHandlerFunction _onBeforeHandler;
+  
   int              _currentArgCount;
   RequestArgument* _currentArgs;
   HTTPUpload       _currentUpload;
@@ -182,3 +187,4 @@ protected:
 
 
 #endif //ESP8266WEBSERVER_H
+


### PR DESCRIPTION
ith adding a onBefore() it is easy to block/grant access, log requests, verify data etc. for any on()-webrequest.

bool AllowWebServerAccess() {
 HTTPMethod m = webserver->method();

if (m == HTTP_POST) {
 if (webserver->client().remoteIP().toString().startsWith("192.168.")) {
 return true;
 } else {
 Serial.print("Access blocked to ");
 return false;
 }
 } else {
 return true;
 }

// paranoid.
 return false;
 }