### PR TITLE
device test for #4516 (WiFiClient leaking)

### DIFF
--- a/tests/device/test_ClientContext/test_ClientContext.ino
+++ b/tests/device/test_ClientContext/test_ClientContext.ino
@@ -2,7 +2,6 @@
 #include <BSTest.h>
 #include <test_config.h>
 #include <ESP8266WiFi.h>
-#include <Ticker.h>
 
 extern "C" {
 #include "user_interface.h"
@@ -36,24 +35,25 @@ void setup()
 
 TEST_CASE("WiFi release ClientContext", "[clientcontext]")
 {
-    #define MAXLOOPS       50
+    #define MAXLOOPS     50
     #define SUCCESS_GOAL 10
+    #define srv          SERVER_IP
+    #define srv          WiFi.gatewayIP()
 
-    // will search for a tcp server these gateway's ports
-    int ports [] = { 21, 23, 80, 443, 22,
-                     0 };
     WiFiClient client;
     
-    Serial.print(WiFi.gatewayIP());
+    Serial.print(srv);
 
     // look for reachable port on gateway
     int port;
-    for (int i = 0; (port = ports[i]); i++)
-        if (client.connect(WiFi.gatewayIP(), ports[i]))
+    for (port = 8266; port <= 8285; port++)
+        if (client.connect(srv, port))
         {
             client.stop();
             break;
         }
+    if (port > 8285)
+        port = 0;
 
     Serial.printf(":%d\r\n", port);
     

--- a/tests/device/test_ClientContext/test_ClientContext.ino
+++ b/tests/device/test_ClientContext/test_ClientContext.ino
@@ -1,0 +1,91 @@
+#include <Arduino.h>
+#include <BSTest.h>
+#include <test_config.h>
+#include <ESP8266WiFi.h>
+#include <Ticker.h>
+
+extern "C" {
+#include "user_interface.h"
+}
+
+BS_ENV_DECLARE();
+
+// no need for #include
+struct tcp_pcb;
+extern struct tcp_pcb* tcp_tw_pcbs;
+extern "C" void tcp_abort (struct tcp_pcb* pcb);
+
+void tcpCleanup (void) {
+  while (tcp_tw_pcbs)
+    tcp_abort(tcp_tw_pcbs);
+}
+
+void setup()
+{
+    Serial.begin(115200);
+    Serial.setDebugOutput(true);
+    WiFi.persistent(false);
+    WiFi.mode(WIFI_STA);
+    WiFi.begin(STA_SSID, STA_PASS);
+    while (WiFi.status() != WL_CONNECTED) {
+        delay(500);
+    }
+    BS_RUN(Serial);
+}
+
+TEST_CASE("WiFi release ClientContext", "[clientcontext]")
+{
+    #define LOOPS 20
+
+    // will search for a tcp server these gateway's ports
+    int ports [] = { 21, 23, 80, 443, 22,
+                     0 };
+    WiFiClient client;
+    
+    Serial.print(WiFi.gatewayIP());
+
+    // look for reachable port on gateway
+    int port;
+    for (int i = 0; (port = ports[i]); i++)
+    	if (client.connect(WiFi.gatewayIP(), ports[i])) {
+    	    client.stop();
+    	    break;
+    	}
+
+    Serial.printf(":%d\r\n", port);
+    
+    int loops = 0;
+    int heapLost = 123456;
+
+    if (port) {
+    
+        tcpCleanup();
+        int heapStart = ESP.getFreeHeap();
+        int minHeap = heapStart / 2;
+        int heap = heapStart;
+	Serial.printf("heap: %d\r\n", heap);
+
+        while (++loops < LOOPS && (int)ESP.getFreeHeap() > minHeap)
+            if (client.connect(WiFi.gatewayIP(), port)) {
+                client.stop();
+                tcpCleanup();
+                int newHeap = (int)ESP.getFreeHeap();
+		Serial.printf("%03d %5d %d\r\n", loops, newHeap, newHeap - heap);
+		heap = newHeap;
+            }
+
+        heapLost = heapStart - ESP.getFreeHeap();
+
+        Serial.printf("min heap: %d\r\nheap: %d\r\nloops: %d\r\nheapLost: %d\r\n",
+            minHeap,
+            ESP.getFreeHeap(),
+            loops,
+            (int)heapLost);
+    }
+
+    REQUIRE(loops == LOOPS && heapLost <= 0);
+}
+
+void loop()
+{
+}

--- a/tests/device/test_ClientContext/test_ClientContext.ino
+++ b/tests/device/test_ClientContext/test_ClientContext.ino
@@ -38,7 +38,6 @@ TEST_CASE("WiFi release ClientContext", "[clientcontext]")
     #define MAXLOOPS     50
     #define SUCCESS_GOAL 10
     #define srv          SERVER_IP
-    #define srv          WiFi.gatewayIP()
 
     WiFiClient client;
     

--- a/tests/device/test_ClientContext/test_ClientContext.ino
+++ b/tests/device/test_ClientContext/test_ClientContext.ino
@@ -68,7 +68,7 @@ TEST_CASE("WiFi release ClientContext", "[clientcontext]")
         Serial.printf("heap: %d\r\n", heap);
 
         while (success < SUCCESS_GOAL && ++loops <= MAXLOOPS && (int)ESP.getFreeHeap() > minHeap)
-            if (client.connect(WiFi.gatewayIP(), port))
+            if (client.connect(srv, port))
             {
                 client.stop();
                 tcpCleanup();

--- a/tests/device/test_ClientContext/test_ClientContext.ino
+++ b/tests/device/test_ClientContext/test_ClientContext.ino
@@ -58,7 +58,6 @@ TEST_CASE("WiFi release ClientContext", "[clientcontext]")
     Serial.printf(":%d\r\n", port);
     
     int loops = 0;
-    int heapLost = 123456;
     int success = 0;
 
     if (port)
@@ -81,10 +80,9 @@ TEST_CASE("WiFi release ClientContext", "[clientcontext]")
                 heap = newHeap;
             }
 
-        Serial.printf("heap: %d\r\nheapLost: %d\r\n"
+        Serial.printf("heap: %d\r\n"
                       "loops: %d\r\nstable-loops: %d\r\n",
             ESP.getFreeHeap(),
-            heapLost,
             loops,
             success);
     }

--- a/tests/device/test_ClientContext/test_ClientContext.py
+++ b/tests/device/test_ClientContext/test_ClientContext.py
@@ -1,0 +1,60 @@
+from mock_decorators import setup, teardown
+from flask import Flask, request
+from threading import Thread
+import socket
+import select
+import sys
+import os
+
+@setup('WiFi release ClientContext')
+def setup_tcpsrv(e):
+
+    global thread
+
+    app = Flask(__name__)
+
+    def run():
+
+        global running
+
+        running = False
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        for port in range(8266, 8285 + 1):
+            try:
+                print >>sys.stderr, 'trying port', port
+                server_address = ("0.0.0.0", port)
+                sock.bind(server_address)
+                sock.listen(1)
+                running = True
+                break
+            except Exception:
+                print >>sys.stderr, 'busy'
+        if not running:
+            return
+        print >>sys.stderr, 'starting up on %s port %s' % server_address
+        print >>sys.stderr, 'waiting for connections'
+        while running:
+            print >>sys.stderr, 'loop'
+            readable, writable, errored = select.select([sock], [], [], 1.0)
+            if readable:
+                connection, client_address = sock.accept()
+                try:
+                    print >>sys.stderr, 'client connected:', client_address
+                finally:
+                    print >>sys.stderr, 'close'
+                    connection.shutdown(socket.SHUT_RDWR)
+                    connection.close()
+
+    thread = Thread(target=run)
+    thread.start()
+
+@teardown('WiFi release ClientContext')
+def teardown_tcpsrv(e):
+    
+    global thread
+    global running
+    
+    print >>sys.stderr, 'closing'
+    running = False
+    thread.join()
+    return 0


### PR DESCRIPTION
This test needs any TCP server and tries to find one on the gateway.
20 tcp connections are made, heap is measured.
Might be improvable (python tcp server, better measurement?)

Problem is heap does not depend on the sketch only, even if one tries to keep it straight.
See the success run, measurement must not stop at the bad moment.
Also we cannot presume how much is lost on each loop (64 here).

The same test is good too with 200 connections instead of 20, se we could make averages that would lower glitches.

Suggestions are welcome.

failed run (without fix):
```
10.43.1.254:80
heap: 44824
001 44760 -64
002 44696 -64
003 44632 -64
004 44568 -64
005 44504 -64
006 44440 -64
007 44376 -64
008 44312 -64
009 44248 -64
010 44184 -64
011 44120 -64
012 44056 -64
013 43992 -64
014 43928 -64
015 43864 -64
016 43800 -64
017 43736 -64
018 43672 -64
019 43608 -64
min heap: 22412
heap: 43608
loops: 20
heapLost: 1216
```

success run with fix (#4516):
```
10.43.1.254:80
heap: 44824
001 44824 0
002 44824 0
003 44824 0
004 44824 0
005 44824 0
006 44824 0
007 44824 0
008 44824 0
009 44824 0
010 44824 0
011 44824 0
012 44696 -128
013 44824 128
014 44824 0
015 44824 0
016 44696 -128
017 44824 128
018 44824 0
019 44824 0
min heap: 22412
heap: 44824
loops: 20
heapLost: 0
```
