### PR TITLE
BearSSL: WiFiClientSecure insecure by default + setFingerprint(const char*) and example update

### DIFF
--- a/cores/esp8266/FunctionalInterrupt.cpp
+++ b/cores/esp8266/FunctionalInterrupt.cpp
@@ -1,24 +1,70 @@
 #include <FunctionalInterrupt.h>
-
+#include <Schedule.h>
+#include "Arduino.h"
+#include <ScheduledFunctions.h>
 
 // Duplicate typedefs from core_esp8266_wiring_digital_c
 typedef void (*voidFuncPtr)(void);
+typedef void (*voidFuncPtrArg)(void*);
 
 // Helper functions for Functional interrupt routines
 extern "C" void ICACHE_RAM_ATTR __attachInterruptArg(uint8_t pin, voidFuncPtr userFunc, void*fp , int mode);
 
-// Structure for communication
-struct ArgStructure {
-	std::function<void(void)> reqFunction;
-};
 
 void interruptFunctional(void* arg)
 {
-	((ArgStructure*)arg)->reqFunction();
+    ArgStructure* localArg = (ArgStructure*)arg;
+	if (localArg->functionInfo->reqScheduledFunction)
+	{
+      scheduledInterrupts->scheduleFunctionReg(std::bind(localArg->functionInfo->reqScheduledFunction,InterruptInfo(*(localArg->interruptInfo))), false, true);
+	}
+	if (localArg->functionInfo->reqFunction)
+	{
+	  localArg->functionInfo->reqFunction();
+	}
+}
+
+extern "C"
+{
+   void cleanupFunctional(void* arg)
+   {
+	 ArgStructure* localArg = (ArgStructure*)arg;
+	 delete (FunctionInfo*)localArg->functionInfo;
+     delete (InterruptInfo*)localArg->interruptInfo;
+	 delete localArg;
+   }
 }
 
 void attachInterrupt(uint8_t pin, std::function<void(void)> intRoutine, int mode)
 {
 	// use the local interrupt routine which takes the ArgStructure as argument
-	__attachInterruptArg (pin, (voidFuncPtr)interruptFunctional, new ArgStructure{intRoutine}, mode);
+
+	InterruptInfo* ii = nullptr;
+
+	FunctionInfo* fi = new FunctionInfo;
+	fi->reqFunction = intRoutine;
+
+	ArgStructure* as = new ArgStructure;
+	as->interruptInfo = ii;
+	as->functionInfo = fi;
+
+	__attachInterruptArg (pin, (voidFuncPtr)interruptFunctional, as, mode);
+}
+
+void attachScheduledInterrupt(uint8_t pin, std::function<void(InterruptInfo)> scheduledIntRoutine, int mode)
+{
+	if (!scheduledInterrupts)
+	{
+		scheduledInterrupts = new ScheduledFunctions(32);
+	}
+	InterruptInfo* ii = new InterruptInfo;
+
+	FunctionInfo* fi = new FunctionInfo;
+	fi->reqScheduledFunction = scheduledIntRoutine;
+
+	ArgStructure* as = new ArgStructure;
+	as->interruptInfo = ii;
+	as->functionInfo = fi;
+
+	__attachInterruptArg (pin, (voidFuncPtr)interruptFunctional, as, mode);
 }

--- a/cores/esp8266/FunctionalInterrupt.h
+++ b/cores/esp8266/FunctionalInterrupt.h
@@ -4,12 +4,34 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <functional>
+#include <ScheduledFunctions.h>
 
 extern "C" {
 #include "c_types.h"
 #include "ets_sys.h"
 }
 
+// Structures for communication
+
+struct InterruptInfo {
+	uint8_t pin = 0;
+	uint8_t value = 0;
+	uint32_t micro = 0;
+};
+
+struct FunctionInfo {
+    std::function<void(void)> reqFunction = nullptr;
+	std::function<void(InterruptInfo)> reqScheduledFunction = nullptr;
+};
+
+struct ArgStructure {
+	InterruptInfo* interruptInfo = nullptr;
+	FunctionInfo* functionInfo = nullptr;
+};
+
+static ScheduledFunctions* scheduledInterrupts;
 void attachInterrupt(uint8_t pin, std::function<void(void)> intRoutine, int mode);
