### PR TITLE
Const-correctness for MD5Builder (#1175)

### DIFF
--- a/cores/esp8266/MD5Builder.cpp
+++ b/cores/esp8266/MD5Builder.cpp
@@ -1,26 +1,22 @@
 #include <Arduino.h>
 #include <MD5Builder.h>
 
-uint8_t hex_char_to_byte(uint8_t c)
-{
+uint8_t hex_char_to_byte(uint8_t c){
     return  (c >= 'a' && c <= 'f') ? (c - ((uint8_t)'a' - 0xa)) :
             (c >= 'A' && c <= 'F') ? (c - ((uint8_t)'A' - 0xA)) :
             (c >= '0' &&  c<= '9') ? (c - (uint8_t)'0') : 0;
 }
 
-void MD5Builder::begin(void)
-{
+void MD5Builder::begin(void){
     memset(_buf, 0x00, 16);
     MD5Init(&_ctx);
 }
 
-void MD5Builder::add(uint8_t * data, uint16_t len)
-{
+void MD5Builder::add(const uint8_t * data, const uint16_t len){
     MD5Update(&_ctx, data, len);
 }
 
-void MD5Builder::addHexString(const char * data)
-{
+void MD5Builder::addHexString(const char * data){
     uint16_t i, len = strlen(data);
     uint8_t * tmp = (uint8_t*)malloc(len/2);
     if(tmp == NULL) {
@@ -35,8 +31,7 @@ void MD5Builder::addHexString(const char * data)
     free(tmp);
 }
 
-bool MD5Builder::addStream(Stream & stream, const size_t maxLen)
-{
+bool MD5Builder::addStream(Stream & stream, const size_t maxLen){
     const int buf_size = 512;
     int maxLengthLeft = maxLen;
     uint8_t * buf = (uint8_t*) malloc(buf_size);
@@ -76,25 +71,21 @@ bool MD5Builder::addStream(Stream & stream, const size_t maxLen)
     return true;
 }
 
-void MD5Builder::calculate(void)
-{
+void MD5Builder::calculate(void){
     MD5Final(_buf, &_ctx);
 }
 
-void MD5Builder::getBytes(uint8_t * output)
-{
+void MD5Builder::getBytes(uint8_t * output){
     memcpy(output, _buf, 16);
 }
 
-void MD5Builder::getChars(char * output)
-{
+void MD5Builder::getChars(char * output){
     for(uint8_t i = 0; i < 16; i++) {
         sprintf(output + (i * 2), "%02x", _buf[i]);
     }
 }
 
-String MD5Builder::toString(void)
-{
+String MD5Builder::toString(void){
     char out[33];
     getChars(out);
     return String(out);

--- a/cores/esp8266/MD5Builder.h
+++ b/cores/esp8266/MD5Builder.h
@@ -1,9 +1,9 @@
-/* 
+/*
   md5.h - exposed md5 ROM functions for esp8266
 
   Copyright (c) 2015 Hristo Gochkov. All rights reserved.
   This file is part of the esp8266 core for Arduino environment.
- 
+
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
   License as published by the Free Software Foundation; either
@@ -31,13 +31,13 @@ class MD5Builder {
     uint8_t _buf[16];
   public:
     void begin(void);
-    void add(uint8_t * data, uint16_t len);
-    void add(const char * data){ add((uint8_t*)data, strlen(data)); }
+    void add(const uint8_t * data, const uint16_t len);
+    void add(const char * data){ add((const uint8_t*)data, strlen(data)); }
     void add(char * data){ add((const char*)data); }
-    void add(String data){ add(data.c_str()); }
+    void add(const String data){ add(data.c_str()); }
     void addHexString(const char * data);
     void addHexString(char * data){ addHexString((const char*)data); }
-    void addHexString(String data){ addHexString(data.c_str()); }
+    void addHexString(const String data){ addHexString(data.c_str()); }
     bool addStream(Stream & stream, const size_t maxLen);
     void calculate(void);
     void getBytes(uint8_t * output);

--- a/cores/esp8266/md5.h
+++ b/cores/esp8266/md5.h
@@ -1,11 +1,11 @@
-/* 
+/*
   md5.h - exposed md5 ROM functions for esp8266
 
   Copyright (c) 2015 Hristo Gochkov. All rights reserved.
   This file is part of the esp8266 core for Arduino environment.
- 
+
   original C source from https://github.com/morrissinger/ESP8266-Websocket/raw/master/MD5.h
- 
+
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
   License as published by the Free Software Foundation; either
@@ -34,7 +34,7 @@ typedef struct {
 } md5_context_t;
 
 extern void MD5Init (md5_context_t *);
-extern void MD5Update (md5_context_t *, uint8_t *, uint16_t);
+extern void MD5Update (md5_context_t *, const uint8_t *, const uint16_t);
 extern void MD5Final (uint8_t [16], md5_context_t *);
 
 #ifdef __cplusplus

--- a/tests/host/core/test_md5builder.cpp
+++ b/tests/host/core/test_md5builder.cpp
@@ -35,15 +35,25 @@ TEST_CASE("MD5Builder::add works as expected", "[core][MD5Builder]")
 
 TEST_CASE("MD5Builder::addHexString works as expected", "[core][MD5Builder]")
 {
-    MD5Builder builder;
-    builder.begin();
-    builder.addHexString("1234567890abcdeffedcba98765432106469676974616c7369676e61747572656170706c69636174696f6e73");
-    builder.calculate();
-    REQUIRE(builder.toString() == "47b937a6f9f12a4c389fa5854e023efb");
+    WHEN("A char array is parsed"){
+      MD5Builder builder;
+      builder.begin();
+      const char * myPayload = "1234567890abcdeffedcba98765432106469676974616c7369676e61747572656170706c69636174696f6e73";
+      builder.addHexString(myPayload);
+      builder.calculate();
+      REQUIRE(builder.toString() == "47b937a6f9f12a4c389fa5854e023efb");
+    }
+
+    WHEN("A Arduino String is parsed"){
+      MD5Builder builder;
+      builder.begin();
+      builder.addHexString(String("1234567890abcdeffedcba98765432106469676974616c7369676e61747572656170706c69636174696f6e73"));
+      builder.calculate();
+      REQUIRE(builder.toString() == "47b937a6f9f12a4c389fa5854e023efb");
+    }
 }
 
-TEST_CASE("MD5Builder::addStream works", "[core][MD5Builder]")
-{
+TEST_CASE("MD5Builder::addStream works", "[core][MD5Builder]"){
     MD5Builder builder;
     const char* str = "MD5Builder::addStream_works_longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong";
     {


### PR DESCRIPTION
- const for constant function arguments of MD5Builder
solves : https://github.com/esp8266/Arduino/issues/1175