### PR TITLE
Improve general TCP stability

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -41,6 +41,8 @@ extern "C"
 #include "include/ClientContext.h"
 #include "c_types.h"
 
+char lwip_bufferize = 1;
+
 uint16_t WiFiClient::_localPort = 0;
 
 template<>
@@ -161,6 +163,10 @@ bool WiFiClient::getNoDelay() {
     if (!_client)
         return false;
     return _client->getNoDelay();
+}
+
+size_t WiFiClient::ESPWriteAvailable() {
+    return _client->writeAvailable();
 }
 
 size_t WiFiClient::write(uint8_t b)

--- a/libraries/ESP8266WiFi/src/WiFiClient.h
+++ b/libraries/ESP8266WiFi/src/WiFiClient.h
@@ -30,6 +30,8 @@
 
 #define WIFICLIENT_MAX_PACKET_SIZE 1460
 
+extern char lwip_bufferize;
+
 class ClientContext;
 class WiFiServer;
 
@@ -74,6 +76,8 @@ public:
   bool getNoDelay();
   void setNoDelay(bool nodelay);
   static void setLocalPortStart(uint16_t port) { _localPort = port; }
+
+  size_t ESPWriteAvailable();
 
   friend class WiFiServer;
 

--- a/tools/sdk/lwip/src/LWIP-CHANGE-MSS
+++ b/tools/sdk/lwip/src/LWIP-CHANGE-MSS
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+
+mss=$1
+
+[ -z "$mss" ] && { echo "syntax: $0 <mss>    (try with 256)"; exit 1; }
+
+[ -f ../include/lwipopts.h.orig ] || mv ../include/lwipopts.h ../include/lwipopts.h.orig
+
+< ../include/lwipopts.h.orig \
+> ../include/lwipopts.h \
+sed "s,^[ \t]*#define[ \t]*TCP_MSS\(.*\)$,#define TCP_MSS $mss //\1,g"
+
+make clean
+make
+for i in liblwip_gcc.a liblwip.a liblwip_536.a; do 
+    test -f ../../lib/${i}.orig || mv ../../lib/${i} ../../lib/${i}.orig
+done
+
+ln -sf ../lwip/src/liblwip_src.a ../../lib/liblwip_gcc.a


### PR DESCRIPTION
This commit on one hand allows to optionally use a per-tcp-connection
circular buffer to move received data out from esp internal link layer
incoming area, thus preventing most of the "LmacRxBlk:1" cases.  The
circular buffer has to have a minimum size of lwip's TCP_WND (because TCP
window size ensures no more data can be received until the user consume a
byte).

On the other hand, lowering TCP_MSS lets esp handle smaller buffers (user
data are actually small on this device, so there is little effect).  This of
course does not prevent sending large buffer at the cost of more tcp
packets.  This constant is currently 1460 which is standard but needlessly
way too high for our small esp device.

To test the benefits of these changes, TCP_MSS is set to 256, a tcp service
sending back all received data is setup in a sketch, and clients on a PC are
started to send then check received data.  Two clients are continuously
running and two others starts new sessions every some hundreds of bytes.
The shaken ESP has been running hours, no memory leak was detected, and an
average of 20-25 KBytes were still available from heap.  The ESP
"LmacRxBlk:1" hangs at the very first second when not using the circular
buffers, even with a 256 bytes MSS.

A new global variable: "lwip_bufferize" >0 let the ESP use circular buffers
for every new tcp connection.  A shell script is provided to automatically
change and recompile LWIP with a new MSS: "tools/sdk/lwip/src/LWIP-CHANGE-MSS".