### PR TITLE
Add instantly option to deepSleep

### DIFF
--- a/cores/esp8266/Esp.cpp
+++ b/cores/esp8266/Esp.cpp
@@ -107,10 +107,14 @@ void EspClass::wdtFeed(void)
 
 extern "C" void esp_yield();
 
-void EspClass::deepSleep(uint64_t time_us, WakeMode mode)
+void EspClass::deepSleep(uint64_t time_us, WakeMode mode, bool instantly)
 {
     system_deep_sleep_set_option(static_cast<int>(mode));
-    system_deep_sleep(time_us);
+    if (instantly) {
+      system_deep_sleep_instant(time_us);
+    } else {
+      system_deep_sleep(time_us);
+    }
     esp_yield();
 }
 

--- a/cores/esp8266/Esp.cpp
+++ b/cores/esp8266/Esp.cpp
@@ -107,14 +107,17 @@ void EspClass::wdtFeed(void)
 
 extern "C" void esp_yield();
 
-void EspClass::deepSleep(uint64_t time_us, WakeMode mode, bool instantly)
+void EspClass::deepSleep(uint64_t time_us, WakeMode mode)
 {
     system_deep_sleep_set_option(static_cast<int>(mode));
-    if (instantly) {
-      system_deep_sleep_instant(time_us);
-    } else {
-      system_deep_sleep(time_us);
-    }
+    system_deep_sleep(time_us);
+    esp_yield();
+}
+
+void EspClass::deepSleepInstant(uint64_t time_us, WakeMode mode)
+{
+    system_deep_sleep_set_option(static_cast<int>(mode));
+    system_deep_sleep_instant(time_us);
     esp_yield();
 }
 

--- a/cores/esp8266/Esp.h
+++ b/cores/esp8266/Esp.h
@@ -92,7 +92,7 @@ class EspClass {
         void wdtDisable();
         void wdtFeed();
 
-        void deepSleep(uint64_t time_us, RFMode mode = RF_DEFAULT);
+        void deepSleep(uint64_t time_us, RFMode mode = RF_DEFAULT, bool instantly = false);
         uint64_t deepSleepMax();
 
         bool rtcUserMemoryRead(uint32_t offset, uint32_t *data, size_t size);

--- a/cores/esp8266/Esp.h
+++ b/cores/esp8266/Esp.h
@@ -92,7 +92,8 @@ class EspClass {
         void wdtDisable();
         void wdtFeed();
 
-        void deepSleep(uint64_t time_us, RFMode mode = RF_DEFAULT, bool instantly = false);
+        void deepSleep(uint64_t time_us, RFMode mode = RF_DEFAULT);
+        void deepSleepInstant(uint64_t time_us, RFMode mode = RF_DEFAULT);
         uint64_t deepSleepMax();
 
         bool rtcUserMemoryRead(uint32_t offset, uint32_t *data, size_t size);

--- a/doc/libraries.rst
+++ b/doc/libraries.rst
@@ -71,7 +71,9 @@ ESP-specific APIs
 
 Some ESP-specific APIs related to deep sleep, RTC and flash memories are available in the ``ESP`` object.
 
-``ESP.deepSleep(microseconds, mode, instantly)`` will put the chip into deep sleep. ``mode`` is one of ``WAKE_RF_DEFAULT``, ``WAKE_RFCAL``, ``WAKE_NO_RFCAL``, ``WAKE_RF_DISABLED``. ``instantly`` defaults to false, setting to true means sleep instantly without waiting for WiFi to shutdown. (GPIO16 needs to be tied to RST to wake from deepSleep.) The chip can sleep for at most ``ESP.deepSleepMax()`` microseconds.
+``ESP.deepSleep(microseconds, mode)`` will put the chip into deep sleep. ``mode`` is one of ``WAKE_RF_DEFAULT``, ``WAKE_RFCAL``, ``WAKE_NO_RFCAL``, ``WAKE_RF_DISABLED``. (GPIO16 needs to be tied to RST to wake from deepSleep.) The chip can sleep for at most ``ESP.deepSleepMax()`` microseconds.
+
+``ESP.deepSleepInstant(microseconds, mode)`` works similarly to ``ESP.deepSleep`` but  sleeps instantly without waiting for WiFi to shutdown.
 
 ``ESP.rtcUserMemoryWrite(offset, &data, sizeof(data))`` and ``ESP.rtcUserMemoryRead(offset, &data, sizeof(data))`` allow data to be stored in and retrieved from the RTC user memory of the chip respectively. Total size of RTC user memory is 512 bytes, so ``offset + sizeof(data)`` shouldn't exceed 512. Data should be 4-byte aligned. The stored data can be retained between deep sleep cycles. However, the data might be lost after power cycling the chip.
 

--- a/doc/libraries.rst
+++ b/doc/libraries.rst
@@ -71,7 +71,7 @@ ESP-specific APIs
 
 Some ESP-specific APIs related to deep sleep, RTC and flash memories are available in the ``ESP`` object.
 
-``ESP.deepSleep(microseconds, mode)`` will put the chip into deep sleep. ``mode`` is one of ``WAKE_RF_DEFAULT``, ``WAKE_RFCAL``, ``WAKE_NO_RFCAL``, ``WAKE_RF_DISABLED``. (GPIO16 needs to be tied to RST to wake from deepSleep.) The chip can sleep for at most ``ESP.deepSleepMax()`` microseconds.
+``ESP.deepSleep(microseconds, mode, instantly)`` will put the chip into deep sleep. ``mode`` is one of ``WAKE_RF_DEFAULT``, ``WAKE_RFCAL``, ``WAKE_NO_RFCAL``, ``WAKE_RF_DISABLED``. ``instantly`` defaults to false, setting to true means sleep instantly without waiting for WiFi to shutdown. (GPIO16 needs to be tied to RST to wake from deepSleep.) The chip can sleep for at most ``ESP.deepSleepMax()`` microseconds.
 
 ``ESP.rtcUserMemoryWrite(offset, &data, sizeof(data))`` and ``ESP.rtcUserMemoryRead(offset, &data, sizeof(data))`` allow data to be stored in and retrieved from the RTC user memory of the chip respectively. Total size of RTC user memory is 512 bytes, so ``offset + sizeof(data)`` shouldn't exceed 512. Data should be 4-byte aligned. The stored data can be retained between deep sleep cycles. However, the data might be lost after power cycling the chip.
 


### PR DESCRIPTION
As mentioned in https://github.com/esp8266/Arduino/issues/3408#issuecomment-413279368 here's an update to add an 'instantly' option to the deepSleep function.