### PR TITLE
Enable ESP8266 Updater class to support third party firmware crypto signing / verification

### DIFF
--- a/cores/esp8266/Updater.cpp
+++ b/cores/esp8266/Updater.cpp
@@ -360,6 +360,9 @@ size_t UpdaterClass::writeStream(Stream &data) {
                 return written;
             }
         }
+        if(_handler) {
+          _handler(UPDATE_OPERATION_WRITE, _buffer + _bufferLen, toRead);
+        }
         _bufferLen += toRead;
         if((_bufferLen == remaining() || _bufferLen == FLASH_SECTOR_SIZE) && !_writeBuffer())
             return written;

--- a/cores/esp8266/Updater.h
+++ b/cores/esp8266/Updater.h
@@ -16,7 +16,17 @@
 #define UPDATE_ERROR_FLASH_CONFIG       (8)
 #define UPDATE_ERROR_NEW_FLASH_CONFIG   (9)
 #define UPDATE_ERROR_MAGIC_BYTE         (10)
+#define UPDATE_ERROR_CRYPTO             (11)
 
+#define UPDATE_OPERATION_BEGIN          (1)
+#define UPDATE_OPERATION_WRITE          (2)
+#define UPDATE_OPERATION_END            (3)
+
+// UpdateHandlerFunction provides external hook for signing and verification of the firmware.
+// This allows reuse of all existing update libraries and using your choice of crypto
+// signature verification. Examples how to build your own external crypto should be available from
+// https://github.com/kotl/esp8266-cryptosign
+typedef uint8_t (*UpdateHandlerFunction) (uint8_t op, uint8_t * data, size_t len);
 
 #define U_FLASH   0
 #define U_SPIFFS  100
@@ -83,6 +93,11 @@ class UpdaterClass {
       returns the MD5 String of the sucessfully ended firmware
     */
     String md5String(void){ return _md5.toString(); }
+
+    /*
+      set handler to verify crypto signature of the firmware
+    */
+    void setCryptoHandler(UpdateHandlerFunction handler);
 
     /*
       populated the result with the md5 bytes of the sucessfully ended firmware
@@ -159,6 +174,7 @@ class UpdaterClass {
 
     String _target_md5;
     MD5Builder _md5;
+    UpdateHandlerFunction _handler;
 };
 
 extern UpdaterClass Update;

--- a/cores/esp8266/base64.cpp
+++ b/cores/esp8266/base64.cpp
@@ -61,3 +61,25 @@ String base64::encode(String text) {
     return base64::encode((uint8_t *) text.c_str(), text.length());
 }
 
+/**
+ * convert input data from base64
+ * @param text String base64 encoded zero-terminated string
+ * @param data uint8_t * byte array to hold resulting decoded data
+ * @param maxlength size_t maximum number of bytes we can copy to array
+ * @return number of bytes copied, including zero terminating char
+ */
+size_t base64::decode(char* text, uint8_t * data, size_t maxlength) {
+  // allocate big enough array to hold result
+  char* plaintext = new char[strlen(text)];
+  int len = base64_decode_chars(text, strlen(text), plaintext);
+  if (len <= maxlength) {
+    // in case output array can contain extra zero character, it will be copied.
+    size_t bytes_to_copy = min(maxlength, len+1);
+    memcpy(data, plaintext, bytes_to_copy);
+    delete(plaintext);
+    return bytes_to_copy;
+  } else {
+    delete(plaintext);
+    return 0;
+  }
+}

--- a/cores/esp8266/base64.h
+++ b/cores/esp8266/base64.h
@@ -29,6 +29,7 @@ class base64 {
     public:
         static String encode(uint8_t * data, size_t length);
         static String encode(String text);
+        static size_t decode(char* text, uint8_t * data, size_t maxlength);
     private:
 };
 


### PR DESCRIPTION
this change will allow use of signing / verification library that I have developed here https://github.com/kotl/esp8266-cryptosign and also allow any other implementation to be plugged in. 
