### PR TITLE
Scheduled Interrupt

### DIFF
--- a/cores/esp8266/FunctionalInterrupt.cpp
+++ b/cores/esp8266/FunctionalInterrupt.cpp
@@ -1,24 +1,66 @@
 #include <FunctionalInterrupt.h>
-
+#include <schedule.h>
+#include "Arduino.h"
 
 // Duplicate typedefs from core_esp8266_wiring_digital_c
 typedef void (*voidFuncPtr)(void);
+typedef void (*voidFuncPtrArg)(void*);
 
 // Helper functions for Functional interrupt routines
 extern "C" void ICACHE_RAM_ATTR __attachInterruptArg(uint8_t pin, voidFuncPtr userFunc, void*fp , int mode);
 
-// Structure for communication
-struct ArgStructure {
-	std::function<void(void)> reqFunction;
-};
 
 void interruptFunctional(void* arg)
 {
-	((ArgStructure*)arg)->reqFunction();
+    ArgStructure* localArg = (ArgStructure*)arg;
+	if (localArg->functionInfo->reqScheduledFunction)
+	{
+      schedule_function(std::bind(localArg->functionInfo->reqScheduledFunction,InterruptInfo(*(localArg->interruptInfo))));
+	}
+	if (localArg->functionInfo->reqFunction)
+	{
+	  localArg->functionInfo->reqFunction();
+	}
+}
+
+extern "C"
+{
+   void cleanupFunctional(void* arg)
+   {
+	 ArgStructure* localArg = (ArgStructure*)arg;
+	 delete (FunctionInfo*)localArg->functionInfo;
+     delete (InterruptInfo*)localArg->interruptInfo;
+	 delete localArg;
+   }
 }
 
 void attachInterrupt(uint8_t pin, std::function<void(void)> intRoutine, int mode)
 {
 	// use the local interrupt routine which takes the ArgStructure as argument
-	__attachInterruptArg (pin, (voidFuncPtr)interruptFunctional, new ArgStructure{intRoutine}, mode);
+
+	InterruptInfo* ii = nullptr;
+
+	FunctionInfo* fi = new FunctionInfo;
+	fi->reqFunction = intRoutine;
+
+	ArgStructure* as = new ArgStructure;
+	as->interruptInfo = ii;
+	as->functionInfo = fi;
+
+	__attachInterruptArg (pin, (voidFuncPtr)interruptFunctional, as, mode);
+}
+
+void attachScheduledInterrupt(uint8_t pin, std::function<void(InterruptInfo)> scheduledIntRoutine, int mode)
+{
+
+	InterruptInfo* ii = new InterruptInfo;
+
+	FunctionInfo* fi = new FunctionInfo;
+	fi->reqScheduledFunction = scheduledIntRoutine;
+
+	ArgStructure* as = new ArgStructure;
+	as->interruptInfo = ii;
+	as->functionInfo = fi;
+
+	__attachInterruptArg (pin, (voidFuncPtr)interruptFunctional, as, mode);
 }

--- a/cores/esp8266/FunctionalInterrupt.h
+++ b/cores/esp8266/FunctionalInterrupt.h
@@ -10,6 +10,26 @@ extern "C" {
 #include "ets_sys.h"
 }
 
+// Structures for communication
+
+struct InterruptInfo {
+	uint8_t pin = 0;
+	uint8_t value = 0;
+	uint32_t micro = 0;
+};
+
+struct FunctionInfo {
+    std::function<void(void)> reqFunction = nullptr;
+	std::function<void(InterruptInfo)> reqScheduledFunction = nullptr;
+};
+
+struct ArgStructure {
+	InterruptInfo* interruptInfo = nullptr;
+	FunctionInfo* functionInfo = nullptr;
+};
+
 void attachInterrupt(uint8_t pin, std::function<void(void)> intRoutine, int mode);
+void attachScheduledInterrupt(uint8_t pin, std::function<void(InterruptInfo)> scheduledIntRoutine, int mode);
+
 
 #endif //INTERRUPTS_H


### PR DESCRIPTION
Hi,

This PR adds the possibility to schedule (= execute after loop) the ISR routine.
In this way 
- The need for setting a switch and checking in loop is prevented.
- No limitation of execution of flash/long running functions as the actual execution is outside the ISR.

This builds on top of the functional interrupt functionality (https://github.com/esp8266/Arduino/pull/2745)

In this implementation I took std::function<void(InterruptInfo)>
InterruptInfo containing pin, pinstatus and micros() from time of interrupt.

@devyte : This also solves the memory leak you mentioned for FunctionalInterrupt

Comments are welcome.
