### PR TITLE
Identify aarch64 properly.

### DIFF
--- a/tools/get.py
+++ b/tools/get.py
@@ -102,7 +102,7 @@ def identify_platform():
     if sys.maxsize > 2**32:
         bits = 64
     sys_name = platform.system()
-    if 'Linux' in sys_name and platform.platform().find('arm') > 0:
+    if 'Linux' in sys_name and (platform.machine().find('arm') > 0 or platform.machine().find('aarch64') > 0):
         sys_name = 'LinuxARM'
     if 'CYGWIN_NT' in sys_name:
         sys_name = 'Windows'

--- a/tools/get.py
+++ b/tools/get.py
@@ -102,7 +102,7 @@ def identify_platform():
     if sys.maxsize > 2**32:
         bits = 64
     sys_name = platform.system()
-    if 'Linux' in sys_name and (platform.machine().find('arm') > 0 or platform.machine().find('aarch64') > 0):
+    if 'Linux' in sys_name and (platform.platform().find('arm') > 0 or platform.platform().find('aarch64') > 0):
         sys_name = 'LinuxARM'
     if 'CYGWIN_NT' in sys_name:
         sys_name = 'Windows'


### PR DESCRIPTION
Attempt to fix #4049.

Overall, whole `identify_platform()` should be rewritten to utilize platform.machine() and platform.system() to figure out CPU arch / OS type.
I didn't want to introduce large changes, as I'm not sure about dependent code, but do let me know if you want me to provide a rewrite.