### PR TITLE
Accept WebServer Query Arguments not containing an equals sign (and ALEXA issue)

### DIFF
--- a/libraries/ESP8266WebServer/src/Parsing.cpp
+++ b/libraries/ESP8266WebServer/src/Parsing.cpp
@@ -337,6 +337,14 @@ void ESP8266WebServer::_parseArguments(String data) {
       break;
     pos = next_arg_index + 1;
   }
+  if (iarg == 0) {
+#ifdef DEBUG_ESP_HTTP_SERVER
+     DEBUG_OUTPUT.println("add plain data");
+#endif
+     RequestArgument& arg = _currentArgs[iarg++];
+     arg.key = "plain";
+     arg.value = data;
+  }
   _currentArgCount = iarg;
 #ifdef DEBUG_ESP_HTTP_SERVER
   DEBUG_OUTPUT.print("args count: ");


### PR DESCRIPTION
This PR fixes the following issues and also Alexa queries.

* Solves issues (Arduino): https://github.com/esp8266/Arduino/issues/4235, https://github.com/esp8266/Arduino/issues/2611
* Solves issues (Sonoff-Tasmota): https://github.com/arendst/Sonoff-Tasmota/issues/1639, https://github.com/arendst/Sonoff-Tasmota/issues/1434
* Solves rebased (Arduino) PRs: https://github.com/esp8266/Arduino/pull/4151, https://github.com/esp8266/Arduino/pull/4236, https://github.com/esp8266/Arduino/pull/4573
* Solves 3 items in 2.5.0 milestone: https://github.com/esp8266/Arduino/milestone/8

The actual codebase behavior is to completely ignore the argument (if not contains an equals sign), yet still include it in the argument count. (The use of "key=value" arguments is a convention, not an actual requirement in URLs.) This PR aims to fix that.

**For example:**

* If you send

   http://xxxx/index.html?foo=baa       OR       http://xxxx/index.html?foo=

You will get an `args()` result.

* If you send

   http://xxxx/index.html?foo

the foo is lost, no `args()`, nothing.

**Another example**:

Amazon Echo (Alexa) sends a put-request with content-type "application/x-www-form-urlencoded" set in the headers but sends out json encoded data. `_parseArguments` fails to parse the arguments (which is correct) but completly discards the data. This change checks if the parser picked something up and if it didn't, it just adds it as plain data to the arguments.

Please, take this PR into account in order to solve these issues. Thanks.

@reloxx13, @holgerlembke, @jasonharper, @OFreddy, @Monarch73, @arendst, @andrethomas, @Jason2866, @d-a-v 