### PR TITLE
fix board generator and related documentation when using core-release regarding missing file

### DIFF
--- a/doc/faq/readme.rst
+++ b/doc/faq/readme.rst
@@ -46,7 +46,7 @@ How can I get some extra KBs in flash ?
 * Using ``*printf()`` with floats is enabled by default.  Some KBs of flash can
   be saved by using the option ``--nofloat`` with the boards generator:
 
-  ``./tools/boards.txt.py --nofloat --allgen``
+  ``./tools/boards.txt.py --nofloat --boardsgen``
 
 * Use the debug level option ``NoAssert-NDEBUG`` (in the Tools menu)
 
@@ -58,7 +58,7 @@ Why can't I use WPS ?
 WPS is disabled by default, this offers an extra 4KB in ram/heap.  To enable
 WPS (and lose 4KB of useable ram), use this boards generator option:
 
-``./tools/boards.txt.py --allowWPS --allgen``
+``./tools/boards.txt.py --allowWPS --boardsgen``
 
 `Read more <a05-board-generator.rst>`__.
 

--- a/tools/boards.txt.py
+++ b/tools/boards.txt.py
@@ -1294,6 +1294,9 @@ def package ():
     checkdir()
 
     if packagegen:
+        if not os.path.isfile(pkgfname):
+            print('will not regenerate non-existing file: ' + pkgfname)
+            return
         pkgfname_read = pkgfname + '.orig'
         if os.path.isfile(pkgfname_read):
             os.remove(pkgfname_read)
@@ -1327,6 +1330,9 @@ def doc ():
 
         # check if backup already exists
         if not os.path.isfile("doc/boards.rst.orig"):
+            if not os.path.isfile("doc/boards.rst"):
+                print('will not regenerate non-existing file: doc/boards.rst')
+                return
             os.rename("doc/boards.rst", "doc/boards.rst.orig")
 
         realstdout = sys.stdout


### PR DESCRIPTION
Luckily, release 2.4.2 is still ok regarding issue #5005