### PR TITLE
Soft-AP documentation update

### DIFF
--- a/doc/esp8266wifi/readme.rst
+++ b/doc/esp8266wifi/readme.rst
@@ -125,7 +125,7 @@ Soft Access Point
 ~~~~~~~~~~~~~~~~~
 
 An `access point (AP) <https://en.wikipedia.org/wiki/Wireless_access_point>`__ is a device that provides access to Wi-Fi network to other devices (stations)
-and connects them further to a wired network. ESP8266 can provide similar functionality except it does not have interface to a wired network. Such mode of operation is called soft access point (soft-AP). The maximum number of stations connected to the soft-AP is five.
+and connects them further to a wired network. ESP8266 can provide similar functionality except it does not have interface to a wired network. Such mode of operation is called soft access point (soft-AP). The maximum number of stations that can simultaneously be connected to the soft-AP is 4 by default.
 
 .. figure:: pictures/esp8266-soft-access-point.png
    :alt: ESP8266 operating in the Soft Access Point mode

--- a/doc/esp8266wifi/readme.rst
+++ b/doc/esp8266wifi/readme.rst
@@ -125,7 +125,7 @@ Soft Access Point
 ~~~~~~~~~~~~~~~~~
 
 An `access point (AP) <https://en.wikipedia.org/wiki/Wireless_access_point>`__ is a device that provides access to Wi-Fi network to other devices (stations)
-and connects them further to a wired network. ESP8266 can provide similar functionality except it does not have interface to a wired network. Such mode of operation is called soft access point (soft-AP). The maximum number of stations that can simultaneously be connected to the soft-AP is 4 by default.
+and connects them further to a wired network. ESP8266 can provide similar functionality except it does not have interface to a wired network. Such mode of operation is called soft access point (soft-AP). The maximum number of stations that can simultaneously be connected to the soft-AP can be set `from 1 to 8 <https://bbs.espressif.com/viewtopic.php?f=46&t=481&p=1832&hilit=max_connection#p1832>`__, but defaults to 4.
 
 .. figure:: pictures/esp8266-soft-access-point.png
    :alt: ESP8266 operating in the Soft Access Point mode

--- a/doc/esp8266wifi/soft-access-point-class.rst
+++ b/doc/esp8266wifi/soft-access-point-class.rst
@@ -131,7 +131,7 @@ Get the count of the stations that are connected to the soft-AP interface.
 
     Stations connected to soft-AP = 2
 
-Note: the maximum number of stations that may be connected to ESP8266 soft-AP is 4 by default. This can be changed from 1 to 4 via the ``max_connection`` argument of the soft-AP constructor.
+Note: the maximum number of stations that may be connected to ESP8266 soft-AP is 4 by default. This can be changed from 1 to 4 via the ``max_connection`` argument of the softAP method.
 
 softAPdisconnect
 ^^^^^^^^^^^^^^^^

--- a/doc/esp8266wifi/soft-access-point-class.rst
+++ b/doc/esp8266wifi/soft-access-point-class.rst
@@ -48,7 +48,7 @@ To set up password protected network, or to configure additional network paramet
 
 The first parameter of this function is required, remaining four are optional.
 
-Meaning of all parameters is as follows: - ``ssid`` - character string containing network SSID (max. 63 characters) \* ``password`` - optional character string with a password. For WPA2-PSK network it should be at least 8 character long. If not specified, the access point will be open for anybody to connect. \* ``channel`` - optional parameter to set Wi-Fi channel, from 1 to 13. Default channel = 1. \* ``hidden`` - optional parameter, if set to ``true`` will hide SSID. \* ``max_connection`` - optional parameter to set max simultaneous connected clients, from 1 to 4. Defaults to 4.
+Meaning of all parameters is as follows: - ``ssid`` - character string containing network SSID (max. 63 characters) \* ``password`` - optional character string with a password. For WPA2-PSK network it should be at least 8 character long. If not specified, the access point will be open for anybody to connect. \* ``channel`` - optional parameter to set Wi-Fi channel, from 1 to 13. Default channel = 1. \* ``hidden`` - optional parameter, if set to ``true`` will hide SSID. \* ``max_connection`` - optional parameter to set max simultaneous connected stations, from 1 to 4. Defaults to 4. Once the max number has been reached, any other station that wants to connect will be forced to wait until an already connected station disconnects.
 
 Function will return ``true`` or ``false`` depending on result of setting the soft-AP.
 

--- a/doc/esp8266wifi/soft-access-point-class.rst
+++ b/doc/esp8266wifi/soft-access-point-class.rst
@@ -44,11 +44,11 @@ To set up password protected network, or to configure additional network paramet
 
 .. code:: cpp
 
-    WiFi.softAP(ssid, password, channel, hidden)
+    WiFi.softAP(ssid, password, channel, hidden, max_connection)
 
-The first parameter of this function is required, remaining three are optional.
+The first parameter of this function is required, remaining four are optional.
 
-Meaning of all parameters is as follows: - ``ssid`` - character string containing network SSID (max. 63 characters) \* ``password`` - optional character string with a password. For WPA2-PSK network it should be at least 8 character long. If not specified, the access point will be open for anybody to connect. \* ``channel`` - optional parameter to set Wi-Fi channel, from 1 to 13. Default channel = 1. \* ``hidden`` - optional parameter, if set to ``true`` will hide SSID
+Meaning of all parameters is as follows: - ``ssid`` - character string containing network SSID (max. 63 characters) \* ``password`` - optional character string with a password. For WPA2-PSK network it should be at least 8 character long. If not specified, the access point will be open for anybody to connect. \* ``channel`` - optional parameter to set Wi-Fi channel, from 1 to 13. Default channel = 1. \* ``hidden`` - optional parameter, if set to ``true`` will hide SSID. \* ``max_connection`` - optional parameter to set max simultaneous connected clients, from 1 to 4. Defaults to 4.
 
 Function will return ``true`` or ``false`` depending on result of setting the soft-AP.
 
