### PR TITLE
[WIP] WiFiClientSecure: make functions for certificate verification more consistent

### DIFF
--- a/libraries/ESP8266WiFi/keywords.txt
+++ b/libraries/ESP8266WiFi/keywords.txt
@@ -138,6 +138,8 @@ loadCertificate	KEYWORD2
 loadPrivateKey	KEYWORD2
 loadCACert	KEYWORD2
 allowSelfSignedCerts	KEYWORD2
+setFingerprint	KEYWORD2
+setSPKI	KEYWORD2
 
 #WiFiServer
 hasClient	KEYWORD2

--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.h
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.h
@@ -38,7 +38,9 @@ public:
   int connect(IPAddress ip, uint16_t port) override;
   int connect(const char* name, uint16_t port) override;
 
-  bool verify(const char* fingerprint, const char* domain_name);
+  /* Deprecated; call setFingerprint(fingerprint) and then verifyCertChain(domain_name) */
+  bool verify(const char* fingerprint, const char* domain_name) __attribute__((deprecated));
+  
   bool verifyCertChain(const char* domain_name);
 
   uint8_t connected() override;
@@ -61,6 +63,9 @@ public:
   bool loadCACert(Stream& stream, size_t size);
   bool loadCertificate(Stream& stream, size_t size);
   bool loadPrivateKey(Stream& stream, size_t size);
+
+  bool setFingerprint(const char* fp);
+  bool setSPKI(const char* spki);
 
   void allowSelfSignedCerts();
 


### PR DESCRIPTION
Currently WiFiClientSecure has two ways to verify that the remote server is using an expected certificate: 

- `verify(fingerprint, hostname)`, which compares SHA1 fingerprint of the server certificate to a known value, and
- `setCACert`/`loadCACert` + `verifyCertChain`, which checks the certificate chain, given the root certificate.

This PR attempts to make all ways of verification follow the same pattern:

1. set verification data using one of WiFiClientSecure methods (`setCACert`, `setFingerprint`, `setSPKI`, `allowSelfSignedCerts`)
2. call verifyCertChain, which checks that the certificate chain is valid, and uses the strongest of the previously set methods to verify.

This approach makes it possible to use WiFiClientSecure methods (`setCACert`, `setFingerprint`, `setSPKI`, `allowSelfSignedCerts`) together with HTTPClient: first call HTTPClient::begin, then set verification method on the underlying WiFiClientSecure, then call HTTPClient::GET or POST to connect and issue the request. Internally, that calls WiFiClientSecure::verifyCertChain once the connection is established.

This PR also adds verification using subjectPublicKeyInfo (SPKI), which was present in axTLS-8266 for a while now. SPKI is a SHA256 hash of the public key, and it doesn't change as often as the certificates are reissued, hence may require less often updates compared to SHA1 fingerprint of the certifiacate.

Currently WIP as only WiFiClientSecure changes are in place.

- [ ] update WiFiClientSecure examples, demonstrate various ways to verify the certificate
- [ ] change signatures of `begin` functions in HTTPClient, add explicit functions to use TLS support
- [ ] refactor verification flow in HTTPClient to match the new approach
- [ ] update HTTPClient examples
- [ ] update docs