### PR TITLE
Really free stack after last BearSSL obj destroyed

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
@@ -229,6 +229,7 @@ class WiFiClientSecure : public WiFiClient {
   private:
     // Single memory buffer used for BearSSL auxilliary stack, insead of growing main Arduino stack for all apps
     static std::shared_ptr<uint8_t> _bearssl_stack;
+    void _ensureStackAvailable(); // Allocate the stack if necessary
     // The local copy, only used to enable a reference count
     std::shared_ptr<uint8_t> _local_bearssl_stack;
 };


### PR DESCRIPTION
The BearSSL second stack, once allocated, was never deallocated.  The
reference count of the stack pointer never hit 0 due to the initial
creation counting as one.  Now, check to see if there is only one use_count
and if so then delete the stack.