### PR TITLE
HTTP Client method for specifying whole authorization data

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -156,7 +156,8 @@ bool HTTPClient::beginInternal(String url, const char* expectedProtocol)
         // auth info
         String auth = host.substring(0, index);
         host.remove(0, index + 1); // remove auth part including @
-        _base64Authorization = base64::encode(auth);
+        _rawAuthorization = "Basic ";
+        _rawAuthorization += base64::encode(auth);
     }
 
     // get port
@@ -269,7 +270,7 @@ void HTTPClient::setUserAgent(const String& userAgent)
 }
 
 /**
- * set the Authorizatio for the http request
+ * set the Authorization for the http request
  * @param user const char *
  * @param password const char *
  */
@@ -279,18 +280,31 @@ void HTTPClient::setAuthorization(const char * user, const char * password)
         String auth = user;
         auth += ":";
         auth += password;
-        _base64Authorization = base64::encode(auth);
+        _rawAuthorization = "Basic ";
+        _rawAuthorization += base64::encode(auth);
     }
 }
 
 /**
- * set the Authorizatio for the http request
+ * set the Authorization for the http request
  * @param auth const char * base64
  */
 void HTTPClient::setAuthorization(const char * auth)
 {
     if(auth) {
-        _base64Authorization = auth;
+        _rawAuthorization = "Basic ";
+        _rawAuthorization += auth;
+    }
+}
+
+/**
+ * set the full raw Authorization header value for the http request
+ * @param rawAuth const char *
+ */
+void HTTPClient::setRawAuthorization(const char * rawAuth)
+{
+    if(rawAuth) {
+        _rawAuthorization = rawAuth;
     }
 }
 
@@ -742,7 +756,7 @@ void HTTPClient::addHeader(const String& name, const String& value, bool first, 
     if(!name.equalsIgnoreCase(F("Connection")) &&
        !name.equalsIgnoreCase(F("User-Agent")) &&
        !name.equalsIgnoreCase(F("Host")) &&
-       !(name.equalsIgnoreCase(F("Authorization")) && _base64Authorization.length())){
+       !(name.equalsIgnoreCase(F("Authorization")) && _rawAuthorization.length())){
 
         String headerLine = name;
         headerLine += ": ";
@@ -901,10 +915,10 @@ bool HTTPClient::sendHeader(const char * type)
         header += F("Accept-Encoding: identity;q=1,chunked;q=0.1,*;q=0\r\n");
     }
 
-    if(_base64Authorization.length()) {
-        _base64Authorization.replace("\n", "");
-        header += F("Authorization: Basic ");
-        header += _base64Authorization;
+    if (_rawAuthorization.length()) {
+        _rawAuthorization.replace("\n", "");
+        header += F("Authorization: ");
+        header += _rawAuthorization;
         header += "\r\n";
     }
 

--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.h
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.h
@@ -148,6 +148,7 @@ public:
     void setUserAgent(const String& userAgent);
     void setAuthorization(const char * user, const char * password);
     void setAuthorization(const char * auth);
+    void setRawAuthorization(const char * rawAuth);
     void setTimeout(uint16_t timeout);
 
     void useHTTP10(bool usehttp10 = true);
@@ -213,7 +214,7 @@ protected:
     String _protocol;
     String _headers;
     String _userAgent = "ESP8266HTTPClient";
-    String _base64Authorization;
+    String _rawAuthorization;
 
     /// Response handling
     RequestArgument* _currentHeaders = nullptr;


### PR DESCRIPTION
If already there is a separate method for specifying the base64-encoded data for basic auth, then it would be nice to allow for specifying the whole auth header. Right now, I'm using this to send request to pushetta.com's API, which needs a different kind of auth data (Token <your-auth-token>). Sure, I could simply set the header itself instead - but then again, that could be done for basic auth with pre-encoded data.