### PR TITLE
Configurable WiFiClientSecure connect timeout, better default value

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
@@ -353,7 +353,7 @@ int WiFiClientSecure::_connectSSL(const char* hostName)
         _ssl = new SSLContext;
         _ssl->ref();
     }
-    _ssl->connect(_client, hostName, 5000);
+    _ssl->connect(_client, hostName, _timeout);
 
     auto status = ssl_handshake_status(*_ssl);
     if (status != SSL_OK) {

--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
@@ -298,6 +298,8 @@ ClientContext* SSLContext::s_io_ctx = nullptr;
 
 WiFiClientSecure::WiFiClientSecure()
 {
+    // TLS handshake may take more than the 5 second default timeout
+    _timeout = 15000;
 }
 
 WiFiClientSecure::~WiFiClientSecure()


### PR DESCRIPTION
- Use Client::_timeout in WiFiClientSecure::connect instead of a hardcoded value. This can be modified via Client::setTimeout before connecting.
- Set default _timeout for WiFiClientSecure to 15 seconds.

Ref. https://github.com/esp8266/Arduino/issues/3944