### PR TITLE
Fix erase size in ESP.eraseConfig

### DIFF
--- a/cores/esp8266/Esp.cpp
+++ b/cores/esp8266/Esp.cpp
@@ -397,22 +397,16 @@ struct rst_info * EspClass::getResetInfoPtr(void) {
 
 bool EspClass::eraseConfig(void) {
     bool ret = true;
-    size_t cfgAddr = (ESP.getFlashChipSize() - 0x4000);
-    size_t cfgSize = (8*1024);
+    const size_t cfgSize = 0x4000;
+    size_t cfgAddr = ESP.getFlashChipSize() - cfgSize;
 
-    noInterrupts();
-    while(cfgSize) {
-
-        if(spi_flash_erase_sector((cfgAddr / SPI_FLASH_SEC_SIZE)) != SPI_FLASH_RESULT_OK) {
-            ret = false;
+    for (size_t offset = 0; offset < cfgSize; offset += SPI_FLASH_SEC_SIZE) {
+        if (!flashEraseSector((cfgAddr + offset) / SPI_FLASH_SEC_SIZE)) {
+            return false;
         }
-
-        cfgSize -= SPI_FLASH_SEC_SIZE;
-        cfgAddr += SPI_FLASH_SEC_SIZE;
     }
-    interrupts();
 
-    return ret;
+    return true;
 }
 
 uint32_t EspClass::getSketchSize() {


### PR DESCRIPTION
SDK uses final 4 sectors of flash for configuration data.
ESP.eraseConfig would only erase 2 sectors, so in some cases of
corrupted data ("system param error"), users could not fix the issue
using ESP.eraseConfig, and had to use esptool instead.

Thanks @HugoML for reporting this.