### PR TITLE
Add a workaround-delay in Serial.flush()

### DIFF
--- a/cores/esp8266/HardwareSerial.cpp
+++ b/cores/esp8266/HardwareSerial.cpp
@@ -154,7 +154,7 @@ void HardwareSerial::flush()
     uart_wait_tx_empty(_uart);
     //Workaround for a bug in serial not actually being finished yet
     //Wait for 8 data bits, 1 parity and 2 stop bits, just in case
-    delayMicroseconds(1100000 / uart_get_baudrate(_uart) + 1);
+    delayMicroseconds(11000000 / uart_get_baudrate(_uart) + 1);
 }
 
 size_t HardwareSerial::write(uint8_t c)

--- a/cores/esp8266/HardwareSerial.cpp
+++ b/cores/esp8266/HardwareSerial.cpp
@@ -152,6 +152,9 @@ void HardwareSerial::flush()
     }
 
     uart_wait_tx_empty(_uart);
+    //Workaround for a bug in serial not actually being finished yet
+    //Wait for 8 data bits, 1 parity and 2 stop bits, just in case
+    delayMicroseconds(1100000 / uart_get_baudrate(_uart) + 1));
 }
 
 size_t HardwareSerial::write(uint8_t c)

--- a/cores/esp8266/HardwareSerial.cpp
+++ b/cores/esp8266/HardwareSerial.cpp
@@ -154,7 +154,7 @@ void HardwareSerial::flush()
     uart_wait_tx_empty(_uart);
     //Workaround for a bug in serial not actually being finished yet
     //Wait for 8 data bits, 1 parity and 2 stop bits, just in case
-    delayMicroseconds(1100000 / uart_get_baudrate(_uart) + 1));
+    delayMicroseconds(1100000 / uart_get_baudrate(_uart) + 1);
 }
 
 size_t HardwareSerial::write(uint8_t c)


### PR DESCRIPTION
In relation to #2536 and #2502

Tested at 80MHz and 160MHz with flash-frequency at both 40MHz and 80MHz, the bug mentioned in the above issues manifests in all cases. The proposed workaround seems to work fine, I tested at 2400bps, 9600bps, 115200bps, 230400bps and 2Mbps and didn't see anomalous output.