### PR TITLE
UpdaterClass::printError now accepts the Print object

### DIFF
--- a/cores/esp8266/Updater.cpp
+++ b/cores/esp8266/Updater.cpp
@@ -371,7 +371,7 @@ size_t UpdaterClass::writeStream(Stream &data) {
     return written;
 }
 
-void UpdaterClass::printError(Stream &out){
+void UpdaterClass::printError(Print &out){
   out.printf_P(PSTR("ERROR[%u]: "), _error);
   if(_error == UPDATE_ERROR_OK){
     out.println(F("No Error"));

--- a/cores/esp8266/Updater.h
+++ b/cores/esp8266/Updater.h
@@ -72,7 +72,7 @@ class UpdaterClass {
     /*
       Prints the last error to an output stream
     */
-    void printError(Stream &out);
+    void printError(Print &out);
 
     /*
       sets the expected MD5 for the firmware (hexString)


### PR DESCRIPTION
Makes change to printError detailed in #4007.