### PR TITLE
increase HTTP SEND/POST timeout to 5s

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -40,8 +40,8 @@ enum HTTPAuthMethod { BASIC_AUTH, DIGEST_AUTH };
 #define HTTP_UPLOAD_BUFLEN 2048
 #endif
 
-#define HTTP_MAX_DATA_WAIT 1000 //ms to wait for the client to send the request
-#define HTTP_MAX_POST_WAIT 1000 //ms to wait for POST data to arrive
+#define HTTP_MAX_DATA_WAIT 5000 //ms to wait for the client to send the request
+#define HTTP_MAX_POST_WAIT 5000 //ms to wait for POST data to arrive
 #define HTTP_MAX_SEND_WAIT 5000 //ms to wait for data chunk to be ACKed
 #define HTTP_MAX_CLOSE_WAIT 2000 //ms to wait for the client to close the connection
 


### PR DESCRIPTION
#3699

I instrumented ```Parsing.cpp:readBytesWithTimeout()``` and found with my current ideal setup (the esp alone distant to 1 meter of the AP's antenna and PC on ethernet) that I have a maximum "tries" time of 1154ms (it is 99% less than 5ms but sometimes increased for a single packet to around 1 second).
I did not try to tcpdump though, but with a bigger timeout it just works.

I think it is not too expensive to increase the timeout to 5 seconds.