@@ -131,7 +131,7 @@ Get the count of the stations that are connected to the soft-AP interface.
 
     Stations connected to soft-AP = 2
 
-Note: the maximum number of stations that may be connected to ESP8266 soft-AP is five.
+Note: the maximum number of stations that may be connected to ESP8266 soft-AP is 4 by default. This can be changed from 1 to 4 via the ``max_connection`` argument of the soft-AP constructor.
 
 softAPdisconnect
 ^^^^^^^^^^^^^^^^

--- a/doc/esp8266wifi/soft-access-point-class.rst
+++ b/doc/esp8266wifi/soft-access-point-class.rst
@@ -48,7 +48,7 @@ To set up password protected network, or to configure additional network paramet
 
 The first parameter of this function is required, remaining four are optional.
 
-Meaning of all parameters is as follows: - ``ssid`` - character string containing network SSID (max. 63 characters) \* ``password`` - optional character string with a password. For WPA2-PSK network it should be at least 8 character long. If not specified, the access point will be open for anybody to connect. \* ``channel`` - optional parameter to set Wi-Fi channel, from 1 to 13. Default channel = 1. \* ``hidden`` - optional parameter, if set to ``true`` will hide SSID. \* ``max_connection`` - optional parameter to set max simultaneous connected stations, from 1 to 4. Defaults to 4. Once the max number has been reached, any other station that wants to connect will be forced to wait until an already connected station disconnects.
+Meaning of all parameters is as follows: - ``ssid`` - character string containing network SSID (max. 63 characters) \* ``password`` - optional character string with a password. For WPA2-PSK network it should be at least 8 character long. If not specified, the access point will be open for anybody to connect. \* ``channel`` - optional parameter to set Wi-Fi channel, from 1 to 13. Default channel = 1. \* ``hidden`` - optional parameter, if set to ``true`` will hide SSID. \* ``max_connection`` - optional parameter to set max simultaneous connected stations, `from 1 to 8 <https://bbs.espressif.com/viewtopic.php?f=46&t=481&p=1832&hilit=max_connection#p1832>`__. Defaults to 4. Once the max number has been reached, any other station that wants to connect will be forced to wait until an already connected station disconnects.
 
 Function will return ``true`` or ``false`` depending on result of setting the soft-AP.
 
@@ -131,7 +131,7 @@ Get the count of the stations that are connected to the soft-AP interface.
 
     Stations connected to soft-AP = 2
 
-Note: the maximum number of stations that may be connected to ESP8266 soft-AP is 4 by default. This can be changed from 1 to 4 via the ``max_connection`` argument of the softAP method.
+Note: the maximum number of stations that may be connected to ESP8266 soft-AP is 4 by default. This can be changed from 1 to 8 via the ``max_connection`` argument of the softAP method.
 
 softAPdisconnect
 ^^^^^^^^^^^^^^^^

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiAP.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiAP.cpp
@@ -89,7 +89,7 @@ static bool softap_config_equal(const softap_config& lhs, const softap_config& r
  * @param passphrase        (for WPA2 min 8 char, for open use NULL)
  * @param channel           WiFi channel number, 1 - 13.
  * @param ssid_hidden       Network cloaking (0 = broadcast SSID, 1 = hide SSID)
- * @param max_connection    Max simultaneous connected clients, 1 - 4.
+ * @param max_connection    Max simultaneous connected clients, 1 - 8. https://bbs.espressif.com/viewtopic.php?f=46&t=481&p=1832&hilit=max_connection#p1832
  */
 bool ESP8266WiFiAPClass::softAP(const char* ssid, const char* passphrase, int channel, int ssid_hidden, int max_connection) {
 


### PR DESCRIPTION
In several places of the documentation one can read "the maximum number of stations that may be connected to ESP8266 soft-AP is five." or something along those lines. However, the [softAP method](https://github.com/esp8266/Arduino/blob/9634f79f45eead2e053e30460b973ea000a0a8f6/libraries/ESP8266WiFi/src/ESP8266WiFiAP.h#L39) has a `int max_connection = 4` argument which represents ["Max simultaneous connected clients"](https://github.com/esp8266/Arduino/blob/9634f79f45eead2e053e30460b973ea000a0a8f6/libraries/ESP8266WiFi/src/ESP8266WiFiAP.cpp#L86). It would thus seem that the maximum number of stations that may be connected to ESP8266 soft-AP is four by default. This PR brings the documentation in line with the source code.

While looking into this issue I noticed that the topic may not be quite as simple as it first seems. Although the softAP method claims the max number of clients is 4, I've read other [claims](https://github.com/esp8266/Arduino/issues/570#issuecomment-338116826) that the [max is actually 8](https://bbs.espressif.com/viewtopic.php?f=46&t=481&p=1832&hilit=max_connection#p1832). @D-A-V even seems to have been able to get [12 simultaneous connections working](https://github.com/esp8266/Arduino/issues/4460#issuecomment-370382586) (though I'm not sure if that test is applicable here), and there are [some claims](https://bbs.espressif.com/viewtopic.php?t=4472 ) that the main limiting factor is actually only available memory.

Sadly I do not have enough ESPs to try where the max limit is for myself, so it would be good if @D-A-V or someone else with knowledge on this topic could confirm whether the max actually is 4, 8, 12 or something else.