### PR TITLE
Collect all headers of incoming web server request (and don't just drop them)

### DIFF
--- a/libraries/ESP8266WebServer/src/Parsing.cpp
+++ b/libraries/ESP8266WebServer/src/Parsing.cpp
@@ -259,6 +259,7 @@ bool ESP8266WebServer::_parseRequest(WiFiClient& client) {
   return true;
 }
 
+// returns whether the key of the entry was already known (true) or not (false)
 bool ESP8266WebServer::_collectHeader(const char* headerName, const char* headerValue) {
   for (int i = 0; i < _headerKeysCount; i++) {
     if (_currentHeaders[i].key.equalsIgnoreCase(headerName)) {
@@ -266,6 +267,38 @@ bool ESP8266WebServer::_collectHeader(const char* headerName, const char* header
             return true;
         }
   }
+  // key is previously unknown, so we now know one more key
+  _headerKeysCount++;
+  
+  // might be unelegant, but works well:
+  // 1. creates a new array with size n+1 for every new header
+  // 2. copies all known headers
+  // 3. adds the new entry
+  // 4. frees the old array
+
+  // create array for one more header entry:
+  RequestArgument* newHeaders = new RequestArgument[_headerKeysCount];
+  // copy all previously known header entries
+  for(int i = 0; i < (_headerKeysCount -1); i++){
+      newHeaders[i].key = _currentHeaders[i].key;
+      newHeaders[i].value = _currentHeaders[i].value;
+  }
+  // add the newly fonud header key and value
+  newHeaders[_headerKeysCount - 1].key = headerName;
+  newHeaders[_headerKeysCount - 1].value = headerValue;
+  
+  // for debugging purposes define DEBUG_ESP_HTTP_SERVER to make this show the new header name and values
+  #ifdef DEBUG_ESP_HTTP_SERVER
+  DEBUG_OUTPUT.print("added new header, headerName: ");
+  DEBUG_OUTPUT.println(headerName);
+  DEBUG_OUTPUT.print("headerValue: ");
+  DEBUG_OUTPUT.println(headerValue);
+  #endif
+  
+  // free memory of old header array
+  delete[]_currentHeaders;
+  // have _currentHeaders point to the new array of headers
+  _currentHeaders = newHeaders;
   return false;
 }
 


### PR DESCRIPTION
Fixed missing functionality to collect headers. Headers would only be updated if the name property was already known in an entry of the according array.
Now the array of headers gets replaced by a larger array when a previously unknown header name is passed to _collectHeader. In this case the function returns false as before, but the header is saved to the array.
If the passed header name is the same as an already existing entry, the value of the existing entry still gets overwritten and the function returns true, nothing changed here.

This fix is simple, short and tested with the "productive" branch used by the Arduino IDE (but it seems like since this version nothing changed relating to this part of the code)