### PR TITLE
Avoid memory leak on multiple i2s_begin()s

### DIFF
--- a/cores/esp8266/core_esp8266_i2s.c
+++ b/cores/esp8266/core_esp8266_i2s.c
@@ -95,7 +95,10 @@ void ICACHE_FLASH_ATTR i2s_slc_isr(void) {
 void ICACHE_FLASH_ATTR i2s_slc_begin(){
   i2s_slc_queue_len = 0;
   int x, y;
-  
+ 
+  // If a buffer is already allocated, DMA is already running and should be stopped to avoid any race conditions
+  if (i2s_slc_buf_pntr[0]) i2s_end();
+
   for (x=0; x<SLC_BUF_CNT; x++) {
     i2s_slc_buf_pntr[x] = malloc(SLC_BUF_LEN*4);
     for (y=0; y<SLC_BUF_LEN; y++) i2s_slc_buf_pntr[x][y] = 0;
@@ -239,6 +242,10 @@ void ICACHE_FLASH_ATTR i2s_begin(){
 
 void ICACHE_FLASH_ATTR i2s_end(){
   i2s_slc_end();
+  for (int x=0; x<SLC_BUF_CNT; x++) {
+    free(i2s_slc_buf_pntr[x]);
+    i2s_slc_buf_pntr[x] = NULL;
+  }
   pinMode(2, INPUT);
   pinMode(3, INPUT);
   pinMode(15, INPUT);


### PR DESCRIPTION
i2s_begin allocated sample buffers every time it is called, but those
buffers were never freed in the _end() call.  Calling i2s_begin more
than a single time ever would therefore result in the leak of the old
buffers.

Free the buffers on i2s_end(), and ensure that no i2s is running in
the i2s_start() call to avoid the leak and any potential race conditions.