### PR TITLE
Remove 2 compiler warnings

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -281,6 +281,8 @@ void ESP8266WebServer::handleClient() {
 
   if (_currentClient.connected()) {
     switch (_currentStatus) {
+    case HC_NONE:
+        break;
     case HC_WAIT_READ:
       // Wait for data from client to become available
       if (_currentClient.available()) {

--- a/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.cpp
+++ b/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.cpp
@@ -76,6 +76,7 @@ HTTPUpdateResult ESP8266HTTPUpdate::updateSpiffs(const String& url, const String
 HTTPUpdateResult ESP8266HTTPUpdate::update(const String& host, uint16_t port, const String& uri, const String& currentVersion,
         bool https, const String& httpsFingerprint, bool reboot)
 {
+    (void)https;
     rebootOnUpdate(reboot);
     if (httpsFingerprint.length() == 0) {
         return update(host, port, uri, currentVersion);


### PR DESCRIPTION
Removes 2 warnings:

 - `warning: unused parameter 'https'` in ESP8266httpUpdate.cpp
 - `warning: enumeration value 'HC_NONE' not handled in switch` in ESP8266WebServer.cpp

This should cover https://github.com/esp8266/Arduino/issues/3778 I think.
