### PR TITLE
Fix a very small typo in http client tests

### DIFF
--- a/tests/device/test_http_client/test_http_client.ino
+++ b/tests/device/test_http_client/test_http_client.ino
@@ -75,7 +75,7 @@ TEST_CASE("HTTPS GET request", "[HTTPClient]")
         REQUIRE(payload == "hello!!!");
     }
     {
-        // request which returns 8000 bytes
+        // request which returns 4000 bytes
         HTTPClient http;
         http.begin(getenv("SERVER_IP"), 8088, "/data?size=4000", fp);
         auto httpCode = http.GET();


### PR DESCRIPTION
The comment indicates that 8K bytes are being requested while the code was asking for 4K, I changed the comment to match the code