### PR TITLE
Added micros64 and used to fix and improve gettimeofday.

### DIFF
--- a/cores/esp8266/Arduino.h
+++ b/cores/esp8266/Arduino.h
@@ -202,6 +202,7 @@ void analogWriteRange(uint32_t range);
 
 unsigned long millis(void);
 unsigned long micros(void);
+uint64_t micros64(void);
 void delay(unsigned long);
 void delayMicroseconds(unsigned int us);
 unsigned long pulseIn(uint8_t pin, uint8_t state, unsigned long timeout);

--- a/cores/esp8266/core_esp8266_wiring.c
+++ b/cores/esp8266/core_esp8266_wiring.c
@@ -71,6 +71,13 @@ unsigned long ICACHE_RAM_ATTR micros() {
     return system_get_time();
 }
 
+uint64_t ICACHE_RAM_ATTR micros64() {
+    uint32_t low32_us = system_get_time();
+    uint32_t high32_us = micros_overflow_count + ((low32_us < micros_at_last_overflow_tick) ? 1 : 0);
+    uint64_t duration64_us = (uint64_t)high32_us << 32 | low32_us;
+    return duration64_us;
+}
+
 void ICACHE_RAM_ATTR delayMicroseconds(unsigned int us) {
     os_delay_us(us);
 }


### PR DESCRIPTION
This resolves #3814 and adds a `micros64()` global function that is very useful.

There is certainly more that can be done to improve wallclock time-keeping, but this is a step in the right direction I feel.  This allows my application to have a reasonably decent current timestamp.

This now works well enough for me, when it previously was wrong:
```
auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
```

I purposely did not touch `clock_gettime()` or `time()` because I want to focus on achieving a functional `gettimeofday` first.  If this PR is accepted, I'm willing to work on those functions too.