### PR TITLE
Allow cipher specification for BearSSL

### DIFF
--- a/libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation.ino
+++ b/libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation.ino
@@ -193,11 +193,12 @@ BearSSL does verify the notValidBefore/After fields.
   fetchURL(&client, host, port, path);
 }
 
-void fetchAxTLS() {
+void fetchFaster() {
   Serial.printf(R"EOF(
 The ciphers used to set up the SSL connection can be configured to
-be the same as axTLS. They are faster, but less secure, so if you care
-about security you won't want to do this.
+only support faster but less secure ciphers.  If you care about security
+you won't want to do this.  If you need to maximize battery life, these
+may make sense
 )EOF");
   BearSSL::WiFiClientSecure client;
   client.setInsecure();
@@ -206,10 +207,10 @@ about security you won't want to do this.
   uint32_t delta = millis() - now;
   now = millis();
   client.setInsecure();
-  client.setAxTLSCiphers();
+  client.setCiphersLessSecure();
   fetchURL(&client, host, port, path);
   uint32_t delta2 = millis() - now;
-  Serial.printf("Using more secure: %dms\nUsiing axTLS ciphers: %dms\n", delta, delta2);
+  Serial.printf("Using more secure: %dms\nUsing less secure ciphers: %dms\n", delta, delta2);
 }
 
 void setup() {
@@ -239,7 +240,7 @@ void setup() {
   fetchSelfSigned();
   fetchKnownKey();
   fetchCertAuthority();
-  fetchAxTLS();
+  fetchFaster();
 }
 
 

--- a/libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation.ino
+++ b/libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation.ino
@@ -193,6 +193,25 @@ BearSSL does verify the notValidBefore/After fields.
   fetchURL(&client, host, port, path);
 }
 
+void fetchAxTLS() {
+  Serial.printf(R"EOF(
+The ciphers used to set up the SSL connection can be configured to
+be the same as axTLS. They are faster, but less secure, so if you care
+about security you won't want to do this.
+)EOF");
+  BearSSL::WiFiClientSecure client;
+  client.setInsecure();
+  uint32_t now = millis();
+  fetchURL(&client, host, port, path);
+  uint32_t delta = millis() - now;
+  now = millis();
+  client.setInsecure();
+  client.setAxTLSCiphers();
+  fetchURL(&client, host, port, path);
+  uint32_t delta2 = millis() - now;
+  Serial.printf("Using more secure: %dms\nUsiing axTLS ciphers: %dms\n", delta, delta2);
+}
+
 void setup() {
   Serial.begin(115200);
   Serial.println();
@@ -220,6 +239,7 @@ void setup() {
   fetchSelfSigned();
   fetchKnownKey();
   fetchCertAuthority();
+  fetchAxTLS();
 }
 
 

--- a/libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation.ino
+++ b/libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation.ino
@@ -205,12 +205,18 @@ may make sense
   uint32_t now = millis();
   fetchURL(&client, host, port, path);
   uint32_t delta = millis() - now;
-  now = millis();
   client.setInsecure();
   client.setCiphersLessSecure();
+  now = millis();
   fetchURL(&client, host, port, path);
   uint32_t delta2 = millis() - now;
-  Serial.printf("Using more secure: %dms\nUsing less secure ciphers: %dms\n", delta, delta2);
+  std::vector<uint16_t> myCustomList = { BR_TLS_RSA_WITH_AES_256_CBC_SHA256, BR_TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, BR_TLS_RSA_WITH_3DES_EDE_CBC_SHA };
+  client.setInsecure();
+  client.setCiphers(myCustomList);
+  now = millis();
+  fetchURL(&client, host, port, path);
+  uint32_t delta3 = millis() - now;
+  Serial.printf("Using more secure: %dms\nUsing less secure ciphers: %dms\nUsing custom cipher list: %dms\n", delta, delta2, delta3);
 }
 
 void setup() {

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
@@ -687,8 +687,8 @@ extern "C" {
     BR_TLS_RSA_WITH_3DES_EDE_CBC_SHA
   };
 
-  // For apps which want to use less secure but faster axTLS ciphers, only
-  static const uint16_t axtls_suites_P[] PROGMEM = {
+  // For apps which want to use less secure but faster ciphers, only
+  static const uint16_t faster_suites_P[] PROGMEM = {
     BR_TLS_RSA_WITH_AES_256_CBC_SHA256,
     BR_TLS_RSA_WITH_AES_128_CBC_SHA256,
     BR_TLS_RSA_WITH_AES_256_CBC_SHA,
@@ -735,10 +735,10 @@ extern "C" {
 
 }
 
-// Set the AXTLS ciphers as the only ones allowed
-void WiFiClientSecure::setAxTLSCiphers()
+// Set the faster ciphers as the only ones allowed
+void WiFiClientSecure::setCiphersLessSecure()
 {
-  setCiphers(axtls_suites_P, sizeof(axtls_suites_P)/sizeof(axtls_suites_P[0]));
+  setCiphers(faster_suites_P, sizeof(faster_suites_P)/sizeof(faster_suites_P[0]));
 }
 
 // Installs the appropriate X509 cert validation method for a client connection

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
@@ -104,12 +104,17 @@ class WiFiClientSecure : public WiFiClient {
       _certStore = certStore;
     }
 
+    // Select specific ciphers (i.e. optimize for speed over security)
+    // These may be in PROGMEM or RAM, either will run properly
+    void setCiphers(const uint16_t *cipherAry, int cipherCount) { _cipher_list = cipherAry; _cipher_cnt = cipherCount; }
+    void setAxTLSCiphers(); // Only use the limited set of axTLS ciphers
+
     // Check for Maximum Fragment Length support for given len
     static bool probeMaxFragmentLength(IPAddress ip, uint16_t port, uint16_t len);
     static bool probeMaxFragmentLength(const char *hostname, uint16_t port, uint16_t len);
     static bool probeMaxFragmentLength(const String host, uint16_t port, uint16_t len);
 
-    // AXTLS compatbile wrappers
+    // AXTLS compatible wrappers
     bool verify(const char* fingerprint, const char* domain_name) { (void) fingerprint; (void) domain_name; return false; } // Can't handle this case, need app code changes
     bool verifyCertChain(const char* domain_name) { (void)domain_name; return connected(); } // If we're connected, the cert passed validation during handshake
 
@@ -169,6 +174,10 @@ class WiFiClientSecure : public WiFiClient {
     bool _use_self_signed;
     const BearSSLPublicKey *_knownkey;
     unsigned _knownkey_usages;
+
+    // Custom cipher list pointer or NULL if default
+    const uint16_t *_cipher_list;
+    uint16_t _cipher_cnt;
 
     unsigned char *_recvapp_buf;
     size_t _recvapp_len;

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
@@ -23,6 +23,7 @@
 
 #ifndef wificlientbearssl_h
 #define wificlientbearssl_h
+#include <vector>
 #include "WiFiClient.h"
 #include <bearssl/bearssl.h>
 #include "BearSSLHelpers.h"
@@ -106,8 +107,9 @@ class WiFiClientSecure : public WiFiClient {
 
     // Select specific ciphers (i.e. optimize for speed over security)
     // These may be in PROGMEM or RAM, either will run properly
-    void setCiphers(const uint16_t *cipherAry, int cipherCount) { _cipher_list = cipherAry; _cipher_cnt = cipherCount; }
-    void setCiphersLessSecure(); // Only use the limited set of RSA ciphers without EC
+    bool setCiphers(const uint16_t *cipherAry, int cipherCount);
+    bool setCiphers(std::vector<uint16_t> list);
+    bool setCiphersLessSecure(); // Only use the limited set of RSA ciphers without EC
 
     // Check for Maximum Fragment Length support for given len
     static bool probeMaxFragmentLength(IPAddress ip, uint16_t port, uint16_t len);
@@ -176,8 +178,8 @@ class WiFiClientSecure : public WiFiClient {
     unsigned _knownkey_usages;
 
     // Custom cipher list pointer or NULL if default
-    const uint16_t *_cipher_list;
-    uint16_t _cipher_cnt;
+    uint16_t *_cipher_list;
+    uint8_t _cipher_cnt;
 
     unsigned char *_recvapp_buf;
     size_t _recvapp_len;

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
@@ -107,7 +107,7 @@ class WiFiClientSecure : public WiFiClient {
     // Select specific ciphers (i.e. optimize for speed over security)
     // These may be in PROGMEM or RAM, either will run properly
     void setCiphers(const uint16_t *cipherAry, int cipherCount) { _cipher_list = cipherAry; _cipher_cnt = cipherCount; }
-    void setAxTLSCiphers(); // Only use the limited set of axTLS ciphers
+    void setCiphersLessSecure(); // Only use the limited set of RSA ciphers without EC
 
     // Check for Maximum Fragment Length support for given len
     static bool probeMaxFragmentLength(IPAddress ip, uint16_t port, uint16_t len);


### PR DESCRIPTION
BearSSL has many more ciphers than axTLS, but they are more compute intensive
and slower.  Add an option to use only the same, limited security, axTLS ciphers
as well as allow users to specify any suite of ciphers they want using standard
BearSSL formats.

Fixes #5110