### PR TITLE
Improve dns debugging

### DIFF
--- a/libraries/DNSServer/src/DNSServer.cpp
+++ b/libraries/DNSServer/src/DNSServer.cpp
@@ -144,17 +144,9 @@ void DNSServer::replyWithIP()
 
 
 
-  #ifdef DEBUG
-    DEBUG_OUTPUT.print("DNS responds: ");
-    DEBUG_OUTPUT.print(_resolvedIP[0]);
-    DEBUG_OUTPUT.print(".");
-    DEBUG_OUTPUT.print(_resolvedIP[1]);
-    DEBUG_OUTPUT.print(".");
-    DEBUG_OUTPUT.print(_resolvedIP[2]);
-    DEBUG_OUTPUT.print(".");
-    DEBUG_OUTPUT.print(_resolvedIP[3]);
-    DEBUG_OUTPUT.print(" for ");
-    DEBUG_OUTPUT.println(getDomainNameWithoutWwwPrefix());
+  #ifdef DEBUG_ESP_DNS
+    DEBUG_ESP_PORT.printf("DNS responds: %s for %s\n",
+            IPAddress(_resolvedIP).toString().c_str(), getDomainNameWithoutWwwPrefix().c_str() );
   #endif
 }
 


### PR DESCRIPTION
Other ESP8266 libraries share [a standard debug-output enablement scheme](http://arduino-esp8266.readthedocs.io/en/latest/Troubleshooting/debugging.html) that allows the user to turn on sections of debug output by building with "-DDEBUG_ESP_FOO" and "-DDEBUG_ESP_PORT=<SomethingLikeAHardwareSerial>". This way you can enable implement your own debug output stream as your application might need.

This pull request makes the debug output of DNSServer and ESP8266nDNS conform to that standard.