### PR TITLE
Fix too wide 'word' type -- it should be 16-bit instead of 32-bit

### DIFF
--- a/cores/esp8266/Arduino.h
+++ b/cores/esp8266/Arduino.h
@@ -178,7 +178,7 @@ void ets_intr_unlock();
 #define _NOP() do { __asm__ volatile ("nop"); } while (0)
 #endif
 
-typedef unsigned int word;
+typedef uint16_t word;
 
 #define bit(b) (1UL << (b))
 #define _BV(b) (1UL << (b))


### PR DESCRIPTION
The _word_ type is an alias for _unsigned int_. It came directly from original Arduino SDK because ATmega-based boards has 16-bit int. But int for esp8266 board stores 32-bit value so _word_ in meaning _combination of two bytes_ is broken here.

For esp8266 it should be defined 16-bit long explicitly.