### PR TITLE
update ClientContext's flush and call WiFiClient::flush from ::stop

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -264,17 +264,18 @@ size_t WiFiClient::peekBytes(uint8_t *buffer, size_t length) {
     return _client->peekBytes((char *)buffer, count);
 }
 
-void WiFiClient::flush()
+void WiFiClient::flush(int maxWaitMs)
 {
     if (_client)
-        _client->wait_until_sent();
+        _client->wait_until_sent(maxWaitMs);
 }
 
-void WiFiClient::stop()
+void WiFiClient::stop(int maxWaitMs)
 {
     if (!_client)
         return;
 
+    _client->wait_until_sent(maxWaitMs);
     _client->close();
 }
 

--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -264,19 +264,21 @@ size_t WiFiClient::peekBytes(uint8_t *buffer, size_t length) {
     return _client->peekBytes((char *)buffer, count);
 }
 
-void WiFiClient::flush(int maxWaitMs)
+bool WiFiClient::flush(int maxWaitMs)
 {
     if (_client)
-        _client->wait_until_sent(maxWaitMs);
+        return !_client || _client->wait_until_sent(maxWaitMs);
+    return true;
 }
 
-void WiFiClient::stop(int maxWaitMs)
+bool WiFiClient::stop(int maxWaitMs)
 {
     if (!_client)
-        return;
+        return true;
 
-    _client->wait_until_sent(maxWaitMs);
-    _client->close();
+    bool ok = _client->wait_until_sent(maxWaitMs);
+    ok &= _client->close() == ERR_OK;
+    return ok;
 }
 
 uint8_t WiFiClient::connected()

--- a/libraries/ESP8266WiFi/src/WiFiClient.h
+++ b/libraries/ESP8266WiFi/src/WiFiClient.h
@@ -28,7 +28,12 @@
 #include "IPAddress.h"
 #include "include/slist.h"
 
-#define WIFICLIENT_MAX_PACKET_SIZE 1460
+#ifndef TCP_MSS
+#define TCP_MSS 1460 // lwip1.4
+#endif
+
+#define WIFICLIENT_MAX_PACKET_SIZE TCP_MSS
+#define WIFICLIENT_MAX_FLUSH_WAIT_MS 100
 
 #define TCP_DEFAULT_KEEPALIVE_IDLE_SEC          7200 // 2 hours
 #define TCP_DEFAULT_KEEPALIVE_INTERVAL_SEC      75   // 75 sec
@@ -67,8 +72,10 @@ public:
   size_t peekBytes(char *buffer, size_t length) {
     return peekBytes((uint8_t *) buffer, length);
   }
-  virtual void flush();
-  virtual void stop();
+  void flush(int maxWaitMs);
+  void stop(int maxWaitMs);
+  virtual void flush() { flush(WIFICLIENT_MAX_FLUSH_WAIT_MS); }
+  virtual void stop() { stop(WIFICLIENT_MAX_FLUSH_WAIT_MS); }
   virtual uint8_t connected();
   virtual operator bool();
 

--- a/libraries/ESP8266WiFi/src/WiFiClient.h
+++ b/libraries/ESP8266WiFi/src/WiFiClient.h
@@ -72,8 +72,8 @@ public:
   size_t peekBytes(char *buffer, size_t length) {
     return peekBytes((uint8_t *) buffer, length);
   }
-  void flush(int maxWaitMs);
-  void stop(int maxWaitMs);
+  bool flush(int maxWaitMs);
+  bool stop(int maxWaitMs);
   virtual void flush() { flush(WIFICLIENT_MAX_FLUSH_WAIT_MS); }
   virtual void stop() { stop(WIFICLIENT_MAX_FLUSH_WAIT_MS); }
   virtual uint8_t connected();

--- a/libraries/ESP8266WiFi/src/include/ClientContext.h
+++ b/libraries/ESP8266WiFi/src/include/ClientContext.h
@@ -296,7 +296,7 @@ public:
         _rx_buf_offset = 0;
     }
 
-    bool wait_until_sent(int max_wait_ms = 100)
+    bool wait_until_sent(int max_wait_ms = WIFICLIENT_MAX_FLUSH_WAIT_MS)
     {
         // https://github.com/esp8266/Arduino/pull/3967#pullrequestreview-83451496
         // option 1 done

--- a/libraries/ESP8266WiFi/src/include/ClientContext.h
+++ b/libraries/ESP8266WiFi/src/include/ClientContext.h
@@ -296,20 +296,27 @@ public:
         _rx_buf_offset = 0;
     }
 
-    void wait_until_sent()
+    bool wait_until_sent(int max_wait_ms = 100)
     {
-        // fix option 1 in
         // https://github.com/esp8266/Arduino/pull/3967#pullrequestreview-83451496
-        // TODO: option 2
+        // option 1 done
+        // option 2 / _write_some() not necessary since _datasource is always nullptr here
 
-        #define WAIT_TRIES_MS 10	// at most 10ms
+        max_wait_ms++;
 
-        int tries = 1+ WAIT_TRIES_MS;
-
-        while (state() == ESTABLISHED && tcp_sndbuf(_pcb) != TCP_SND_BUF && --tries) {
-            _write_some();
+        // wait for peer's acks flushing lwIP's output buffer
+        while (state() == ESTABLISHED && tcp_sndbuf(_pcb) != TCP_SND_BUF && --max_wait_ms) {
             delay(1); // esp_ schedule+yield
         }
+
+        #ifdef DEBUGV
+        if (max_wait_ms == 0) {
+            // wait until sent: timeout
+            DEBUGV(":wustmo\n");
+        }
+        #endif
+
+        return max_wait_ms > 0;
     }
 
     uint8_t state() const


### PR DESCRIPTION
* Simplification of `ClientContext::wait_until_send` (with parametric timeout), because `_datasource` is always nullptr
* call `WiFiClient::flush` from `::stop` with return value for both (true if flushing is confirmed)