### PR TITLE
WebServer query arguments not containing an equals sign are now accepted…

### DIFF
--- a/libraries/ESP8266WebServer/src/Parsing.cpp
+++ b/libraries/ESP8266WebServer/src/Parsing.cpp
@@ -311,19 +311,13 @@ void ESP8266WebServer::_parseArguments(String data) {
     DEBUG_OUTPUT.print(" &@ ");
     DEBUG_OUTPUT.println(next_arg_index);
 #endif
-    if ((equal_sign_index == -1) || ((equal_sign_index > next_arg_index) && (next_arg_index != -1))) {
-#ifdef DEBUG_ESP_HTTP_SERVER
-      DEBUG_OUTPUT.print("arg missing value: ");
-      DEBUG_OUTPUT.println(iarg);
-#endif
-      if (next_arg_index == -1)
-        break;
-      pos = next_arg_index + 1;
-      continue;
-    }
     RequestArgument& arg = _currentArgs[iarg];
-    arg.key = urlDecode(data.substring(pos, equal_sign_index));
-    arg.value = urlDecode(data.substring(equal_sign_index + 1, next_arg_index));
+    if ((equal_sign_index == -1) || ((equal_sign_index > next_arg_index) && (next_arg_index != -1))) {
+      arg.key = urlDecode(data.substring(pos, next_arg_index));
+    } else {
+      arg.key = urlDecode(data.substring(pos, equal_sign_index));
+      arg.value = urlDecode(data.substring(equal_sign_index + 1, next_arg_index));
+    }
 #ifdef DEBUG_ESP_HTTP_SERVER
     DEBUG_OUTPUT.print("arg ");
     DEBUG_OUTPUT.print(iarg);


### PR DESCRIPTION
as a key with an empty value.  Previous behavior was to completely ignore the argument, yet still include it in the argument count.

(The use of "key=value" arguments is a convention, not an actual requirement in URLs.)

Fixes bug #2611.