### PR TITLE
A0 pin number can be changed in the variants

### DIFF
--- a/variants/generic/common.h
+++ b/variants/generic/common.h
@@ -47,7 +47,9 @@ static const uint8_t MOSI  = PIN_SPI_MOSI;
 static const uint8_t MISO  = PIN_SPI_MISO;
 static const uint8_t SCK   = PIN_SPI_SCK;
 
+#ifndef PIN_A0
 #define PIN_A0 (17)
+#endif /* PIN_A0 */
 
 static const uint8_t A0 = PIN_A0;
 


### PR DESCRIPTION
The current version of `../generic/common.h` does not allow to specify a different pin number A0 in the boards variants. This change will not affect the existing boards, but will allow to change A0 without duplicating the `../generic/common.h` code.
It is needed here https://github.com/esp8266/Arduino/pull/3916 
and may help here https://github.com/esp8266/Arduino/blob/master/variants/wifio/pins_arduino.h