### PR TITLE
Bugfix and accepting put data

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServerSecure.cpp
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServerSecure.cpp
@@ -27,6 +27,11 @@
 #include "WiFiClient.h"
 #include "ESP8266WebServerSecure.h"
 
+#ifdef DEBUG_ESP_PORT
+#define DEBUG_OUTPUT DEBUG_ESP_PORT
+#else
+#define DEBUG_OUTPUT Serial
+#endif
 
 ESP8266WebServerSecure::ESP8266WebServerSecure(IPAddress addr, int port) 
 : _serverSecure(addr, port)

--- a/libraries/ESP8266WebServer/src/Parsing.cpp
+++ b/libraries/ESP8266WebServer/src/Parsing.cpp
@@ -332,6 +332,16 @@ void ESP8266WebServer::_parseArguments(String data) {
       break;
     pos = next_arg_index + 1;
   }
+
+  if (iarg == 0) {
+#ifdef DEBUG_ESP_HTTP_SERVER
+	DEBUG_OUTPUT.println("add plain data");
+#endif
+	RequestArgument& arg = _currentArgs[iarg++];
+	arg.key = "plain";
+	arg.value = data;
+  }
+  
   _currentArgCount = iarg;
 #ifdef DEBUG_ESP_HTTP_SERVER
   DEBUG_OUTPUT.print("args count: ");


### PR DESCRIPTION
ESP8266WebServer.cpp does not compile if Debug-Level HTTP_SERVER is enabled. (DEBUG_OUTPUT not declared in this scope) This commit fixes the issue.

The other file contains a feature request: I have one application (actualy a Amazon Echo 1st Gen) that sends a put-request with contentype "application/x-www-form-urlencoded" set in the headers but sends out json encoded data.  _parseArguments fails to parse the arguments (which is correct) but completly discards the data.  This change checks if the parser picked something up and if it didn't, it just adds it as plain data to the arguments.