### PR TITLE
Enclose PROGMEM segment names in quotes

### DIFF
--- a/cores/esp8266/pgmspace.h
+++ b/cores/esp8266/pgmspace.h
@@ -21,7 +21,7 @@
 #define __STRINGIZE_NX(A) #A
 #define __STRINGIZE(A) __STRINGIZE_NX(A)
 
-#define PROGMEM      __attribute__((section( ".irom.text." __FILE__ "." __STRINGIZE(__LINE__) "."  __STRINGIZE(__COUNTER__))))
+#define PROGMEM      __attribute__((section( "\".irom.text." __FILE__ "." __STRINGIZE(__LINE__) "."  __STRINGIZE(__COUNTER__) "\"")))
 
 #define PGM_P  		const char *
 #define PGM_VOID_P  const void *


### PR DESCRIPTION
__FILE__ is used to name the segments used for each PROGMEM constant,
but __FILE__ may have a space in it.  This would cause compilation
errors.

Add quotes around the entire segment name to work around this.