### PR TITLE
SPI Write16, Write32, WriteBytes optimizations

### DIFF
--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -398,7 +398,7 @@ void SPIClass::writeBytes_(uint8_t * data, uint8_t size) {
     // Set Bits to transfer
     setDataBits(size * 8);
 
-    volatile uint32_t * fifoPtr = &SPI1W0;
+    uint32_t * fifoPtr = (uint32_t*)&SPI1W0;
     uint32_t * dataPtr = (uint32_t*) data;
     uint8_t dataSize = ((size + 3) / 4);
 
@@ -408,6 +408,7 @@ void SPIClass::writeBytes_(uint8_t * data, uint8_t size) {
         fifoPtr++;
     }
 
+    __sync_synchronize();
     SPI1CMD |= SPIBUSY;
     while(SPI1CMD & SPIBUSY) {}
 }

--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -343,12 +343,11 @@ void SPIClass::write16(uint16_t data, bool msb) {
     if(msb) {
         // MSBFIRST Byte first
         SPI1W0 = (data >> 8) | (data << 8);
-        SPI1CMD |= SPIBUSY;
     } else {
         // LSBFIRST Byte first
         SPI1W0 = data;
-        SPI1CMD |= SPIBUSY;
     }
+    SPI1CMD |= SPIBUSY;
     while(SPI1CMD & SPIBUSY) {}
 }
 
@@ -367,14 +366,11 @@ void SPIClass::write32(uint32_t data, bool msb) {
         } data_;
         data_.l = data;
         // MSBFIRST Byte first
-        SPI1W0 = (data_.b[3] | (data_.b[2] << 8) | (data_.b[1] << 16) | (data_.b[0] << 24));
-        SPI1CMD |= SPIBUSY;
-    } else {
-        // LSBFIRST Byte first
-        SPI1W0 = data;
-        SPI1CMD |= SPIBUSY;
+        data = (data_.b[3] | (data_.b[2] << 8) | (data_.b[1] << 16) | (data_.b[0] << 24));
     }
-    while(SPI1CMD & SPIBUSY) {}	
+    SPI1W0 = data;
+    SPI1CMD |= SPIBUSY;
+    while(SPI1CMD & SPIBUSY) {}
 }
 
 /**

--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -400,7 +400,7 @@ void SPIClass::writeBytes_(uint8_t * data, uint8_t size) {
 
     uint32_t * fifoPtr = (uint32_t*)&SPI1W0;
     uint32_t * dataPtr = (uint32_t*) data;
-    uint8_t dataSize = ((size + 3) / 4);
+    uint32_t dataSize = ((size + 3) / 4);
 
     while(dataSize--) {
         *fifoPtr = *dataPtr;


### PR DESCRIPTION
A few patches to decrease idle time while refilling FIFO, as well as decrease codespace.