### PR TITLE
Add build_even/odd types to split Arduino tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ cache:
 matrix:
   include:
     - env:
-      - BUILD_TYPE=build
+      - BUILD_TYPE=build_even
+    - env:
+      - BUILD_TYPE=build_odd
     - env:
       - BUILD_TYPE=platformio
     - env:

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -39,12 +39,19 @@ function build_sketches()
     local srcpath=$2
     local build_arg=$3
     local build_dir=build.tmp
+    local build_mod=$4
+    local build_rem=$5
     mkdir -p $build_dir
     local build_cmd="python tools/build.py -b generic -v -w all -s 4M1M -v -k -p $PWD/$build_dir $build_arg "
-    local sketches=$(find $srcpath -name *.ino)
+    local sketches=$(find $srcpath -name *.ino | sort)
     print_size_info >size.log
     export ARDUINO_IDE_PATH=$arduino
+    local testcnt=0
     for sketch in $sketches; do
+        testcnt=$(( ($testcnt + 1) % $build_mod ))
+        if [ $testcnt -ne $build_rem ]; then
+            continue  # Not ours to do
+        fi
         rm -rf $build_dir/*
         local sketchdir=$(dirname $sketch)
         local sketchdirname=$(basename $sketchdir)
@@ -202,9 +209,12 @@ function install_arduino()
 
 function build_sketches_with_arduino()
 {
+    local build_mod=$1
+    local build_rem=$2
+
     # Compile sketches
     echo -e "travis_fold:start:sketch_test"
-    build_sketches $HOME/arduino_ide $TRAVIS_BUILD_DIR/libraries "-l $HOME/Arduino/libraries"
+    build_sketches $HOME/arduino_ide $TRAVIS_BUILD_DIR/libraries "-l $HOME/Arduino/libraries" $1 $2
     echo -e "travis_fold:end:sketch_test"
 
     # Generate size report
@@ -239,7 +249,13 @@ fi
 
 if [ "$BUILD_TYPE" = "build" ]; then
     install_arduino
-    build_sketches_with_arduino
+    build_sketches_with_arduino 1 0
+elif [ "$BUILD_TYPE" = "build_even" ]; then
+    install_arduino
+    build_sketches_with_arduino 2 0
+elif [ "$BUILD_TYPE" = "build_odd" ]; then
+    install_arduino
+    build_sketches_with_arduino 2 1
 elif [ "$BUILD_TYPE" = "platformio" ]; then
     # PlatformIO
     install_platformio


### PR DESCRIPTION
Arduino builds are now taking 49 minutes or more, and failing due to
Travis timeouts.

Split the Arduino build task into even and odd halves, where each job
will build every other test.  This will reduce any test's runtime
by 50% and speed up checks to avoid the timeout.