### PR TITLE
Bugfix/esp8266 http client

### DIFF
--- a/libraries/ESP8266HTTPClient/examples/BasicHttpsClient/BasicHttpsClient.ino
+++ b/libraries/ESP8266HTTPClient/examples/BasicHttpsClient/BasicHttpsClient.ino
@@ -41,13 +41,14 @@ void loop() {
   // wait for WiFi connection
   if ((WiFiMulti.run() == WL_CONNECTED)) {
 
-    BearSSL::WiFiClientSecure client;
-    client.setFingerprint(fingerprint);
+    BearSSL::WiFiClientSecure *client = new BearSSL::WiFiClientSecure;
+
+    client->setFingerprint(fingerprint);
 
     HTTPClient https;
 
     Serial.print("[HTTPS] begin...\n");
-    if (https.begin(client, "https://jigsaw.w3.org/HTTP/connection.html")) {  // HTTPS
+    if (https.begin(*client, "https://jigsaw.w3.org/HTTP/connection.html")) {  // HTTPS
 
 
       Serial.print("[HTTPS] GET...\n");
@@ -72,6 +73,8 @@ void loop() {
     } else {
       Serial.printf("[HTTPS] Unable to connect\n");
     }
+
+    delete client;
   }
 
   delay(10000);

--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -123,7 +123,7 @@ HTTPClient::HTTPClient()
 HTTPClient::~HTTPClient()
 {
     if(_client) {
-        _client->stop();
+        DEBUG_HTTPCLIENT("[HTTP-Client][~HTTPClient] end() not called before destruction of HTTPClient\n");
     }
     if(_currentHeaders) {
         delete[] _currentHeaders;
@@ -196,7 +196,7 @@ bool HTTPClient::begin(WiFiClient &client, String host, uint16_t port, String ur
 #ifdef HTTPCLIENT_1_1_COMPATIBLE
 bool HTTPClient::begin(String url, String httpsFingerprint)
 {
-    if(_client) _canReuse = false;
+    _canReuse = false;
     end();
 
     _port = 443;
@@ -214,7 +214,7 @@ bool HTTPClient::begin(String url, String httpsFingerprint)
 
 bool HTTPClient::begin(String url, const uint8_t httpsFingerprint[20])
 {
-    if(_client) _canReuse = false;
+    _canReuse = false;
     end();
 
     _port = 443;
@@ -237,7 +237,7 @@ bool HTTPClient::begin(String url, const uint8_t httpsFingerprint[20])
  */
 bool HTTPClient::begin(String url)
 {
-    if(_client) _canReuse = false;
+    _canReuse = false;
     end();
 
     _port = 80;
@@ -299,7 +299,7 @@ bool HTTPClient::beginInternal(String url, const char* expectedProtocol)
 #ifdef HTTPCLIENT_1_1_COMPATIBLE
 bool HTTPClient::begin(String host, uint16_t port, String uri)
 {
-    if(_client) _canReuse = false;
+    _canReuse = false;
     end();
 
     clear();
@@ -325,7 +325,7 @@ bool HTTPClient::begin(String host, uint16_t port, String uri, bool https, Strin
 
 bool HTTPClient::begin(String host, uint16_t port, String uri, String httpsFingerprint)
 {
-    if(_client) _canReuse = false;
+    _canReuse = false;
     end();
 
     clear();
@@ -343,7 +343,7 @@ bool HTTPClient::begin(String host, uint16_t port, String uri, String httpsFinge
 
 bool HTTPClient::begin(String host, uint16_t port, String uri, const uint8_t httpsFingerprint[20])
 {
-    if(_client) _canReuse = false;
+    _canReuse = false;
     end();
 
     clear();
@@ -367,6 +367,7 @@ bool HTTPClient::begin(String host, uint16_t port, String uri, const uint8_t htt
  */
 void HTTPClient::end(void)
 {
+    _canReuse = false;
     disconnect();
     clear();
 }


### PR DESCRIPTION
Fix for issue #5216 + minor changes: removing unnecessary tests and make sure that end() also closes the connection if it was a Keep-Alive connection.
Changed BasicHttpsClient.ino to also allocate the BearSSL::WiFiClientSecure on the heap in stead of on the stack.