### PR TITLE
Allow usage of byte arrays to set RootCAs

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
@@ -547,20 +547,28 @@ bool WiFiClientSecure::verifyCertChain(const char* domain_name)
     return _verifyDN(domain_name);
 }
 
-void WiFiClientSecure::setCertificate(const uint8_t* cert_data, size_t size)
+bool WiFiClientSecure::setCACert(const uint8_t* pk, size_t size)
 {
     if (!_ssl) {
-        return;
+        return false;
     }
-    _ssl->loadObject(SSL_OBJ_X509_CERT, cert_data, size);
+    return _ssl->loadObject(SSL_OBJ_X509_CACERT, pk, size);
 }
 
-void WiFiClientSecure::setPrivateKey(const uint8_t* pk, size_t size)
+bool WiFiClientSecure::setCertificate(const uint8_t* pk, size_t size)
 {
     if (!_ssl) {
-        return;
+        return false;
     }
-    _ssl->loadObject(SSL_OBJ_RSA_KEY, pk, size);
+    return _ssl->loadObject(SSL_OBJ_X509_CERT, pk, size);
+}
+
+bool WiFiClientSecure::setPrivateKey(const uint8_t* pk, size_t size)
+{
+    if (!_ssl) {
+        return false;
+    }
+    return _ssl->loadObject(SSL_OBJ_RSA_KEY, pk, size);
 }
 
 bool WiFiClientSecure::loadCACert(Stream& stream, size_t size)

--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.h
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.h
@@ -50,12 +50,13 @@ public:
   size_t peekBytes(uint8_t *buffer, size_t length) override;
   void stop() override;
 
-  void setCertificate(const uint8_t* cert_data, size_t size);
-  void setPrivateKey(const uint8_t* pk, size_t size);
+  bool setCACert(const uint8_t* pk, size_t size);
+  bool setCertificate(const uint8_t* pk, size_t size);
+  bool setPrivateKey(const uint8_t* pk, size_t size);
 
+  bool loadCACert(Stream& stream, size_t size);
   bool loadCertificate(Stream& stream, size_t size);
   bool loadPrivateKey(Stream& stream, size_t size);
-  bool loadCACert(Stream& stream, size_t size);
 
   template<typename TFile>
   bool loadCertificate(TFile& file) {


### PR DESCRIPTION
Something like this is now possible:
```c
const size_t DST_Root_CA_X3_len = 846;
const uint8_t DST_Root_CA_X3[] = {0x30, ....., 0xfd}; 
client.setCACert(DST_Root_CA_X3, DST_Root_CA_X3_len);
```