### PR TITLE
Minor cleanup of SSL server methods, missing macros

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServerSecure.cpp
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServerSecure.cpp
@@ -27,6 +27,12 @@
 #include "WiFiClient.h"
 #include "ESP8266WebServerSecure.h"
 
+//#define DEBUG_ESP_HTTP_SERVER
+#ifdef DEBUG_ESP_PORT
+#define DEBUG_OUTPUT DEBUG_ESP_PORT
+#else
+#define DEBUG_OUTPUT Serial
+#endif
 
 ESP8266WebServerSecure::ESP8266WebServerSecure(IPAddress addr, int port) 
 : _serverSecure(addr, port)

--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
@@ -329,14 +329,6 @@ public:
         return reinterpret_cast<SSLContext*>(fd)->io_ctx;
     }
 
-    int loadServerX509Cert(const uint8_t *cert, int len) {
-        return ssl_obj_memory_load(SSLContext::_ssl_ctx, SSL_OBJ_X509_CERT, cert, len, NULL);
-    }
-
-    int loadServerRSAKey(const uint8_t *rsakey, int len) {
-        return ssl_obj_memory_load(SSLContext::_ssl_ctx, SSL_OBJ_RSA_KEY, rsakey, len, NULL);
-    }
-
 protected:
     int _readAll()
     {
@@ -471,23 +463,18 @@ WiFiClientSecure::WiFiClientSecure(ClientContext* client, bool usePMEM, const ui
     _ssl->ref();
 
     if (usePMEM) {
-        // When using PMEM based certs, allocate stack and copy from flash to DRAM, call SSL functions to avoid
-        // heap fragmentation that would happen w/malloc()
-        uint8_t *stackData = (uint8_t*)alloca(max(certLen, rsakeyLen));
         if (rsakey && rsakeyLen) {
-              memcpy_P(stackData, rsakey, rsakeyLen);
-              _ssl->loadServerRSAKey(stackData, rsakeyLen);
+            _ssl->loadObject_P(SSL_OBJ_RSA_KEY, rsakey, rsakeyLen);
         }
         if (cert && certLen) {
-            memcpy_P(stackData, cert, certLen);
-            _ssl->loadServerX509Cert(stackData, certLen);
+            _ssl->loadObject_P(SSL_OBJ_X509_CERT, cert, certLen);
         }
     } else {
         if (rsakey && rsakeyLen) {
-            _ssl->loadServerRSAKey(rsakey, rsakeyLen);
+            _ssl->loadObject(SSL_OBJ_RSA_KEY, rsakey, rsakeyLen);
         }
         if (cert && certLen) {
-            _ssl->loadServerX509Cert(cert, certLen);
+            _ssl->loadObject(SSL_OBJ_X509_CERT, cert, certLen);
         }
     }
     _client->ref();


### PR DESCRIPTION
The first of these commits removes duplicated code for loading certs.  There's already a method to do this, so the add'l ones added for support of ESP8266WiFiServerSecure were not needed.

The second one fixes a compile error found in the WebServerSecure class when HTTP_SERVER debugging is enabled.  The output macro wasn't brought in from the original, non-secure file.
