### PR TITLE
Added verifyCert() to the header file

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.h
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.h
@@ -63,7 +63,8 @@ public:
   bool loadPrivateKey(Stream& stream, size_t size);
 
   void allowSelfSignedCerts();
-
+  bool verifyCert();
+  
   template<typename TFile>
   bool loadCertificate(TFile& file) {
     return loadCertificate(file, file.size());


### PR DESCRIPTION
This fixed the no member named compilation error when trying to call verifyCert