### PR TITLE
display login failure to client

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -129,7 +129,7 @@ bool ESP8266WebServer::authenticate(const char * username, const char * password
 
 void ESP8266WebServer::requestAuthentication(){
   sendHeader("WWW-Authenticate", "Basic realm=\"Login Required\"");
-  send(401);
+  send(401,"text/html","<h1>Access Denied</h1>");
 }
 
 void ESP8266WebServer::on(const String &uri, ESP8266WebServer::THandlerFunction handler) {


### PR DESCRIPTION
just displaying Access Denied instead of a blank page
it can be left to the user to decide what to display too if we passed an argument from the function call but I didn't want to propose a major change in the class unless I have enough knowlwdge 
I want to know how to propose such features correctly as I am new to the GitHub Community :D