### PR TITLE
Create non-blocking socket with WiFiClientSecure

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
@@ -56,7 +56,7 @@ public:
     SSLContext()
     {
         if (_ssl_ctx_refcnt == 0) {
-            _ssl_ctx = ssl_ctx_new(SSL_SERVER_VERIFY_LATER | SSL_DEBUG_OPTS | SSL_CONNECT_IN_PARTS | SSL_READ_BLOCKING | SSL_NO_DEFAULT_KEY, 0);
+            _ssl_ctx = ssl_ctx_new(SSL_SERVER_VERIFY_LATER | SSL_DEBUG_OPTS | SSL_CONNECT_IN_PARTS | SSL_NO_DEFAULT_KEY, 0);
         }
         ++_ssl_ctx_refcnt;
     }


### PR DESCRIPTION
SSL_READ_BLOCKING was causing the code to get stuck on functions using
SSL socket (available(), connected() etc.) when connection to the server
suddenly broke (in a manner that ESP still was associated to the AP and had an IP).
As this was not really a stuck CPU WDT never fired.