### PR TITLE
Move some exception strings to PROGMEM

### DIFF
--- a/cores/esp8266/core_esp8266_postmortem.c
+++ b/cores/esp8266/core_esp8266_postmortem.c
@@ -166,7 +166,7 @@ void __wrap_system_restart_local() {
 
     // Use cap-X formatting to ensure the standard EspExceptionDecoder doesn't match the address
     if (umm_last_fail_alloc_addr) {
-      ets_printf("\nlast failed alloc call: %08X(%d)\n", (uint32_t)umm_last_fail_alloc_addr, umm_last_fail_alloc_size);
+      ets_printf_P("\nlast failed alloc call: %08X(%d)\n", (uint32_t)umm_last_fail_alloc_addr, umm_last_fail_alloc_size);
     }
 
     custom_crash_callback( &rst_info, sp + offset, stack_end );

--- a/cores/esp8266/debug.h
+++ b/cores/esp8266/debug.h
@@ -23,7 +23,7 @@ extern "C" {
 #endif
 
 void __panic_func(const char* file, int line, const char* func) __attribute__((noreturn));
-#define panic() __panic_func(__FILE__, __LINE__, __func__)
+#define panic() __panic_func(PSTR(__FILE__), __LINE__, __func__)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The memory allocation failure message was accidentally stored in RAM
and not in PROGMEM.

panic() did not place the `__FILE__` string in PROGMEM, either.

Move both to PROGMEM, save ~200 (!!) bytes of heap (depends on length of path
of the Arduino core library).