### PR TITLE
Use correct cast for downcasting reference.

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -63,7 +63,7 @@ public:
 
     bool verify(WiFiClient& client, const char* host) override
     {
-        auto wcs = reinterpret_cast<WiFiClientSecure&>(client);
+        auto wcs = static_cast<WiFiClientSecure&>(client);
         return wcs.verify(_fingerprint.c_str(), host);
     }
 


### PR DESCRIPTION
For downcasting, static_cast<> is the appropriate cast. Using reinterpret_cast<> will NOT correctly adjust the `this` pointer and dereferencing such a value is undefined by spec. See [expr.reinterpret.cast]p7 for the relevant passage. The only legal use of this pointer is in another set of reinterpret_cast expressions that either land it into a numeric value, or back to the original type.