### PR TITLE
Sleep gpio state

### DIFF
--- a/cores/esp8266/Arduino.h
+++ b/cores/esp8266/Arduino.h
@@ -45,19 +45,21 @@ extern "C" {
 #define PWMRANGE 1023
 
 //GPIO FUNCTIONS
-#define INPUT             0x00
-#define INPUT_PULLUP      0x02
-#define INPUT_PULLDOWN_16 0x04 // PULLDOWN only possible for pin16
-#define OUTPUT            0x01
-#define OUTPUT_OPEN_DRAIN 0x03
-#define WAKEUP_PULLUP     0x05
-#define WAKEUP_PULLDOWN   0x07
-#define SPECIAL           0xF8 //defaults to the usable BUSes uart0rx/tx uart1tx and hspi
-#define FUNCTION_0        0x08
-#define FUNCTION_1        0x18
-#define FUNCTION_2        0x28
-#define FUNCTION_3        0x38
-#define FUNCTION_4        0x48
+#define INPUT                 0x00
+#define INPUT_PULLUP          0x02
+#define INPUT_PULLDOWN_16     0x04 // PULLDOWN only possible for pin16
+#define OUTPUT                0x01
+#define OUTPUT_OPEN_DRAIN     0x03
+#define OUTPUT_SLEEP_PULLDOWN 0x11
+#define OUTPUT_SLEEP_PULLUP   0x12
+#define WAKEUP_PULLUP         0x05
+#define WAKEUP_PULLDOWN       0x07
+#define SPECIAL               0xF8 //defaults to the usable BUSes uart0rx/tx uart1tx and hspi
+#define FUNCTION_0            0x08
+#define FUNCTION_1            0x18
+#define FUNCTION_2            0x28
+#define FUNCTION_3            0x38
+#define FUNCTION_4            0x48
 
 #define PI 3.1415926535897932384626433832795
 #define HALF_PI 1.5707963267948966192313216916398

--- a/cores/esp8266/core_esp8266_wiring_digital.c
+++ b/cores/esp8266/core_esp8266_wiring_digital.c
@@ -42,10 +42,12 @@ extern void __pinMode(uint8_t pin, uint8_t mode) {
       GPEC = (1 << pin); //Disable
       GPF(pin) = GPFFS((mode >> 4) & 0x07);
       if(pin == 13 && mode == FUNCTION_4) GPF(pin) |= (1 << GPFPU);//enable pullup on RX
-    }  else if(mode == OUTPUT || mode == OUTPUT_OPEN_DRAIN){
+    }  else if(mode == OUTPUT || mode == OUTPUT_OPEN_DRAIN || mode == OUTPUT_SLEEP_PULLDOWN || mode == OUTPUT_SLEEP_PULLUP){
       GPF(pin) = GPFFS(GPFFS_GPIO(pin));//Set mode to GPIO
       GPC(pin) = (GPC(pin) & (0xF << GPCI)); //SOURCE(GPIO) | DRIVER(NORMAL) | INT_TYPE(UNCHANGED) | WAKEUP_ENABLE(DISABLED)
       if(mode == OUTPUT_OPEN_DRAIN) GPC(pin) |= (1 << GPCD);
+	  if(mode == OUTPUT_SLEEP_PULLDOWN) GPF(pin) = (GPF(pin) & ~(1 << GPFSPU)) | (1 << GPFSPD); // Enable low state during sleep
+	  if(mode == OUTPUT_SLEEP_PULLUP) GPF(pin) = (GPF(pin) & ~(1 << GPFSPD)) | (1 << GPFSPU); // Enable high state during sleep
       GPES = (1 << pin); //Enable
     } else if(mode == INPUT || mode == INPUT_PULLUP){
       GPF(pin) = GPFFS(GPFFS_GPIO(pin));//Set mode to GPIO

--- a/cores/esp8266/core_esp8266_wiring_digital.c
+++ b/cores/esp8266/core_esp8266_wiring_digital.c
@@ -46,8 +46,8 @@ extern void __pinMode(uint8_t pin, uint8_t mode) {
       GPF(pin) = GPFFS(GPFFS_GPIO(pin));//Set mode to GPIO
       GPC(pin) = (GPC(pin) & (0xF << GPCI)); //SOURCE(GPIO) | DRIVER(NORMAL) | INT_TYPE(UNCHANGED) | WAKEUP_ENABLE(DISABLED)
       if(mode == OUTPUT_OPEN_DRAIN) GPC(pin) |= (1 << GPCD);
-	  if(mode == OUTPUT_SLEEP_PULLDOWN) GPF(pin) = (GPF(pin) & ~(1 << GPFSPU)) | (1 << GPFSPD); // Enable low state during sleep
-	  if(mode == OUTPUT_SLEEP_PULLUP) GPF(pin) = (GPF(pin) & ~(1 << GPFSPD)) | (1 << GPFSPU); // Enable high state during sleep
+      if(mode == OUTPUT_SLEEP_PULLDOWN) GPF(pin) = (GPF(pin) & ~(1 << GPFSPU)) | (1 << GPFSPD); // Enable low state during sleep
+      if(mode == OUTPUT_SLEEP_PULLUP) GPF(pin) = (GPF(pin) & ~(1 << GPFSPD)) | (1 << GPFSPU); // Enable high state during sleep
       GPES = (1 << pin); //Enable
     } else if(mode == INPUT || mode == INPUT_PULLUP){
       GPF(pin) = GPFFS(GPFFS_GPIO(pin));//Set mode to GPIO


### PR DESCRIPTION
Hi guys,

the purpose of this proposal is to allow selecting the GPIO state during the ESP deep sleep. From my experiments, it seems that the ESP changes the GPIO state to high when going to deep sleep: this is a problem if you are using that GPIO to control, for example, a transitor and want to preserve the low state. Googling around there are a lot of people asking about this topic, so I think would be useful to add this feature to this beautiful library.

Looking at the code and studying the technical reference, I found that the skeleton for adding this feature was already in esp8266_peri.h, namely in the pin function section. So I just added the code to set the right bits, while maintaining the same design principle of the pinMode function, which uses all-inclusive (that is, encapsulating all the dependencies) states.

Therefore, even if I believe that the sleep state function bit could be set in an independent manner (that is, I don't think it hurts even if you set the GPIO to the INPUT mode), I preferred to add an all-inclusive "OUTPUT_SLEEP_PULLDOWN/UP" mode (in the same manner as the existent "OUTPUT_OPEN_DRAIN" mode).

I am new to the ESP board and I could easily miss something, so please let me know your thoughts about this.





