### PR TITLE
Require sphinx 1.7 due to bugs with new v1.8

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 # Requirements file for pip
 # list of Python packages used in documentation build
-sphinx
+sphinx==1.7.9
 sphinx-rtd-theme
 breathe
 nbsphinx


### PR DESCRIPTION
Sphinx 1.8.0 seems to always fail to build the docs due to interactions
with doctest.py.  This means no CI builds can pass and no new PRs can be
applied.

Fix the version at 1.7 for now until the dependencies get updated to with 1.8.

The error seen is:
  File "/home/travis/.local/lib/python2.7/site-packages/sphinx/highlighting.py", line 26, in <module>
    from sphinx.ext import doctest
SyntaxError: unqualified exec is not allowed in function 'run' it contains a nested function with free variables (doctest.py, line 97)
The full traceback has been saved in /tmp/sphinx-err-e8JyUQ.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!