### PR TITLE
Clear calloc block only if malloc succeeds

### DIFF
--- a/cores/esp8266/umm_malloc/umm_malloc.c
+++ b/cores/esp8266/umm_malloc/umm_malloc.c
@@ -1685,7 +1685,9 @@ void *umm_calloc( size_t num, size_t item_size ) {
 
   size += POISON_SIZE(size);
   ret = _umm_malloc(size);
-  memset(ret, 0x00, size);
+  if (ret) {
+    memset(ret, 0x00, size);
+  }
 
   ret = GET_POISONED(ret, size);
 


### PR DESCRIPTION
Calloc was calling memset(0) on NULL when its implicit malloc failed,
causing a crash in UMM.  Instead, only do the memset if the memory
allocation succeeds.

Fixes issue #4207 