### PR TITLE
Make unique sections for ICACHE_* variables

### DIFF
--- a/tools/sdk/include/c_types.h
+++ b/tools/sdk/include/c_types.h
@@ -84,9 +84,13 @@ typedef enum {
 #define SHMEM_ATTR
 
 #ifdef ICACHE_FLASH
-#define ICACHE_FLASH_ATTR   __attribute__((section(".irom0.text")))
-#define ICACHE_RAM_ATTR     __attribute__((section(".iram.text")))
-#define ICACHE_RODATA_ATTR  __attribute__((section(".irom.text")))
+// The following two macros cause a parameter to be enclosed in quotes
+// by the preopressor (i.e. for concatenating ints to strings)
+#define __ICACHE_STRINGIZE_NX(A) #A
+#define __ICACHE_STRINGIZE(A) __ICACHE_STRINGIZE_NX(A)
+#define ICACHE_FLASH_ATTR   __attribute__((section( "\".irom0.text." __FILE__ "." __ICACHE_STRINGIZE(__LINE__) "."  __ICACHE_STRINGIZE(__COUNTER__) "\"")))
+#define ICACHE_RAM_ATTR     __attribute__((section( "\".iram.text." __FILE__ "." __ICACHE_STRINGIZE(__LINE__) "."  __ICACHE_STRINGIZE(__COUNTER__) "\"")))
+#define ICACHE_RODATA_ATTR  __attribute__((section( "\".irom.text." __FILE__ "." __ICACHE_STRINGIZE(__LINE__) "."  __ICACHE_STRINGIZE(__COUNTER__) "\"")))
 #else
 #define ICACHE_FLASH_ATTR
 #define ICACHE_RAM_ATTR

--- a/tools/sdk/ld/eagle.app.v6.common.ld.h
+++ b/tools/sdk/ld/eagle.app.v6.common.ld.h
@@ -127,7 +127,7 @@ SECTIONS
     *libwpa.a:(.literal.* .text.*)
     *libwpa2.a:(.literal.* .text.*)
     *libwps.a:(.literal.* .text.*)
-    *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text .irom.text.*)
+    *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom0.text.* .irom.text .irom.text.*)
     _irom0_text_end = ABSOLUTE(.);
     _flash_code_end = ABSOLUTE(.);
   } >irom0_0_seg :irom0_0_phdr
@@ -164,8 +164,8 @@ SECTIONS
     *(.init.literal)
     *(.init)
     *(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
-    *.cpp.o(.iram.text)
-    *.c.o(.iram.text)
+    *.cpp.o(.iram.text .iram.text.*)
+    *.c.o(.iram.text .iram.text.*)
 #ifdef VTABLES_IN_IRAM
     *(.rodata._ZTV*) /* C++ vtables */
 #endif


### PR DESCRIPTION
Similar to PROGMEM changes, make the name of each ICACHE_* variable/fuction
unique to avoid issues with section conflicts.

Fixes #5115