### PR TITLE
small fix to stop crash on unrecognized packets #4090

### DIFF
--- a/libraries/ArduinoOTA/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/ArduinoOTA.cpp
@@ -149,10 +149,10 @@ int ArduinoOTAClass::parseInt(){
   for(index = 0; index < sizeof(data); ++index){
     value = _udp_ota->peek();
     if(value < '0' || value > '9'){
-      data[index++] = '\0';
+      data[index] = '\0';
       return atoi(data);
     }
-    data[index++] = _udp_ota->read();
+    data[index] = _udp_ota->read();
   }
   return 0;
 }


### PR DESCRIPTION
Small fix to changes previously made by @yoursunny on #4090.  This stops ESP from crashing when receiving unrecognized UDP packets.