### PR TITLE
Configurable timeout for WiFiClient connect and write operations

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.h
@@ -98,6 +98,7 @@ class ESP8266WiFiGenericClass {
     public:
 
         int hostByName(const char* aHostname, IPAddress& aResult);
+        int hostByName(const char* aHostname, IPAddress& aResult, uint32_t timeout_ms);
 
     protected:
 

--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -48,12 +48,13 @@ WiFiClient* SList<WiFiClient>::_s_first = 0;
 
 
 WiFiClient::WiFiClient()
-: _client(0)
+: _client(0), _timeout(5000)
 {
     WiFiClient::_add(this);
 }
 
-WiFiClient::WiFiClient(ClientContext* client) : _client(client)
+WiFiClient::WiFiClient(ClientContext* client)
+: _client(client), _timeout(5000)
 {
     _client->ref();
     WiFiClient::_add(this);
@@ -69,6 +70,8 @@ WiFiClient::~WiFiClient()
 WiFiClient::WiFiClient(const WiFiClient& other)
 {
     _client = other._client;
+    _timeout = other._timeout;
+    _localPort = other._localPort;
     if (_client)
         _client->ref();
     WiFiClient::_add(this);
@@ -79,6 +82,8 @@ WiFiClient& WiFiClient::operator=(const WiFiClient& other)
    if (_client)
         _client->unref();
     _client = other._client;
+    _timeout = other._timeout;
+    _localPort = other._localPort;
     if (_client)
         _client->ref();
     return *this;

--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -163,6 +163,7 @@ size_t WiFiClient::write(const uint8_t *buf, size_t size)
     {
         return 0;
     }
+    _client->setTimeout(_timeout);
     return _client->write(buf, size);
 }
 
@@ -178,6 +179,7 @@ size_t WiFiClient::write(Stream& stream)
     {
         return 0;
     }
+    _client->setTimeout(_timeout);
     return _client->write(stream);
 }
 
@@ -187,6 +189,7 @@ size_t WiFiClient::write_P(PGM_P buf, size_t size)
     {
         return 0;
     }
+    _client->setTimeout(_timeout);
     return _client->write_P(buf, size);
 }
 


### PR DESCRIPTION
WiFiClient inherits `Stream::setTimeout` method. The value passed to `setTimeout` is used by `Stream` methods like `readBytes`, `readStringUntil` and so on. Other operations with WiFiClient such as `connect` and `write` previously didn't have configurable timeouts. `connect` would time out after 5 seconds, and `write` would return only if LwIP reported an error.

This change implements timeout during `connect` and `write`. For `connect`, same timeout value is used for name resolution and the actual connection, so it is possible that worst case timeout will be twice the timeout requested. For writes, `write` function will return the amount of data sent by the time the timeout has happened.

Fixes #1420, #3247, #2120