### PR TITLE
cont.h: cont_yield() should be __attribute__d as ((returns_twice))

### DIFF
--- a/cores/esp8266/cont.h
+++ b/cores/esp8266/cont.h
@@ -60,7 +60,7 @@ void cont_run(cont_t*, void (*pfn)(void));
 
 // Return to the point where cont_run was called, saving the
 // execution state (registers and stack)
-void cont_yield(cont_t*);
+void cont_yield(cont_t*) __attribute__((returns_twice));
 
 // Check guard bytes around the stack. Return 0 in case everything is ok,
 // return 1 if guard bytes were overwritten.


### PR DESCRIPTION
GCC manual says, "The returns_twice attribute tells the compiler that a function may return more than one time."