### PR TITLE
Remove forced OTA DNS announce

### DIFF
--- a/libraries/ArduinoOTA/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/ArduinoOTA.cpp
@@ -127,12 +127,14 @@ void ArduinoOTAClass::begin() {
   if(!_udp_ota->listen(*IP_ADDR_ANY, _port))
     return;
   _udp_ota->onRx(std::bind(&ArduinoOTAClass::_onRx, this));
-  MDNS.begin(_hostname.c_str());
+  if(!MDNS.started()) {
+    MDNS.begin(_hostname.c_str());
 
-  if (_password.length()) {
-    MDNS.enableArduino(_port, true);
-  } else {
-    MDNS.enableArduino(_port);
+    if (_password.length()) {
+      MDNS.enableArduino(_port, true);
+    } else {
+      MDNS.enableArduino(_port);
+    }
   }
   _initialized = true;
   _state = OTA_IDLE;
@@ -253,7 +255,7 @@ void ArduinoOTAClass::_runUpdate() {
     if (_error_callback) {
       _error_callback(OTA_BEGIN_ERROR);
     }
-    
+
     StreamString ss;
     Update.printError(ss);
     _udp_ota->append("ERR: ", 5);

--- a/libraries/ESP8266mDNS/ESP8266mDNS.cpp
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.cpp
@@ -171,6 +171,8 @@ bool MDNSResponder::begin(const char* hostname){
     _restart();
   });
 
+  _started = true;
+
   return _listen();
 }
 

--- a/libraries/ESP8266mDNS/ESP8266mDNS.h
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.h
@@ -79,7 +79,7 @@ public:
   void addService(String service, String proto, uint16_t port){
     addService(service.c_str(), proto.c_str(), port);
   }
-  
+
   bool addServiceTxt(char *name, char *proto, char * key, char * value);
   bool addServiceTxt(const char *name, const char *proto, const char *key,const char * value){
     return addServiceTxt((char *)name, (char *)proto, (char *)key, (char *)value);
@@ -87,7 +87,7 @@ public:
   bool addServiceTxt(String name, String proto, String key, String value){
     return addServiceTxt(name.c_str(), proto.c_str(), key.c_str(), value.c_str());
   }
-  
+
   int queryService(char *service, char *proto);
   int queryService(const char *service, const char *proto){
     return queryService((char *)service, (char *)proto);
@@ -98,7 +98,7 @@ public:
   String hostname(int idx);
   IPAddress IP(int idx);
   uint16_t port(int idx);
-  
+
   void enableArduino(uint16_t port, bool auth=false);
 
   void setInstanceName(String name);
@@ -107,6 +107,10 @@ public:
   }
   void setInstanceName(char * name){
     setInstanceName(String(name));
+  }
+
+  bool started() {
+      return _started;
   }
 
 private:
@@ -120,7 +124,8 @@ private:
   bool _waitingForAnswers;
   WiFiEventHandler _disconnectedHandler;
   WiFiEventHandler _gotIPHandler;
-  
+  bool _started = false;
+
 
   uint16_t _getServicePort(char *service, char *proto);
   MDNSTxt * _getServiceTxt(char *name, char *proto);


### PR DESCRIPTION
OTA should not force a DNS publication. This is not the job of the OTA server, and it interferes with previously configured DNS announcements.