### PR TITLE
Refresh api.github.com x509 certificate

### DIFF
--- a/libraries/ESP8266WiFi/examples/HTTPSRequest/HTTPSRequest.ino
+++ b/libraries/ESP8266WiFi/examples/HTTPSRequest/HTTPSRequest.ino
@@ -27,7 +27,7 @@ const int httpsPort = 443;
 
 // Use web browser to view and copy
 // SHA1 fingerprint of the certificate
-const char* fingerprint = "CF 05 98 89 CA FF 8E D8 5E 5C E0 C2 E4 F7 E6 C3 C7 50 DD 5C";
+const char* fingerprint = "35 85 74 EF 67 35 A7 CE 40 69 50 F3 C0 F6 80 CF 80 3B 2E 19";
 
 void setup() {
   Serial.begin(115200);


### PR DESCRIPTION
The certificate fingerprint included with the HTTPSRequest example seems
to be for an expired api.github.com certificate.  Replace with the current
one to avoid reporting "certificate mismatch" errors when running.

![image](https://user-images.githubusercontent.com/11875/35842734-cd0d29b8-0ab8-11e8-97b6-d04657062a88.png)
