### PR TITLE
UDP updates

### DIFF
--- a/libraries/ESP8266WiFi/examples/WiFiUDPUsingCallback/WiFiUDPUsingCallback.ino
+++ b/libraries/ESP8266WiFi/examples/WiFiUDPUsingCallback/WiFiUDPUsingCallback.ino
@@ -1,6 +1,6 @@
 
 #include <ESP8266WiFi.h>
-#include <WiFiUDP.h>
+#include <WiFiUdp.h>
 #include <ArduinoOTA.h>
 
 

--- a/libraries/ESP8266WiFi/examples/WiFiUDPUsingCallback/WiFiUDPUsingCallback.ino
+++ b/libraries/ESP8266WiFi/examples/WiFiUDPUsingCallback/WiFiUDPUsingCallback.ino
@@ -1,6 +1,8 @@
 
 #include <ESP8266WiFi.h>
 #include <WiFiUDP.h>
+#include <ArduinoOTA.h>
+
 
 WiFiUDP udp;
 const char * ssid = "fyffest";
@@ -40,8 +42,28 @@ void setup() {
 
   udp.begin(9000);
 
+  ArduinoOTA.onStart([]() {
+    String type;
+    if (ArduinoOTA.getCommand() == U_FLASH)
+      type = "sketch";
+    else // U_SPIFFS
+      type = "filesystem";
+
+    // NOTE: if updating SPIFFS this would be the place to unmount SPIFFS using SPIFFS.end()
+    Serial.println("Start updating " + type);
+  });
+  ArduinoOTA.onEnd([]() {
+    Serial.println("\nEnd");
+  });
+  ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
+    Serial.printf("Progress: %u%%\r", (progress / (total / 100)));
+  });
+  
+  ArduinoOTA.begin();
+  
+
 }
 
 void loop() {
-
+ArduinoOTA.handle();
 }

--- a/libraries/ESP8266WiFi/examples/WiFiUDPUsingCallback/WiFiUDPUsingCallback.ino
+++ b/libraries/ESP8266WiFi/examples/WiFiUDPUsingCallback/WiFiUDPUsingCallback.ino
@@ -5,8 +5,8 @@
 
 
 WiFiUDP udp;
-const char * ssid = "fyffest";
-const char * pass = "wellcometrust";
+const char * ssid = "ssid";
+const char * pass = "password";
 
 
 void setup() {

--- a/libraries/ESP8266WiFi/examples/WiFiUDPUsingCallback/WiFiUDPUsingCallback.ino
+++ b/libraries/ESP8266WiFi/examples/WiFiUDPUsingCallback/WiFiUDPUsingCallback.ino
@@ -1,0 +1,47 @@
+
+#include <ESP8266WiFi.h>
+#include <WiFiUDP.h>
+
+WiFiUDP udp;
+const char * ssid = "fyffest";
+const char * pass = "wellcometrust";
+
+
+void setup() {
+  // put your setup code here, to run once:
+  Serial.begin(115200);
+  Serial.println();
+  Serial.println();
+
+  Serial.println("Booting...");
+  
+  WiFi.persistent(false);
+  WiFi.mode(WIFI_STA);
+  Serial.print("Connecting to Wi-Fi");
+  WiFi.begin(ssid, pass);
+
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+
+  Serial.printf("IP: %s\n", WiFi.localIP().toString().c_str() );
+
+  // Bind a callback function.  
+  // warning: handler is called from tcp stack context
+  // esp_yield and non-reentrant functions which depend on it will fail.
+  udp.onRx( []() {
+    size_t len = udp.available();
+    std::unique_ptr<char[]> buf(new char[len + 1]);
+    udp.read(buf.get(), len);
+    buf[len] = '\0';
+    Serial.printf("Packet Recieved: len = %u, data = %s\n", len, buf.get());
+  });
+
+  udp.begin(9000);
+
+}
+
+void loop() {
+
+}

--- a/libraries/ESP8266WiFi/src/WiFiUdp.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiUdp.cpp
@@ -85,6 +85,7 @@ uint8_t WiFiUDP::begin(uint16_t port)
     _ctx->ref();
     ip_addr_t addr;
     addr.addr = INADDR_ANY;
+    _ctx->onRx(std::bind(&WiFiUDP::_onRx, this));
     return (_ctx->listen(addr, port)) ? 1 : 0;
 }
 
