### PR TITLE
Minimizing code redundancy

### DIFF
--- a/cores/esp8266/WString.cpp
+++ b/cores/esp8266/WString.cpp
@@ -113,10 +113,7 @@ String::String(double value, unsigned char decimalPlaces) {
 }
 
 String::~String() {
-    if(buffer) {
-        free(buffer);
-    }
-    init();
+    invalidate();
 }
 
 // /*********************************************/


### PR DESCRIPTION
String's destructor does the same as the 'invalidate' method.