### PR TITLE
EEPROM: Clear dirty flag in begin and reallocate only if necessary, add getConstDataPtr method (#2217)

### DIFF
--- a/libraries/EEPROM/EEPROM.h
+++ b/libraries/EEPROM/EEPROM.h
@@ -38,6 +38,7 @@ public:
   void end();
 
   uint8_t * getDataPtr();
+  uint8_t const * getConstDataPtr();
 
   template<typename T> 
   T &get(int address, T &t) {

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp
@@ -40,16 +40,33 @@ bool ESP8266WiFiMulti::addAP(const char* ssid, const char *passphrase) {
 
 wl_status_t ESP8266WiFiMulti::run(void) {
 
-    int8_t scanResult;
     wl_status_t status = WiFi.status();
     if(status == WL_DISCONNECTED || status == WL_NO_SSID_AVAIL || status == WL_IDLE_STATUS || status == WL_CONNECT_FAILED) {
 
-        scanResult = WiFi.scanComplete();
+        int8_t scanResult = WiFi.scanComplete();
+
         if(scanResult == WIFI_SCAN_RUNNING) {
-            // scan is running
-            return WL_NO_SSID_AVAIL;
-        } else if(scanResult > 0) {
-            // scan done analyze
+            // scan is running, do nothing yet
+            status = WL_NO_SSID_AVAIL;
+            return status;
+        } 
+
+        if(scanResult == 0) {
+            // scan done, no ssids found. Start another scan.
+            DEBUG_WIFI_MULTI("[WIFI] scan done\n");
+            DEBUG_WIFI_MULTI("[WIFI] no networks found\n");
+            WiFi.scanDelete();
+            DEBUG_WIFI_MULTI("\n\n");
+            delay(0);
+            WiFi.disconnect();
+            DEBUG_WIFI_MULTI("[WIFI] start scan\n");
+            // scan wifi async mode
+            WiFi.scanNetworks(true);
+            return status;
+        } 
+
+        if(scanResult > 0) {
+            // scan done, analyze
             WifiAPlist_t bestNetwork { NULL, NULL };
             int bestNetworkDb = INT_MIN;
             uint8 bestBSSID[6];
@@ -58,48 +75,44 @@ wl_status_t ESP8266WiFiMulti::run(void) {
             DEBUG_WIFI_MULTI("[WIFI] scan done\n");
             delay(0);
 
-            if(scanResult <= 0) {
-                DEBUG_WIFI_MULTI("[WIFI] no networks found\n");
-            } else {
-                DEBUG_WIFI_MULTI("[WIFI] %d networks found\n", scanResult);
-                for(int8_t i = 0; i < scanResult; ++i) {
+            DEBUG_WIFI_MULTI("[WIFI] %d networks found\n", scanResult);
+            for(int8_t i = 0; i < scanResult; ++i) {
 
-                    String ssid_scan;
-                    int32_t rssi_scan;
-                    uint8_t sec_scan;
-                    uint8_t* BSSID_scan;
-                    int32_t chan_scan;
-                    bool hidden_scan;
+                String ssid_scan;
+                int32_t rssi_scan;
+                uint8_t sec_scan;
+                uint8_t* BSSID_scan;
+                int32_t chan_scan;
+                bool hidden_scan;
 
-                    WiFi.getNetworkInfo(i, ssid_scan, sec_scan, rssi_scan, BSSID_scan, chan_scan, hidden_scan);
+                WiFi.getNetworkInfo(i, ssid_scan, sec_scan, rssi_scan, BSSID_scan, chan_scan, hidden_scan);
 
-                    bool known = false;
-                    for(uint32_t x = 0; x < APlist.size(); x++) {
-                        WifiAPlist_t entry = APlist[x];
+                bool known = false;
+                for(uint32_t x = 0; x < APlist.size(); x++) {
+                    WifiAPlist_t entry = APlist[x];
 
-                        if(ssid_scan == entry.ssid) { // SSID match
-                            known = true;
-                            if(rssi_scan > bestNetworkDb) { // best network
-                                if(sec_scan == ENC_TYPE_NONE || entry.passphrase) { // check for passphrase if not open wlan
-                                    bestNetworkDb = rssi_scan;
-                                    bestChannel = chan_scan;
-                                    memcpy((void*) &bestNetwork, (void*) &entry, sizeof(bestNetwork));
-                                    memcpy((void*) &bestBSSID, (void*) BSSID_scan, sizeof(bestBSSID));
-                                }
+                    if(ssid_scan == entry.ssid) { // SSID match
+                        known = true;
+                        if(rssi_scan > bestNetworkDb) { // best network
+                            if(sec_scan == ENC_TYPE_NONE || entry.passphrase) { // check for passphrase if not open wlan
+                                bestNetworkDb = rssi_scan;
+                                bestChannel = chan_scan;
+                                memcpy((void*) &bestNetwork, (void*) &entry, sizeof(bestNetwork));
+                                memcpy((void*) &bestBSSID, (void*) BSSID_scan, sizeof(bestBSSID));
                             }
-                            break;
                         }
+                        break;
                     }
-
-                    if(known) {
-                        DEBUG_WIFI_MULTI(" ---> ");
-                    } else {
-                        DEBUG_WIFI_MULTI("      ");
-                    }
-
-                    DEBUG_WIFI_MULTI(" %d: [%d][%02X:%02X:%02X:%02X:%02X:%02X] %s (%d) %c\n", i, chan_scan, BSSID_scan[0], BSSID_scan[1], BSSID_scan[2], BSSID_scan[3], BSSID_scan[4], BSSID_scan[5], ssid_scan.c_str(), rssi_scan, (sec_scan == ENC_TYPE_NONE) ? ' ' : '*');
-                    delay(0);
                 }
+
+                if(known) {
+                    DEBUG_WIFI_MULTI(" ---> ");
+                } else {
+                    DEBUG_WIFI_MULTI("      ");
+                }
+
+                DEBUG_WIFI_MULTI(" %d: [%d][%02X:%02X:%02X:%02X:%02X:%02X] %s (%d) %c\n", i, chan_scan, BSSID_scan[0], BSSID_scan[1], BSSID_scan[2], BSSID_scan[3], BSSID_scan[4], BSSID_scan[5], ssid_scan.c_str(), rssi_scan, (sec_scan == ENC_TYPE_NONE) ? ' ' : '*');
+                delay(0);
             }
 
             // clean up ram
@@ -146,15 +159,18 @@ wl_status_t ESP8266WiFiMulti::run(void) {
             } else {
                 DEBUG_WIFI_MULTI("[WIFI] no matching wifi found!\n");
             }
-        } else {
-            // start scan
-            DEBUG_WIFI_MULTI("[WIFI] delete old wifi config...\n");
-            WiFi.disconnect();
 
-            DEBUG_WIFI_MULTI("[WIFI] start scan\n");
-            // scan wifi async mode
-            WiFi.scanNetworks(true);
+            return status;
         }
+       
+       
+        // scan failed, or some other condition not handled above. Start another scan.
+        DEBUG_WIFI_MULTI("[WIFI] delete old wifi config...\n");
+        WiFi.disconnect();
+
+        DEBUG_WIFI_MULTI("[WIFI] start scan\n");
+        // scan wifi async mode
+        WiFi.scanNetworks(true);
     }
     return status;
 }


### PR DESCRIPTION
Fixes #2217 .