### PR TITLE
Fix concat not 0-terminating when String shrunk

### DIFF
--- a/cores/esp8266/WString.cpp
+++ b/cores/esp8266/WString.cpp
@@ -270,8 +270,9 @@ unsigned char String::concat(const String &s) {
             return 1;
         if (!reserve(newlen))
             return 0;
-        memcpy(s.buffer + len, s.buffer, len);
+        memcpy(buffer + len, buffer, len);
         len = newlen;
+        buffer[len] = 0;
         return 1;
     } else {
         return concat(s.buffer, s.len);


### PR DESCRIPTION
As @devyte noticed, PR #4955 has an issue when you catenate a string to
itself and the string used to hold a longer value because it does not
explicitly 0-terminate the resulting string.  If the string was extended,
however, reserve() would 0-terminate by default.

Always terminate the result of `s += s;` now.