### PR TITLE
Prevent endless loop in run_scheduled_functions

### DIFF
--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -65,12 +65,12 @@ bool schedule_function(std::function<void(void)> fn)
 
 void run_scheduled_functions()
 {
-    while (sFirst) {
-        scheduled_fn_t* item = sFirst;
-        sFirst = item->mNext;
-        if (sFirst == NULL) {
-            sLast = NULL;
-        }
+	scheduled_fn_t* rFirst = sFirst;
+	sFirst = NULL;
+	sLast  = NULL;
+    while (rFirst) {
+        scheduled_fn_t* item = rFirst;
+        rFirst = item->mNext;
         item->mFunc();
         item->mFunc = std::function<void(void)>();
         recycle_fn(item);


### PR DESCRIPTION
When scheduling the same function from within a scheduled function the "run_scheduled_function" does not finish -> loop is not being called anymore.

Example function is : 
```
void CommandExecutor::getStreamChars(Stream* reqStream)
{
	if (reqStream->available())
	{
		executorReceive(reqStream->read());
	}
	schedule_function(std::bind(&CommandExecutor::getStreamChars,this,reqStream));
}
```

I am using this in order to have all the code within my classes and not dependent on (addtional) calls from within the loop fucntion,

This patch starts a a new chain of scheduled functions when starting current cycle