### PR TITLE
spiffs auto format selector (true by default)

### DIFF
--- a/cores/esp8266/Esp.cpp
+++ b/cores/esp8266/Esp.cpp
@@ -574,3 +574,13 @@ String EspClass::getSketchMD5()
     result = md5.toString();
     return result;
 }
+
+bool _spiffsAutoFormat = true;
+
+void EspClass::setAutoFormatSPIFFS (bool autoFormat) {
+    _spiffsAutoFormat = autoFormat;
+}
+
+bool EspClass::getAutoFormatSPIFFS () {
+    return _spiffsAutoFormat;
+}

--- a/cores/esp8266/Esp.h
+++ b/cores/esp8266/Esp.h
@@ -153,6 +153,9 @@ class EspClass {
         bool eraseConfig();
 
         inline uint32_t getCycleCount();
+
+        bool getAutoFormatSPIFFS ();
+        void setAutoFormatSPIFFS (bool autoFormat);
 };
 
 uint32_t EspClass::getCycleCount()

--- a/cores/esp8266/spiffs_api.h
+++ b/cores/esp8266/spiffs_api.h
@@ -32,6 +32,7 @@
 #include "spiffs/spiffs.h"
 #include "debug.h"
 #include "flash_utils.h"
+#include "Esp.h" // ESP.getAutoFormatSPIFFS()
 
 using namespace fs;
 
@@ -123,6 +124,9 @@ public:
         }
         if (_tryMount()) {
             return true;
+        }
+        if (!ESP.getAutoFormatSPIFFS()) {
+            return false;
         }
         auto rc = SPIFFS_format(&_fs);
         if (rc != SPIFFS_OK) {

--- a/libraries/esp8266/keywords.txt
+++ b/libraries/esp8266/keywords.txt
@@ -60,6 +60,8 @@ getResetInfo	KEYWORD2
 getResetInfoPtr	KEYWORD2
 eraseConfig	KEYWORD2
 getCycleCount	KEYWORD2
+setAutoFormatSPIFFS	KEYWORD2
+getAutoFormatSPIFFS	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
To help debugging #2581 (wemos/lolin d1 mini pro and/or 16MB flash):
`ESP.setAutoFormatSPIFFS()` will not format SPIFFS when mount fails.

Helpers set in ESP:: because this is the most simple way.
SPIFFS real interface is hard to reach from userland.