### PR TITLE
Fix typo in MDNS multi-interface advertising code

### DIFF
--- a/libraries/ESP8266mDNS/ESP8266mDNS.cpp
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.cpp
@@ -888,7 +888,7 @@ size_t MDNSResponder::advertiseServices(){
       if (ip)
         _reply(0x0F, servicePtr->_name, servicePtr->_proto, servicePtr->_port, ip);
 
-      wifi_get_ip_info(SOFTAP_IF, &ip_info);
+      wifi_get_ip_info(STATION_IF, &ip_info);
       ip = ip_info.ip.addr;
       if (ip)
         _reply(0x0F, servicePtr->_name, servicePtr->_proto, servicePtr->_port, ip);


### PR DESCRIPTION
MDNSResponder::advertiseServices() was transmitting all service adverts
on the same interface (AP) rather than once on STA and once on AP. Fix
this simple mistake.

With this change, both "ping esp8266.local" and "avahi-browse -a" see
the ESP8266 from a test Linux PC, on both AP and STA interfaces (where
applicable), with the ESP8266 running mDNS_Web_Server.ino modified for
each of AP-only, STA-only and AP+STA modes.

Note that no attempt has been made to make MDNSResponder::queryService()
operate correctly with multiple interfaces, either in this commit or the
commit this commit fixes.

Fixes: a546d64e07d2 ("ESP8266mDNS: support AP and STA interfaces at once")
Fixes #3101