### PR TITLE
Removed unused init_lists() function that serves no purpose

### DIFF
--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -14,26 +14,6 @@ static scheduled_fn_t* sLastUnused = 0;
 
 static int sCount = 0;
 
-static void init_lists() __attribute__((unused));
-static void init_lists()
-{
-    if (sCount != 0) {
-        return;
-    }
-    while (sCount < SCHEDULED_FN_INITIAL_COUNT) {
-        scheduled_fn_t* it = new scheduled_fn_t;
-        if (sCount == 0) {
-            sFirstUnused = it;
-        }
-        else {
-            sLastUnused->mNext = it;
-        }
-        sLastUnused = it;
-        ++sCount;
-    }
-    sLastUnused->mNext = NULL;
-}
-
 static scheduled_fn_t* get_fn() {
     scheduled_fn_t* result = NULL;
     // try to get an item from unused items list


### PR DESCRIPTION
Removed init_lists(). It was already marked as unused, so it doesn't generate a warning, but in truth it serves no purpose. The function pre-inits to 4 empty function slots, but the linked-list algorithms work without doing that init, and pre-initing that way has no performance advantage either.
If the function is ever needed in the future, for whatever reason, it can be retrieved from the file history.