@@ -109,6 +110,7 @@ uint8_t WiFiUDP::beginMulticast(IPAddress interfaceAddr, IPAddress multicast, ui
     if (!_ctx->listen(*IP_ADDR_ANY, port)) {
         return 0;
     }
+    _ctx->onRx(std::bind(&WiFiUDP::_onRx, this));
 
     return 1;
 }
@@ -297,4 +299,15 @@ void WiFiUDP::stopAllExcept(WiFiUDP * exC) {
             it->stop();
         }
     }
+}
+
+void WiFiUDP::onRx(rx_callback_t cb) {
+    _cb = cb; 
+}
+
+void WiFiUDP::_onRx()
+{
+    if(!_ctx->next()) return;
+    if (!_cb) return;
+    _cb(); 
 }

--- a/libraries/ESP8266WiFi/src/WiFiUdp.h
+++ b/libraries/ESP8266WiFi/src/WiFiUdp.h
@@ -33,6 +33,7 @@ class UdpContext;
 class WiFiUDP : public UDP, public SList<WiFiUDP> {
 private:
   UdpContext* _ctx;
+  enum { UNINIT, NORMAL, MULTICAST } _type{UNINIT}; 
 
 public:
 
@@ -49,6 +50,7 @@ public:
   virtual uint8_t begin(uint16_t port);	
   // Finish with the UDP connetion
   virtual void stop();
+  virtual bool restart(); 
   // join a multicast group and listen on the given port
   uint8_t beginMulticast(IPAddress interfaceAddr, IPAddress multicast, uint16_t port); 
 
@@ -112,10 +114,16 @@ public:
 
   static void stopAll();
   static void stopAllExcept(WiFiUDP * exC);
+  static void restartAll(); 
 
 private:
   rx_callback_t _cb; 
   void _onRx(); 
+  uint8_t _begin(); 
+  IPAddress _ip{INADDR_NONE};
+  IPAddress _ifaddr{INADDR_NONE};  
+
+  uint16_t _port{0}; 
 
 };
 

--- a/libraries/ESP8266WiFi/src/WiFiUdp.h
+++ b/libraries/ESP8266WiFi/src/WiFiUdp.h
@@ -24,6 +24,7 @@
 
 #include <Udp.h>
 #include <include/slist.h>
+#include <functional>
 
 #define UDP_TX_PACKET_MAX_SIZE 8192
 
@@ -34,6 +35,8 @@ private:
   UdpContext* _ctx;
 
 public:
+
+  typedef std::function<void(void)> rx_callback_t; 
   WiFiUDP();  // Constructor
   WiFiUDP(const WiFiUDP& other);
   WiFiUDP& operator=(const WiFiUDP& rhs);
@@ -104,8 +107,15 @@ public:
   // Return the local port for outgoing packets
   uint16_t localPort();
 
+  // Set an Rx callback.  
+  void onRx(rx_callback_t cb); 
+
   static void stopAll();
   static void stopAllExcept(WiFiUDP * exC);
+
+private:
+  rx_callback_t _cb; 
+  void _onRx(); 
 
 };
 

--- a/libraries/ESP8266mDNS/ESP8266mDNS.h
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.h
@@ -51,7 +51,7 @@ License (MIT license):
 #define ARDUINO_BOARD "generic"
 #endif
 
-class UdpContext;
+//class UdpContext;
 
 struct MDNSService;
 struct MDNSTxt;
@@ -111,7 +111,8 @@ public:
 
 private:
   struct MDNSService * _services;
-  UdpContext* _conn;
+  //UdpContext* _conn;
+  WiFiUDP _conn; 
   String _hostName;
   String _instanceName;
   struct MDNSAnswer * _answers;


### PR DESCRIPTION
1)  Allows an Rx callback to be attached to WiFiUDP
2) Initial proof of concept idea to get MDNS to use WiFiUDP instance and not UDPContext. 

not expecting this to get merged straight away.  But kind of the direction I'm suggesting.  
Having an Rx callback makes WiFiUDP more attractive.

comments please. 

The callback is still compatible with the existing parsePacket() and available methods, they just never get called as the onRx function gets called first. 
