### PR TITLE
Raise an exception when assert fails

### DIFF
--- a/cores/esp8266/core_esp8266_main.cpp
+++ b/cores/esp8266/core_esp8266_main.cpp
@@ -33,6 +33,7 @@ extern "C" {
 #include "cont.h"
 }
 #include <core_version.h>
+#include "gdb_hooks.h"
 
 #define LOOP_TASK_PRIORITY 1
 #define LOOP_QUEUE_SIZE    1
@@ -136,12 +137,6 @@ static void do_global_ctors(void) {
     while (p != &__init_array_start)
         (*--p)();
 }
-
-extern "C" void __gdb_init() {}
-extern "C" void gdb_init(void) __attribute__ ((weak, alias("__gdb_init")));
-
-extern "C" void __gdb_do_break(){}
-extern "C" void gdb_do_break(void) __attribute__ ((weak, alias("__gdb_do_break")));
 
 void init_done() {
     system_set_os_print(1);

--- a/cores/esp8266/core_esp8266_postmortem.c
+++ b/cores/esp8266/core_esp8266_postmortem.c
@@ -197,6 +197,7 @@ void __assert_func(const char *file, int line, const char *func, const char *wha
     s_panic_line = line;
     s_panic_func = func;
     gdb_do_break();     /* if GDB is not present, this is a no-op */
+    raise_exception();
 }
 
 void __panic_func(const char* file, int line, const char* func) {

--- a/cores/esp8266/gdb_hooks.c
+++ b/cores/esp8266/gdb_hooks.c
@@ -1,0 +1,36 @@
+/*
+ gdb_hooks.c - Default (no-op) hooks for GDB Stub library
+ Copyright (c) 2018 Ivan Grokhotkov.  All right reserved.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "ets_sys.h"
+#include "gdb_hooks.h"
+
+
+/* gdb_init and gdb_do_break do not return anything, but since the return
+   value is in register, it doesn't hurt to return a bool, so that the
+   same stub can be used for gdb_present. */
+
+bool ICACHE_RAM_ATTR __gdb_no_op()
+{
+    return false;
+}
+
+extern void gdb_init(void) __attribute__ ((weak, alias("__gdb_no_op")));
+extern void gdb_do_break(void) __attribute__ ((weak, alias("__gdb_no_op")));
+extern bool gdb_present(void) __attribute__ ((weak, alias("__gdb_no_op")));
+

--- a/cores/esp8266/gdb_hooks.h
+++ b/cores/esp8266/gdb_hooks.h
@@ -1,0 +1,57 @@
+/*
+ gdb_hooks.h - Hooks for GDB Stub library
+ Copyright (c) 2018 Ivan Grokhotkov.  All right reserved.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialize GDB stub, if present
+ * 
+ * By default, this function is a no-op. When GDBStub library is linked,
+ * this function is overriden and does necessary initialization of that library.
+ * Called early at startup.
+ */
+void gdb_init(void);
+
+/**
+ * @brief Break into GDB, if present
+ * 
+ * By default, this function is a no-op. When GDBStub library is linked,
+ * this function is overriden and triggers entry into the debugger, which
+ * looks like a breakpoint hit.
+ */
+void gdb_do_break(void);
+
+/**
+ * @brief Check if GDB stub is present.
+ * 
+ * By default, this function returns false. When GDBStub library is linked,
+ * this function is overriden and returns true. Can be used to check whether
+ * GDB is used.
+ * 
+ * @return true if GDB stub is present
+ */
+bool gdb_present(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/libraries/GDBStub/src/GDBStub.h
+++ b/libraries/GDBStub/src/GDBStub.h
@@ -3,6 +3,4 @@
 
 // this header is intentionally left blank
 
-bool crash_for_gdb = 1;
-
 #endif //GDBSTUB_H

--- a/libraries/GDBStub/src/internal/gdbstub.c
+++ b/libraries/GDBStub/src/internal/gdbstub.c
@@ -792,5 +792,11 @@ void ATTR_GDBFN gdbstub_do_break_wrapper() {
 	gdbstub_do_break();
 }
 
-extern void gdb_do_break() __attribute__((weak, alias("gdbstub_do_break_wrapper")));
-extern void gdb_init() __attribute__((weak, alias("gdbstub_init")));
+bool ATTR_GDBINIT gdb_present()
+{
+	return true;
+}
+
+extern void gdb_do_break() __attribute__((alias("gdbstub_do_break_wrapper")));
+extern void gdb_init() __attribute__((alias("gdbstub_init")));
+


### PR DESCRIPTION
- Raise an exception when assert fails
- Move GDB stub hooks into a separate file, provide header for it
- Use syscall instruction raise user mode exception
- Remove unused code in postmortem.c

Fixes #4480 