### PR TITLE
[FIX] MDNS queryService emtpy buffer before query service

### DIFF
--- a/libraries/ESP8266mDNS/ESP8266mDNS.cpp
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.cpp
@@ -115,14 +115,17 @@ struct MDNSQuery {
   char _proto[4];
 };
 
-
-MDNSResponder::MDNSResponder() : _conn(0) { 
-  _services = 0;
-  _instanceName = ""; 
+void MDNSResponder::_initVar() {
   _answers = 0;
   _query = 0;
   _newQuery = false;
   _waitingForAnswers = false;
+}
+
+MDNSResponder::MDNSResponder() : _conn(0) {
+  _initVar();
+  _services = 0;
+  _instanceName = "";
 }
 MDNSResponder::~MDNSResponder() {
   if (_query != 0) {
@@ -283,7 +286,9 @@ int MDNSResponder::queryService(char *service, char *proto) {
 #ifdef MDNS_DEBUG_TX
   Serial.printf("queryService %s %s\n", service, proto);
 #endif  
-  
+
+  _initVar();
+
   if (_query != 0) {
     os_free(_query);
     _query = 0;
@@ -292,7 +297,7 @@ int MDNSResponder::queryService(char *service, char *proto) {
   os_strcpy(_query->_service, service);
   os_strcpy(_query->_proto, proto);
   _newQuery = true;
-  
+
   char underscore[] = "_";
 
   // build service name with _

--- a/libraries/ESP8266mDNS/ESP8266mDNS.h
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.h
@@ -122,6 +122,7 @@ private:
   WiFiEventHandler _gotIPHandler;
   
 
+  void _initVar();
   uint16_t _getServicePort(char *service, char *proto);
   MDNSTxt * _getServiceTxt(char *name, char *proto);
   uint16_t _getServiceTxtLen(char *name, char *proto);


### PR DESCRIPTION
Fix previous data left to in buffer for queryService()
In case of queried service doesn't exist on the net, there was a problem of queryService returning previously queried results.

Signed-off-by: Dongsoo Kim <dongsoo.kim@gmail.com>