### PR TITLE
Add stack repainting call to cont_utils

### DIFF
--- a/cores/esp8266/Esp.cpp
+++ b/cores/esp8266/Esp.cpp
@@ -183,6 +183,11 @@ uint32_t EspClass::getFreeContStack()
     return cont_get_free_stack(g_pcont);
 }
 
+void EspClass::resetFreeContStack()
+{
+    cont_repaint_stack(g_pcont);
+}
+
 uint32_t EspClass::getChipId(void)
 {
     return system_get_chip_id();

--- a/cores/esp8266/Esp.h
+++ b/cores/esp8266/Esp.h
@@ -111,6 +111,7 @@ class EspClass {
         void getHeapStats(uint32_t* free = nullptr, uint16_t* max = nullptr, uint8_t* frag = nullptr);
 
         uint32_t getFreeContStack();
+        void resetFreeContStack();
 
         const char * getSdkVersion();
         String getCoreVersion();

--- a/cores/esp8266/cont.h
+++ b/cores/esp8266/cont.h
@@ -74,6 +74,12 @@ int cont_get_free_stack(cont_t* cont);
 // continuation stack
 bool cont_can_yield(cont_t* cont);
 
+// Repaint the stack from the current SP to the end, to allow individual
+// routines' stack usages to be calculated by re-painting, checking current
+// free, running the routine, then checking the max free
+void cont_repaint_stack(cont_t *cont);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/cores/esp8266/cont_util.c
+++ b/cores/esp8266/cont_util.c
@@ -64,3 +64,18 @@ bool ICACHE_RAM_ATTR cont_can_yield(cont_t* cont) {
     return !ETS_INTR_WITHINISR() &&
            cont->pc_ret != 0 && cont->pc_yield == 0;
 }
+
+// No need for this to be in IRAM, not expected to be IRQ called
+void cont_repaint_stack(cont_t *cont)
+{
+    register uint32_t *sp asm("a1");
+    // Ensure 64 bytes adjacent to the current SP don't get touched to endure
+    // we don't accidentally trounce over locals or IRQ temps.
+    uint32_t sp_safe = CONT_STACKSIZE/4 - ((sp - &cont->stack[0] - 64)/4);
+
+    // Fill stack with magic values
+    for(uint32_t pos = 0; pos < sp_safe; pos++)
+    {
+        cont->stack[pos] = CONT_STACKGUARD;
+    }
+}

--- a/libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation.ino
+++ b/libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation.ino
@@ -6,6 +6,7 @@
 
 #include <ESP8266WiFi.h>
 #include <time.h>
+#include <cont.h>
 
 const char *ssid = "....";
 const char *pass = "....";
@@ -38,6 +39,8 @@ void fetchURL(BearSSL::WiFiClientSecure *client, const char *host, const uint16_
     path = "/";
   }
 
+  cont_repaint_stack(g_pcont);
+  uint32_t freeStackStart = cont_get_free_stack(g_pcont);
   Serial.printf("Trying: %s:443...", host);
   client->connect(host, port);
   if (!client->connected()) {
@@ -72,7 +75,8 @@ void fetchURL(BearSSL::WiFiClientSecure *client, const char *host, const uint16_
     } while (millis() < to);
   }
   client->stop();
-  Serial.printf("\n-------\n\n");
+  uint32_t freeStackEnd = cont_get_free_stack(g_pcont);
+  Serial.printf("\nCONT stack used: %d\n-------\n\n", freeStackStart - freeStackEnd);
 }
 
 void fetchNoConfig() {

--- a/libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation.ino
+++ b/libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation.ino
@@ -6,7 +6,6 @@
 
 #include <ESP8266WiFi.h>
 #include <time.h>
-#include <cont.h>
 
 const char *ssid = "....";
 const char *pass = "....";
@@ -39,8 +38,8 @@ void fetchURL(BearSSL::WiFiClientSecure *client, const char *host, const uint16_
     path = "/";
   }
 
-  cont_repaint_stack(g_pcont);
-  uint32_t freeStackStart = cont_get_free_stack(g_pcont);
+  ESP.resetFreeContStack();
+  uint32_t freeStackStart = ESP.getFreeContStack();
   Serial.printf("Trying: %s:443...", host);
   client->connect(host, port);
   if (!client->connected()) {
@@ -75,7 +74,7 @@ void fetchURL(BearSSL::WiFiClientSecure *client, const char *host, const uint16_
     } while (millis() < to);
   }
   client->stop();
-  uint32_t freeStackEnd = cont_get_free_stack(g_pcont);
+  uint32_t freeStackEnd = ESP.getFreeContStack();
   Serial.printf("\nCONT stack used: %d\n-------\n\n", freeStackStart - freeStackEnd);
 }
 


### PR DESCRIPTION
Allow the unused stack to be reset to the check value at any time in
the application, allowing for delta-stack calculations to be done.

Add in some dumping in the BearSSL_Validation example to show the
usage for those that care.