### PR TITLE
Add None+No ASSERT Debug Level

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -192,6 +192,8 @@ generic.menu.Debug.Serial1.build.debug_port=-DDEBUG_ESP_PORT=Serial1
 
 generic.menu.DebugLevel.None____=None
 generic.menu.DebugLevel.None____.build.debug_level=
+generic.menu.DebugLevel.No_ASSERT____=None + No Asserts
+generic.menu.DebugLevel.No_ASSERT____.build.debug_level=-DNDEBUG
 generic.menu.DebugLevel.Core____=Core
 generic.menu.DebugLevel.Core____.build.debug_level=-DDEBUG_ESP_CORE
 generic.menu.DebugLevel.SSL_____=Core + SSL


### PR DESCRIPTION
ASSERT macros are very useful in debugging, but they require significant
RAM resources to store the strings of every `__FILE__ and `__FUNCTION__
and condition they're checking.  In a memory constrained system (especially
SSL servers) this can add up to 800+ bytes (depending on the path of the
compilation files) which can be the difference between a successfully
running AXTLS and one that crashes with out of memory errors.

This patch adds a super-level to "None", "None + No ASSERTs" which defines
NDEBUG which completely removes the assertion check and the string/RAM
it uses. For normal operation, "None" should still be used and is unaffected.
