### PR TITLE
restore HardwareSerial::write(str)

### DIFF
--- a/cores/esp8266/HardwareSerial.h
+++ b/cores/esp8266/HardwareSerial.h
@@ -157,6 +157,10 @@ public:
     {
         return uart_write(_uart, (const char*)buffer, size);
     }
+    size_t write(const char *buffer)
+    {
+        return buffer? uart_write(_uart, buffer, strlen(size)): 0;
+    }
     operator bool() const
     {
         return _uart != 0;


### PR DESCRIPTION
[reference](https://github.com/esp8266/Arduino/commit/f8f205d54af42f34502ad011fd015e104b63d911#r28247210)