### PR TITLE
Add warning when no authenticator, drop verify()

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
@@ -847,6 +847,13 @@ bool WiFiClientSecure::_connectSSL(const char* hostName) {
   _freeSSL();
   _oom_err = false;
 
+#ifdef DEBUG_ESP_SSL
+  // BearSSL will reject all connections unless an authentication option is set, warn in DEBUG builds
+  if (!_use_insecure && !_use_fingerprint && !_use_self_signed && !_knownkey && !_certStore && !_ta) {
+    DEBUGV("BSSL: Connection *will* fail, no authentication method is setup");
+  }
+#endif
+
   _sc = std::make_shared<br_ssl_client_context>();
   _eng = &_sc->eng; // Allocation/deallocation taken care of by the _sc shared_ptr
   _iobuf_in = std::shared_ptr<unsigned char>(new unsigned char[_iobuf_in_size], std::default_delete<unsigned char[]>());

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
@@ -120,7 +120,7 @@ class WiFiClientSecure : public WiFiClient {
     static bool probeMaxFragmentLength(const String host, uint16_t port, uint16_t len);
 
     // AXTLS compatible wrappers
-    bool verify(const char* fingerprint, const char* domain_name) { (void) fingerprint; (void) domain_name; return false; } // Can't handle this case, need app code changes
+    // Cannot implement this mode, we need FP before we can connect: bool verify(const char* fingerprint, const char* domain_name)
     bool verifyCertChain(const char* domain_name) { (void)domain_name; return connected(); } // If we're connected, the cert passed validation during handshake
 
     bool setCACert(const uint8_t* pk, size_t size);


### PR DESCRIPTION
Print a warning when in debug mode when a BearSSL connection tries to
connect without having any defined authentication methods, since it will
fail.

Completely remove the empty axTLS compatibilty method
"::verify(char *fp, char *name)" because it can't be done w/BearSSL w/o
code changes, and always failed.  Better to have a compile failure when
we know at compile time the app won't do what is expected.

Completes the changes started by @d-a-v in PR #4833