### PR TITLE
prepare lwip2

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -38,6 +38,7 @@ extern "C" {
 #include "lwip/opt.h"
 #include "lwip/err.h"
 #include "lwip/dns.h"
+#include "lwip/init.h" // LWIP_VERSION_
 }
 
 #include "WiFiClient.h"
@@ -419,7 +420,11 @@ bool ESP8266WiFiGenericClass::forceSleepWake() {
 // ------------------------------------------------ Generic Network function ---------------------------------------------
 // -----------------------------------------------------------------------------------------------------------------------
 
+#if LWIP_VERSION_MAJOR == 1
 void wifi_dns_found_callback(const char *name, ip_addr_t *ipaddr, void *callback_arg);
+#else
+void wifi_dns_found_callback(const char *name, const ip_addr_t *ipaddr, void *callback_arg);
+#endif
 
 /**
  * Resolve the given hostname to an IP address.
@@ -465,7 +470,12 @@ int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResul
  * @param ipaddr
  * @param callback_arg
  */
-void wifi_dns_found_callback(const char *name, ip_addr_t *ipaddr, void *callback_arg) {
+#if LWIP_VERSION_MAJOR == 1
+void wifi_dns_found_callback(const char *name, ip_addr_t *ipaddr, void *callback_arg)
+#else
+void wifi_dns_found_callback(const char *name, const ip_addr_t *ipaddr, void *callback_arg)
+#endif
+{
     (void) name;
     if(ipaddr) {
         (*reinterpret_cast<IPAddress*>(callback_arg)) = ipaddr->addr;

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
@@ -36,6 +36,7 @@ extern "C" {
 #include "smartconfig.h"
 #include "lwip/err.h"
 #include "lwip/dns.h"
+#include "lwip/init.h" // LWIP_VERSION_
 }
 
 #include "debug.h"
@@ -400,8 +401,13 @@ IPAddress ESP8266WiFiSTAClass::gatewayIP() {
  * @return IPAddress DNS Server IP
  */
 IPAddress ESP8266WiFiSTAClass::dnsIP(uint8_t dns_no) {
+#if LWIP_VERSION_MAJOR == 1
     ip_addr_t dns_ip = dns_getserver(dns_no);
     return IPAddress(dns_ip.addr);
+#else
+    const ip_addr_t* dns_ip = dns_getserver(dns_no);
+    return IPAddress(dns_ip->addr);
+#endif
 }
 
 

--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -106,11 +106,13 @@ int WiFiClient::connect(IPAddress ip, uint16_t port)
     // if the default interface is down, tcp_connect exits early without
     // ever calling tcp_err
     // http://lists.gnu.org/archive/html/lwip-devel/2010-05/msg00001.html
+#if LWIP_VERSION_MAJOR == 1
     netif* interface = ip_route(&addr);
     if (!interface) {
         DEBUGV("no route to host\r\n");
         return 0;
     }
+#endif
 
     tcp_pcb* pcb = tcp_new();
     if (!pcb)

--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -165,6 +165,11 @@ bool WiFiClient::getNoDelay() {
     return _client->getNoDelay();
 }
 
+size_t WiFiClient::availableForWrite ()
+{
+    return _client->availableForWrite();
+}
+
 size_t WiFiClient::write(uint8_t b)
 {
     return write(&b, 1);

--- a/libraries/ESP8266WiFi/src/WiFiClient.h
+++ b/libraries/ESP8266WiFi/src/WiFiClient.h
@@ -75,6 +75,8 @@ public:
   void setNoDelay(bool nodelay);
   static void setLocalPortStart(uint16_t port) { _localPort = port; }
 
+  size_t availableForWrite();
+
   friend class WiFiServer;
 
   using Print::write;

--- a/libraries/ESP8266WiFi/src/include/ClientContext.h
+++ b/libraries/ESP8266WiFi/src/include/ClientContext.h
@@ -124,6 +124,11 @@ public:
         }
     }
 
+    size_t availableForWrite ()
+    {
+        return _pcb? tcp_sndbuf(_pcb): 0;
+    }
+
     void setNoDelay(bool nodelay)
     {
         if(!_pcb) {


### PR DESCRIPTION
This PR brings minimum changes for libraries to compile with lwip2 (https://github.com/d-a-v/esp8266-phy).
#3075 seems to have been solved with it.

It is harmless otherwise.