### PR TITLE
ESP8266mDNS: Fix flushing answers when there is no query response.

### DIFF
--- a/libraries/ESP8266mDNS/ESP8266mDNS.h
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.h
@@ -116,7 +116,6 @@ private:
   String _instanceName;
   struct MDNSAnswer * _answers;
   struct MDNSQuery * _query;
-  bool _newQuery;
   bool _waitingForAnswers;
   WiFiEventHandler _disconnectedHandler;
   WiFiEventHandler _gotIPHandler;


### PR DESCRIPTION
* moved cleanup of answerse from `parsedPackage` to `queryService`
* removed `_newQuery`

Relates to #3068 