+void attachScheduledInterrupt(uint8_t pin, std::function<void(InterruptInfo)> scheduledIntRoutine, int mode);
+
 
 #endif //INTERRUPTS_H

--- a/cores/esp8266/ScheduledFunctions.cpp
+++ b/cores/esp8266/ScheduledFunctions.cpp
@@ -1,0 +1,117 @@
+/*
+ * ScheduledFunctions.cpp
+ *
+ *  Created on: 27 apr. 2018
+ *      Author: Herman
+ */
+#include "ScheduledFunctions.h"
+
+std::list<ScheduledFunctions::ScheduledElement> ScheduledFunctions::scheduledFunctions;
+
+ScheduledFunctions::ScheduledFunctions()
+:ScheduledFunctions(UINT_MAX)
+{
+}
+
+ScheduledFunctions::ScheduledFunctions(unsigned int reqMax)
+{
+	maxElements = reqMax;
+}
+
+ScheduledFunctions::~ScheduledFunctions() {
+}
+
+ScheduledRegistration ScheduledFunctions::insertElement(ScheduledElement se, bool front)
+{
+	if (countElements >= maxElements)
+	{
+		return nullptr;
+	}
+	else
+	{
+		countElements++;
+		if (front)
+		 {
+			scheduledFunctions.push_front(se);
+			return scheduledFunctions.begin()->registration;
+		 }
+		 else
+		 {
+			 scheduledFunctions.push_back(se);
+			 return scheduledFunctions.rbegin()->registration;
+		 }
+	}
+}
+
+std::list<ScheduledFunctions::ScheduledElement>::iterator ScheduledFunctions::eraseElement(std::list<ScheduledFunctions::ScheduledElement>::iterator it)
+{
+	countElements--;
+	return scheduledFunctions.erase(it);
+}
+
+bool ScheduledFunctions::scheduleFunction(ScheduledFunction sf, bool continuous, bool front)
+{
+	return (insertElement({this,continuous,nullptr,sf}, front) == nullptr);
+}
+
+bool ScheduledFunctions::scheduleFunction(ScheduledFunction sf)
+{
+	return scheduleFunction(sf, false, false);
+}
+
+ScheduledRegistration ScheduledFunctions::scheduleFunctionReg (ScheduledFunction sf, bool continuous, bool front)
+{
+	return insertElement({this,continuous,std::make_shared<int>(1),sf},front);
+}
+
+void ScheduledFunctions::runScheduledFunctions()
+{
+	auto lastElement = scheduledFunctions.end(); // do not execute elements added during runScheduledFunctions
+	auto it = scheduledFunctions.begin();
+	while (it != lastElement)
+	{
+		bool erase = false;
+		if (it->registration == nullptr)
+		{
+			it->function();
+		}
+		else
+		{
+			if (it->registration.use_count() > 1)
+			{
+				it->function();
+			}
+			else
+			{
+				erase = true;
+			}
+		}
+		if ((!it->continuous) || (erase))
+		{
+			it = it->_this->eraseElement(it);
+		}
+		else
+		{
+			it++;
+		}
+	}
+}
+
+void ScheduledFunctions::removeFunction(ScheduledRegistration sr)
+{
+	auto it = scheduledFunctions.begin();
+	bool removed = false;
+	while ((!removed) && (it != scheduledFunctions.end()))
+	{
+		if (it->registration == sr)
+		{
+			it = eraseElement(it);
+			removed = true;
+		}
+		else
+		{
+			it++;
+		}
+	}
+}
+

