### PR TITLE
Change argument to Esp.deepSleep from uint32 to uint64 to match SDK, …

### DIFF
--- a/cores/esp8266/Esp.cpp
+++ b/cores/esp8266/Esp.cpp
@@ -107,11 +107,20 @@ void EspClass::wdtFeed(void)
 
 extern "C" void esp_yield();
 
-void EspClass::deepSleep(uint32_t time_us, WakeMode mode)
+void EspClass::deepSleep(uint64_t time_us, WakeMode mode)
 {
     system_deep_sleep_set_option(static_cast<int>(mode));
     system_deep_sleep(time_us);
     esp_yield();
+}
+
+//this calculation was taken verbatim from the SDK api reference for SDK 2.1.0.
+//Note: system_rtc_clock_cali_proc() returns a uint32_t, even though system_deep_sleep() takes a uint64_t.
+uint64_t EspClass::deepSleepMax()
+{
+  //cali*(2^31-1)/(2^12)
+  return (uint64_t)system_rtc_clock_cali_proc()*(0x80000000-1)/(0x1000);
+
 }
 
 bool EspClass::rtcUserMemoryRead(uint32_t offset, uint32_t *data, size_t size)

--- a/cores/esp8266/Esp.h
+++ b/cores/esp8266/Esp.h
@@ -92,7 +92,8 @@ class EspClass {
         void wdtDisable();
         void wdtFeed();
 
-        void deepSleep(uint32_t time_us, RFMode mode = RF_DEFAULT);
+        void deepSleep(uint64_t time_us, RFMode mode = RF_DEFAULT);
+        uint64_t deepSleepMax();
 
         bool rtcUserMemoryRead(uint32_t offset, uint32_t *data, size_t size);
         bool rtcUserMemoryWrite(uint32_t offset, uint32_t *data, size_t size);


### PR DESCRIPTION
…add deepSleepMax based on the cali_proc function per SDK.

Fixes #3719 for 2.4.1.