### PR TITLE
Fix warnings

### DIFF
--- a/cores/esp8266/Esp.cpp
+++ b/cores/esp8266/Esp.cpp
@@ -433,7 +433,7 @@ uint32_t EspClass::getSketchSize() {
         section_index < image_header.num_segments;
         ++section_index)
     {
-        section_header_t section_header = {0};
+        section_header_t section_header = {0, 0};
         if (spi_flash_read(pos, (uint32_t*) &section_header, sizeof(section_header))) {
             return 0;
         }

--- a/cores/esp8266/Esp.cpp
+++ b/cores/esp8266/Esp.cpp
@@ -83,6 +83,7 @@ EspClass ESP;
 
 void EspClass::wdtEnable(uint32_t timeout_ms)
 {
+    (void) timeout_ms;
     /// This API can only be called if software watchdog is stopped
     system_soft_wdt_restart();
 }

--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -16,6 +16,7 @@ static int sCount = 0;
 
 static void init_lists()
 {
+    (void) init_lists;
     if (sCount != 0) {
         return;
     }

--- a/cores/esp8266/abi.cpp
+++ b/cores/esp8266/abi.cpp
@@ -104,11 +104,13 @@ void __throw_bad_alloc()
 
 void __throw_logic_error(const char* str)
 {
+    (void) str;
     panic();
 }
 
 void __throw_out_of_range(const char* str)
 {
+    (void) str;
     panic();
 }
 }

--- a/cores/esp8266/cont_util.c
+++ b/cores/esp8266/cont_util.c
@@ -32,7 +32,7 @@ void ICACHE_RAM_ATTR cont_init(cont_t* cont) {
     cont->struct_start = (unsigned*) cont;
     
     // fill stack with magic values to check high water mark
-    for(int pos = 0; pos < sizeof(cont->stack) / 4; pos++)
+    for(int pos = 0; pos < (int)(sizeof(cont->stack) / 4); pos++)
     {
         cont->stack[pos] = CONT_STACKGUARD;
     }

--- a/cores/esp8266/core_esp8266_main.cpp
+++ b/cores/esp8266/core_esp8266_main.cpp
@@ -52,6 +52,7 @@ const char* core_release =
 } // extern "C"
 
 int atexit(void (*func)()) {
+    (void) func;
     return 0;
 }
 
@@ -125,6 +126,7 @@ static void loop_wrapper() {
 }
 
 static void loop_task(os_event_t *events) {
+    (void) events;
     g_micros_at_task_start = system_get_time();
     cont_run(&g_cont, &loop_wrapper);
     if (cont_check(&g_cont) != 0) {

--- a/cores/esp8266/core_esp8266_postmortem.c
+++ b/cores/esp8266/core_esp8266_postmortem.c
@@ -46,6 +46,9 @@ static void print_stack(uint32_t start, uint32_t end);
 //static void print_pcs(uint32_t start, uint32_t end);
 
 extern void __custom_crash_callback( struct rst_info * rst_info, uint32_t stack, uint32_t stack_end ) {
+    (void) rst_info;
+    (void) stack;
+    (void) stack_end;
 }
 
 extern void custom_crash_callback( struct rst_info * rst_info, uint32_t stack, uint32_t stack_end ) __attribute__ ((weak, alias("__custom_crash_callback")));
@@ -183,6 +186,7 @@ void abort(){
 }
 
 void __assert_func(const char *file, int line, const char *func, const char *what) {
+    (void) what;
     s_panic_file = file;
     s_panic_line = line;
     s_panic_func = func;

--- a/cores/esp8266/core_esp8266_timer.c
+++ b/cores/esp8266/core_esp8266_timer.c
@@ -30,6 +30,7 @@
 static volatile timercallback timer1_user_cb = NULL;
 
 void ICACHE_RAM_ATTR timer1_isr_handler(void *para){
+    (void) para;
     if ((T1C & ((1 << TCAR) | (1 << TCIT))) == 0) TEIE &= ~TEIE1;//edge int disable
     T1I = 0;
     if (timer1_user_cb) {
@@ -77,6 +78,7 @@ void ICACHE_RAM_ATTR timer1_disable(){
 static volatile timercallback timer0_user_cb = NULL;
 
 void ICACHE_RAM_ATTR timer0_isr_handler(void* para){
+    (void) para;
     if (timer0_user_cb) {
         // to make ISR compatible to Arduino AVR model where interrupts are disabled
         // we disable them before we call the client ISR

--- a/cores/esp8266/core_esp8266_wiring.c
+++ b/cores/esp8266/core_esp8266_wiring.c
@@ -36,6 +36,7 @@ static uint32_t micros_overflow_count = 0;
 #define REPEAT 1
 
 void delay_end(void* arg) {
+    (void) arg;
     esp_schedule();
 }
 
@@ -53,6 +54,7 @@ void delay(unsigned long ms) {
 }
 
 void micros_overflow_tick(void* arg) {
+    (void) arg;
     uint32_t m = system_get_time();
     if(m < micros_at_last_overflow_tick)
         ++micros_overflow_count;

--- a/cores/esp8266/core_esp8266_wiring_digital.c
+++ b/cores/esp8266/core_esp8266_wiring_digital.c
@@ -115,6 +115,7 @@ static interrupt_handler_t interrupt_handlers[16];
 static uint32_t interrupt_reg = 0;
 
 void ICACHE_RAM_ATTR interrupt_handler(void *arg) {
+  (void) arg;
   uint32_t status = GPIE;
   GPIEC = status;//clear them interrupts
   uint32_t levels = GPI;

--- a/cores/esp8266/heap.c
+++ b/cores/esp8266/heap.c
@@ -10,46 +10,60 @@
 
 void* _malloc_r(struct _reent* unused, size_t size)
 {
+    (void) unused;
     return malloc(size);
 }
 
 void _free_r(struct _reent* unused, void* ptr)
 {
+    (void) unused;
     return free(ptr);
 }
 
 void* _realloc_r(struct _reent* unused, void* ptr, size_t size)
 {
+    (void) unused;
     return realloc(ptr, size);
 }
 
 void* _calloc_r(struct _reent* unused, size_t count, size_t size)
 {
+    (void) unused;
     return calloc(count, size);
 }
 
 void* ICACHE_RAM_ATTR pvPortMalloc(size_t size, const char* file, int line)
 {
+    (void) file;
+    (void) line;
     return malloc(size);
 }
 
 void ICACHE_RAM_ATTR vPortFree(void *ptr, const char* file, int line)
 {
+    (void) file;
+    (void) line;
     free(ptr);
 }
 
 void* ICACHE_RAM_ATTR pvPortCalloc(size_t count, size_t size, const char* file, int line)
 {
+    (void) file;
+    (void) line;
     return calloc(count, size);
 }
 
 void* ICACHE_RAM_ATTR pvPortRealloc(void *ptr, size_t size, const char* file, int line)
 {
+    (void) file;
+    (void) line;
     return realloc(ptr, size);
 }
 
 void* ICACHE_RAM_ATTR pvPortZalloc(size_t size, const char* file, int line)
 {
+    (void) file;
+    (void) line;
     return calloc(1, size);
 }
 

--- a/cores/esp8266/libc_replacements.c
+++ b/cores/esp8266/libc_replacements.c
@@ -83,6 +83,7 @@ int ICACHE_RAM_ATTR _read_r(struct _reent* unused, int file, char *ptr, int len)
 }
 
 int ICACHE_RAM_ATTR _write_r(struct _reent* r, int file, char *ptr, int len) {
+    (void) r;
     if (file == STDOUT_FILENO) {
         while(len--) {
             ets_putc(*ptr);
@@ -93,6 +94,7 @@ int ICACHE_RAM_ATTR _write_r(struct _reent* r, int file, char *ptr, int len) {
 }
 
 int ICACHE_RAM_ATTR _putc_r(struct _reent* r, int c, FILE* file) {
+    (void) r;
     if (file->_file == STDOUT_FILENO) {
         return ets_putc(c);
     }

--- a/cores/esp8266/spiffs/spiffs_hydrogen.c
+++ b/cores/esp8266/spiffs/spiffs_hydrogen.c
@@ -22,6 +22,7 @@ static s32_t spiffs_fflush_cache(spiffs *fs, spiffs_file fh);
 
 #if SPIFFS_BUFFER_HELP
 u32_t SPIFFS_buffer_bytes_for_filedescs(spiffs *fs, u32_t num_descs) {
+  (void) fs;
   return num_descs * sizeof(spiffs_fd);
 }
 #if SPIFFS_CACHE

--- a/cores/esp8266/spiffs_api.h
+++ b/cores/esp8266/spiffs_api.h
@@ -49,7 +49,7 @@ class SPIFFSImpl : public FSImpl
 {
 public:
     SPIFFSImpl(uint32_t start, uint32_t size, uint32_t pageSize, uint32_t blockSize, uint32_t maxOpenFds)
-        : _fs({0})
+        : _fs{{0, 0, 0, 0, 0, 0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
     , _start(start)
     , _size(size)
     , _pageSize(pageSize)
@@ -176,7 +176,7 @@ protected:
 
     bool _tryMount()
     {
-        spiffs_config config = {0};
+        spiffs_config config = {0, 0, 0, 0, 0, 0, 0, 0};
 
         config.hal_read_f       = &spiffs_hal_read;
         config.hal_write_f      = &spiffs_hal_write;
@@ -273,7 +273,7 @@ public:
     SPIFFSFileImpl(SPIFFSImpl* fs, spiffs_file fd)
         : _fs(fs)
         , _fd(fd)
-        , _stat({0})
+        , _stat{0, 0, 0, 0, {0}}
     , _written(false)
     {
         _getStat();
@@ -381,7 +381,7 @@ protected:
         auto rc = SPIFFS_fstat(_fs->getFs(), _fd, &_stat);
         if (rc != SPIFFS_OK) {
             DEBUGV("SPIFFS_fstat rc=%d\r\n", rc);
-            _stat = {0};
+            _stat = {0, 0, 0, 0, {0}};
         }
         _written = false;
     }

--- a/cores/esp8266/spiffs_api.h
+++ b/cores/esp8266/spiffs_api.h
@@ -242,6 +242,11 @@ protected:
     static void _check_cb(spiffs_check_type type, spiffs_check_report report,
                           uint32_t arg1, uint32_t arg2)
     {
+        (void) type;
+        (void) report;
+        (void) arg1;
+        (void) arg2;
+        
         // TODO: spiffs doesn't pass any context pointer along with _check_cb,
         // so we can't do anything useful here other than perhaps
         // feeding the watchdog

--- a/cores/esp8266/spiffs_api.h
+++ b/cores/esp8266/spiffs_api.h
@@ -49,13 +49,13 @@ class SPIFFSImpl : public FSImpl
 {
 public:
     SPIFFSImpl(uint32_t start, uint32_t size, uint32_t pageSize, uint32_t blockSize, uint32_t maxOpenFds)
-        : _fs{{0, 0, 0, 0, 0, 0, 0, 0}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-    , _start(start)
+        : _start(start)
     , _size(size)
     , _pageSize(pageSize)
     , _blockSize(blockSize)
     , _maxOpenFds(maxOpenFds)
     {
+        memset(&_fs, 0, sizeof(_fs));
     }
 
     FileImplPtr open(const char* path, OpenMode openMode, AccessMode accessMode) override;
@@ -176,7 +176,8 @@ protected:
 
     bool _tryMount()
     {
-        spiffs_config config = {0, 0, 0, 0, 0, 0, 0, 0};
+        spiffs_config config;
+        memset(&config, 0, sizeof(config));
 
         config.hal_read_f       = &spiffs_hal_read;
         config.hal_write_f      = &spiffs_hal_write;
@@ -273,9 +274,9 @@ public:
     SPIFFSFileImpl(SPIFFSImpl* fs, spiffs_file fd)
         : _fs(fs)
         , _fd(fd)
-        , _stat{0, 0, 0, 0, {0}}
     , _written(false)
     {
+        memset(&_stat, 0, sizeof(_stat));
         _getStat();
     }
 
@@ -381,7 +382,7 @@ protected:
         auto rc = SPIFFS_fstat(_fs->getFs(), _fd, &_stat);
         if (rc != SPIFFS_OK) {
             DEBUGV("SPIFFS_fstat rc=%d\r\n", rc);
-            _stat = {0, 0, 0, 0, {0}};
+            memset(&_stat, 0, sizeof(_stat));
         }
         _written = false;
     }

--- a/cores/esp8266/time.c
+++ b/cores/esp8266/time.c
@@ -77,6 +77,7 @@ void configTime(int timezone, int daylightOffset_sec, const char* server1, const
 
 int clock_gettime(clockid_t unused, struct timespec *tp)
 {
+    (void) unused;
     tp->tv_sec  = millis() / 1000;
     tp->tv_nsec = micros() * 1000;
     return 0;
@@ -94,6 +95,8 @@ time_t time(time_t * t)
 
 int _gettimeofday_r(struct _reent* unused, struct timeval *tp, void *tzp)
 {
+    (void) unused;
+    (void) tzp;
     if (tp)
     {
         ensureBootTimeIsSet();

--- a/cores/esp8266/uart.c
+++ b/cores/esp8266/uart.c
@@ -480,6 +480,7 @@ bool uart_rx_enabled(uart_t* uart)
 
 static void uart_ignore_char(char c)
 {
+    (void) c;
 }
 
 static void uart0_write_char(char c)

--- a/libraries/ESP8266WebServer/src/Parsing.cpp
+++ b/libraries/ESP8266WebServer/src/Parsing.cpp
@@ -361,7 +361,7 @@ uint8_t ESP8266WebServer::_uploadReadByte(WiFiClient& client){
 }
 
 bool ESP8266WebServer::_parseForm(WiFiClient& client, String boundary, uint32_t len){
-
+  (void) len;
 #ifdef DEBUG_ESP_HTTP_SERVER
   DEBUG_OUTPUT.print("Parse Form: Boundary: ");
   DEBUG_OUTPUT.print(boundary);

--- a/libraries/ESP8266WebServer/src/detail/RequestHandler.h
+++ b/libraries/ESP8266WebServer/src/detail/RequestHandler.h
@@ -4,10 +4,10 @@
 class RequestHandler {
 public:
     virtual ~RequestHandler() { }
-    virtual bool canHandle(HTTPMethod method, String uri) { return false; }
-    virtual bool canUpload(String uri) { return false; }
-    virtual bool handle(ESP8266WebServer& server, HTTPMethod requestMethod, String requestUri) { return false; }
-    virtual void upload(ESP8266WebServer& server, String requestUri, HTTPUpload& upload) {}
+    virtual bool canHandle(HTTPMethod method, String uri) { (void) method; (void) uri; return false; }
+    virtual bool canUpload(String uri) { (void) uri; return false; }
+    virtual bool handle(ESP8266WebServer& server, HTTPMethod requestMethod, String requestUri) { (void) server; (void) requestMethod; (void) requestUri; return false; }
+    virtual void upload(ESP8266WebServer& server, String requestUri, HTTPUpload& upload) { (void) server; (void) requestUri; (void) upload; }
 
     RequestHandler* next() { return _next; }
     void next(RequestHandler* r) { _next = r; }

--- a/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
@@ -31,6 +31,7 @@ public:
     }
 
     bool handle(ESP8266WebServer& server, HTTPMethod requestMethod, String requestUri) override {
+        (void) server;
         if (!canHandle(requestMethod, requestUri))
             return false;
 
@@ -39,6 +40,8 @@ public:
     }
 
     void upload(ESP8266WebServer& server, String requestUri, HTTPUpload& upload) override {
+        (void) server;
+        (void) upload;
         if (canUpload(requestUri))
             _ufn();
     }

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -153,6 +153,7 @@ WiFiEventHandler ESP8266WiFiGenericClass::onStationModeGotIP(std::function<void(
 WiFiEventHandler ESP8266WiFiGenericClass::onStationModeDHCPTimeout(std::function<void(void)> f)
 {
     WiFiEventHandler handler = std::make_shared<WiFiEventHandlerOpaque>(WIFI_EVENT_STAMODE_DHCP_TIMEOUT, [f](System_Event_t* e){
+        (void) e;
         f();
     });
     sCbEventList.push_back(handler);
@@ -452,6 +453,7 @@ int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResul
  * @param callback_arg
  */
 void wifi_dns_found_callback(const char *name, ip_addr_t *ipaddr, void *callback_arg) {
+    (void) name;
     if(ipaddr) {
         (*reinterpret_cast<IPAddress*>(callback_arg)) = ipaddr->addr;
     }

--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -135,6 +135,7 @@ int WiFiClient::connect(IPAddress ip, uint16_t port)
 
 int8_t WiFiClient::_connected(void* pcb, int8_t err)
 {
+    (void) err;
     tcp_pcb* tpcb = reinterpret_cast<tcp_pcb*>(pcb);
     _client = new ClientContext(tpcb, 0, 0);
     _client->ref();
@@ -144,6 +145,7 @@ int8_t WiFiClient::_connected(void* pcb, int8_t err)
 
 void WiFiClient::_err(int8_t err)
 {
+    (void) err;
     DEBUGV(":err %d\r\n", err);
     esp_schedule();
 }
@@ -177,6 +179,7 @@ size_t WiFiClient::write(const uint8_t *buf, size_t size)
 
 size_t WiFiClient::write(Stream& stream, size_t unused)
 {
+    (void) unused;
     return WiFiClient::write(stream);
 }
 

--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
@@ -214,6 +214,7 @@ public:
 
     static ClientContext* getIOContext(int fd)
     {
+        (void) fd;
         return s_io_ctx;
     }
 
@@ -623,6 +624,7 @@ extern "C" void ax_port_write() __attribute__ ((weak, alias("__ax_port_write")))
 
 extern "C" int __ax_get_file(const char *filename, uint8_t **buf)
 {
+    (void) filename;
     *buf = 0;
     return 0;
 }
@@ -637,6 +639,8 @@ extern "C" void ax_get_file() __attribute__ ((weak, alias("__ax_get_file")));
 
 extern "C" void* ax_port_malloc(size_t size, const char* file, int line)
 {
+    (void) file;
+    (void) line;
     void* result = malloc(size);
     if (result == nullptr) {
         DEBUG_TLS_MEM_PRINT("%s:%d malloc %d failed, left %d\r\n", file, line, size, ESP.getFreeHeap());
@@ -656,6 +660,8 @@ extern "C" void* ax_port_calloc(size_t size, size_t count, const char* file, int
 
 extern "C" void* ax_port_realloc(void* ptr, size_t size, const char* file, int line)
 {
+    (void) file;
+    (void) line;
     void* result = realloc(ptr, size);
     if (result == nullptr) {
         DEBUG_TLS_MEM_PRINT("%s:%d realloc %d failed, left %d\r\n", file, line, size, ESP.getFreeHeap());

--- a/libraries/ESP8266WiFi/src/WiFiServer.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiServer.cpp
@@ -97,6 +97,7 @@ bool WiFiServer::hasClient() {
 }
 
 WiFiClient WiFiServer::available(byte* status) {
+    (void) status;
     if (_unclaimed) {
         WiFiClient result(_unclaimed);
         _unclaimed = _unclaimed->next();
@@ -134,6 +135,8 @@ size_t WiFiServer::write(uint8_t b) {
 size_t WiFiServer::write(const uint8_t *buffer, size_t size) {
     // write to all clients
     // not implemented
+    (void) buffer;
+    (void) size;
     return 0;
 }
 
@@ -149,6 +152,7 @@ T* slist_append_tail(T* head, T* item) {
 }
 
 int8_t WiFiServer::_accept(tcp_pcb* apcb, int8_t err) {
+    (void) err;
     DEBUGV("WS:ac\r\n");
     ClientContext* client = new ClientContext(apcb, &WiFiServer::_s_discard, this);
     _unclaimed = slist_append_tail(_unclaimed, client);
@@ -157,6 +161,7 @@ int8_t WiFiServer::_accept(tcp_pcb* apcb, int8_t err) {
 }
 
 void WiFiServer::_discard(ClientContext* client) {
+    (void) client;
     // _discarded = slist_append_tail(_discarded, client);
     DEBUGV("WS:dis\r\n");
 }

--- a/libraries/ESP8266WiFi/src/include/ClientContext.h
+++ b/libraries/ESP8266WiFi/src/include/ClientContext.h
@@ -372,6 +372,8 @@ protected:
 
     err_t _sent(tcp_pcb* pcb, uint16_t len)
     {
+        (void) pcb;
+        (void) len;
         DEBUGV(":sent %d\r\n", len);
         _write_some_from_cb();
         return ERR_OK;
@@ -405,6 +407,8 @@ protected:
 
     recv_ret_t _recv(tcp_pcb* pcb, pbuf* pb, err_t err)
     {
+        (void) pcb;
+        (void) err;
         if(pb == 0) { // connection closed
             DEBUGV(":rcl\r\n");
             _cancel_write();
@@ -425,6 +429,7 @@ protected:
 
     void _error(err_t err)
     {
+        (void) err;
         DEBUGV(":er %d %08x\r\n", err, (uint32_t) _datasource);
         tcp_arg(_pcb, NULL);
         tcp_sent(_pcb, NULL);

--- a/libraries/ESP8266WiFi/src/include/DataSource.h
+++ b/libraries/ESP8266WiFi/src/include/DataSource.h
@@ -75,6 +75,7 @@ public:
 
     void release_buffer(const uint8_t* buffer, size_t size) override
     {
+        (void) buffer;
         _pos += size;
     }
 

--- a/libraries/ESP8266WiFi/src/include/UdpContext.h
+++ b/libraries/ESP8266WiFi/src/include/UdpContext.h
@@ -330,6 +330,9 @@ private:
     void _recv(udp_pcb *upcb, pbuf *pb,
             ip_addr_t *addr, u16_t port)
     {
+        (void) upcb;
+        (void) addr;
+        (void) port;
         if (_rx_buf)
         {
             // there is some unread data

--- a/libraries/ESP8266mDNS/ESP8266mDNS.cpp
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.cpp
@@ -160,10 +160,12 @@ bool MDNSResponder::begin(const char* hostname){
   if (_instanceName.equals("") ) _instanceName=hostname;
 
   _gotIPHandler = WiFi.onStationModeGotIP([this](const WiFiEventStationModeGotIP& event){
+    (void) event;
     _restart();
   });
 
   _disconnectedHandler = WiFi.onStationModeDisconnected([this](const WiFiEventStationModeDisconnected& event) {
+    (void) event;
     _restart();
   });
 
@@ -550,6 +552,9 @@ void MDNSResponder::_parsePacket(){
       uint32_t answerTtl = _conn_read32(); // Read ttl
       uint16_t answerRdlength = _conn_read16(); // Read rdlength
 
+      (void) answerClass;
+      (void) answerTtl;
+
       if(answerRdlength > 255){
         if(answerType == MDNS_TYPE_TXT && answerRdlength < 1460){
           while(--answerRdlength) _conn->read();
@@ -599,6 +604,9 @@ void MDNSResponder::_parsePacket(){
         uint16_t answerPrio = _conn_read16(); // Read priority
         uint16_t answerWeight = _conn_read16(); // Read weight
         answerPort = _conn_read16(); // Read port
+
+        (void) answerPrio;
+        (void) answerWeight;
 
         // Read hostname
         tmp8 = _conn_read8();

--- a/libraries/ESP8266mDNS/ESP8266mDNS.h
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.h
@@ -64,6 +64,8 @@ public:
   bool begin(const char* hostName);
   //for compatibility
   bool begin(const char* hostName, IPAddress ip, uint32_t ttl=120){
+    (void) ip;
+    (void) ttl;
     return begin(hostName);
   }
   /* Application should call this whenever AP is configured/disabled */


### PR DESCRIPTION
Hello!
I fixed some warnings related to unused variables and uninitialized fields. I think not everyone is Core developer, so users should not see warnings in Core code when they compile their sketches. Related issue: #2587.