### PR TITLE
ESP8266HTTPClient: allow changing connection timeout using setTimeout

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -840,6 +840,7 @@ bool HTTPClient::connect(void)
     }
 
     _tcp = _transportTraits->create();
+    _tcp->setTimeout(_tcpTimeout);
 
     if(!_tcp->connect(_host.c_str(), _port)) {
         DEBUG_HTTPCLIENT("[HTTP-Client] failed connect to %s:%u\n", _host.c_str(), _port);
@@ -854,8 +855,6 @@ bool HTTPClient::connect(void)
         return false;
     }
 
-    // set Timeout for readBytesUntil and readStringUntil
-    _tcp->setTimeout(_tcpTimeout);
 
 #ifdef ESP8266
     _tcp->setNoDelay(true);


### PR DESCRIPTION
Call Client::setTimeout before connection to influence connection
timeout.

Closes https://github.com/esp8266/Arduino/issues/3451.