--- a/cores/esp8266/ScheduledFunctions.h
+++ b/cores/esp8266/ScheduledFunctions.h
@@ -1,0 +1,51 @@
+/*
+ * ScheduledFunctions.h
+ *
+ *  Created on: 27 apr. 2018
+ *      Author: Herman
+ */
+#include "Arduino.h"
+#include "Schedule.h"
+
+#include <functional>
+#include <memory>
+#include <list>
+#include <climits>
+
+#ifndef SCHEDULEDFUNCTIONS_H_
+#define SCHEDULEDFUNCTIONS_H_
+
+typedef std::function<void(void)> ScheduledFunction;
+typedef std::shared_ptr<void> ScheduledRegistration;
+
+class ScheduledFunctions {
+
+public:
+	ScheduledFunctions();
+	ScheduledFunctions(unsigned int reqMax);
+	virtual ~ScheduledFunctions();
+
+	struct ScheduledElement
+	{
+		ScheduledFunctions* _this;
+		bool continuous;
+		ScheduledRegistration registration;
+		ScheduledFunction function;
+	};
+
+	ScheduledRegistration insertElement(ScheduledElement se, bool front);
+	std::list<ScheduledElement>::iterator eraseElement(std::list<ScheduledElement>::iterator);
+	bool scheduleFunction(ScheduledFunction sf, bool continuous, bool front);
+	bool scheduleFunction(ScheduledFunction sf);
+	ScheduledRegistration scheduleFunctionReg (ScheduledFunction sf, bool continuous, bool front);
+	static void runScheduledFunctions();
+	void removeFunction(ScheduledRegistration sr);
+
+
+	static std::list<ScheduledElement> scheduledFunctions;
+	unsigned int maxElements;
+	unsigned int countElements = 0;
+
+};
+
+#endif /* SCHEDULEDFUNCTIONS_H_ */

--- a/cores/esp8266/core_esp8266_wiring_digital.c
+++ b/cores/esp8266/core_esp8266_wiring_digital.c
@@ -112,6 +112,17 @@ typedef struct {
   void * arg;
 } interrupt_handler_t;
 
+//duplicate from functionalInterrupt.h keep in sync
+typedef struct InterruptInfo {
+	uint8_t pin;
+	uint8_t value;
+	uint32_t micro;
+} InterruptInfo;
+
+typedef struct {
+	InterruptInfo* interruptInfo;
+	void* functionInfo;
+} ArgStructure;
 
 static interrupt_handler_t interrupt_handlers[16];
 static uint32_t interrupt_reg = 0;
