### PR TITLE
WiFiClientSecure: don't use the broken max_fragment_length extension

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
@@ -113,7 +113,6 @@ public:
     {
         SSL_EXTENSIONS* ext = ssl_ext_new();
         ssl_ext_set_host_name(ext, hostName);
-        ssl_ext_set_max_fragment_size(ext, 4096);
         if (_ssl) {
             /* Creating a new TLS session on top of a new TCP connection.
                ssl_free will want to send a close notify alert, but the old TCP connection


### PR DESCRIPTION
axTLS does not correctly implement max_fragment_length extension. This
causes servers which understand this extension (currently GnuTLS- and
WolfSSL-based) to reject the client hello.

Until this is fixed in axTLS, remove the call to enable this extension
from WiFiClientSecure.

Fixes https://github.com/esp8266/Arduino/issues/3932.