### PR TITLE
Update debugging.rst

### DIFF
--- a/doc/Troubleshooting/debugging.rst
+++ b/doc/Troubleshooting/debugging.rst
@@ -74,7 +74,7 @@ Debug Level
 All defines for the different levels starts with ``DEBUG_ESP_``
 
 a full list can be found here in the
-`boards.txt <https://github.com/esp8266/Arduino/blob/master/boards.txt#L353>`__
+`boards.txt <https://github.com/esp8266/Arduino/blob/master/tools/boards.txt.py#L1045-L1047>`__
 
 Example for own debug messages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/Troubleshooting/debugging.rst
+++ b/doc/Troubleshooting/debugging.rst
@@ -74,7 +74,7 @@ Debug Level
 All defines for the different levels starts with ``DEBUG_ESP_``
 
 a full list can be found here in the
-`boards.txt <https://github.com/esp8266/Arduino/blob/master/boards.txt#L180>`__
+`boards.txt <https://github.com/esp8266/Arduino/blob/master/boards.txt#L353>`__
 
 Example for own debug messages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
PLEASE REVIEW
The current link definitely points to the wrong line, where there's nothing remotely resembling a list of DEBUG_ESP_* definitions. There's not an actual "full list" in the whole boards.txt file really, but this is the closest thing that can be found in that file.
Some additional explanation is needed though, unless there is an actual list and it's somewhere else.