@@ -134,7 +145,14 @@ void ICACHE_RAM_ATTR interrupt_handler(void *arg) {
          (handler->mode & 1) == !!(levels & (1 << i)))) {
       // to make ISR compatible to Arduino AVR model where interrupts are disabled
       // we disable them before we call the client ISR
-      uint32_t savedPS = xt_rsil(15); // stop other interrupts 
+      uint32_t savedPS = xt_rsil(15); // stop other interrupts
+      ArgStructure* localArg = (ArgStructure*)handler->arg;
+      if (localArg->interruptInfo)
+      {
+         localArg->interruptInfo->pin = i;
+         localArg->interruptInfo->value = __digitalRead(i);
+         localArg->interruptInfo->micro = micros();
+      }
       if (handler->arg)
       {
     	  ((voidFuncPtrArg)handler->fn)(handler->arg);
@@ -149,12 +167,18 @@ void ICACHE_RAM_ATTR interrupt_handler(void *arg) {
   ETS_GPIO_INTR_ENABLE();
 }
 
+extern void cleanupFunctional(void* arg);
+
 extern void ICACHE_RAM_ATTR __attachInterruptArg(uint8_t pin, voidFuncPtr userFunc, void *arg, int mode) {
   if(pin < 16) {
     ETS_GPIO_INTR_DISABLE();
     interrupt_handler_t *handler = &interrupt_handlers[pin];
     handler->mode = mode;
     handler->fn = userFunc;
+    if (handler->arg)  // Clean when new attach without detach
+	{
+	  cleanupFunctional(handler->arg);
+	}
     handler->arg = arg;
     interrupt_reg |= (1 << pin);
     GPC(pin) &= ~(0xF << GPCI);//INT mode disabled
@@ -179,6 +203,10 @@ extern void ICACHE_RAM_ATTR __detachInterrupt(uint8_t pin) {
     interrupt_handler_t *handler = &interrupt_handlers[pin];
     handler->mode = 0;
     handler->fn = 0;
+    if (handler->arg)
+		{
+		  cleanupFunctional(handler->arg);
+		}
     handler->arg = 0;
     if (interrupt_reg)
       ETS_GPIO_INTR_ENABLE();

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL-fp.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL-fp.cpp
@@ -11,25 +11,24 @@ static uint8_t htoi (unsigned char c)
          : 255;
 }
 
-void WiFiClientSecure::setFingerprint(const char* fingerprint) {
+void WiFiClientSecure::setFingerprint(const String& fingerprint) {
 
     uint8_t fp [20];
     uint8_t c, d;
     int idx = 0;
+    const char* _fingerprint = fingerprint.c_str();
 
-    while (idx < 20 && (c = *fingerprint++) && (d = *fingerprint++)) {
-    	c = htoi(c);
-    	d = htoi(d);
+    while (idx < 20 && (c = *_fingerprint++) && (d = *_fingerprint++)) {
+        c = htoi(c);
+        d = htoi(d);
         if (c > 15 || d > 15) {
             // skip separator
-            fingerprint--;
+            _fingerprint--;
             continue;
         }
         fp[idx++] = (c << 4) + d;
     }
 
-    _use_insecure = false; // even with bad fingerprint
-    
     if (idx == 20)
         setFingerprint(fp);
 }

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
@@ -92,7 +92,6 @@ WiFiClientSecure::WiFiClientSecure() : WiFiClient() {
     br_esp8266_stack_proxy_init(_bearssl_stack.get(), stacksize);
   }
   _local_bearssl_stack = _bearssl_stack;
-  _use_insecure = true; // default https client behaviour
 }
 
 WiFiClientSecure::~WiFiClientSecure() {
@@ -769,6 +768,11 @@ bool WiFiClientSecure::_installClientX509Validator() {
 bool WiFiClientSecure::_connectSSL(const char* hostName) {
   _freeSSL();
   _oom_err = false;
+#ifdef DEBUG_ESP_SSL
+  if (!_use_insecure && !_use_fingerprint && !_use_self_signed && !_knownkey && !_sk) {
+    DEBUG_ESP_PORT.println(FPSTR("BearSSL: connection *will* fail, no authentication method is setup"));
+  }
+#endif
 
   _sc = std::make_shared<br_ssl_client_context>();
   _eng = &_sc->eng; // Allocation/deallocation taken care of by the _sc shared_ptr

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
@@ -67,15 +67,13 @@ class WiFiClientSecure : public WiFiClient {
       _knownkey_usages = usages;
     }
     // Only check SHA1 fingerprint of certificate
-    void setFingerprint(const char* fingerprint);
+    void setFingerprint(const String& fingerprint);
     void setFingerprint(const uint8_t fingerprint[20]) {
-      _use_insecure = false;
       _use_fingerprint = true;
       memcpy_P(_fingerprint, fingerprint, 20);
     }
     // Accept any certificate that's self-signed
     void allowSelfSignedCerts() {
-      _use_insecure = false;
       _use_self_signed = true;
     }
     // Install certificates of trusted CAs or specific site
@@ -109,10 +107,10 @@ class WiFiClientSecure : public WiFiClient {
 
     // AXTLS compatible wrappers
     bool verifyCertChain(const char* domain_name) { (void)domain_name; return connected(); } // If we're connected, the cert passed validation during handshake
-    bool verify(const char* fingerprint, const char* domain_name) { 
+    bool verify(const String& fingerprint, const String& domain_name) { 
         (void) fingerprint;
         (void) domain_name;
-        WiFiClientSecure::verify__is_unavailable_with_BearSSL__use_setFingerprint_instead();
+        WiFiClientSecure_verify__is_unavailable_with_BearSSL__use_setFingerprint_instead();
         return false;
     }
 
@@ -217,7 +215,7 @@ class WiFiClientSecure : public WiFiClient {
     // The local copy, only used to enable a reference count
     std::shared_ptr<uint8_t> _local_bearssl_stack;
 
-    void verify__is_unavailable_with_BearSSL__use_setFingerprint_instead (void);
+    void WiFiClientSecure_verify__is_unavailable_with_BearSSL__use_setFingerprint_instead (void);
 };
 
 };


### PR DESCRIPTION
Made to help transition from axTLS:

* set BearSSL client insecured by default
* overload `setFingerprint()` with axTLS's `char*` format (in a separate source file to save flash if unused)
* generate a linker error message when trying to use unimplementable `::verify()`
