### PR TITLE
Put WiFi into station mode in examples

### DIFF
--- a/libraries/ESP8266AVRISP/examples/Arduino_Wifi_AVRISP/Arduino_Wifi_AVRISP.ino
+++ b/libraries/ESP8266AVRISP/examples/Arduino_Wifi_AVRISP/Arduino_Wifi_AVRISP.ino
@@ -17,6 +17,7 @@ void setup() {
     Serial.println("Arduino AVR-ISP over TCP");
     avrprog.setReset(false); // let the AVR run
 
+    WiFi.mode(WIFI_STA)
     WiFi.begin(ssid, pass);
     while (WiFi.waitForConnectResult() != WL_CONNECTED);
 

--- a/libraries/ESP8266AVRISP/examples/Arduino_Wifi_AVRISP/Arduino_Wifi_AVRISP.ino
+++ b/libraries/ESP8266AVRISP/examples/Arduino_Wifi_AVRISP/Arduino_Wifi_AVRISP.ino
@@ -17,7 +17,7 @@ void setup() {
     Serial.println("Arduino AVR-ISP over TCP");
     avrprog.setReset(false); // let the AVR run
 
-    WiFi.mode(WIFI_STA)
+    WiFi.mode(WIFI_STA);
     WiFi.begin(ssid, pass);
     while (WiFi.waitForConnectResult() != WL_CONNECTED);
 

--- a/libraries/ESP8266HTTPClient/examples/Authorization/Authorization.ino
+++ b/libraries/ESP8266HTTPClient/examples/Authorization/Authorization.ino
@@ -31,6 +31,7 @@ void setup() {
         delay(1000);
     }
 
+    WiFi.mode(WIFI_STA);
     WiFiMulti.addAP("SSID", "PASSWORD");
 
 }

--- a/libraries/ESP8266HTTPClient/examples/BasicHttpClient/BasicHttpClient.ino
+++ b/libraries/ESP8266HTTPClient/examples/BasicHttpClient/BasicHttpClient.ino
@@ -31,6 +31,7 @@ void setup() {
         delay(1000);
     }
 
+    WiFi.mode(WIFI_STA);
     WiFiMulti.addAP("SSID", "PASSWORD");
 
 }

--- a/libraries/ESP8266HTTPClient/examples/ReuseConnection/ReuseConnection.ino
+++ b/libraries/ESP8266HTTPClient/examples/ReuseConnection/ReuseConnection.ino
@@ -34,6 +34,7 @@ void setup() {
         delay(1000);
     }
 
+    WiFi.mode(WIFI_STA);
     WiFiMulti.addAP("SSID", "PASSWORD");
 
     // allow reuse (if server supports it)

--- a/libraries/ESP8266HTTPClient/examples/StreamHttpClient/StreamHttpClient.ino
+++ b/libraries/ESP8266HTTPClient/examples/StreamHttpClient/StreamHttpClient.ino
@@ -31,6 +31,7 @@ void setup() {
         delay(1000);
     }
 
+    WiFi.mode(WIFI_STA);
     WiFiMulti.addAP("SSID", "PASSWORD");
 
 }

