### PR TITLE
Mention ESP.deepSleepMax() in the list of ESP-specific functions

### DIFF
--- a/doc/libraries.rst
+++ b/doc/libraries.rst
@@ -71,7 +71,7 @@ ESP-specific APIs
 
 Some ESP-specific APIs related to deep sleep, RTC and flash memories are available in the ``ESP`` object.
 
-``ESP.deepSleep(microseconds, mode)`` will put the chip into deep sleep. ``mode`` is one of ``WAKE_RF_DEFAULT``, ``WAKE_RFCAL``, ``WAKE_NO_RFCAL``, ``WAKE_RF_DISABLED``. (GPIO16 needs to be tied to RST to wake from deepSleep.)
+``ESP.deepSleep(microseconds, mode)`` will put the chip into deep sleep. ``mode`` is one of ``WAKE_RF_DEFAULT``, ``WAKE_RFCAL``, ``WAKE_NO_RFCAL``, ``WAKE_RF_DISABLED``. (GPIO16 needs to be tied to RST to wake from deepSleep.) The chip can sleep for at most ``ESP.deepSleepMax()`` microseconds.
 
 ``ESP.rtcUserMemoryWrite(offset, &data, sizeof(data))`` and ``ESP.rtcUserMemoryRead(offset, &data, sizeof(data))`` allow data to be stored in and retrieved from the RTC user memory of the chip respectively. Total size of RTC user memory is 512 bytes, so ``offset + sizeof(data)`` shouldn't exceed 512. Data should be 4-byte aligned. The stored data can be retained between deep sleep cycles. However, the data might be lost after power cycling the chip.
 


### PR DESCRIPTION
Lack of documentation became obvious when I worked on https://thingpulse.com/2018/04/10/max-deep-sleep-for-esp8266/