### PR TITLE
base64::encode() adds newlines every 72 (encoded) chars output.

### DIFF
--- a/cores/esp8266/base64.cpp
+++ b/cores/esp8266/base64.cpp
@@ -35,13 +35,20 @@ extern "C" {
  * @param length size_t
  * @return String
  */
-String base64::encode(uint8_t * data, size_t length) {
+String base64::encode(uint8_t * data, size_t length, bool doNewLines) {
     // base64 needs more size then the source data
     size_t size = ((length * 1.6f) + 1);
     char * buffer = (char *) malloc(size);
     if(buffer) {
         base64_encodestate _state;
-        base64_init_encodestate(&_state);
+        if(doNewLines)
+        {
+            base64_init_encodestate(&_state);
+        }
+        else 
+        {
+            base64_init_encodestate_nonewlines(&_state);
+        }
         int len = base64_encode_block((const char *) &data[0], length, &buffer[0], &_state);
         len = base64_encode_blockend((buffer + len), &_state);
 
@@ -57,7 +64,7 @@ String base64::encode(uint8_t * data, size_t length) {
  * @param text String
  * @return String
  */
-String base64::encode(String text) {
-    return base64::encode((uint8_t *) text.c_str(), text.length());
+String base64::encode(String text, bool doNewLines) {
+    return base64::encode((uint8_t *) text.c_str(), text.length(), doNewLines);
 }
 

--- a/cores/esp8266/base64.h
+++ b/cores/esp8266/base64.h
@@ -27,8 +27,11 @@
 
 class base64 {
     public:
-        static String encode(uint8_t * data, size_t length);
-        static String encode(String text);
+        // NOTE: The default behaviour of backend (lib64)
+        // is to add a newline every 72 (encoded) characters output.
+        // This may 'break' longer uris and json variables
+        static String encode(uint8_t * data, size_t length, bool doNewLines = true);
+        static String encode(String text, bool doNewLines = true);
     private:
 };
 

--- a/cores/esp8266/libb64/cencode.c
+++ b/cores/esp8266/libb64/cencode.c
@@ -13,6 +13,13 @@ void base64_init_encodestate(base64_encodestate* state_in){
   state_in->step = step_A;
   state_in->result = 0;
   state_in->stepcount = 0;
+  state_in->stepsnewline = CHARS_PER_LINE;
+}
+
+
+void base64_init_encodestate_nonewlines(base64_encodestate* state_in){
+  base64_init_encodestate(state_in);
+  state_in->stepsnewline = -1;
 }
 
 char base64_encode_value(char value_in){
@@ -65,7 +72,7 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
       *codechar++ = base64_encode_value(result);
       
       ++(state_in->stepcount);
-      if (state_in->stepcount == CHARS_PER_LINE/4){
+      if ((state_in->stepcount == CHARS_PER_LINE/4) && (state_in->stepsnewline > 0)){
         *codechar++ = '\n';
         state_in->stepcount = 0;
       }

--- a/cores/esp8266/libb64/cencode.h
+++ b/cores/esp8266/libb64/cencode.h
@@ -22,9 +22,11 @@ typedef struct {
   base64_encodestep step;
   char result;
   int stepcount;
+  int stepsnewline;
 } base64_encodestate;
 
 void base64_init_encodestate(base64_encodestate* state_in);
+void base64_init_encodestate_nonewlines(base64_encodestate* state_in);
 
 char base64_encode_value(char value_in);
 

--- a/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
@@ -96,13 +96,6 @@ public:
 
         String contentType = getContentType(path);
 
-        // If content type not matched on path, then try for uri
-	// Useful for minified javascript et al.
-        if (contentType.equals("application/octet-stream"))
-        {
-            contentType = getContentType(requestUri);
-        }
-
         // look for gz file, only if the original specified path is not a gz.  So part only works to send gzip via content encoding when a non compressed is asked for
         // if you point the the path to gzip you will serve the gzip as content type "application/x-gzip", not text or javascript etc...
         if (!path.endsWith(".gz") && !_fs.exists(path))  {

--- a/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
@@ -96,6 +96,13 @@ public:
 
         String contentType = getContentType(path);
 
+        // If content type not matched on path, then try for uri
+	// Useful for minified javascript et al.
+        if (contentType.equals("application/octet-stream"))
+        {
+            contentType = getContentType(requestUri);
+        }
+
         // look for gz file, only if the original specified path is not a gz.  So part only works to send gzip via content encoding when a non compressed is asked for
         // if you point the the path to gzip you will serve the gzip as content type "application/x-gzip", not text or javascript etc...
         if (!path.endsWith(".gz") && !_fs.exists(path))  {


### PR DESCRIPTION
Add option to disable any newlines in output.
Resolves #3194