### PR TITLE
Fixed libb64 decoder.

### DIFF
--- a/cores/esp8266/libb64/cdecode.c
+++ b/cores/esp8266/libb64/cdecode.c
@@ -86,17 +86,14 @@ static int base64_decode_chars_signed(const int8_t* code_in, const int length_in
   return len;
 }
 
-int base64_decode_value(char value_in)
-{
-	return base64_decode_value_signed(*((int8_t *) &value_in));
+int base64_decode_value(char value_in){
+  return base64_decode_value_signed(*((int8_t *) &value_in));
 }
 
-int base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in)
-{
-	return base64_decode_block_signed( (int8_t *) code_in, length_in, (int8_t *) plaintext_out, state_in );
+int base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in){
+  return base64_decode_block_signed((int8_t *) code_in, length_in, (int8_t *) plaintext_out, state_in);
 }
 
-int base64_decode_chars(const char* code_in, const int length_in, char* plaintext_out)
-{
-	return base64_decode_chars_signed( (int8_t *) code_in, length_in, (int8_t *) plaintext_out );
+int base64_decode_chars(const char* code_in, const int length_in, char* plaintext_out){
+  return base64_decode_chars_signed((int8_t *) code_in, length_in, (int8_t *) plaintext_out);
 }

--- a/cores/esp8266/libb64/cdecode.c
+++ b/cores/esp8266/libb64/cdecode.c
@@ -6,10 +6,11 @@ For details, see http://sourceforge.net/projects/libb64
 */
 
 #include "cdecode.h"
+#include <stdint.h>
 
-int base64_decode_value(char value_in){
-  static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
-  static const char decoding_size = sizeof(decoding);
+static int base64_decode_value_signed(int8_t value_in){
+  static const int8_t decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
+  static const int8_t decoding_size = sizeof(decoding);
   value_in -= 43;
   if (value_in < 0 || value_in > decoding_size) return -1;
   return decoding[(int)value_in];
@@ -20,10 +21,10 @@ void base64_init_decodestate(base64_decodestate* state_in){
   state_in->plainchar = 0;
 }
 
-int base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in){
-  const char* codechar = code_in;
-  char* plainchar = plaintext_out;
-  char fragment;
+static int base64_decode_block_signed(const int8_t* code_in, const int length_in, int8_t* plaintext_out, base64_decodestate* state_in){
+  const int8_t* codechar = code_in;
+  int8_t* plainchar = plaintext_out;
+  int8_t fragment;
   
   *plainchar = state_in->plainchar;
   
@@ -36,7 +37,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
             state_in->plainchar = *plainchar;
             return plainchar - plaintext_out;
           }
-          fragment = (char)base64_decode_value(*codechar++);
+          fragment = (int8_t)base64_decode_value_signed(*codechar++);
         } while (fragment < 0);
         *plainchar    = (fragment & 0x03f) << 2;
       case step_b:
@@ -46,7 +47,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
             state_in->plainchar = *plainchar;
             return plainchar - plaintext_out;
           }
-          fragment = (char)base64_decode_value(*codechar++);
+          fragment = (int8_t)base64_decode_value_signed(*codechar++);
         } while (fragment < 0);
         *plainchar++ |= (fragment & 0x030) >> 4;
         *plainchar    = (fragment & 0x00f) << 4;
@@ -57,7 +58,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
             state_in->plainchar = *plainchar;
             return plainchar - plaintext_out;
           }
-          fragment = (char)base64_decode_value(*codechar++);
+          fragment = (int8_t)base64_decode_value_signed(*codechar++);
         } while (fragment < 0);
         *plainchar++ |= (fragment & 0x03c) >> 2;
         *plainchar    = (fragment & 0x003) << 6;
@@ -68,7 +69,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
             state_in->plainchar = *plainchar;
             return plainchar - plaintext_out;
           }
-          fragment = (char)base64_decode_value(*codechar++);
+          fragment = (int8_t)base64_decode_value_signed(*codechar++);
         } while (fragment < 0);
         *plainchar++   |= (fragment & 0x03f);
     }
@@ -77,10 +78,25 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
   return plainchar - plaintext_out;
 }
 
-int base64_decode_chars(const char* code_in, const int length_in, char* plaintext_out){
+static int base64_decode_chars_signed(const int8_t* code_in, const int length_in, int8_t* plaintext_out){
   base64_decodestate _state;
   base64_init_decodestate(&_state);
-  int len = base64_decode_block(code_in, length_in, plaintext_out, &_state);
+  int len = base64_decode_block_signed(code_in, length_in, plaintext_out, &_state);
   if(len > 0) plaintext_out[len] = 0;
   return len;
+}
+
+int base64_decode_value(char value_in)
+{
+	return base64_decode_value_signed(*((int8_t *) &value_in));
+}
+
+int base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in)
+{
+	return base64_decode_block_signed( (int8_t *) code_in, length_in, (int8_t *) plaintext_out, state_in );
+}
+
+int base64_decode_chars(const char* code_in, const int length_in, char* plaintext_out)
+{
+	return base64_decode_chars_signed( (int8_t *) code_in, length_in, (int8_t *) plaintext_out );
 }


### PR DESCRIPTION
Libb64 decoder works when "char" type is signed. In esp8266 xtensa gcc "char" is unsigned, so libb64 decoder does not work. In the implementation file I replaced "char" to "int8_t" and created function wrappers in order to keep existing interface.

I  tested it, it works!