### PR TITLE
uart: fix wdt input overrun

### DIFF
--- a/cores/esp8266/HardwareSerial.h
+++ b/cores/esp8266/HardwareSerial.h
@@ -137,6 +137,11 @@ public:
     bool isRxEnabled(void);
     int  baudRate(void);
 
+    bool hasOverrun(void)
+    {
+        return uart_has_overrun(_uart);
+    }
+
 protected:
     int _uart_nr;
     uart_t* _uart = nullptr;

--- a/cores/esp8266/uart.h
+++ b/cores/esp8266/uart.h
@@ -112,6 +112,7 @@ extern "C" {
 
 struct uart_;
 typedef struct uart_ uart_t;
+extern uint8_t uart_overrun; // 1=>detected, can be set to 2 once action taken, or 0 to redetect
 
 uart_t* uart_init(int uart_nr, int baudrate, int config, int mode, int tx_pin, size_t rx_size);
 void uart_uninit(uart_t* uart);

--- a/cores/esp8266/uart.h
+++ b/cores/esp8266/uart.h
@@ -112,7 +112,6 @@ extern "C" {
 
 struct uart_;
 typedef struct uart_ uart_t;
-extern uint8_t uart_overrun; // 1=>detected, can be set to 2 once action taken, or 0 to redetect
 
 uart_t* uart_init(int uart_nr, int baudrate, int config, int mode, int tx_pin, size_t rx_size);
 void uart_uninit(uart_t* uart);
@@ -136,6 +135,8 @@ size_t uart_rx_available(uart_t* uart);
 size_t uart_tx_free(uart_t* uart);
 void uart_wait_tx_empty(uart_t* uart);
 void uart_flush(uart_t* uart);
+
+bool uart_has_overrun (uart_t* uart); // returns then clear overrun flag
 
 void uart_set_debug(int uart_nr);
 int uart_get_debug();


### PR DESCRIPTION
WDT is triggerred when uart is flooded but not read (quickly enough) by user.
Here's a fix with a message on debug console (generally same uart though).

MCVE:
```
#define PRINT_INTV_MS 5000

unsigned long next;

void setup() {
  Serial.setRxBufferSize(8);
  Serial.begin(115200);
  Serial.setDebugOutput(true);
  Serial.println("please type in chars");
  next = millis() + PRINT_INTV_MS;
}

void loop() {
  static int last = 0;
  int avail = Serial.available();
  if (last != avail)
  {
    last = avail;
    Serial.printf("available: %i\n", avail);
  }

  if (millis() > next)
  {
    Serial.print("reading serial: ");
    while (Serial.available())
      Serial.print((char)Serial.read());
    Serial.println();
    next += PRINT_INTV_MS;
  }
}
```

A choice has to be made when receive buffer is full:
discard oldest data, or newest data ?
Current master tries to discard newest data (with the wdt bug)
This PR has the two (fixed) ways, I personally prefer discarding the oldest
(with this scheme, I may not be the last leaving among you :)

newest discarded (input is '1234567890'):
```
00:42:35.122 -> SDK:2.2.1(cfd48f3)/Core:2.4.1-32-g546c8b7/lwIP:2.0.3(STABLE-2_0_3_RELEASE/glue:arduino-2.4.1)
00:42:35.122 -> please type in chars
00:42:38.464 -> available: 1
00:42:38.465 -> available: 4
00:42:38.465 -> available: 5
00:42:38.497 -> available: 6
00:42:38.497 -> available: 7
00:42:38.497 -> available: 8
00:42:38.497 -> available: 9
00:42:38.497 -> available: 10
00:42:38.497 -> available: 11
00:42:38.497 -> uart input full!
00:42:38.497 -> available: 7
00:42:40.139 -> reading serial: 1234567
00:42:40.139 -> available: 0
```

oldest discarded (input is '1234567890'):
```
00:49:12.791 -> SDK:2.2.1(cfd48f3)/Core:2.4.1-32-g546c8b7/lwIP:2.0.3(STABLE-2_0_3_RELEASE/glue:arduino-2.4.1)
00:49:12.794 -> please type in chars
00:49:15.531 -> available: 1
00:49:15.532 -> available: 4
00:49:15.532 -> available: 5
00:49:15.532 -> available: 6
00:49:15.533 -> available: 7
00:49:15.533 -> available: 8
00:49:15.534 -> available: 9
00:49:15.534 -> available: 10
00:49:15.534 -> available: 11
00:49:15.535 -> uart input full!
00:49:15.535 -> available: 7
00:49:17.796 -> reading serial: 567890
00:49:17.796 -> 
00:49:17.796 -> available: 0
00:49:22.770 -> reading serial: 
00:49:27.779 -> reading serial: 
00:49:32.791 -> reading serial: 
```
