### PR TITLE
Remove warnings when NDEBUG build option used

### DIFF
--- a/libraries/ESP8266WiFi/src/include/ClientContext.h
+++ b/libraries/ESP8266WiFi/src/include/ClientContext.h
@@ -543,6 +543,7 @@ protected:
     err_t _connected(struct tcp_pcb *pcb, err_t err)
     {
         (void) err;
+        (void) pcb;
         assert(pcb == _pcb);
         assert(_connect_pending);
         esp_schedule();

--- a/libraries/ESP8266WiFi/src/include/DataSource.h
+++ b/libraries/ESP8266WiFi/src/include/DataSource.h
@@ -31,12 +31,14 @@ public:
 
     const uint8_t* get_buffer(size_t size) override
     {
+        (void) size;
         assert(_pos + size <= _size);
         return _data + _pos;
     }
 
     void release_buffer(const uint8_t* buffer, size_t size) override
     {
+        (void) buffer;
         assert(buffer == _data + _pos);
         _pos += size;
     }
@@ -70,6 +72,7 @@ public:
         }
         size_t cb = _stream.readBytes(reinterpret_cast<char*>(_buffer.get()), size);
         assert(cb == size);
+        (void) cb;
         return _buffer.get();
     }
 


### PR DESCRIPTION
Sorry for the duplicate.  Something weird with git is making it impossible for me to clean up #4066, so I'm closing that one and opening this as a new PR.  It has *only* the WiFiClient changes to clear up the NDEBUG build warnings, and does not touch the core (that's moved into #4187  completely).

...snip...
When building using the new NDEBUG option recently added, the assert()
macro is defined to nothing. This leaves a few variables unused in the
WiFi stack causing compiler warnings. Add in empty casts to remove
these warnings. Does not affect actual assert use when NDEBUG is not
defined.