### PR TITLE
initialize io_ctx to nullptr

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
@@ -420,7 +420,7 @@ protected:
     size_t _available = 0;
     BufferList _writeBuffers;
     bool _allowSelfSignedCerts = false;
-    ClientContext* io_ctx;
+    ClientContext* io_ctx = nullptr;
 };
 
 SSL_CTX* SSLContext::_ssl_ctx = nullptr;


### PR DESCRIPTION
This was a static, but when it was converted the initialization to nullptr was lost resulting in exception 28 on connect. Since it is no longer being initialized, it appears to be pointing to some random memory address.

I am seeing this exception occur everytime I connect to aws iot with client certificates.

https://github.com/esp8266/Arduino/commit/bd1c7ce1dc4f56d707637f2829f6473e888e533d#diff-26b5fb5b4e7d777dc7a201a0cdd26b2dL397 

```
Fatal exception 28(LoadProhibitedCause):
epc1=0x4020bb67, epc2=0x00000000, epc3=0x00000000, excvaddr=0x007e8008, depc=0x00000000

Exception (28):
epc1=0x4020bb67 epc2=0x00000000 epc3=0x00000000 excvaddr=0x007e8008 depc=0x00000000

ctx: cont
sp: 3fff1840 end: 3fff1b90 offset: 01a0

>>>stack>>>
3fff19e0:  62755362 65696c43 205d746e 65747441
3fff19f0:  6974706d 4d20676e 20545451 402122b0
3fff1a00:  3fff1a40 3fff0740 00000000 4020f931
3fff1a10:  c025c177 3fff1a70 3fff0688 3ffe93c8
3fff1a20:  3fff3104 3ffea930 3fff3104 00000000
3fff1a30:  3fff1dbc 000004c8 000004c8 3ffe93c8
3fff1a40:  3fff0a74 3fff0740 3fff09c4 4020fab0
3fff1a50:  00000000 00000000 3fff0a9c 402022bc
3fff1a60:  3fff0a74 3fff0740 3fff09c4 40213f84
3fff1a70:  00000000 00000000 00000000 40217be4
3fff1a80:  3fff0a74 3fff09c4 3fff0740 40214420
3fff1a90:  3ffe93c8 00000000 000003e8 00000000
3fff1aa0:  3fff608c 3fff60cc 3ffe93c8 00000000
3fff1ab0:  000003e8 3fff1b10 3fff3e04 3fff3fcc
3fff1ac0:  3ffe93c8 00000000 000003e8 40201951
3fff1ad0:  3fff3d6c 3fff2cac 3fff3e44 4010020c
3fff1ae0:  40213c8c 4021414c 3fff1b10 40100690
3fff1af0:  3fff06dc 3fff1b10 3fff0a9c 3fff071c
3fff1b00:  00000324 3fff06dc 3fff06c8 40214cbe
3fff1b10:  00000000 00000000 00000000 feefeffe
3fff1b20:  feefeffe feefeffe feefeffe feefeffe
3fff1b30:  feefeffe feefeffe feefeffe feefeffe
3fff1b40:  feefeffe feefeffe feefeffe feefeffe
3fff1b50:  feefeffe feefeffe feefeffe 3fff0b5c
3fff1b60:  3fffdad0 00000000 3fff0b54 40216850
3fff1b70:  feefeffe feefeffe feefeffe 40202f84
3fff1b80:  feefeffe feefeffe 3fff0b70 4020536c
<<<stack<<<

 ets Jan  8 2013,rst cause:2, boot mode:(1,7)


 ets Jan  8 2013,rst cause:4, boot mode:(1,7)

wdt reset

Exception 28: LoadProhibited: A load referenced a page mapped with an attribute that does not permit loads
Decoding 18 results
0x4020bb67: WiFiClientSecure::connected() at ?? line ?
0x4020bb67: WiFiClientSecure::connected() at ?? line ?
0x402122b0: PubSubClient::connected() at ?? line ?
0x4020f931: PubSubClient::connect(char const*, char const*, char const*, char const*, unsigned char, unsigned char, char const*) at ?? line ?
0x4020fab0: PubSubClient::connect(char const*, char const*, char const*) at ?? line ?
0x402022bc: String::~String() at ?? line ?
0x40213f84: InterlockPubSubClient::reconnect() at ?? line ?
0x40217be4: std::_Function_base::~_Function_base() at ?? line ?
0x40214420: InterlockPubSubClient::initialize() at ?? line ?
0x40201951: Print::write(char const*) at ?? line ?
0x4010020c: _umm_free at umm_malloc.c line ?
0x40213c8c: std::_Function_base::_Base_manager ::_M_manager(std::_Any_data&, std::_Function_base::_Base_manager  const&, std::_Manager_operation) at InterlockPubSubClient.cpp line ?
0x4021414c: std::_Function_handler ::_M_invoke(std::_Any_data const&, char*, unsigned char*, unsigned int) at InterlockPubSubClient.cpp line ?
0x40100690: free at ?? line ?
0x40214cbe: Program::initialize() at ?? line ?
0x40216850: setup at ?? line ?
0x40202f84: loop_wrapper() at core_esp8266_main.cpp line ?
0x4020536c: cont_norm at cont.o line ?

```
