### PR TITLE
Use fixed TCP port in ArduinoOTA to facilitate firewall configuration

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -118,7 +118,7 @@ tools.esptool.upload.protocol=esp
 tools.esptool.upload.params.verbose=-vv
 tools.esptool.upload.params.quiet=
 tools.esptool.upload.pattern="{path}/{cmd}" {upload.verbose} -cd {upload.resetmethod} -cb {upload.speed} -cp "{serial.port}" -ca 0x00000 -cf "{build.path}/{build.project_name}.bin"
-tools.esptool.upload.network_pattern="{network_cmd}" "{runtime.platform.path}/tools/espota.py" -i "{serial.port}" -p "{network.port}" "--auth={network.password}" -f "{build.path}/{build.project_name}.bin"
+tools.esptool.upload.network_pattern="{network_cmd}" "{runtime.platform.path}/tools/espota.py" -i "{serial.port}" -p "{network.port}" -P "8266" "--auth={network.password}" -f "{build.path}/{build.project_name}.bin"
 
 tools.mkspiffs.cmd=mkspiffs
 tools.mkspiffs.cmd.windows=mkspiffs.exe


### PR DESCRIPTION
Use a fixed network port for TCP firmware transfer in ArduinoOTA. This step of the transfer is not clearly documented, and presents an issue for systems behind a firewall. A fixed port allows configuring the developer computer's firewall or forwarding on a router to accept the connection from the esp device to download the new firmware, after authentication via UDP. Perhaps this could be made configurable.