### PR TITLE
Fix boundary condition on resize

### DIFF
--- a/cores/esp8266/cbuf.cpp
+++ b/cores/esp8266/cbuf.cpp
@@ -39,7 +39,7 @@ size_t cbuf::resize(size_t newSize) {
 
 	// not lose any data
 	// if data can be lost use remove or flush before resize
-    if((newSize < bytes_available) || (newSize == _size)) {
+    if((newSize <= bytes_available) || (newSize == _size)) {
         return _size;
     }
 


### PR DESCRIPTION
cbuf.size() must be at least one byte larger than cbuf.available() for
logic to work.  reject request to resize = available.  Issue #4002.