### PR TITLE
Allow other ESP debug port class types

### DIFF
--- a/cores/esp8266/HardwareSerial.cpp
+++ b/cores/esp8266/HardwareSerial.cpp
@@ -40,7 +40,7 @@ void HardwareSerial::begin(unsigned long baud, SerialConfig config, SerialMode m
     end();
     _uart = uart_init(_uart_nr, baud, (int) config, (int) mode, tx_pin, _rx_size);
 #if defined(DEBUG_ESP_PORT) && !defined(NDEBUG)
-    if (this == &DEBUG_ESP_PORT)
+    if (static_cast<void*>(this) == static_cast<void*>(&DEBUG_ESP_PORT))
     {
         setDebugOutput(true);
         println();


### PR DESCRIPTION
My use case is that I have implemented an alternative `DEBUG_ESP_PORT` object inheriting from the `Print` class, so that I can embed the debug output in our own framing method by overriding the lowest-level `write()` functions. The pointer comparison added in #4467 broke the ability to provide a different object type. Casting to void pointers before the comparison restores that ability.

My use case basically looks like:
``` c++
/** This class has an interface like Arduino's HardwareSerial
 *  Its intent is to wrap plain-ascii debug messages in framed packets appropriate for our application.
 *
 *  This also works well with the ESP8266 Arduino debug output methodology that depends on a
 *  command-line definition of which HardwareSerial instance its source libraries should print to.
 *  By building with "-DDEBUG_ESP_PORT=Debug" (see public global instance below), the debug output of the source
 *  libraries can be cleanly wrapped as we desire in our application.
 */
class SerialDebugOut: public Print {
    // My private members for our framing format
public:
    SerialDebugOut();
    ~SerialDebugOut();
    // Implement a look-alike of HardwareSerial's method
    void begin(unsigned long baud);
    // Implement a look-alike of HardwareSerial's method
    void setDebugOutput(bool en);
    // Implement the virtual method from the Print interface for single-character writes
    size_t write( uint8_t byte );
    // Implement the virtual method from the Print interface for character-buffer writes
    size_t write(const uint8_t *buffer, size_t size);
};
// A single global definition must be provided by the user application
extern SerialDebugOut Debug;
```

I'll admit it's not as ideal as making the `HardwareSerial` class more inheritable, but it does function well.