### PR TITLE
help needed: platform.txt's WINDOWS SCRIPT to handle git versioning in debug message

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -72,8 +72,8 @@ compiler.elf2hex.extra_flags=
 ## needs bash, git, and echo
 recipe.hooks.core.prebuild.1.pattern=bash -c "mkdir -p {build.path}/core && echo \#define ARDUINO_ESP8266_GIT_VER 0x`git --git-dir {runtime.platform.path}/.git rev-parse --short=8 HEAD 2>/dev/null || echo ffffffff` >{build.path}/core/core_version.h"
 recipe.hooks.core.prebuild.2.pattern=bash -c "mkdir -p {build.path}/core && echo \#define ARDUINO_ESP8266_GIT_DESC `cd {runtime.platform.path}; git describe --tags 2>/dev/null || echo unix-{version}` >>{build.path}/core/core_version.h"
-## windows-compatible version without git
-recipe.hooks.core.prebuild.1.pattern.windows=cmd.exe /c mkdir {build.path}\core & (echo #define ARDUINO_ESP8266_GIT_VER 0x00000000 & echo #define ARDUINO_ESP8266_GIT_DESC win-{version} ) > {build.path}\core\core_version.h
+## windows-compatible version - HELP NEEDED: this line below does not work because of unquotable spaces in {runtime.platform.path}="C:\Program Files\..." even when calling with 'cmd.exe /c ...'
+recipe.hooks.core.prebuild.1.pattern.windows="{runtime.platform.path}\tools\MakeCoreVer.bat" "{build.path}" "{runtime.platform.path}" "{version}"
 recipe.hooks.core.prebuild.2.pattern.windows=
 
 ## Compile c files

--- a/tools/MakeCoreVer.bat
+++ b/tools/MakeCoreVer.bat
@@ -1,0 +1,29 @@
+@echo off
+
+set buildpath=%1
+set platformpath=%2
+set version=%3
+
+REM test by hand, from .\tools
+REM set buildpath=.
+REM set platformpath=..
+REM set version=3.7.2-plus
+
+REM todo: check args
+
+if not exist "%buildpath%\core" mkdir "%buildpath%\core"
+
+git --version > nul
+if NOT ERRORLEVEL 1 goto :git
+
+echo *** git is not available
+( echo #define ARDUINO_ESP8266_GIT_VER 0x00000000 & echo #define ARDUINO_ESP8266_GIT_DESC win-%version% ) > "%buildpath%\core\core_version.h"
+goto :end
+
+:git
+REM echo without newline: echo | set /p="nonewline"
+
+( echo | set /p="#define ARDUINO_ESP8266_GIT_VER 0x" & git --git-dir "%platformpath%/.git" rev-parse --short=8 HEAD ) > "%buildpath%\core\core_version.h"
+( echo | set /p="#define ARDUINO_ESP8266_GIT_DESC " & git --git-dir "%platformpath%/.git" describe --tags ) >> "%buildpath%\core\core_version.h"
+
+:end


### PR DESCRIPTION
Help from a windows developer using git will be appreciated:

```
HELP NEEDED: this line below does not work because of unquotable spaces in 
{runtime.platform.path}="C:\Program Files\..." even when calling with 'cmd.exe /c ...'

recipe.hooks.core.prebuild.1.pattern.windows="{runtime.platform.path}\tools\MakeCoreVer.bat" "{build.path}" "{runtime.platform.path}" "{version}"
```