### PR TITLE
ESP8266mDNS - Add support for removing TXT records. Issue #3212

### DIFF
--- a/libraries/ESP8266mDNS/ESP8266mDNS.cpp
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.cpp
@@ -268,8 +268,20 @@ void MDNSResponder::clearServiceTxt(const char *name, const char *proto){
     //Checking Service names
     if(strcmp(servicePtr->_name, name) == 0 && strcmp(servicePtr->_proto, proto) == 0){
       //found a service name match
-      servicePtr->_txts = 0;
-      servicePtr->_txtLen = 0;
+      if (servicePtr->_txts != 0) {
+      	MDNSTxt * txtPtr = servicePtr->_txts;
+      	MDNSTxt * nextPtr = txtPtr->_next;
+      	delete txtPtr;
+      	txtPtr = 0;
+      	while (nextPtr !=0) {
+      		txtPtr = nextPtr;
+      		nextPtr = txtPtr->_next;
+      		delete txtPtr;
+      		txtPtr = 0;
+      	} 
+      	servicePtr->_txts = 0;
+      	servicePtr->_txtLen = 0;
+      }
     }
   }
 }

--- a/libraries/ESP8266mDNS/ESP8266mDNS.cpp
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.cpp
@@ -261,7 +261,7 @@ bool MDNSResponder::addServiceTxt(char *name, char *proto, char *key, char *valu
   return false;
 }
 
-void MDNSResponder::clearServiceTxt(char *name, char *proto){
+void MDNSResponder::clearServiceTxt(const char *name, const char *proto){
 	MDNSService* servicePtr;
 	//Find the service
   for (servicePtr = _services; servicePtr; servicePtr = servicePtr->_next) {

--- a/libraries/ESP8266mDNS/ESP8266mDNS.cpp
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.cpp
@@ -261,6 +261,19 @@ bool MDNSResponder::addServiceTxt(char *name, char *proto, char *key, char *valu
   return false;
 }
 
+void MDNSResponder::clearServiceTxt(char *name, char *proto){
+	MDNSService* servicePtr;
+	//Find the service
+  for (servicePtr = _services; servicePtr; servicePtr = servicePtr->_next) {
+    //Checking Service names
+    if(strcmp(servicePtr->_name, name) == 0 && strcmp(servicePtr->_proto, proto) == 0){
+      //found a service name match
+      servicePtr->_txts = 0;
+      servicePtr->_txtLen = 0;
+    }
+  }
+}
+
 void MDNSResponder::addService(char *name, char *proto, uint16_t port){
   if(_getServicePort(name, proto) != 0) return;
   if(os_strlen(name) > 32 || os_strlen(proto) != 3) return; //bad arguments

--- a/libraries/ESP8266mDNS/ESP8266mDNS.h
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.h
@@ -87,6 +87,14 @@ public:
   void addServiceTxt(String name, String proto, String key, String value){
     addServiceTxt(name.c_str(), proto.c_str(), key.c_str(), value.c_str());
   }
+
+  void clearServiceTxt(char *name, char *proto);
+  void clearServiceTxt(const char *name, const char *proto){
+    clearServiceTxt((char *)name, (char *)proto);
+  }
+  void clearServiceTxt(String name, String proto){
+    clearServiceTxt(name.c_str(), proto.c_str());
+  }
   
   int queryService(char *service, char *proto);
   int queryService(const char *service, const char *proto){

--- a/libraries/ESP8266mDNS/ESP8266mDNS.h
+++ b/libraries/ESP8266mDNS/ESP8266mDNS.h
@@ -88,10 +88,7 @@ public:
     addServiceTxt(name.c_str(), proto.c_str(), key.c_str(), value.c_str());
   }
 
-  void clearServiceTxt(char *name, char *proto);
-  void clearServiceTxt(const char *name, const char *proto){
-    clearServiceTxt((char *)name, (char *)proto);
-  }
+  void clearServiceTxt(const char *name, const char *proto);
   void clearServiceTxt(String name, String proto){
     clearServiceTxt(name.c_str(), proto.c_str());
   }


### PR DESCRIPTION
I have added a method to clear the TXT record as a whole. This will clear all key, value pairs and allow the entire TXT record to be rebuilt as needed. 