### PR TITLE
Add UART interrupt dispatcher

### DIFF
--- a/cores/esp8266/HardwareSerial.h
+++ b/cores/esp8266/HardwareSerial.h
@@ -184,6 +184,16 @@ public:
         return uart_has_overrun(_uart);
     }
 
+    void attachIsr(void (*isr)(void*), void *arg)
+    {
+	uart_isr_attach(_uart, isr, arg);
+    }
+
+    void detachIsr()
+    {
+	uart_isr_detach(_uart);
+    }
+
 protected:
     int _uart_nr;
     uart_t* _uart = nullptr;

--- a/cores/esp8266/uart.h
+++ b/cores/esp8266/uart.h
@@ -125,6 +125,9 @@ bool uart_rx_enabled(uart_t* uart);
 void uart_set_baudrate(uart_t* uart, int baud_rate);
 int uart_get_baudrate(uart_t* uart);
 
+void uart_isr_attach(uart_t* uart, void (*isr)(void*), void *arg);
+void uart_isr_detach(uart_t* uart);
+
 size_t uart_resize_rx_buffer(uart_t* uart, size_t new_size);
 
 size_t uart_write_char(uart_t* uart, char c);


### PR DESCRIPTION
ESP8266 UART ports share a single interrupt service routine (ISR).
This code adds an interrupt dispatcher that allows to define a
different ISR for each UART port.

Why?

NeoPixelBus can use an ISR to send data though Serial1 asynchronously. But it only works when Serial0 is configured as TX_ONLY. Otherwise NeoPixelBus and Serial-RX ISRs conflicts and the ESP8266 reboots. This commit allows both ISRs to coexist.