### PR TITLE
Fix exception_causes.rst formatting

### DIFF
--- a/doc/exception_causes.rst
+++ b/doc/exception_causes.rst
@@ -1,124 +1,95 @@
 Exception Causes (EXCCAUSE)
 ===========================
 
-+--------+------------+-----------------------------------------+-----------+--------+
-| EXCCAU | Cause Name | Cause Description                       | Required  | EXCVAD |
-| SE     |            |                                         | Option    | DR     |
-| Code   |            |                                         |           | Loaded |
-+========+============+=========================================+===========+========+
-| 0      | IllegalIns | Illegal instruction                     | Exception | No     |
-|        | tructionCa |                                         |           |        |
-|        | use        |                                         |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 1      | SyscallCau | SYSCALL instruction                     | Exception | No     |
-|        | se         |                                         |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 2      | Instructio | Processor internal physical address or  | Exception | Yes    |
-|        | nFetchErro | data error during instruction fetch     |           |        |
-|        | rCause     |                                         |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 3      | LoadStoreE | Processor internal physical address or  | Exception | Yes    |
-|        | rrorCause  | data error during load or store         |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 4      | Level1Inte | Level-1 interrupt as indicated by set   | Interrupt | No     |
-|        | rruptCause | level-1 bits in the INTERRUPT register  |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 5      | AllocaCaus | MOVSP instruction, if caller’s          | Windowed  | No     |
-|        | e          | registers are not in the register file  | Register  |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 6      | IntegerDiv | QUOS, QUOU, REMS, or REMU divisor       | 32-bit    | No     |
-|        | ideByZeroC | operand is zero                         | Integer   |        |
-|        | ause       |                                         | Divide    |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 7      | Reserved   |                                         |           |        |
-|        | for        |                                         |           |        |
-|        | Tensilica  |                                         |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 8      | Privileged | Attempt to execute a privileged         | MMU       | No     |
-|        | Cause      | operation when CRING != 0               |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 9      | LoadStoreA | Load or store to an unaligned address   | Unaligned | Yes    |
-|        | lignmentCa |                                         | Exception |        |
-|        | use        |                                         |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 10..11 | Reserved   |                                         |           |        |
-|        | for        |                                         |           |        |
-|        | Tensilica  |                                         |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 12     | InstrPIFDa | PIF data error during instruction fetch | Processor | Yes    |
-|        | taErrorCau |                                         | Interface |        |
-|        | se         |                                         |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 13     | LoadStoreP | Synchronous PIF data error during       | Processor | Yes    |
-|        | IFDataErro | LoadStore access                        | Interface |        |
-|        | rCause     |                                         |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 14     | InstrPIFAd | PIF address error during instruction    | Processor | Yes    |
-|        | drErrorCau | fetch                                   | Interface |        |
-|        | se         |                                         |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 15     | LoadStoreP | Synchronous PIF address error during    | Processor | Yes    |
-|        | IFAddrErro | LoadStore access                        | Interface |        |
-|        | rCause     |                                         |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 16     | InstTLBMis | Error during Instruction TLB refill     | MMU       | Yes    |
-|        | sCause     |                                         |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 17     | InstTLBMul | Multiple instruction TLB entries        | MMU       | Yes    |
-|        | tiHitCause | matched                                 |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 18     | InstFetchP | An instruction fetch referenced a       | MMU       | Yes    |
-|        | rivilegeCa | virtual address at a ring level less    |           |        |
-|        | use        | than CRING                              |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 19     | Reserved   |                                         |           |        |
-|        | for        |                                         |           |        |
-|        | Tensilica  |                                         |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 20     | InstFetchP | An instruction fetch referenced a page  | Region    | Yes    |
-|        | rohibitedC | mapped with an attribute that does not  | Protectio |        |
-|        | ause       | permit instruction fetch                | n         |        |
-|        |            |                                         | or MMU    |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 21..23 | Reserved   |                                         |           |        |
-|        | for        |                                         |           |        |
-|        | Tensilica  |                                         |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 24     | LoadStoreT | Error during TLB refill for a load or   | MMU       | Yes    |
-|        | LBMissCaus | store                                   |           |        |
-|        | e          |                                         |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 25     | LoadStoreT | Multiple TLB entries matched for a load | MMU       | Yes    |
-|        | LBMultiHit | or store                                |           |        |
-|        | Cause      |                                         |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 26     | LoadStoreP | A load or store referenced a virtual    | MMU       | Yes    |
-|        | rivilegeCa | address at a ring level less than CRING |           |        |
-|        | use        |                                         |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 27     | Reserved   |                                         |           |        |
-|        | for        |                                         |           |        |
-|        | Tensilica  |                                         |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 28     | LoadProhib | A load referenced a page mapped with an | Region    | Yes    |
-|        | itedCause  | attribute that does not permit loads    | Protectio |        |
-|        |            |                                         | n         |        |
-|        |            |                                         | or MMU    |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 29     | StoreProhi | A store referenced a page mapped with   | Region    | Yes    |
-|        | bitedCause | an attribute that does not permit       | Protectio |        |
-|        |            | stores                                  | n         |        |
-|        |            |                                         | or MMU    |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 30..31 | Reserved   |                                         |           |        |
-|        | for        |                                         |           |        |
-|        | Tensilica  |                                         |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 32..39 | Coprocesso | Coprocessor n instruction when cpn      | Coprocess | No     |
-|        | rnDisabled | disabled. n varies 0..7 as the cause    | or        |        |
-|        |            | varies 32..39                           |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
-| 40..63 | Reserved   |                                         |           |        |
-+--------+------------+-----------------------------------------+-----------+--------+
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| EXCCAUSE | Cause Name                     | Cause Description                       | Required    | EXCVADDR |
+| Code     |                                |                                         | Option      | Loaded   |
++==========+================================+=========================================+=============+==========+
+| 0        | IllegalInstructionCause        | Illegal instruction                     | Exception   | No       |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 1        | SyscallCause                   | SYSCALL instruction                     | Exception   | No       |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 2        | InstructionFetchErrorCause     | Processor internal physical address or  | Exception   | Yes      |
+|          |                                | data error during instruction fetch     |             |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 3        | LoadStoreErrorCause            | Processor internal physical address or  | Exception   | Yes      |
+|          |                                | data error during load or store         |             |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 4        | Level1InterruptCause           | Level-1 interrupt as indicated by set   | Interrupt   | No       |
+|          |                                | level-1 bits in the INTERRUPT register  |             |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 5        | AllocaCause                    | MOVSP instruction, if caller’s          | Windowed    | No       |
+|          |                                | registers are not in the register file  | Register    |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 6        | IntegerDivideByZeroCause       | QUOS, QUOU, REMS, or REMU divisor       | 32-bit      | No       |
+|          |                                | operand is zero                         | Integer     |          |
+|          |                                |                                         | Divide      |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 7        | Reserved for Tensilica         |                                         |             |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 8        | PrivilegedCause                | Attempt to execute a privileged         | MMU         | No       |
+|          |                                | operation when CRING != 0               |             |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 9        | LoadStoreAlignmentCause        | Load or store to an unaligned address   | Unaligned   | Yes      |
+|          |                                |                                         | Exception   |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 10..11   | Reserved for Tensilica         |                                         |             |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 12       | InstrPIFDateErrorCause         | PIF data error during instruction fetch | Processor   | Yes      |
+|          |                                |                                         | Interface   |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 13       | LoadStorePIFDataErrorCause     | Synchronous PIF data error during       | Processor   | Yes      |
+|          |                                | LoadStore access                        | Interface   |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 14       | InstrPIFAddrErrorCause         | PIF address error during instruction    | Processor   | Yes      |
+|          |                                | fetch                                   | Interface   |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 15       | LoadStorePIFAddrErrorCause     | Synchronous PIF address error during    | Processor   | Yes      |
+|          |                                | LoadStore access                        | Interface   |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 16       | InstTLBMissCause               | Error during Instruction TLB refill     | MMU         | Yes      |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 17       | InstTLBMultiHitCause           | Multiple instruction TLB entries        | MMU         | Yes      |
+|          |                                | matched                                 |             |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 18       | InstFetchPrivilegeCause        | An instruction fetch referenced a       | MMU         | Yes      |
+|          |                                | virtual address at a ring level less    |             |          |
+|          |                                | than CRING                              |             |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 19       | Reserved for Tensilica         |                                         |             |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 20       | InstFetchProhibitedCause       | An instruction fetch referenced a page  | Region      | Yes      |
+|          |                                | mapped with an attribute that does not  | Protection  |          |
+|          |                                | permit instruction fetch                | or MMU      |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 21..23   | Reserved for Tensilica         |                                         |             |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 24       | LoadStoreTLBMissCause          | Error during TLB refill for a load or   | MMU         | Yes      |
+|          |                                | store                                   |             |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 25       | LoadStoreTLBMultiHitCause      | Multiple TLB entries matched for a load | MMU         | Yes      |
+|          |                                | or store                                |             |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 26       | LoadStorePrivilegeCause        | A load or store referenced a virtual    | MMU         | Yes      |
+|          |                                | address at a ring level less than CRING |             |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 27       | Reserved for Tensilica         |                                         |             |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 28       | LoadProhibitedCause            | A load referenced a page mapped with an | Region      | Yes      |
+|          |                                | attribute that does not permit loads    | Protection  |          |
+|          |                                |                                         | or MMU      |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 29       | StoreProhibitedCause           | A store referenced a page mapped with   | Region      | Yes      |
+|          |                                | an attribute that does not permit       | Protection  |          |
+|          |                                |                                         | or MMU      |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 30..31   | Reserved for Tensilica         |                                         |             |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 32..39   | CoprocessornDisabled           | Coprocessor n instruction when cpn      | Coprocessor | No       |
+|          |                                | disabled. n varies 0..7 as the cause    |             |          |
+|          |                                | varies 32..39                           |             |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
+| 40..63   | Reserved                       |                                         |             |          |
++----------+--------------------------------+-----------------------------------------+-------------+----------+
 
 Infos from Xtensa Instruction Set Architecture (ISA) Reference Manual


### PR DESCRIPTION
The RST spec does not appear to believe in intra-cell line continuation as appeared to be expected by the original author.  Widen columns and unbreak words to fix output.