### PR TITLE
fix: WiFiClient::flush() yields but can be called from events

### DIFF
--- a/libraries/ESP8266WiFi/src/include/ClientContext.h
+++ b/libraries/ESP8266WiFi/src/include/ClientContext.h
@@ -331,11 +331,9 @@ public:
                 prevsndbuf = sndbuf;
                 // We just sent a bit, move timeout forward
                 last_sent = millis();
-
-                // yield because we are staying longer
-                // (only if possible because we can be called from events)
-                esp_yield();
             }
+
+            esp_yield(); // from sys or os context
 
             if ((state() != ESTABLISHED) || (sndbuf == TCP_SND_BUF)) {
                 break;

--- a/libraries/ESP8266WiFi/src/include/ClientContext.h
+++ b/libraries/ESP8266WiFi/src/include/ClientContext.h
@@ -331,9 +331,11 @@ public:
                 prevsndbuf = sndbuf;
                 // We just sent a bit, move timeout forward
                 last_sent = millis();
-            }
 
-            yield();
+                // yield because we are staying longer
+                // (only if possible because we can be called from events)
+                esp_yield();
+            }
 
             if ((state() != ESTABLISHED) || (sndbuf == TCP_SND_BUF)) {
                 break;


### PR DESCRIPTION
for #5237 

Bug introduced by #5167 which replaced `delay()` by `yield()`,
and that should have been `esp_yield()` which is the one `delay()` calls.
To be noted for current maintainers included myself:
`delay()` and `esp_yield()` can be called from sys context