### PR TITLE
Only stop waveforms actually running in ISR

### DIFF
--- a/cores/esp8266/core_esp8266_waveform.c
+++ b/cores/esp8266/core_esp8266_waveform.c
@@ -282,7 +282,7 @@ static ICACHE_RAM_ATTR void timer1Interrupt() {
   // Check for timed-out waveforms out of the high-frequency toggle loop
   for (size_t i = 0; i < countof(waveform); i++) {
     Waveform *wave = &waveform[i];
-    if (wave->timeLeftCycles) {
+    if (wave->enabled && wave->timeLeftCycles) {
       // Check for unsigned underflow with new > old
       if (deltaCycles >= wave->timeLeftCycles) {
         // Done, remove!


### PR DESCRIPTION
The ISR could end up writing a 0 to a GPIO that had previously been
stopped, effectively overwriting user writes to those pins.  Fix to
only actually disable and write when a pin was enabled and times out.

Fixes #5306