### PR TITLE
build: place generated ld script into build directory

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -74,13 +74,13 @@ compiler.elf2hex.extra_flags=
 ## generate file with git version number
 ## needs bash, git, and echo
 recipe.hooks.core.prebuild.1.pattern=bash -c "mkdir -p {build.path}/core && echo \#define ARDUINO_ESP8266_GIT_VER 0x`git --git-dir {runtime.platform.path}/.git rev-parse --short=8 HEAD 2>/dev/null || echo ffffffff` >{build.path}/core/core_version.h"
-recipe.hooks.core.prebuild.2.pattern=bash -c "mkdir -p {build.path}/core && echo \#define ARDUINO_ESP8266_GIT_DESC `cd {runtime.platform.path}; git describe --tags 2>/dev/null || echo unix-{version}` >>{build.path}/core/core_version.h"
+recipe.hooks.core.prebuild.2.pattern=bash -c "mkdir -p {build.path}/core && echo \#define ARDUINO_ESP8266_GIT_DESC `cd "{runtime.platform.path}"; git describe --tags 2>/dev/null || echo unix-{version}` >>{build.path}/core/core_version.h"
 ## windows-compatible version without git
 recipe.hooks.core.prebuild.1.pattern.windows=cmd.exe /c mkdir {build.path}\core & (echo #define ARDUINO_ESP8266_GIT_VER 0x00000000 & echo #define ARDUINO_ESP8266_GIT_DESC win-{version} ) > {build.path}\core\core_version.h
 recipe.hooks.core.prebuild.2.pattern.windows=
 
 ## Build the app.ld linker file
-recipe.hooks.linking.prelink.1.pattern="{compiler.path}{compiler.c.cmd}" -CC -E -P {build.vtable_flags} "{runtime.platform.path}/tools/sdk/ld/eagle.app.v6.common.ld.h" -o "{runtime.platform.path}/tools/sdk/ld/eagle.app.v6.common.ld"
+recipe.hooks.linking.prelink.1.pattern="{compiler.path}{compiler.c.cmd}" -CC -E -P {build.vtable_flags} "{runtime.platform.path}/tools/sdk/ld/eagle.app.v6.common.ld.h" -o "{build.path}/eagle.app.v6.common.ld"
 
 ## Compile c files
 recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.cpreprocessor.flags} {compiler.c.flags} -DF_CPU={build.f_cpu} {build.lwip_flags} {build.debug_port} {build.debug_level} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DARDUINO_BOARD="{build.board}" {build.led} {compiler.c.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"

--- a/tools/boards.txt.py
+++ b/tools/boards.txt.py
@@ -1144,7 +1144,7 @@ def flash_size (size_bytes, display, optname, ld, desc, max_upload_size, spiffs_
         print("PROVIDE ( _SPIFFS_page = 0x%X );" % page)
         print("PROVIDE ( _SPIFFS_block = 0x%X );" % block)
         print("")
-        print('INCLUDE "../ld/eagle.app.v6.common.ld"')
+        print('INCLUDE "eagle.app.v6.common.ld"')
 
         if ldgen:
             sys.stdout.close()

--- a/tools/sdk/ld/eagle.flash.16m.ld
+++ b/tools/sdk/ld/eagle.flash.16m.ld
@@ -16,4 +16,4 @@ PROVIDE ( _SPIFFS_end = 0x411FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x2000 );
 
-INCLUDE "../ld/eagle.app.v6.common.ld"
+INCLUDE "eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.1m0.ld
+++ b/tools/sdk/ld/eagle.flash.1m0.ld
@@ -15,4 +15,4 @@ PROVIDE ( _SPIFFS_end = 0x402FB000 );
 PROVIDE ( _SPIFFS_page = 0x0 );
 PROVIDE ( _SPIFFS_block = 0x0 );
 
-INCLUDE "../ld/eagle.app.v6.common.ld"
+INCLUDE "eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.1m128.ld
+++ b/tools/sdk/ld/eagle.flash.1m128.ld
@@ -16,4 +16,4 @@ PROVIDE ( _SPIFFS_end = 0x402FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x1000 );
 
-INCLUDE "../ld/eagle.app.v6.common.ld"
+INCLUDE "eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.1m144.ld
+++ b/tools/sdk/ld/eagle.flash.1m144.ld
@@ -16,4 +16,4 @@ PROVIDE ( _SPIFFS_end = 0x402FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x1000 );
 
-INCLUDE "../ld/eagle.app.v6.common.ld"
+INCLUDE "eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.1m160.ld
+++ b/tools/sdk/ld/eagle.flash.1m160.ld
@@ -16,4 +16,4 @@ PROVIDE ( _SPIFFS_end = 0x402FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x1000 );
 
-INCLUDE "../ld/eagle.app.v6.common.ld"
+INCLUDE "eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.1m192.ld
+++ b/tools/sdk/ld/eagle.flash.1m192.ld
@@ -16,4 +16,4 @@ PROVIDE ( _SPIFFS_end = 0x402FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x1000 );
 
-INCLUDE "../ld/eagle.app.v6.common.ld"
+INCLUDE "eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.1m256.ld
+++ b/tools/sdk/ld/eagle.flash.1m256.ld
@@ -16,4 +16,4 @@ PROVIDE ( _SPIFFS_end = 0x402FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x1000 );
 
-INCLUDE "../ld/eagle.app.v6.common.ld"
+INCLUDE "eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.1m512.ld
+++ b/tools/sdk/ld/eagle.flash.1m512.ld
@@ -16,4 +16,4 @@ PROVIDE ( _SPIFFS_end = 0x402FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x2000 );
 
-INCLUDE "../ld/eagle.app.v6.common.ld"
+INCLUDE "eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.1m64.ld
+++ b/tools/sdk/ld/eagle.flash.1m64.ld
@@ -16,4 +16,4 @@ PROVIDE ( _SPIFFS_end = 0x402FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x1000 );
 
-INCLUDE "../ld/eagle.app.v6.common.ld"
+INCLUDE "eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.2m.ld
+++ b/tools/sdk/ld/eagle.flash.2m.ld
@@ -16,4 +16,4 @@ PROVIDE ( _SPIFFS_end = 0x403FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x2000 );
 
-INCLUDE "../ld/eagle.app.v6.common.ld"
+INCLUDE "eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.4m.ld
+++ b/tools/sdk/ld/eagle.flash.4m.ld
@@ -16,4 +16,4 @@ PROVIDE ( _SPIFFS_end = 0x405FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x2000 );
 
-INCLUDE "../ld/eagle.app.v6.common.ld"
+INCLUDE "eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.4m1m.ld
+++ b/tools/sdk/ld/eagle.flash.4m1m.ld
@@ -17,4 +17,4 @@ PROVIDE ( _SPIFFS_end = 0x405FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x2000 );
 
-INCLUDE "../ld/eagle.app.v6.common.ld"
+INCLUDE "eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.4m2m.ld
+++ b/tools/sdk/ld/eagle.flash.4m2m.ld
@@ -17,4 +17,4 @@ PROVIDE ( _SPIFFS_end = 0x405FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x2000 );
 
-INCLUDE "../ld/eagle.app.v6.common.ld"
+INCLUDE "eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.512k0.ld
+++ b/tools/sdk/ld/eagle.flash.512k0.ld
@@ -15,4 +15,4 @@ PROVIDE ( _SPIFFS_end = 0x4027B000 );
 PROVIDE ( _SPIFFS_page = 0x0 );
 PROVIDE ( _SPIFFS_block = 0x0 );
 
-INCLUDE "../ld/eagle.app.v6.common.ld"
+INCLUDE "eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.512k128.ld
+++ b/tools/sdk/ld/eagle.flash.512k128.ld
@@ -16,4 +16,4 @@ PROVIDE ( _SPIFFS_end = 0x4027B000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x1000 );
 
-INCLUDE "../ld/eagle.app.v6.common.ld"
+INCLUDE "eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.512k32.ld
+++ b/tools/sdk/ld/eagle.flash.512k32.ld
@@ -16,4 +16,4 @@ PROVIDE ( _SPIFFS_end = 0x4027B000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x1000 );
 
-INCLUDE "../ld/eagle.app.v6.common.ld"
+INCLUDE "eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.512k64.ld
+++ b/tools/sdk/ld/eagle.flash.512k64.ld
@@ -16,4 +16,4 @@ PROVIDE ( _SPIFFS_end = 0x4027B000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x1000 );
 
-INCLUDE "../ld/eagle.app.v6.common.ld"
+INCLUDE "eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.8m.ld
+++ b/tools/sdk/ld/eagle.flash.8m.ld
@@ -16,4 +16,4 @@ PROVIDE ( _SPIFFS_end = 0x409FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x2000 );
 
-INCLUDE "../ld/eagle.app.v6.common.ld"
+INCLUDE "eagle.app.v6.common.ld"


### PR DESCRIPTION
arduino-builder 1.3.25 (shipped with Arduino 1.8.5) forces full
recompilation when any file in the core directory is modified. Avoid
full recompilation by placing generated ld script into build
directory, not source directory.

Also fix an issue where git version description would not be generated
if there were spaces in build path.

Closes #5008.