### PR TITLE
add option to override fingerprint with *

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -66,7 +66,7 @@ public:
     bool verify(WiFiClient& client, const char* host) override
     {
         auto wcs = static_cast<WiFiClientSecure&>(client);
-        return wcs.verify(_fingerprint.c_str(), host);
+        return _fingerprint.equals("*") || wcs.verify(_fingerprint.c_str(), host);
     }
 
 protected:


### PR DESCRIPTION
For some projects which make requests from a remote server that requires https, putting a fingerprint in the code is not an option because it may change at any moment.

This gives the ability to make https requests using a "*" to intentionally override the fingerprint verification. Using the "*" rather than omitting it completely makes it apparent that it is intentionally being overridden. While this may be slightly less secure in some cases, depending on the user's application it may also add a lot of functionality.

For example, `http.begin("https://www.meethue.com/api/nupnp", "*");`