### PR TITLE
#3570 - Software i2c crashing ESP

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -58,7 +58,6 @@ void TwoWire::begin(int sda, int scl){
   default_sda_pin = sda;
   default_scl_pin = scl;
   twi_init(sda, scl);
-  flush();
 }
 
 void TwoWire::pins(int sda, int scl){


### PR DESCRIPTION
If software i2c is initialised before the arduino setup function (e.g. In a class constructor) it crashes due to Exception (28). flush() is conflicting with something external to Wire.h and causing the crash. Its unnecessary because the buffers are initialised to 0 anyway.