### PR TITLE
#2557 - ESP8266WebServer uses >2kb of stack when reinitialized in setup()

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -279,6 +279,7 @@ void ESP8266WebServer::handleClient() {
   if (!_currentClient.connected()) {
     _currentClient = WiFiClient();
     _currentStatus = HC_NONE;
+    _currentUpload.reset();
     return;
   }
 
@@ -288,6 +289,7 @@ void ESP8266WebServer::handleClient() {
       if (millis() - _statusChange > HTTP_MAX_DATA_WAIT) {
         _currentClient = WiFiClient();
         _currentStatus = HC_NONE;
+        _currentUpload.reset();
       }
       yield();
       return;
@@ -296,6 +298,7 @@ void ESP8266WebServer::handleClient() {
     if (!_parseRequest(_currentClient)) {
       _currentClient = WiFiClient();
       _currentStatus = HC_NONE;
+      _currentUpload.reset();
       return;
     }
     _currentClient.setTimeout(HTTP_MAX_SEND_WAIT);
@@ -305,6 +308,7 @@ void ESP8266WebServer::handleClient() {
     if (!_currentClient.connected()) {
       _currentClient = WiFiClient();
       _currentStatus = HC_NONE;
+      _currentUpload.reset();
       return;
     } else {
       _currentStatus = HC_WAIT_CLOSE;
@@ -317,6 +321,7 @@ void ESP8266WebServer::handleClient() {
     if (millis() - _statusChange > HTTP_MAX_CLOSE_WAIT) {
       _currentClient = WiFiClient();
       _currentStatus = HC_NONE;
+      _currentUpload.reset();
     } else {
       yield();
       return;

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -276,56 +276,49 @@ void ESP8266WebServer::handleClient() {
     _statusChange = millis();
   }
 
-  if (!_currentClient.connected()) {
+  bool keepCurrentClient = false;
+  bool callYield = false;
+
+  if (_currentClient.connected()) {
+    switch (_currentStatus) {
+    case HC_WAIT_READ:
+      // Wait for data from client to become available
+      if (_currentClient.available()) {
+        if (_parseRequest(_currentClient)) {
+          _currentClient.setTimeout(HTTP_MAX_SEND_WAIT);
+          _contentLength = CONTENT_LENGTH_NOT_SET;
+          _handleRequest();
+
+          if (_currentClient.connected()) {
+            _currentStatus = HC_WAIT_CLOSE;
+            _statusChange = millis();
+            keepCurrentClient = true;
+          }
+        }
+      } else { // !_currentClient.available()
+        if (millis() - _statusChange <= HTTP_MAX_DATA_WAIT) {
+          keepCurrentClient = true;
+        }
+        callYield = true;
+      }
+      break;
+    case HC_WAIT_CLOSE:
+      // Wait for client to close the connection
+      if (millis() - _statusChange <= HTTP_MAX_CLOSE_WAIT) {
+        keepCurrentClient = true;
+        callYield = true;
+      }
+    }
+  }
+
+  if (!keepCurrentClient) {
     _currentClient = WiFiClient();
     _currentStatus = HC_NONE;
     _currentUpload.reset();
-    return;
   }
 
-  // Wait for data from client to become available
-  if (_currentStatus == HC_WAIT_READ) {
-    if (!_currentClient.available()) {
-      if (millis() - _statusChange > HTTP_MAX_DATA_WAIT) {
-        _currentClient = WiFiClient();
-        _currentStatus = HC_NONE;
-        _currentUpload.reset();
-      }
-      yield();
-      return;
-    }
-
-    if (!_parseRequest(_currentClient)) {
-      _currentClient = WiFiClient();
-      _currentStatus = HC_NONE;
-      _currentUpload.reset();
-      return;
-    }
-    _currentClient.setTimeout(HTTP_MAX_SEND_WAIT);
-    _contentLength = CONTENT_LENGTH_NOT_SET;
-    _handleRequest();
-
-    if (!_currentClient.connected()) {
-      _currentClient = WiFiClient();
-      _currentStatus = HC_NONE;
-      _currentUpload.reset();
-      return;
-    } else {
-      _currentStatus = HC_WAIT_CLOSE;
-      _statusChange = millis();
-      return;
-    }
-  }
-
-  if (_currentStatus == HC_WAIT_CLOSE) {
-    if (millis() - _statusChange > HTTP_MAX_CLOSE_WAIT) {
-      _currentClient = WiFiClient();
-      _currentStatus = HC_NONE;
-      _currentUpload.reset();
-    } else {
-      yield();
-      return;
-    }
+  if (callYield) {
+    yield();
   }
 }
 

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -25,6 +25,7 @@
 #define ESP8266WEBSERVER_H
 
 #include <functional>
+#include <memory>
 #include <ESP8266WiFi.h>
 
 enum HTTPMethod { HTTP_ANY, HTTP_GET, HTTP_POST, HTTP_PUT, HTTP_PATCH, HTTP_DELETE, HTTP_OPTIONS };
@@ -93,7 +94,7 @@ public:
   String uri() { return _currentUri; }
   HTTPMethod method() { return _currentMethod; }
   WiFiClient client() { return _currentClient; }
-  HTTPUpload& upload() { return _currentUpload; }
+  HTTPUpload& upload() { return *_currentUpload; }
 
   String arg(String name);        // get request argument value by name
   String arg(int i);              // get request argument value by number
@@ -177,7 +178,7 @@ protected:
 
   int              _currentArgCount;
   RequestArgument* _currentArgs;
-  HTTPUpload       _currentUpload;
+  std::unique_ptr<HTTPUpload> _currentUpload;
 
   int              _headerKeysCount;
   RequestArgument* _currentHeaders;


### PR DESCRIPTION
This PR for #2557 changes the ```_currentUpload``` field in the ```ESP8266WebServer``` class to ```std::unique_ptr<HTTPUpload>```, and allocates/deallocates it on demand.

Commit 67f4fc4 eliminates most of the exit paths in ```ESP8266WebServer::handleClient```. It moves the client reset and ```yield()``` call to the end of the function, introduces ```else``` clauses to remove exit paths, and inverts if/else constructs to simplify the function.