--- a/libraries/ESP8266LLMNR/examples/LLMNR_Web_Server/LLMNR_Web_Server.ino
+++ b/libraries/ESP8266LLMNR/examples/LLMNR_Web_Server/LLMNR_Web_Server.ino
@@ -77,6 +77,7 @@ void setup(void) {
   Serial.begin(115200);
 
   // Connect to WiFi network
+  WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
   Serial.println("");
 

--- a/libraries/ESP8266NetBIOS/examples/ESP_NBNST/ESP_NBNST.ino
+++ b/libraries/ESP8266NetBIOS/examples/ESP_NBNST/ESP_NBNST.ino
@@ -22,6 +22,7 @@ void setup()
     Serial.begin(115200);
 
     // Connect to WiFi network
+    WiFi.mode(WIFI_STA);
     WiFi.begin(ssid, password);
     Serial.println("");
 

--- a/libraries/ESP8266WebServer/examples/AdvancedWebServer/AdvancedWebServer.ino
+++ b/libraries/ESP8266WebServer/examples/AdvancedWebServer/AdvancedWebServer.ino
@@ -93,6 +93,7 @@ void setup ( void ) {
 	pinMode ( led, OUTPUT );
 	digitalWrite ( led, 0 );
 	Serial.begin ( 115200 );
+    WiFi.mode ( WIFI_STA );
 	WiFi.begin ( ssid, password );
 	Serial.println ( "" );
 

--- a/libraries/ESP8266WebServer/examples/AdvancedWebServer/AdvancedWebServer.ino
+++ b/libraries/ESP8266WebServer/examples/AdvancedWebServer/AdvancedWebServer.ino
@@ -93,7 +93,7 @@ void setup ( void ) {
 	pinMode ( led, OUTPUT );
 	digitalWrite ( led, 0 );
 	Serial.begin ( 115200 );
-    WiFi.mode ( WIFI_STA );
+	WiFi.mode ( WIFI_STA );
 	WiFi.begin ( ssid, password );
 	Serial.println ( "" );
 

--- a/libraries/ESP8266WebServer/examples/FSBrowser/FSBrowser.ino
+++ b/libraries/ESP8266WebServer/examples/FSBrowser/FSBrowser.ino
@@ -179,6 +179,7 @@ void setup(void){
   //WIFI INIT
   DBG_OUTPUT_PORT.printf("Connecting to %s\n", ssid);
   if (String(WiFi.SSID()) != String(ssid)) {
+    WiFi.mode(WIFI_STA);
     WiFi.begin(ssid, password);
   }
   

--- a/libraries/ESP8266WebServer/examples/HelloServer/HelloServer.ino
+++ b/libraries/ESP8266WebServer/examples/HelloServer/HelloServer.ino
@@ -37,6 +37,7 @@ void setup(void){
   pinMode(led, OUTPUT);
   digitalWrite(led, 0);
   Serial.begin(115200);
+  WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
   Serial.println("");
 

--- a/libraries/ESP8266WebServer/examples/SDWebServer/SDWebServer.ino
+++ b/libraries/ESP8266WebServer/examples/SDWebServer/SDWebServer.ino
@@ -223,6 +223,7 @@ void setup(void){
   DBG_OUTPUT_PORT.begin(115200);
   DBG_OUTPUT_PORT.setDebugOutput(true);
   DBG_OUTPUT_PORT.print("\n");
+  WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
   DBG_OUTPUT_PORT.print("Connecting to ");
   DBG_OUTPUT_PORT.println(ssid);

--- a/libraries/ESP8266WebServer/examples/SimpleAuthentification/SimpleAuthentification.ino
+++ b/libraries/ESP8266WebServer/examples/SimpleAuthentification/SimpleAuthentification.ino
@@ -95,6 +95,7 @@ void handleNotFound(){
 
 void setup(void){
   Serial.begin(115200);
+  WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
   Serial.println("");
 

--- a/libraries/ESP8266WiFi/examples/HTTPSRequest/HTTPSRequest.ino
+++ b/libraries/ESP8266WiFi/examples/HTTPSRequest/HTTPSRequest.ino
@@ -29,6 +29,7 @@ void setup() {
   Serial.println();
   Serial.print("connecting to ");
   Serial.println(ssid);
+  WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
   while (WiFi.status() != WL_CONNECTED) {
     delay(500);

--- a/libraries/ESP8266WiFi/examples/HTTPSRequestCACert/HTTPSRequestCACert.ino
+++ b/libraries/ESP8266WiFi/examples/HTTPSRequestCACert/HTTPSRequestCACert.ino
@@ -37,6 +37,7 @@ void setup() {
   Serial.println();
   Serial.print("connecting to ");
   Serial.println(ssid);
+  WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
   while (WiFi.status() != WL_CONNECTED) {
     delay(500);

--- a/libraries/ESP8266WiFi/examples/NTPClient/NTPClient.ino
+++ b/libraries/ESP8266WiFi/examples/NTPClient/NTPClient.ino
@@ -49,6 +49,7 @@ void setup()
   // We start by connecting to a WiFi network
   Serial.print("Connecting to ");
   Serial.println(ssid);
+  WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, pass);
   
   while (WiFi.status() != WL_CONNECTED) {

--- a/libraries/ESP8266WiFi/examples/WiFiClientBasic/WiFiClientBasic.ino
+++ b/libraries/ESP8266WiFi/examples/WiFiClientBasic/WiFiClientBasic.ino
@@ -13,6 +13,7 @@ void setup() {
     delay(10);
 
     // We start by connecting to a WiFi network
+    WiFi.mode(WIFI_STA);
     WiFiMulti.addAP("SSID", "passpasspass");
 
     Serial.println();

--- a/libraries/ESP8266WiFi/examples/WiFiMulti/WiFiMulti.ino
+++ b/libraries/ESP8266WiFi/examples/WiFiMulti/WiFiMulti.ino
@@ -12,6 +12,7 @@ void setup() {
     Serial.begin(115200);
     delay(10);
 	
+    WiFi.mode(WIFI_STA);
     wifiMulti.addAP("ssid_from_AP_1", "your_password_for_AP_1");
     wifiMulti.addAP("ssid_from_AP_2", "your_password_for_AP_2");
     wifiMulti.addAP("ssid_from_AP_3", "your_password_for_AP_3");

--- a/libraries/ESP8266WiFi/examples/WiFiTelnetToSerial/WiFiTelnetToSerial.ino
+++ b/libraries/ESP8266WiFi/examples/WiFiTelnetToSerial/WiFiTelnetToSerial.ino
@@ -30,6 +30,7 @@ WiFiClient serverClients[MAX_SRV_CLIENTS];
 
 void setup() {
   Serial1.begin(115200);
+  WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
   Serial1.print("\nConnecting to "); Serial1.println(ssid);
   uint8_t i = 0;

--- a/libraries/ESP8266WiFi/examples/WiFiWebServer/WiFiWebServer.ino
+++ b/libraries/ESP8266WiFi/examples/WiFiWebServer/WiFiWebServer.ino
@@ -30,6 +30,7 @@ void setup() {
   Serial.print("Connecting to ");
   Serial.println(ssid);
   
+  WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
   
   while (WiFi.status() != WL_CONNECTED) {

--- a/libraries/ESP8266httpUpdate/examples/httpUpdate/httpUpdate.ino
+++ b/libraries/ESP8266httpUpdate/examples/httpUpdate/httpUpdate.ino
@@ -32,6 +32,7 @@ void setup() {
         delay(1000);
     }
 
+    WiFi.mode(WIFI_STA);
     WiFiMulti.addAP("SSID", "PASSWORD");
 
 }

--- a/libraries/ESP8266httpUpdate/examples/httpUpdateSPIFFS/httpUpdateSPIFFS.ino
+++ b/libraries/ESP8266httpUpdate/examples/httpUpdateSPIFFS/httpUpdateSPIFFS.ino
@@ -32,6 +32,7 @@ void setup() {
         delay(1000);
     }
 
+    WiFi.mode(WIFI_STA);
     WiFiMulti.addAP("SSID", "PASSWORD");
 
 }

--- a/libraries/ESP8266mDNS/examples/mDNS-SD_Extended/mDNS-SD_Extended.ino
+++ b/libraries/ESP8266mDNS/examples/mDNS-SD_Extended/mDNS-SD_Extended.ino
@@ -26,6 +26,7 @@ void setup() {
   Serial.println(hostString);
   WiFi.hostname(hostString);
 
+  WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
   while (WiFi.status() != WL_CONNECTED) {
     delay(250);

--- a/libraries/ESP8266mDNS/examples/mDNS_Web_Server/mDNS_Web_Server.ino
+++ b/libraries/ESP8266mDNS/examples/mDNS_Web_Server/mDNS_Web_Server.ino
@@ -31,6 +31,7 @@ void setup(void)
   Serial.begin(115200);
   
   // Connect to WiFi network
+  WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
   Serial.println("");  
   


### PR DESCRIPTION
I was surprised that many of the examples implicitly create an
unsecured access point with complete access to my application, which
was based off the WiFiWebServer example. I'm sure I'm not the only one
surprised by this behaviour.

Putting the WiFi into station mode prevents the open access point from being
created.