### PR TITLE
Make ar compatible with GNU and BSD in example

### DIFF
--- a/libraries/ESP8266WiFi/examples/BearSSL_CertStore/certs-from-mozilla.py
+++ b/libraries/ESP8266WiFi/examples/BearSSL_CertStore/certs-from-mozilla.py
@@ -59,7 +59,7 @@ for i in range(0, len(pems)):
 if os.path.exists("data/certs.ar"):
     os.unlink("data/certs.ar");
 
-arCmd = ['ar', 'mcs', 'data/certs.ar'] + derFiles;
+arCmd = ['ar', 'q', 'data/certs.ar'] + derFiles;
 call( arCmd )
 
 for der in derFiles:


### PR DESCRIPTION
Change the "ar" options in the example CertStore.AR archive generator to
make them compatible with both Linux and MacOS.