### PR TITLE
Fixed incorrect usage of memset() in PWM code.

### DIFF
--- a/cores/esp8266/core_esp8266_wiring_pwm.c
+++ b/cores/esp8266/core_esp8266_wiring_pwm.c
@@ -187,7 +187,7 @@ extern void __analogWrite(uint8_t pin, int value)
     }
     if((pwm_mask & (1 << pin)) == 0) {
         if(pwm_mask == 0) {
-            memset(&_pwm_isr_data, 0, sizeof(struct pwm_isr_data*));
+            memset(&_pwm_isr_data, 0, sizeof(_pwm_isr_data));
             start_timer = true;
         }
         pinMode(pin, OUTPUT);


### PR DESCRIPTION
Fixed incorrect usage of memset() in PWM code which leads to incomplete initialization of struct. Thanks to GCC warning -Wsizeof-pointer-memaccess.