### PR TITLE
platform.txt: don't set compiler.warning_flags to -w

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -11,7 +11,7 @@ version=2.3.0
 runtime.tools.xtensa-lx106-elf-gcc.path={runtime.platform.path}/tools/xtensa-lx106-elf
 runtime.tools.esptool.path={runtime.platform.path}/tools/esptool
 
-compiler.warning_flags=-w
+compiler.warning_flags=
 compiler.warning_flags.none=-w
 compiler.warning_flags.default=
 compiler.warning_flags.more=-Wall


### PR DESCRIPTION
makeEspArduino doesn't have any menu logic, so it uses
compiler.warning_flags rather than one of the compiler.warning_flags.*
properties. The GCC option "-w" isn't overridable, so there's no way
for the user to enable warnings.

Set compiler.warning_flags to the same value as
compiler.warning_flags.default, i.e. empty, to fix this.