### PR TITLE
Move all PROGMEM to their own section

### DIFF
--- a/cores/esp8266/Print.cpp
+++ b/cores/esp8266/Print.cpp
@@ -35,7 +35,7 @@
 size_t Print::write(const uint8_t *buffer, size_t size) {
 
 #ifdef DEBUG_ESP_CORE
-    static char not_the_best_way [] ICACHE_RODATA_ATTR STORE_ATTR = "Print::write(data,len) should be overridden for better efficiency\r\n";
+    static char not_the_best_way [] PROGMEM STORE_ATTR = "Print::write(data,len) should be overridden for better efficiency\r\n";
     static bool once = false;
     if (!once) {
         once = true;

--- a/cores/esp8266/heap.c
+++ b/cores/esp8266/heap.c
@@ -84,9 +84,9 @@ void* ICACHE_RAM_ATTR pvPortZalloc(size_t size, const char* file, int line)
 #undef calloc
 #undef realloc
 
-static const char oom_fmt[]   ICACHE_RODATA_ATTR STORE_ATTR = ":oom(%d)@?\n";
-static const char oom_fmt_1[] ICACHE_RODATA_ATTR STORE_ATTR = ":oom(%d)@";
-static const char oom_fmt_2[] ICACHE_RODATA_ATTR STORE_ATTR = ":%d\n";
+static const char oom_fmt[]   PROGMEM STORE_ATTR = ":oom(%d)@?\n";
+static const char oom_fmt_1[] PROGMEM STORE_ATTR = ":oom(%d)@";
+static const char oom_fmt_2[] PROGMEM STORE_ATTR = ":%d\n";
 
 void* malloc (size_t s)
 {

--- a/cores/esp8266/pgmspace.h
+++ b/cores/esp8266/pgmspace.h
@@ -10,7 +10,19 @@
 #include "ets_sys.h"
 #include "osapi.h"
 
-#define PROGMEM     ICACHE_RODATA_ATTR
+// Since __section__ is supposed to be only use for global variables,
+// there could be conflicts when a static/inlined function has them in the
+// same file as a non-static PROGMEM object.
+// Ref: https://gcc.gnu.org/onlinedocs/gcc-3.2/gcc/Variable-Attributes.html
+// Place each progmem object into its own named section, avoiding conflicts
+
+// The following two macros cause a parameter to be enclosed in quotes
+// by the preopressor (i.e. for concatenating ints to strings)
+#define __STRINGIZE_NX(A) #A
+#define __STRINGIZE(A) __STRINGIZE_NX(A)
+
+#define PROGMEM      __attribute__((section( ".irom.text." __FILE__ "." __STRINGIZE(__LINE__) "."  __STRINGIZE(__COUNTER__))))
+
 #define PGM_P  		const char *
 #define PGM_VOID_P  const void *
 #define PSTR(s) (__extension__({static const char __c[] PROGMEM = (s); &__c[0];}))

--- a/cores/esp8266/uart.c
+++ b/cores/esp8266/uart.c
@@ -41,12 +41,13 @@
  *
  */
 #include "Arduino.h"
+#include <pgmspace.h>
 #include "uart.h"
 #include "esp8266_peri.h"
 #include "user_interface.h"
 #include "uart_register.h"
 
-const char overrun_str [] ICACHE_RODATA_ATTR STORE_ATTR = "uart input full!\r\n";
+const char overrun_str [] PROGMEM STORE_ATTR = "uart input full!\r\n";
 static int s_uart_debug_nr = UART0;
 
 

--- a/cores/esp8266/umm_malloc/umm_malloc_cfg.h
+++ b/cores/esp8266/umm_malloc/umm_malloc_cfg.h
@@ -178,7 +178,8 @@ extern char _heap_start;
 // this must be outside from "#ifndef _UMM_MALLOC_CFG_H"
 // because Arduino.h's <cstdlib> does #undef *alloc
 // Arduino.h recall us to redefine them
-#define malloc(s) ({ static const char mem_debug_file[] ICACHE_RODATA_ATTR STORE_ATTR = __FILE__; malloc_loc(s, mem_debug_file, __LINE__); })
-#define calloc(n,s) ({ static const char mem_debug_file[] ICACHE_RODATA_ATTR STORE_ATTR = __FILE__; calloc_loc(n, s, mem_debug_file, __LINE__); })
-#define realloc(p,s) ({ static const char mem_debug_file[] ICACHE_RODATA_ATTR STORE_ATTR = __FILE__; realloc_loc(p, s, mem_debug_file, __LINE__); })
+#include <pgmspace.h>
+#define malloc(s) ({ static const char mem_debug_file[] PROGMEM STORE_ATTR = __FILE__; malloc_loc(s, mem_debug_file, __LINE__); })
+#define calloc(n,s) ({ static const char mem_debug_file[] PROGMEM STORE_ATTR = __FILE__; calloc_loc(n, s, mem_debug_file, __LINE__); })
+#define realloc(p,s) ({ static const char mem_debug_file[] PROGMEM STORE_ATTR = __FILE__; realloc_loc(p, s, mem_debug_file, __LINE__); })
 #endif /* DEBUG_ESP_OOM */

--- a/libraries/ESP8266WebServer/src/detail/mimetable.cpp
+++ b/libraries/ESP8266WebServer/src/detail/mimetable.cpp
@@ -5,7 +5,7 @@ namespace mime
 {
 
 // Table of extension->MIME strings stored in PROGMEM, needs to be global due to GCC section typing rules
-const Entry mimeTable[maxType] ICACHE_RODATA_ATTR = 
+const Entry mimeTable[maxType] PROGMEM = 
 {
     { ".html", "text/html" },
     { ".htm", "text/html" },

--- a/libraries/ESP8266WiFi/examples/WiFiHTTPSServer/make-self-signed-cert.sh
+++ b/libraries/ESP8266WiFi/examples/WiFiHTTPSServer/make-self-signed-cert.sh
@@ -4,11 +4,11 @@
 # Replace your-name-here with somethine appropriate before running and use
 # the generated .H files in your code as follows:
 #
-#      static const uint8_t rsakey[]  ICACHE_RODATA_ATTR = {
+#      static const uint8_t rsakey[] PROGMEM = {
 #        #include "key.h"
 #      };
 #
-#      static const uint8_t x509[] ICACHE_RODATA_ATTR = {
+#      static const uint8_t x509[] PROGMEM = {
 #        #include "x509.h"
 #      };
 #


### PR DESCRIPTION
According to the GCC man page, __section__ attributes should only be used
for global variables.  However, the PROGMEM and ICACHE_RODATA macros use
this variable decorator even for local variables.  Most of the time it works,
but when a static or inlined function tries to use a PROGMEM/PSTR/etc.
variable the compiler can throw an error like:
  error: XXX causes a section type conflict with YYY

Change the PROGMEM macro to emit a section name that is unique (a combo
of the file, line, and counter variables to ensure uniqueness).  The
standard linker script will place them properly in .IROM without
any changes.

Fixes #5036 and others.