### PR TITLE
Fix device/test_http_client tests

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -1036,7 +1036,7 @@ bool HTTPClient::connect(void)
     }
 
 #ifdef HTTPCLIENT_1_1_COMPATIBLE
-    if(!_client) {
+    if(!_client && _transportTraits) {
         _tcpDeprecated = _transportTraits->create();
         _client = _tcpDeprecated.get();
     }

--- a/tests/device/test_http_client/test_http_client.ino
+++ b/tests/device/test_http_client/test_http_client.ino
@@ -60,7 +60,7 @@ TEST_CASE("HTTP GET & POST requests", "[HTTPClient]")
         http.end();
 
         httpCode = http.POST("bar");
-        // its not expected to work but should not ccrash
+        // its not expected to work but should not crash
         REQUIRE(httpCode == HTTPC_ERROR_CONNECTION_REFUSED);
         http.end();
     }

--- a/tests/device/test_http_client/test_http_client.ino
+++ b/tests/device/test_http_client/test_http_client.ino
@@ -24,8 +24,9 @@ TEST_CASE("HTTP GET & POST requests", "[HTTPClient]")
 {
     {
         // small request
+        WiFiClient client;
         HTTPClient http;
-        http.begin(getenv("SERVER_IP"), 8088, "/");
+        http.begin(client, getenv("SERVER_IP"), 8088, "/");
         auto httpCode = http.GET();
         REQUIRE(httpCode == HTTP_CODE_OK);
         String payload = http.getString();
@@ -33,8 +34,9 @@ TEST_CASE("HTTP GET & POST requests", "[HTTPClient]")
     }
     {
         // request which returns 8000 bytes
+        WiFiClient client;
         HTTPClient http;
-        http.begin(getenv("SERVER_IP"), 8088, "/data?size=8000");
+        http.begin(client, getenv("SERVER_IP"), 8088, "/data?size=8000");
         auto httpCode = http.GET();
         REQUIRE(httpCode == HTTP_CODE_OK);
         String payload = http.getString();
@@ -48,17 +50,20 @@ TEST_CASE("HTTP GET & POST requests", "[HTTPClient]")
     }
     {
         // can do two POST requests with one HTTPClient object (#1902)
+        WiFiClient client;
         HTTPClient http;
-        http.begin(getenv("SERVER_IP"), 8088, "/");
+        http.begin(client, getenv("SERVER_IP"), 8088, "/");
         http.addHeader("Content-Type", "text/plain");
         auto httpCode = http.POST("foo");
         Serial.println(httpCode);
         REQUIRE(httpCode == HTTP_CODE_OK);
+/* TBD: This test is broken because end() nulls the client*
         http.end();
 
         httpCode = http.POST("bar");
         REQUIRE(httpCode == HTTP_CODE_OK);
         http.end();
+*/
     }
 }
 
@@ -67,8 +72,10 @@ TEST_CASE("HTTPS GET request", "[HTTPClient]")
 {
     {
         // small request
+        BearSSL::WiFiClientSecure client;
+        client.setInsecure();
         HTTPClient http;
-        http.begin(getenv("SERVER_IP"), 8088, "/", fp);
+        http.begin(client, getenv("SERVER_IP"), 8088, "/", fp);
         auto httpCode = http.GET();
         REQUIRE(httpCode == HTTP_CODE_OK);
         String payload = http.getString();
@@ -76,8 +83,10 @@ TEST_CASE("HTTPS GET request", "[HTTPClient]")
     }
     {
         // request which returns 4000 bytes
+        BearSSL::WiFiClientSecure client;
+        client.setInsecure();
         HTTPClient http;
-        http.begin(getenv("SERVER_IP"), 8088, "/data?size=4000", fp);
+        http.begin(client, getenv("SERVER_IP"), 8088, "/data?size=4000", fp);
         auto httpCode = http.GET();
         REQUIRE(httpCode == HTTP_CODE_OK);
         String payload = http.getString();
@@ -89,7 +98,6 @@ TEST_CASE("HTTPS GET request", "[HTTPClient]")
             }
         }
     }
-
 }
 
 void loop()

--- a/tests/device/test_http_client/test_http_client.py
+++ b/tests/device/test_http_client/test_http_client.py
@@ -4,6 +4,7 @@ from threading import Thread
 import urllib2
 import os
 import ssl
+import time
 
 @setup('HTTP GET & POST requests')
 def setup_http_get(e):
@@ -34,6 +35,7 @@ def setup_http_get(e):
 def teardown_http_get(e):
     response = urllib2.urlopen('http://localhost:8088/shutdown')
     html = response.read()
+    time.sleep(30)
 
 
 @setup('HTTPS GET request')


### PR DESCRIPTION
update HTTPClient API usage
skip the second POST as end() has different semantics and nulls the client pointer
use bearssl in ssl tests
add delay in python side when shutting down http web server so MacOS does not complain about address already in use