### PR TITLE
Optimized SPI transfer

### DIFF
--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 
 #define SPI_HAS_TRANSACTION
+#define SPI_SKIP_INITIAL_BUSY_CHECK //comment this line for backward compatibility if really needed
 
 // This defines are not representing the real Divider of the ESP8266
 // the Defines match to an AVR Arduino on 16MHz for better compatibility
@@ -74,9 +75,9 @@ public:
   void endTransaction(void);
 private:
   bool useHwCs;
-  void writeBytes_(uint8_t * data, uint8_t size);
-  void transferBytes_(uint8_t * out, uint8_t * in, uint8_t size);
-  inline void setDataBits(uint16_t bits);
+  inline void writeBytes_(uint8_t * data, uint32_t size);
+  inline void transferBytes_(uint8_t * out, uint8_t * in, uint32_t size);
+  inline void setDataBits(uint32_t bits);
 };
 
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SPI)


### PR DESCRIPTION
Hi ,
I've optimized the SPI transfer functions for less overhead to increase continuous transfer rate at 80 MHz SPI clock from 18.5 MBit/s to nearly 40 Mbit/s. This was needed to transfer megabytes of data from an FPGA over ESP8266 and Wifi in reasonable time, so now the bottleneck is shifted to Wifi ;-).

The screenshot shows 2 x 64 byte frames using the current implementation on the left side of the screen and the result of my changes on the right side. As one can see the gap between these frames is quite reduced.
![esp8266_spi_speed](https://cloud.githubusercontent.com/assets/24430506/21020187/ac2da404-bd73-11e6-8b15-330b5bef68ae.jpg)

Modifications done:
(1) Changed counter variables and function parameters from 8bit to 32bit as these are handled faster by the Tensilica CPU.
(2) Replaced loops for buffer copying by memcpy and memset calls.
(3) Removed initial check (if SPI interface is busy) as this check is done inside every write and transfer function. These functions are only exited when the interface is not busy any more so the initial check when entering the function is not needed from my point of view.
(4) Restructured write and transfer functions to call _write and _transfer only once in their code so the inline function definitions are really inligned (and not only suggested and ignored by GCC compiler).

Code has been tested with various buffer sizes, the SPI class implementation is only 200ns slower than if copy-and-pasting the _transfer function directly into my code due to some more checks.