### PR TITLE
Move from container to VM per Travis requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: bash
 os: linux
 dist: trusty


### PR DESCRIPTION
Remove "sudo: false" from travis.yaml due to Travis changes:
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration