### PR TITLE
@PlatformIO library manifest for GDBStub

### DIFF
--- a/libraries/GDBStub/library.json
+++ b/libraries/GDBStub/library.json
@@ -1,0 +1,30 @@
+{
+  "name": "GDBStub",
+  "version": "0.2",  
+  "keywords": "gdb, debug",
+  "description": "GDB server stub helps debug crashes when JTAG isn't an option.",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/esp8266/Arduino.git"
+  },
+  "export": {
+    "include": "libraries/GDBStub"
+  },  
+  "authors":
+  [
+    {
+      "name": "Jeroen Domburg"
+    },
+    {
+      "name": "Ivan Grokhotkov",
+      "email": "ivan@esp8266.com",
+      "maintainer": true
+    }
+  ],
+  "frameworks": "arduino",
+  "platforms": "espressif8266",
+  "build": {
+    "libArchive": false
+  }  
+}


### PR DESCRIPTION
Custom manifest for @PlatformIO which instructs PIO Build System to do not archive library's object files. See 

- https://github.com/esp8266/Arduino/pull/3321#issuecomment-319386749
- http://docs.platformio.org/en/latest/librarymanager/config.html#libarchive