### PR TITLE
defined SDA and SCL pins for Olimex MOD-WIFI-ESP8266(-DEV)

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1795,6 +1795,7 @@ nodemcuv2.menu.UploadSpeed.921600.upload.speed=921600
 ##############################################################
 modwifi.name=Olimex MOD-WIFI-ESP8266(-DEV)
 modwifi.build.board=MOD_WIFI_ESP8266
+modwifi.build.variant=modwifi
 modwifi.upload.tool=esptool
 modwifi.upload.maximum_data_size=81920
 modwifi.upload.wait_for_upload_port=true
@@ -1803,7 +1804,6 @@ modwifi.serial.disableDTR=true
 modwifi.serial.disableRTS=true
 modwifi.build.mcu=esp8266
 modwifi.build.core=esp8266
-modwifi.build.variant=generic
 modwifi.build.spiffs_pagesize=256
 modwifi.build.debug_port=
 modwifi.build.debug_level=

--- a/tools/boards.txt.py
+++ b/tools/boards.txt.py
@@ -443,6 +443,7 @@ boards = collections.OrderedDict([
         'name': 'Olimex MOD-WIFI-ESP8266(-DEV)',
         'opts': {
             '.build.board': 'MOD_WIFI_ESP8266',
+            '.build.variant': 'modwifi',
             },
         'macro': [
             'resetmethod_ck',

--- a/variants/modwifi/pins_arduino.h
+++ b/variants/modwifi/pins_arduino.h
@@ -1,0 +1,41 @@
+/*
+  pins_arduino.h - Pin definition functions for Arduino
+  Part of Arduino - http://www.arduino.cc/
+
+  Copyright (c) 2007 David A. Mellis
+  Modified for ESP8266 platform by Ivan Grokhotkov, 2014-2015.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General
+  Public License along with this library; if not, write to the
+  Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+  Boston, MA  02111-1307  USA
+
+  $Id: wiring.h 249 2007-02-03 16:52:51Z mellis $
+*/
+
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#define PIN_WIRE_SDA (2)
+#define PIN_WIRE_SCL (4)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
+#ifndef LED_BUILTIN
+#define LED_BUILTIN 1
+#endif
+
+#include "../generic/common.h"
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
Changed from generic I2C SDA and SCL pin mapping to specific mapping for board modwifi, Olimex MOD-WIFI-ESP8266(-DEV)