### PR TITLE
add support for nightly boards manager packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 language: bash
 os:
   - linux
+env:
+  - BUILD_TYPE=build
 
 addons:
   apt:
@@ -11,40 +13,7 @@ addons:
       - g++-4.8
 
 script:
-  - set -e
-  - export CXX="g++-4.8" CC="gcc-4.8" GCOV="gcov-4.8"
-  - echo -e "travis_fold:start:host_tests"
-  - pushd $TRAVIS_BUILD_DIR/tests/host
-  - make
-  - make clean-objects
-  - echo -e "travis_fold:end:host_tests"
-  - echo -e "travis_fold:start:sketch_test_env_prepare"
-  - popd
-  - wget -O arduino.tar.xz https://www.arduino.cc/download.php?f=/arduino-nightly-linux64.tar.xz
-  - tar xf arduino.tar.xz
-  - mv arduino-nightly $HOME/arduino_ide
-  - cd $HOME/arduino_ide/hardware
-  - mkdir esp8266com
-  - cd esp8266com
-  - ln -s $TRAVIS_BUILD_DIR esp8266
-  - cd esp8266/tools
-  - python get.py
-  - export PATH="$HOME/arduino_ide:$TRAVIS_BUILD_DIR/tools/xtensa-lx106-elf/bin:$PATH"
-  - which arduino
-  - cd $TRAVIS_BUILD_DIR
-  - source tests/common.sh
-  - install_libraries
-  - echo -e "travis_fold:end:sketch_test_env_prepare"
-  - echo -e "travis_fold:start:sketch_test"
-  - build_sketches $HOME/arduino_ide $TRAVIS_BUILD_DIR/libraries "-l $HOME/Arduino/libraries"
-  - echo -e "travis_fold:end:sketch_test"
-  - echo -e "travis_fold:start:size_report"
-  - cat size.log
-  - echo -e "travis_fold:end:size_report"
-
-after_success:
-    - pushd $TRAVIS_BUILD_DIR/tests/host
-    - bash <(curl -s https://codecov.io/bash) -X gcov
+  - $TRAVIS_BUILD_DIR/tests/common.sh
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Boards manager link: `http://arduino.esp8266.com/stable/package_esp8266com_index
 
 Documentation: [http://esp8266.github.io/Arduino/versions/2.3.0/](http://esp8266.github.io/Arduino/versions/2.3.0/)
 
-##### Staging version ![](http://arduino.esp8266.com/staging/badge.svg)
-Boards manager link: `http://arduino.esp8266.com/staging/package_esp8266com_index.json`
+##### Nightly version ![](http://arduino.esp8266.com/nightly/badge.svg)
+Boards manager link: `http://arduino.esp8266.com/nightly/package_esp8266com_index.json`
 
-Documentation: [http://esp8266.github.io/Arduino/versions/2.3.0-rc2/](http://esp8266.github.io/Arduino/versions/2.3.0-rc2/)
+No online documentation available for nightly version yet — work in progress.
 
 ### Using git version
 [![Linux build status](https://travis-ci.org/esp8266/Arduino.svg)](https://travis-ci.org/esp8266/Arduino) [![codecov.io](https://codecov.io/github/esp8266/Arduino/coverage.svg?branch=master)](https://codecov.io/github/esp8266/Arduino?branch=master)

--- a/package/build_boards_manager_package.sh
+++ b/package/build_boards_manager_package.sh
@@ -50,6 +50,7 @@ cat << EOF > exclude.txt
 .gitignore
 .travis.yml
 package
+doc
 EOF
 # Also include all files which are ignored by git
 git ls-files --other --directory >> exclude.txt

--- a/package/deploy_nightly_package.sh
+++ b/package/deploy_nightly_package.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-export PKG_URL_PREFIX=https://dl.bintray.com/igrr/arduino-esp8266/:
+export PKG_URL_PREFIX=https://dl.bintray.com/igrr/arduino-esp8266
 commit=`git rev-parse --short HEAD`
 
 ./build_boards_manager_package.sh

--- a/package/deploy_nightly_package.sh
+++ b/package/deploy_nightly_package.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+export PKG_URL_PREFIX=https://dl.bintray.com/igrr/arduino-esp8266/:
+commit=`git rev-parse --short HEAD`
+
+./build_boards_manager_package.sh
+
+ver=`ls -1 versions`
+bintray_slug=igrr/arduino-esp8266/arduino-esp8266-core
+
+# Upload to bintray
+# URL to the file will look like this: https://dl.bintray.com/igrr/arduino-esp8266/:esp8266-2.4.0-nightly+20170218.zip
+curl --progress-bar \
+	-T versions/$ver/esp8266-$ver.zip \
+	-uigrr:$BINTRAY_API_KEY \
+	-o curl.out \
+	https://api.bintray.com/content/$bintray_slug/$ver/esp8266-$ver.zip
+
+
+# Publish the uploaded file
+curl -uigrr:$BINTRAY_API_KEY \
+	-X POST \
+	https://api.bintray.com/content/$bintray_slug/$ver/publish
+
+# Load deploy key
+echo -n $ESP8266_ARDUINO_DEPLOY_KEY_B64 > ~/.ssh/esp8266_arduino_deploy_b64
+base64 --decode --ignore-garbage ~/.ssh/esp8266_arduino_deploy_b64 > ~/.ssh/esp8266_arduino_deploy
+chmod 600 ~/.ssh/esp8266_arduino_deploy
+echo -e "Host $DEPLOY_HOST_NAME\n\tUser $DEPLOY_USER_NAME\n\tStrictHostKeyChecking no\n\tIdentityFile ~/.ssh/esp8266_arduino_deploy" >> ~/.ssh/config
+
+# Generate the badge (used in Readme.md)
+release_date=$(date "+%b_%d,_%Y")
+curl -o versions/$ver/badge.svg https://img.shields.io/badge/updated-$release_date-blue.svg
+
+# Check old version
+oldver=$(ssh $DEPLOY_HOST_NAME "cat $DEPLOY_PATH_NIGHTLY/version")
+
+if [ "$oldver" = "$ver" ]; then
+	echo "Nightly version hasn't changed, not updating"
+else
+	# Upload new json, version file, and the badge
+	echo $ver > versions/$ver/version
+	scp versions/$ver/{package_esp8266com_index.json,version,badge.svg} $DEPLOY_HOST_NAME:$DEPLOY_PATH_NIGHTLY/
+	curl --data-urlencode "message=Updating **nightly** package from $oldver to $ver" $GITTER_WEBHOOK
+fi

--- a/package/package_esp8266com_index.template.json
+++ b/package/package_esp8266com_index.template.json
@@ -16,8 +16,6 @@
           "category": "ESP8266",
           "url": "",
           "archiveFileName": "",
-          "checksum": "",
-          "size": "",
           "help": {
             "online": ""
           },

--- a/platform.txt
+++ b/platform.txt
@@ -6,7 +6,7 @@
 # https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5---3rd-party-Hardware-specification
 
 name=ESP8266 Modules
-version=2.3.0
+version=2.4.0
 
 runtime.tools.xtensa-lx106-elf-gcc.path={runtime.platform.path}/tools/xtensa-lx106-elf
 runtime.tools.esptool.path={runtime.platform.path}/tools/esptool


### PR DESCRIPTION
Arduino IDE has support for “nightly” versions of boards manager packages (https://github.com/arduino/Arduino/pull/3449). These versions are distinguished by the lack of “size” and “checksum” fields in json file. IDE always uninstalls previously installed nightly version before installing the new one.

This change adds support for generation of nightly package builds.

TODO:

- [x] auto-patch core version in platform.txt
- [x] drop "staging" package links
- [x] update readme with instructions for installing nightly packages
- [x] update travis build script to generate nightly packages and upload them to arduino.esp8266.com