### PR TITLE
macro attributes should be used with brackets

### DIFF
--- a/tools/sdk/include/eagle_soc.h
+++ b/tools/sdk/include/eagle_soc.h
@@ -95,8 +95,8 @@
 //}}
 
 //GPIO reg {{
-#define GPIO_REG_READ(reg)                         READ_PERI_REG(PERIPHS_GPIO_BASEADDR + reg)
-#define GPIO_REG_WRITE(reg, val)                 WRITE_PERI_REG(PERIPHS_GPIO_BASEADDR + reg, val)
+#define GPIO_REG_READ(reg)                         READ_PERI_REG(PERIPHS_GPIO_BASEADDR + (reg))
+#define GPIO_REG_WRITE(reg, val)                 WRITE_PERI_REG(PERIPHS_GPIO_BASEADDR + (reg), val)
 #define GPIO_OUT_ADDRESS                         0x00
 #define GPIO_OUT_W1TS_ADDRESS             0x04
 #define GPIO_OUT_W1TC_ADDRESS             0x08


### PR DESCRIPTION
related to the issue #2617.