### PR TITLE
Fix connection options and update github pubkey

### DIFF
--- a/libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation.ino
+++ b/libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation.ino
@@ -131,13 +131,13 @@ able to establish communications.
   // Extracted by: openssl x509 -pubkey -noout -in servercert.pem
   static const char pubkey[] PROGMEM = R"KEY(
 -----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqcCPMEktuxLoDAxdHQgI
-95FweH4Fa6+LslU2qmmUBF+pu4ZOUvpIQxVU5wqdWaxZauxG1nYUTrAWdPb1n0um
-gLsGE7WYXJnQPJewIK4Qhua0LsrirIdHkcwHQ83NEYj+lswhg0fUQURt06Uta5ak
-LovDdJPLqTuTS/nshOa76hR0ouWnrqucLL1szcvX/obB+Nsbmr58Mrg8prQfRoK6
-ibzlZysV88qPcCpc57lq6QBKQ2F9WgQMssQigXfTNm8lAAQ+L6gCZngd4KfHYPSJ
-YA07oFWmuSOalgh00Wh8PUjuRGrcNxWpmgfALQHHFYgoDcD+a8+GoJk+GdJd3ong
-ZQIDAQAB
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAy+3Up8qBkIn/7S9AfWlH
+Od8SdXmnWx+JCIHvnWzjFcLeLvQb2rMqqCDL5XDlvkyC5SZ8ZyLITemej5aJYuBv
+zcKPzyZ0QfYZiskU9nzL2qBQj8alzJJ/Cc32AWuuWrPrzVxBmOEW9gRCGFCD3m0z
+53y6GjcmBS2wcX7RagqbD7g2frEGko4G7kmW96H6dyh2j9Rou8TwAK6CnbiXPAM/
+5Q6dyfdYlHOCgP75F7hhdKB5gpprm9A/OnQsmZjUPzy4u0EKCxE8MfhBerZrZdod
+88ZdDG3CvTgm050bc+lGlbsT+s09lp0dgxSZIeI8+syV2Owt4YF/PdjeeymtzQdI
+wQIDAQAB
 -----END PUBLIC KEY-----
 )KEY";
   BearSSL::WiFiClientSecure client;

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
@@ -179,7 +179,10 @@ void WiFiClientSecure::stop() {
     _client->abort();
   }
   WiFiClient::stop();
-  _clearAuthenticationSettings();
+  // Only if we've already connected, clear the connection options
+  if (_handshake_done) {
+    _clearAuthenticationSettings();
+  }
   _freeSSL();
 }
 


### PR DESCRIPTION
As part of the "clear connection configuration for reused objects"
patch, a ::stop would reset the self-signed, trust anchors, etc.
WiFiClient, unfortunately, calls ::stop as part of the connection
process, so all of these settings were lost.

Now only clear the connection settings on ::stop if we've already
been connected.

Also update the github public key which changed yet again.

Fixes #5086