### PR TITLE
Don't stop a waveform simply by calling pinMode

### DIFF
--- a/cores/esp8266/core_esp8266_wiring_digital.c
+++ b/cores/esp8266/core_esp8266_wiring_digital.c
@@ -29,7 +29,6 @@
 uint8_t esp8266_gpioToFn[16] = {0x34, 0x18, 0x38, 0x14, 0x3C, 0x40, 0x1C, 0x20, 0x24, 0x28, 0x2C, 0x30, 0x04, 0x08, 0x0C, 0x10};
 
 extern void __pinMode(uint8_t pin, uint8_t mode) {
-  stopWaveform(pin);
   if(pin < 16){
     if(mode == SPECIAL){
       GPC(pin) = (GPC(pin) & (0xF << GPCI)); //SOURCE(GPIO) | DRIVER(NORMAL) | INT_TYPE(UNCHANGED) | WAKEUP_ENABLE(DISABLED)


### PR DESCRIPTION
Setting a pin direction would cause a waveform generator attached to it to stop.
This could cause PWM to stop if pinMode() is called while running (as it was
called in __analogWrite()).

Remove the stopWaveform call from pinMode, the Tone, analogWrite, or Servo
that initiated the waveform has responsibility for stopping it (and it does)
when complete, irrespective of the pinMode.

Fixes #4905