### PR TITLE
Report connected when any bytes are available

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
@@ -228,10 +228,8 @@ bool WiFiClientSecure::_clientConnected() {
 }
 
 uint8_t WiFiClientSecure::connected() {
-  if (_recvapp_len) {
-    return true;
-  }
-  if (_client && _client->state() == ESTABLISHED && _handshake_done) {
+  if (WiFiClient::connected() || available() ||
+      (_clientConnected() && _handshake_done)) {
     return true;
   }
   return false;


### PR DESCRIPTION
The SSL pipeline is multi-stage, and the TCP connection can go down
even though there is still data waiting to be decrypted or in the
decryption buffer.

Explicitly check that there if there can be any data made available
to the app, and if so report that we are still connected().  When
there is no data and there is no TCP connection, report disconnected.

Fixes #4738