### PR TITLE
ci: build and upload releases on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,48 +1,29 @@
 sudo: false
 language: bash
-os:
-  - linux
-
+os: linux
 dist: trusty
+
+env:
+  - BUILD_TYPE=build
 
 install:
   - pip install --user -r doc/requirements.txt
 
 script:
-  - set -e
-  - echo -e "travis_fold:start:docs"
-  - pushd $TRAVIS_BUILD_DIR/doc
-  - SPHINXOPTS="-W" make html
-  - popd
-  - echo -e "travis_fold:end:docs"
-  - echo -e "travis_fold:start:host_tests"
-  - pushd $TRAVIS_BUILD_DIR/tests/host
-  - make
-  - make clean-objects
-  - popd
-  - echo -e "travis_fold:end:host_tests"
-  - echo -e "travis_fold:start:sketch_test_env_prepare"
-  - wget -O arduino.tar.xz https://www.arduino.cc/download.php?f=/arduino-nightly-linux64.tar.xz
-  - tar xf arduino.tar.xz
-  - mv arduino-nightly $HOME/arduino_ide
-  - cd $HOME/arduino_ide/hardware
-  - mkdir esp8266com
-  - cd esp8266com
-  - ln -s $TRAVIS_BUILD_DIR esp8266
-  - cd esp8266/tools
-  - python get.py
-  - export PATH="$HOME/arduino_ide:$TRAVIS_BUILD_DIR/tools/xtensa-lx106-elf/bin:$PATH"
-  - which arduino
-  - cd $TRAVIS_BUILD_DIR
-  - source tests/common.sh
-  - install_libraries
-  - echo -e "travis_fold:end:sketch_test_env_prepare"
-  - echo -e "travis_fold:start:sketch_test"
-  - build_sketches $HOME/arduino_ide $TRAVIS_BUILD_DIR/libraries "-l $HOME/Arduino/libraries"
-  - echo -e "travis_fold:end:sketch_test"
-  - echo -e "travis_fold:start:size_report"
-  - cat size.log
-  - echo -e "travis_fold:end:size_report"
+  - $TRAVIS_BUILD_DIR/tests/common.sh
+
+deploy:
+  provider: releases
+  prerelease: true
+  api_key:
+    secure: A4FBmqyhlzy33oPeZVolg2Q/A3ZcJ3WnRQqQJ3NAPy+qGM5xcboOYtwcLL9vKaHZGfUB7lUP9QVZFGou1Wrmo9DnPvAoe3+XvCaDRGzVMxeIpu7UStbBD4Knbh98tlbMvZCXYRlT4VcusI9bMLK6UWw4sMdPislBh2FEfglTiag=
+  file_glob: true
+  file:
+    - package/versions/$TRAVIS_TAG/esp8266-$TRAVIS_TAG.zip
+    - package/versions/$TRAVIS_TAG/package_esp8266com_index.json
+  on:
+    repo: esp8266/Arduino
+    tags: true
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -38,11 +38,6 @@ Boards manager link: `http://arduino.esp8266.com/stable/package_esp8266com_index
 
 Documentation: [http://esp8266.github.io/Arduino/versions/2.3.0/](http://esp8266.github.io/Arduino/versions/2.3.0/)
 
-##### Staging version ![](http://arduino.esp8266.com/staging/badge.svg)
-Boards manager link: `http://arduino.esp8266.com/staging/package_esp8266com_index.json`
-
-Documentation: [http://esp8266.github.io/Arduino/versions/2.3.0-rc2/](http://esp8266.github.io/Arduino/versions/2.3.0-rc2/)
-
 ### Using git version
 [![Linux build status](https://travis-ci.org/esp8266/Arduino.svg)](https://travis-ci.org/esp8266/Arduino) [![codecov.io](https://codecov.io/github/esp8266/Arduino/coverage.svg?branch=master)](https://codecov.io/github/esp8266/Arduino?branch=master)
 

--- a/package/package_esp8266com_index.template.json
+++ b/package/package_esp8266com_index.template.json
@@ -16,8 +16,6 @@
           "category": "ESP8266",
           "url": "",
           "archiveFileName": "",
-          "checksum": "",
-          "size": "",
           "help": {
             "online": ""
           },

--- a/platform.txt
+++ b/platform.txt
@@ -6,7 +6,7 @@
 # https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5---3rd-party-Hardware-specification
 
 name=ESP8266 Modules
-version=2.3.0
+version=2.4.0
 
 runtime.tools.xtensa-lx106-elf-gcc.path={runtime.platform.path}/tools/xtensa-lx106-elf
 runtime.tools.esptool.path={runtime.platform.path}/tools/esptool


### PR DESCRIPTION
Previously release process used a bunch of shell scripts which I had locally. Following up on https://github.com/esp8266/Arduino/projects/2, this PR implements releases via Travis CI.

Release date badge generation is dropped, to be replaced with https://shields.io/.

Separate "staging" release channel is dropped as well, both final and pre- releases will be available in a single package, distinguished by -rcX suffix in the version name.