### PR TITLE
Add support for AZDelivery NodeMCU LoLin V3 (builtin LED on D4 not D0)

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1016,6 +1016,70 @@ nodemcuv2.menu.FlashSize.4M1M.build.spiffs_pagesize=256
 
 
 ##############################################################
+nodemcu_lolinv3.name=NodeMCU 1.0 LoLin V3 (ESP-12E Module)
+
+nodemcu_lolinv3.upload.tool=esptool
+nodemcu_lolinv3.upload.speed=115200
+nodemcu_lolinv3.upload.resetmethod=nodemcu
+nodemcu_lolinv3.upload.maximum_size=1044464
+nodemcu_lolinv3.upload.maximum_data_size=81920
+nodemcu_lolinv3.upload.wait_for_upload_port=true
+nodemcu_lolinv3.serial.disableDTR=true
+nodemcu_lolinv3.serial.disableRTS=true
+
+nodemcu_lolinv3.build.mcu=esp8266
+nodemcu_lolinv3.build.f_cpu=80000000L
+nodemcu_lolinv3.build.board=ESP8266_NODEMCU
+nodemcu_lolinv3.build.core=esp8266
+nodemcu_lolinv3.build.variant=nodemcu_lolinv3
+nodemcu_lolinv3.build.flash_mode=dio
+nodemcu_lolinv3.build.flash_size=4M
+nodemcu_lolinv3.build.flash_freq=40
+nodemcu_lolinv3.build.debug_port=
+nodemcu_lolinv3.build.debug_level=
+
+nodemcu_lolinv3.menu.CpuFrequency.80=80 MHz
+nodemcu_lolinv3.menu.CpuFrequency.80.build.f_cpu=80000000L
+nodemcu_lolinv3.menu.CpuFrequency.160=160 MHz
+nodemcu_lolinv3.menu.CpuFrequency.160.build.f_cpu=160000000L
+
+nodemcu_lolinv3.menu.UploadSpeed.115200=115200
+nodemcu_lolinv3.menu.UploadSpeed.115200.upload.speed=115200
+nodemcu_lolinv3.menu.UploadSpeed.9600=9600
+nodemcu_lolinv3.menu.UploadSpeed.9600.upload.speed=9600
+nodemcu_lolinv3.menu.UploadSpeed.57600=57600
+nodemcu_lolinv3.menu.UploadSpeed.57600.upload.speed=57600
+nodemcu_lolinv3.menu.UploadSpeed.256000.windows=256000
+nodemcu_lolinv3.menu.UploadSpeed.256000.upload.speed=256000
+nodemcu_lolinv3.menu.UploadSpeed.230400.linux=230400
+nodemcu_lolinv3.menu.UploadSpeed.230400.macosx=230400
+nodemcu_lolinv3.menu.UploadSpeed.230400.macosx=230400
+nodemcu_lolinv3.menu.UploadSpeed.230400.upload.speed=230400
+nodemcu_lolinv3.menu.UploadSpeed.460800.linux=460800
+nodemcu_lolinv3.menu.UploadSpeed.460800.macosx=460800
+nodemcu_lolinv3.menu.UploadSpeed.460800.upload.speed=460800
+nodemcu_lolinv3.menu.UploadSpeed.512000.windows=512000
+nodemcu_lolinv3.menu.UploadSpeed.512000.upload.speed=512000
+nodemcu_lolinv3.menu.UploadSpeed.921600=921600
+nodemcu_lolinv3.menu.UploadSpeed.921600.upload.speed=921600
+
+nodemcu_lolinv3.menu.FlashSize.4M3M=4M (3M SPIFFS)
+nodemcu_lolinv3.menu.FlashSize.4M3M.build.flash_size=4M
+nodemcu_lolinv3.menu.FlashSize.4M3M.build.flash_ld=eagle.flash.4m.ld
+nodemcu_lolinv3.menu.FlashSize.4M3M.build.spiffs_start=0x100000
+nodemcu_lolinv3.menu.FlashSize.4M3M.build.spiffs_end=0x3FB000
+nodemcu_lolinv3.menu.FlashSize.4M3M.build.spiffs_blocksize=8192
+nodemcu_lolinv3.menu.FlashSize.4M3M.build.spiffs_pagesize=256
+
+nodemcu_lolinv3.menu.FlashSize.4M1M=4M (1M SPIFFS)
+nodemcu_lolinv3.menu.FlashSize.4M1M.build.flash_size=4M
+nodemcu_lolinv3.menu.FlashSize.4M1M.build.flash_ld=eagle.flash.4m1m.ld
+nodemcu_lolinv3.menu.FlashSize.4M1M.build.spiffs_start=0x300000
+nodemcu_lolinv3.menu.FlashSize.4M1M.build.spiffs_end=0x3FB000
+nodemcu_lolinv3.menu.FlashSize.4M1M.build.spiffs_blocksize=8192
+nodemcu_lolinv3.menu.FlashSize.4M1M.build.spiffs_pagesize=256
+
+##############################################################
 modwifi.name=Olimex MOD-WIFI-ESP8266(-DEV)
 
 modwifi.upload.tool=esptool

--- a/package/package_esp8266com_index.template.json
+++ b/package/package_esp8266com_index.template.json
@@ -33,6 +33,9 @@
               "name": "NodeMCU 1.0 (ESP-12E Module)"
             },
             {
+              "name": "NodeMCU 1.0 LoLin V3 (ESP-12E Module)"
+            },
+            {
               "name": "Adafruit HUZZAH ESP8266 (ESP-12)"
             },
             {
@@ -46,7 +49,7 @@
             },
             {
               "name": "Phoenix 2.0"
-            },                        
+            },
             {
               "name": "SparkFun Thing"
             },

--- a/variants/nodemcu_lolinv3/pins_arduino.h
+++ b/variants/nodemcu_lolinv3/pins_arduino.h
@@ -1,0 +1,52 @@
+/*
+  pins_arduino.h - Pin definition functions for Arduino
+  Part of Arduino - http://www.arduino.cc/
+
+  Copyright (c) 2007 David A. Mellis
+  Modified for ESP8266 platform by Ivan Grokhotkov, 2014-2015.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General
+  Public License along with this library; if not, write to the
+  Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+  Boston, MA  02111-1307  USA
+
+  $Id: wiring.h 249 2007-02-03 16:52:51Z mellis $
+*/
+
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include "../generic/common.h"
+
+#define PIN_WIRE_SDA (4)
+#define PIN_WIRE_SCL (5)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
+static const uint8_t LED_BUILTIN = 2;
+static const uint8_t BUILTIN_LED = 2;
+
+static const uint8_t D0   = 16;
+static const uint8_t D1   = 5;
+static const uint8_t D2   = 4;
+static const uint8_t D3   = 0;
+static const uint8_t D4   = 2;
+static const uint8_t D5   = 14;
+static const uint8_t D6   = 12;
+static const uint8_t D7   = 13;
+static const uint8_t D8   = 15;
+static const uint8_t D9   = 3;
+static const uint8_t D10  = 1;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
Hello esp8266 community,

I have added support for the AZDelivery NodeMCU Variant [_LoLin V3_](https://amazon.de/AZDelivery-NodeMCU-ESP8266-ESP-12E-Development/dp/B06Y1ZPNMS/ref=pd_sim_147_6?_encoding=UTF8&psc=1&refRID=BXXKKA56Q38FYT8QQ66J).
It is a german distributor who is selling this.

It was as simple as changing the builtin LED from Pin D0 to D4.

I will test the arrangement of the pins D0 to D8 as soon as I can setup a test rig on my breadboard.

Best regards,

Maik