### PR TITLE
 Added Serial.setRxBufferSize method description in libraries reference document

### DIFF
--- a/cores/esp8266/uart.c
+++ b/cores/esp8266/uart.c
@@ -104,6 +104,9 @@ int uart_peek_char(uart_t* uart)
 
 int uart_read_char(uart_t* uart)
 {
+    if(uart == NULL) {
+        return -1;
+    }
     int data = uart_peek_char(uart);
     if(data != -1) {
         uart->rx_buffer->rpos = (uart->rx_buffer->rpos + 1) % uart->rx_buffer->size;

--- a/doc/boards.rst
+++ b/doc/boards.rst
@@ -58,7 +58,7 @@ This module is sold under many names for around $6.50 on AliExpress and it's one
 
 It's an open hardware design with an ESP-12E core and 4 MB of SPI flash.
 
-Acording to the manufacturer, "with a micro USB cable, you can connect NodeMCU devkit to your laptop and flash it without any trouble". This is more or less true: the board comes with a CP2102 onboard USB to serial adapter which just works, well, the majority of the time. Sometimes flashing fails and you have to reset the board by holding down FLASH +
+According to the manufacturer, "with a micro USB cable, you can connect NodeMCU devkit to your laptop and flash it without any trouble". This is more or less true: the board comes with a CP2102 onboard USB to serial adapter which just works, well, the majority of the time. Sometimes flashing fails and you have to reset the board by holding down FLASH +
 RST, then releasing FLASH, then releasing RST. This forces the CP2102 device to power cycle and to be re-numbered by Linux.
 
 The board also features a NCP1117 voltage regulator, a blue LED on GPIO16 and a 220k/100k Ohm voltage divider on the ADC input pin.

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -94,10 +94,11 @@ Serial
 ------
 
 ``Serial`` object works much the same way as on a regular Arduino. Apart
-from hardware FIFO (128 bytes for TX and RX) HardwareSerial has
+from hardware FIFO (128 bytes for TX and RX) ``Serial`` has
 additional 256-byte TX and RX buffers. Both transmit and receive is
 interrupt-driven. Write and read functions only block the sketch
-execution when the respective FIFO/buffers are full/empty.
+execution when the respective FIFO/buffers are full/empty. Note that
+the length of additional 256-bit buffer can be customized.
 
 ``Serial`` uses UART0, which is mapped to pins GPIO1 (TX) and GPIO3
 (RX). Serial may be remapped to GPIO15 (TX) and GPIO13 (RX) by calling
@@ -121,6 +122,9 @@ instead, call ``Serial1.setDebugOutput(true)``.
 You also need to use ``Serial.setDebugOutput(true)`` to enable output
 from ``printf()`` function.
 
+The method ``Serial.setRxBufferSize(size_t size)`` allows to define the
+receiving buffer depth. The default value is 256.
+
 Both ``Serial`` and ``Serial1`` objects support 5, 6, 7, 8 data bits,
 odd (O), even (E), and no (N) parity, and 1 or 2 stop bits. To set the
 desired mode, call ``Serial.begin(baudrate, SERIAL_8N1)``,
@@ -142,6 +146,8 @@ current speed. For example
     // Will print "Serial is 57600 bps"
     Serial.printf("Serial is %d bps", br);
 
+| ``Serial`` and ``Serial1`` objects are both instances of the
+  ``HardwareSerial`` class.
 | I've done this also for official ESP8266 `Software
   Serial <https://github.com/esp8266/Arduino/blob/master/doc/libraries.md#softwareserial>`__
   library, see this `pull


### PR DESCRIPTION
Hi, this is a proposal to fix #1786 