### PR TITLE
Fix WebServerSecure streamFile()

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServerSecure.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServerSecure.h
@@ -42,6 +42,12 @@ public:
   void handleClient() override;
   void close() override;
 
+  template<typename T>
+  size_t streamFile(T &file, const String& contentType) {
+    _streamFileCore(file.size(), file.name(), contentType);
+    return _currentClientSecure.write(file);
+  }
+
 private:
   size_t _currentClientWrite (const char *bytes, size_t len) override { return _currentClientSecure.write((const uint8_t *)bytes, len); }
   size_t _currentClientWrite_P (PGM_P bytes, size_t len) override { return _currentClientSecure.write_P(bytes, len); }

--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
@@ -564,6 +564,29 @@ size_t WiFiClientSecure::write_P(PGM_P buf, size_t size)
     return write(copy, size);
 }
 
+// The axTLS bare libs don't understand anything about Arduino Streams,
+// so we have to manually read and send individual chunks.
+size_t WiFiClientSecure::write(Stream& stream)
+{
+    size_t totalSent = 0;
+    size_t countRead;
+    size_t countSent;
+    if (!_ssl)
+    {
+        return 0;
+    }
+    do {
+        uint8_t temp[128]; // Arbitrary temporary chunk size
+        countSent = 0;
+        countRead = stream.readBytes(temp, sizeof(temp));
+        if (countRead) {
+            countSent = write(temp, countRead);
+            totalSent += countSent;
+        }
+    } while ( (countSent == countRead) && (countSent > 0) );
+    return totalSent;
+}
+
 int WiFiClientSecure::read(uint8_t *buf, size_t size)
 {
     if (!_ssl) {

--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.cpp
@@ -576,13 +576,14 @@ size_t WiFiClientSecure::write(Stream& stream)
         return 0;
     }
     do {
-        uint8_t temp[128]; // Arbitrary temporary chunk size
+        uint8_t temp[256]; // Temporary chunk size same as ClientContext
         countSent = 0;
         countRead = stream.readBytes(temp, sizeof(temp));
         if (countRead) {
             countSent = write(temp, countRead);
             totalSent += countSent;
         }
+        yield(); // Feed the WDT
     } while ( (countSent == countRead) && (countSent > 0) );
     return totalSent;
 }

--- a/libraries/ESP8266WiFi/src/WiFiClientSecure.h
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecure.h
@@ -43,6 +43,7 @@ public:
   uint8_t connected() override;
   size_t write(const uint8_t *buf, size_t size) override;
   size_t write_P(PGM_P buf, size_t size) override;
+  size_t write(Stream& stream); // Note this is not virtual
   int read(uint8_t *buf, size_t size) override;
   int available() override;
   int read() override;


### PR DESCRIPTION
ESP8266WebServerSecure's streamFile was using the base class' method
which did not use SSL encrypt before transmitting, leading to failure.

Add a new template method and required support for
WiFiClientSecure::write(Stream&) (using a local temp buffer since the
SSL libs do not grok Arduino Streams at all).

Fixes #4544