### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/libraries/ArduinoOTA/keywords.txt
+++ b/libraries/ArduinoOTA/keywords.txt
@@ -15,10 +15,10 @@ ArduinoOTA	KEYWORD1
 begin	KEYWORD2
 setup	KEYWORD2
 handle	KEYWORD2
-onStart KEYWORD2
-onEnd   KEYWORD2
-onError KEYWORD2
-onProgress KEYWORD2
+onStart	KEYWORD2
+onEnd	KEYWORD2
+onError	KEYWORD2
+onProgress	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords