### PR TITLE
Free memory we allocated and actually stop i2s.

### DIFF
--- a/cores/esp8266/core_esp8266_i2s.c
+++ b/cores/esp8266/core_esp8266_i2s.c
@@ -146,6 +146,10 @@ void ICACHE_FLASH_ATTR i2s_slc_end(){
   SLCIE = 0;
   SLCTXL &= ~(SLCTXLAM << SLCTXLA); // clear TX descriptor address
   SLCRXL &= ~(SLCRXLAM << SLCRXLA); // clear RX descriptor address
+
+  for (int x = 0; x<SLC_BUF_CNT; x++) {
+	  free(i2s_slc_buf_pntr[x]);
+  }
 }
 
 //This routine pushes a single, 32-bit sample to the I2S buffers. Call this at (on average) 
@@ -238,8 +242,16 @@ void ICACHE_FLASH_ATTR i2s_begin(){
 }
 
 void ICACHE_FLASH_ATTR i2s_end(){
-  i2s_slc_end();
+  I2SC &= ~I2STXS;
+
+  //Reset I2S
+  I2SC &= ~(I2SRST);
+  I2SC |= I2SRST;
+  I2SC &= ~(I2SRST);
+
   pinMode(2, INPUT);
   pinMode(3, INPUT);
   pinMode(15, INPUT);
+
+  i2s_slc_end();
 }


### PR DESCRIPTION
i2s_end was leaking memory and wasn't actually stopping i2s.