### PR TITLE
Resolve updater size check bug

### DIFF
--- a/cores/esp8266/Updater.cpp
+++ b/cores/esp8266/Updater.cpp
@@ -86,7 +86,7 @@ bool UpdaterClass::begin(size_t size, int command) {
     //size of the update rounded to a sector
     uint32_t roundedSize = (size + FLASH_SECTOR_SIZE - 1) & (~(FLASH_SECTOR_SIZE - 1));
     //address where we will start writing the update
-    updateStartAddress = updateEndAddress - roundedSize;
+    updateStartAddress = (updateEndAddress > roundedSize)? (updateEndAddress - roundedSize) : 0;
 
 #ifdef DEBUG_UPDATER
         DEBUG_UPDATER.printf("[begin] roundedSize:       0x%08X (%d)\n", roundedSize, roundedSize);


### PR DESCRIPTION
I accidentially tried to OTA a 2MB+ file, and found the Updater.begin() actually did not report any error.

Turned out there is an arithmetic underflow on an unsigned type.