### PR TITLE
The pgmspace symbols are now exported to C

### DIFF
--- a/cores/esp8266/pgmspace.cpp
+++ b/cores/esp8266/pgmspace.cpp
@@ -24,6 +24,8 @@
 #include <stdarg.h>
 #include "pgmspace.h"
 
+extern "C" {
+
 size_t strnlen_P(PGM_P s, size_t size) {
     const char* cp;
     for (cp = s; size != 0 && pgm_read_byte(cp) != '\0'; cp++, size--);
@@ -286,3 +288,5 @@ int vsnprintf_P(char* str, size_t strSize, PGM_P formatP, va_list ap) {
 
     return ret;
 }
+
+} // extern "C"

--- a/cores/esp8266/pgmspace.h
+++ b/cores/esp8266/pgmspace.h
@@ -4,16 +4,14 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#ifdef __ets__
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#ifdef __ets__
+
 #include "ets_sys.h"
 #include "osapi.h"
-#ifdef __cplusplus
-}
-#endif
 
 #define PROGMEM     ICACHE_RODATA_ATTR
 #define PGM_P  		const char *
@@ -135,5 +133,9 @@ static inline uint16_t pgm_read_word_inlined(const void* addr) {
 #define pgm_read_dword_far(addr) 	pgm_read_dword(addr)
 #define pgm_read_float_far(addr) 	pgm_read_float(addr)
 #define pgm_read_ptr_far(addr)		pgm_read_ptr(addr)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif //__PGMSPACE_H_


### PR DESCRIPTION
pgmspace.h is included from within extern "C" blocks (for example in tools/sdk/libc/xtensa-lx106-elf/include/assert.h) and from C files. This sometimes creates link errors when both the manged and unmangled versions are needed.
This change exports all symbols to C.