### PR TITLE
keepalive(2h,75s,9) API + status helper + change/disable methods (not enabled by default)

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -344,3 +344,29 @@ void WiFiClient::stopAllExcept(WiFiClient* except)
         }
     }
 }
+
+
+void WiFiClient::keepAlive (uint16_t idle_sec, uint16_t intv_sec, uint8_t count)
+{
+    _client->keepAlive(idle_sec, intv_sec, count);
+}
+
+bool WiFiClient::isKeepAliveEnabled () const
+{
+    return _client->isKeepAliveEnabled();
+}
+
+uint16_t WiFiClient::getKeepAliveIdle () const
+{
+    return _client->getKeepAliveIdle();
+}
+
+uint16_t WiFiClient::getKeepAliveInterval () const
+{
+    return _client->getKeepAliveInterval();
+}
+
+uint8_t WiFiClient::getKeepAliveCount () const
+{
+    return _client->getKeepAliveCount();
+}

--- a/libraries/ESP8266WiFi/src/WiFiClient.h
+++ b/libraries/ESP8266WiFi/src/WiFiClient.h
@@ -30,6 +30,10 @@
 
 #define WIFICLIENT_MAX_PACKET_SIZE 1460
 
+#define TCP_DEFAULT_KEEPALIVE_IDLE_SEC          7200 // 2 hours
+#define TCP_DEFAULT_KEEPALIVE_INTERVAL_SEC      75   // 75 sec
+#define TCP_DEFAULT_KEEPALIVE_COUNT             9    // fault after 9 failures
+
 class ClientContext;
 class WiFiServer;
 
@@ -84,6 +88,13 @@ public:
 
   static void stopAll();
   static void stopAllExcept(WiFiClient * c);
+
+  void     keepAlive (uint16_t idle_sec = TCP_DEFAULT_KEEPALIVE_IDLE_SEC, uint16_t intv_sec = TCP_DEFAULT_KEEPALIVE_INTERVAL_SEC, uint8_t count = TCP_DEFAULT_KEEPALIVE_COUNT);
+  bool     isKeepAliveEnabled () const;
+  uint16_t getKeepAliveIdle () const;
+  uint16_t getKeepAliveInterval () const;
+  uint8_t  getKeepAliveCount () const;
+  void     disableKeepAlive () { keepAlive(0, 0, 0); }
 
 protected:
 


### PR DESCRIPTION
(*not yed* automatic) tcp-keep-alive for all new connections with standard default values
#2750
