### PR TITLE
Implement support for HSPI overlap mode

### DIFF
--- a/cores/esp8266/esp8266_peri.h
+++ b/cores/esp8266/esp8266_peri.h
@@ -586,6 +586,10 @@ extern uint8_t esp8266_gpioToFn[16];
 #define SPIE2IHEN 0x3 //SPI_INT_HOLD_ENA
 #define SPIE2IHEN_S 0 //SPI_INT_HOLD_ENA_S
 
+//SPI PIN (SPIxP)
+#define SPIPCS2DIS (1 << 2)
+#define SPIPCS1DIS (1 << 1)
+#define SPIPCS0DIS (1 << 0)
 
 //SLC (DMA) Registers
 #define SLCC0     ESP8266_REG(0xB00) //SLC_CONF0

--- a/doc/libraries.md
+++ b/doc/libraries.md
@@ -56,6 +56,28 @@ else they default to pins 4(SDA) and 5(SCL).
 
 SPI library supports the entire Arduino SPI API including transactions, including setting phase (CPHA).
 Setting the Clock polarity (CPOL) is not supported, yet (SPI_MODE2 and SPI_MODE3 not working).
+The usual SPI pins are: 
+
+- `MOSI` = GPIO13
+- `MISO` = GPIO12
+- `SCLK` = GPIO14
+
+There's an extended mode where you can swap the normal pins to the pin0 hardware pins.
+This is enabled  by calling `SPI.pins(6, 7, 8, 0)` before the call to `SPI.begin()`. The pins would
+change to:
+
+- `MOSI` = SD1
+- `MISO` = SD0
+- `SCLK` = CLK
+- `HWCS` = GPIO0
+
+This mode shares the SPI pins with the controller that reads the program code from flash and is
+controlled by a hardware arbiter (the flash has always higher priority). For this mode the CS
+will be controlled by hardware as you can't handle the CS line with a GPIO, you never actually
+know when the arbiter is going to grant you access to the bus so you must let it handle CS
+automatically.
+
+
 
 ## SoftwareSerial
 

--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -53,6 +53,7 @@ public:
 class SPIClass {
 public:
   SPIClass();
+  bool pins(int8_t sck, int8_t miso, int8_t mosi, int8_t ss);
   void begin();
   void end();
   void setHwCs(bool use);
@@ -74,6 +75,7 @@ public:
   void endTransaction(void);
 private:
   bool useHwCs;
+  uint8_t pinSet;
   void writeBytes_(uint8_t * data, uint8_t size);
   void transferBytes_(uint8_t * out, uint8_t * in, uint8_t size);
   inline void setDataBits(uint16_t bits);


### PR DESCRIPTION
Hey this implement Issue #1062. Allows activation of HSPI overlap mode. I tested this with a 23LC1024 memory and it worked fine. But couldn't make it work with an SD card. The SD card was getting confused by the sharing of the SPI bus.