### PR TITLE
Return data in internal SSL buffers after close

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
@@ -228,8 +228,7 @@ bool WiFiClientSecure::_clientConnected() {
 }
 
 uint8_t WiFiClientSecure::connected() {
-  if (WiFiClient::connected() || available() ||
-      (_clientConnected() && _handshake_done)) {
+  if (available() || (_clientConnected() && _handshake_done)) {
     return true;
   }
   return false;
@@ -398,7 +397,7 @@ int WiFiClientSecure::_run_until(unsigned target, bool blocking) {
     }
 
     if (!(_client->state() == ESTABLISHED) && !WiFiClient::available()) {
-      return -1;
+      return (state & target) ? 0 : -1;
     }
 
     /*


### PR DESCRIPTION
When the TCP socket is closed there may be some data left in the
BearSSL internal buffers which can be read by the application.

The BearSSL pump, however, would always return no data available
in the case the socket was disconnected before checking if the
SSL was in a state where the app could possibly read.

Fix by returning if the state is available, even if the connection
is gone.  Eventually no more data will become available to read
and the original -1 will be returned.