### PR TITLE
Move ICACHE_* to unique sections, local LD script

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -79,7 +79,7 @@ recipe.hooks.core.prebuild.1.pattern.windows=cmd.exe /c mkdir {build.path}\core 
 recipe.hooks.core.prebuild.2.pattern.windows=
 
 ## Build the app.ld linker file
-recipe.hooks.linking.prelink.1.pattern="{compiler.path}{compiler.c.cmd}" -CC -E -P {build.vtable_flags} "{runtime.platform.path}/tools/sdk/ld/eagle.app.v6.common.ld.h" -o "{build.path}/eagle.app.v6.common.ld"
+recipe.hooks.linking.prelink.1.pattern="{compiler.path}{compiler.c.cmd}" -CC -E -P {build.vtable_flags} "{runtime.platform.path}/tools/sdk/ld/eagle.app.v6.common.ld.h" -o "{build.path}/local.eagle.app.v6.common.ld"
 
 ## Compile c files
 recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.cpreprocessor.flags} {compiler.c.flags} -DF_CPU={build.f_cpu} {build.lwip_flags} {build.debug_port} {build.debug_level} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DARDUINO_BOARD="{build.board}" {build.led} {compiler.c.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"

--- a/tools/boards.txt.py
+++ b/tools/boards.txt.py
@@ -1172,7 +1172,7 @@ def flash_map (flashsize_kb, spiffs_kb = 0):
         print("PROVIDE ( _SPIFFS_page = 0x%X );" % page)
         print("PROVIDE ( _SPIFFS_block = 0x%X );" % block)
         print("")
-        print('INCLUDE "eagle.app.v6.common.ld"')
+        print('INCLUDE "local.eagle.app.v6.common.ld"')
 
         if ldgen:
             sys.stdout.close()

--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -168,7 +168,7 @@ assert current_vtables
 
 # Build the eagle.app.v6.common.ld linker file
 app_ld = env.Command(
-    join("$BUILD_DIR", "ld", "eagle.app.v6.common.ld"),
+    join("$BUILD_DIR", "ld", "local.eagle.app.v6.common.ld"),
     join(FRAMEWORK_DIR, "tools", "sdk", "ld", "eagle.app.v6.common.ld.h"),
     env.VerboseAction(
         "$CC -CC -E -P -D%s $SOURCE -o $TARGET" % current_vtables,

--- a/tools/sdk/include/c_types.h
+++ b/tools/sdk/include/c_types.h
@@ -84,9 +84,11 @@ typedef enum {
 #define SHMEM_ATTR
 
 #ifdef ICACHE_FLASH
-#define ICACHE_FLASH_ATTR   __attribute__((section(".irom0.text")))
-#define ICACHE_RAM_ATTR     __attribute__((section(".iram.text")))
-#define ICACHE_RODATA_ATTR  __attribute__((section(".irom.text")))
+#define __ICACHE_STRINGIZE_NX(A) #A
+#define __ICACHE_STRINGIZE(A) __ICACHE_STRINGIZE_NX(A)
+#define ICACHE_FLASH_ATTR   __attribute__((section("\".irom0.text." __FILE__ "." __ICACHE_STRINGIZE(__LINE__) "." __ICACHE_STRINGIZE(__COUNTER__) "\"")))
+#define ICACHE_RAM_ATTR     __attribute__((section("\".iram.text." __FILE__ "." __ICACHE_STRINGIZE(__LINE__) "." __ICACHE_STRINGIZE(__COUNTER__) "\"")))
+#define ICACHE_RODATA_ATTR  __attribute__((section("\".irom.text." __FILE__ "." __ICACHE_STRINGIZE(__LINE__) "." __ICACHE_STRINGIZE(__COUNTER__) "\"")))
 #else
 #define ICACHE_FLASH_ATTR
 #define ICACHE_RAM_ATTR

--- a/tools/sdk/ld/eagle.app.v6.common.ld.h
+++ b/tools/sdk/ld/eagle.app.v6.common.ld.h
@@ -127,7 +127,7 @@ SECTIONS
     *libwpa.a:(.literal.* .text.*)
     *libwpa2.a:(.literal.* .text.*)
     *libwps.a:(.literal.* .text.*)
-    *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text .irom.text.*)
+    *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom0.text.* .irom.text .irom.text.*)
     _irom0_text_end = ABSOLUTE(.);
     _flash_code_end = ABSOLUTE(.);
   } >irom0_0_seg :irom0_0_phdr
@@ -164,8 +164,8 @@ SECTIONS
     *(.init.literal)
     *(.init)
     *(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
-    *.cpp.o(.iram.text)
-    *.c.o(.iram.text)
+    *.cpp.o(.iram.text .iram.text.*)
+    *.c.o(.iram.text .iram.text.*)
 #ifdef VTABLES_IN_IRAM
     *(.rodata._ZTV*) /* C++ vtables */
 #endif

--- a/tools/sdk/ld/eagle.flash.16m14m.ld
+++ b/tools/sdk/ld/eagle.flash.16m14m.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x411FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x2000 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.16m15m.ld
+++ b/tools/sdk/ld/eagle.flash.16m15m.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x411FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x2000 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.1m.ld
+++ b/tools/sdk/ld/eagle.flash.1m.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x402FB000 );
 PROVIDE ( _SPIFFS_page = 0x0 );
 PROVIDE ( _SPIFFS_block = 0x0 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.1m128.ld
+++ b/tools/sdk/ld/eagle.flash.1m128.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x402FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x1000 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.1m144.ld
+++ b/tools/sdk/ld/eagle.flash.1m144.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x402FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x1000 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.1m160.ld
+++ b/tools/sdk/ld/eagle.flash.1m160.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x402FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x1000 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.1m192.ld
+++ b/tools/sdk/ld/eagle.flash.1m192.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x402FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x1000 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.1m256.ld
+++ b/tools/sdk/ld/eagle.flash.1m256.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x402FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x1000 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.1m512.ld
+++ b/tools/sdk/ld/eagle.flash.1m512.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x402FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x2000 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.1m64.ld
+++ b/tools/sdk/ld/eagle.flash.1m64.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x402FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x1000 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.2m.ld
+++ b/tools/sdk/ld/eagle.flash.2m.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x403FB000 );
 PROVIDE ( _SPIFFS_page = 0x0 );
 PROVIDE ( _SPIFFS_block = 0x0 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.2m1m.ld
+++ b/tools/sdk/ld/eagle.flash.2m1m.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x403FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x2000 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.2m512.ld
+++ b/tools/sdk/ld/eagle.flash.2m512.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x403FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x2000 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.4m.ld
+++ b/tools/sdk/ld/eagle.flash.4m.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x405FB000 );
 PROVIDE ( _SPIFFS_page = 0x0 );
 PROVIDE ( _SPIFFS_block = 0x0 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.4m1m.ld
+++ b/tools/sdk/ld/eagle.flash.4m1m.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x405FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x2000 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.4m2m.ld
+++ b/tools/sdk/ld/eagle.flash.4m2m.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x405FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x2000 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.4m3m.ld
+++ b/tools/sdk/ld/eagle.flash.4m3m.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x405FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x2000 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.512k.ld
+++ b/tools/sdk/ld/eagle.flash.512k.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x4027B000 );
 PROVIDE ( _SPIFFS_page = 0x0 );
 PROVIDE ( _SPIFFS_block = 0x0 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.512k128.ld
+++ b/tools/sdk/ld/eagle.flash.512k128.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x4027B000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x1000 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.512k32.ld
+++ b/tools/sdk/ld/eagle.flash.512k32.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x4027B000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x1000 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.512k64.ld
+++ b/tools/sdk/ld/eagle.flash.512k64.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x4027B000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x1000 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.8m6m.ld
+++ b/tools/sdk/ld/eagle.flash.8m6m.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x409FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x2000 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"

--- a/tools/sdk/ld/eagle.flash.8m7m.ld
+++ b/tools/sdk/ld/eagle.flash.8m7m.ld
@@ -19,4 +19,4 @@ PROVIDE ( _SPIFFS_end = 0x409FB000 );
 PROVIDE ( _SPIFFS_page = 0x100 );
 PROVIDE ( _SPIFFS_block = 0x2000 );
 
-INCLUDE "eagle.app.v6.common.ld"
+INCLUDE "local.eagle.app.v6.common.ld"


### PR DESCRIPTION
Similar to PROGMEM changes, make the name of each ICACHE_* variable/fuction
unique to avoid issues with section conflicts.

Also rename the generated LD linker script to avoid issue with older copies
of the eagle.app.v6.common.ld which were generated by the build process
in a global directory before being moved to the {build.path}.  The linker
would use the older, generated *.ld file instead of the generated one, which
would lead to runtime failures on some systems and cause the VTABLE location
to not correspond to the IDE menu selection.

Fixes #5115, and is an update to #5117 and #5116.