### PR TITLE
ScheduledInterrupts should still use current schedule_function(..)

### DIFF
--- a/cores/esp8266/FunctionalInterrupt.cpp
+++ b/cores/esp8266/FunctionalInterrupt.cpp
@@ -16,7 +16,8 @@ void interruptFunctional(void* arg)
     ArgStructure* localArg = (ArgStructure*)arg;
 	if (localArg->functionInfo->reqScheduledFunction)
 	{
-      scheduledInterrupts->scheduleFunctionReg(std::bind(localArg->functionInfo->reqScheduledFunction,InterruptInfo(*(localArg->interruptInfo))), false, true);
+		schedule_function(std::bind(localArg->functionInfo->reqScheduledFunction,InterruptInfo(*(localArg->interruptInfo))));
+//      scheduledInterrupts->scheduleFunctionReg(std::bind(localArg->functionInfo->reqScheduledFunction,InterruptInfo(*(localArg->interruptInfo))), false, true);
 	}
 	if (localArg->functionInfo->reqFunction)
 	{


### PR DESCRIPTION
@devyte 
The ScheduledInterrupt PR uses the new ScheduledFunctions to do the actual scheduling.
But.. that is not yet integrated into the Schedule.h -> The attached function is never called.

This PR fixes this by using the current schedule_function(..).

