### PR TITLE
Updater: enable final checks from outside

### DIFF
--- a/cores/esp8266/Updater.h
+++ b/cores/esp8266/Updater.h
@@ -69,6 +69,8 @@ class UpdaterClass {
     */
     bool end(bool evenIfRemaining = false);
 
+    void abort() { _reset(); clearError(); }
+
     /*
       Prints the last error to an output stream
     */
@@ -98,6 +100,7 @@ class UpdaterClass {
     size_t size(){ return _size; }
     size_t progress(){ return _currentAddress - _startAddress; }
     size_t remaining(){ return _size - (_currentAddress - _startAddress); }
+    uint32_t startAddress(){ return _startAddress; }
 
     /*
       Template to write from objects that expose


### PR DESCRIPTION
As mentioned in #2499, I'm using a custom OTA implementation that fetches only a cryptographically secure checksum via HTTPS and performs the actual update over HTTP (to avoid around running out of memory during the update). To perform the checksum verification, it needs to know where in flash the update has been downloaded to (i.e. _startAddress). To prevent the update from getting applied if the checksum doesn't match but still allow future update attempts, it needs a way to abort an update operation.

These changes are useful not just for performing verification of non-MD5 checksum, but for any kind of post-download verification (e.g. embedded signatures, rollback protection).