### PR TITLE
WiFiClientSecure: don't trash unread decrypted data when writing

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
@@ -193,6 +193,12 @@ public:
         return cb;
     }
 
+    // similar to availble, but doesn't return exact size
+    bool hasData()
+    {
+        return _available > 0 || (s_io_ctx && s_io_ctx->getSize() > 0);
+    }
+
     bool loadObject(int type, Stream& stream, size_t size)
     {
         std::unique_ptr<uint8_t[]> buf(new uint8_t[size]);
@@ -458,7 +464,7 @@ err     x       N           N
 uint8_t WiFiClientSecure::connected()
 {
     if (_ssl) {
-        if (_ssl->available()) {
+        if (_ssl->hasData()) {
             return true;
         }
         if (_client && _client->state() == ESTABLISHED && _ssl->connected()) {


### PR DESCRIPTION
When application requests to write data, check if there is any unread decrypted data left. If there is, don't write immediately, but save the data to be written. When all decrypted data has been consumed by the application, send out the saved outgoing data.

Also don't use `available()` in the test for `connected()` to reduce the chance that plaintext buffer gets filled with incoming data when the application does not actually need it, and does not need to know its exact size.

Fixes https://github.com/esp8266/Arduino/issues/2256.