### PR TITLE
Remove SD file available size saturation

### DIFF
--- a/libraries/SD/src/File.cpp
+++ b/libraries/SD/src/File.cpp
@@ -98,9 +98,7 @@ int File::read(void *buf, uint16_t nbyte) {
 int File::available() {
   if (! _file) return 0;
 
-  uint32_t n = size() - position();
-
-  return n > 0X7FFF ? 0X7FFF : n;
+  return size() - position();
 }
 
 void File::flush() {


### PR DESCRIPTION
A problem with file streaming arose during some experiments with the SDWebServer example. It seems that the current version of the software has a problem with sending large files stored on the SD card to connected clients.

After trying to find the cause of this problem, I have found that large files are always streamed up to the first 32767 bytes, regardless of the value returned by the size() method of the File class. This can be easily seen in browser network diagnostic tools:
![1](https://cloud.githubusercontent.com/assets/2965511/25774479/9a45c79e-328f-11e7-93b1-646a901b89a5.png)

The issue is caused by the SD library's File class available() method, which causes its result to be saturated to 0x7FFF (32767), making the file streaming function behave incorrectly. After removing the value clamping code, the streaming works perfectly for files with sizes larger than 32kB:
![2](https://cloud.githubusercontent.com/assets/2965511/25774480/9a45f9b2-328f-11e7-9755-7fcebdfec3a0.png)

I have also tested the fix with very large files (~40MB) and can confirm that it works (albeit quite slowly).

I suspect that the value saturation code was borrowed from the original Arduino SD libraries, which usually use 8-bit AVR compilers, where the int type (returned by the available() method) is a 16-bit integer - hence the clamping.
