### PR TITLE
Prevent divide by zero error causing tone() to crash

### DIFF
--- a/cores/esp8266/Tone.cpp
+++ b/cores/esp8266/Tone.cpp
@@ -82,7 +82,12 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration) {
         timer1_isr_init();
         timer1_attachInterrupt(t1IntHandler);
         timer1_enable(TIM_DIV1, TIM_EDGE, TIM_LOOP);
-        timer1_write((clockCyclesPerMicrosecond() * 500000) / frequency);
+        if (frequency == 0) {
+          timer1_write((clockCyclesPerMicrosecond() * 500000));
+        }
+        else {
+          timer1_write((clockCyclesPerMicrosecond() * 500000) / frequency);
+        }
         break;
     }
   }

--- a/cores/esp8266/Tone.cpp
+++ b/cores/esp8266/Tone.cpp
@@ -64,6 +64,13 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration) {
     // Set the pinMode as OUTPUT
     pinMode(_pin, OUTPUT);
 
+	  // Alternate handling of zero freqency to avoid divide by zero errors
+	  if (frequency == 0)
+    {
+	    noTone(_pin);
+	    return;
+    }    
+    
     // Calculate the toggle count
     if (duration > 0) {
       toggle_counts[_index] = 2 * frequency * duration / 1000;
@@ -82,12 +89,7 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration) {
         timer1_isr_init();
         timer1_attachInterrupt(t1IntHandler);
         timer1_enable(TIM_DIV1, TIM_EDGE, TIM_LOOP);
-        if (frequency == 0) {
-          timer1_write((clockCyclesPerMicrosecond() * 500000));
-        }
-        else {
-          timer1_write((clockCyclesPerMicrosecond() * 500000) / frequency);
-        }
+        timer1_write((clockCyclesPerMicrosecond() * 500000) / frequency);
         break;
     }
   }

--- a/cores/esp8266/Tone.cpp
+++ b/cores/esp8266/Tone.cpp
@@ -64,8 +64,8 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration) {
     // Set the pinMode as OUTPUT
     pinMode(_pin, OUTPUT);
 
-	  // Alternate handling of zero freqency to avoid divide by zero errors
-	  if (frequency == 0)
+    // Alternate handling of zero freqency to avoid divide by zero errors
+    if (frequency == 0)
     {
 	    noTone(_pin);
 	    return;

--- a/cores/esp8266/Tone.cpp
+++ b/cores/esp8266/Tone.cpp
@@ -67,10 +67,10 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration) {
     // Alternate handling of zero freqency to avoid divide by zero errors
     if (frequency == 0)
     {
-	    noTone(_pin);
-	    return;
-    }    
-    
+        noTone(_pin);
+        return;
+    }
+
     // Calculate the toggle count
     if (duration > 0) {
       toggle_counts[_index] = 2 * frequency * duration / 1000;


### PR DESCRIPTION
As per the issue at #2491, there is a divide by error issue resulting from the specification of 0 as the frequency. This does not appear to affect the AVR implementation, but it crashes on ESP8266s. I have merely removed the division if the frequency is zero, which appears to be giving the expected results (no tone), without any code crashes. 

To test, simply load the toneMelody sketch included with the Arduino IDE (Examples -> 02. Digital -> toneMelody) and change the piezo to something else if you need to. On the Witty module used to test this, I could also tell by the wifi led blinking every time the code crashed as the ESP8266 immediately rebooted.