### PR TITLE
EEPROM: dirty flag, reallocate only if necessary, add getConstDataPtr method (#2217)

### DIFF
--- a/libraries/EEPROM/EEPROM.h
+++ b/libraries/EEPROM/EEPROM.h
@@ -38,6 +38,7 @@ public:
   void end();
 
   uint8_t * getDataPtr();
+  uint8_t const * getConstDataPtr();
 
   template<typename T> 
   T &get(int address, T &t) {


### PR DESCRIPTION
Fixes #2217 .