### PR TITLE
WiFiUDP: fix crash when calling destinationIP with no packet available

### DIFF
--- a/libraries/ESP8266WiFi/src/include/UdpContext.h
+++ b/libraries/ESP8266WiFi/src/include/UdpContext.h
@@ -163,6 +163,9 @@ public:
 
     uint32_t getDestAddress()
     {
+        if (!_rx_buf)
+            return 0;
+
         ip_hdr* iphdr = GET_IP_HDR(_rx_buf);
         return iphdr->dest.addr;
     }


### PR DESCRIPTION
Fixes https://github.com/esp8266/Arduino/issues/3989.