### PR TITLE
Save 2.3K in HTTPClient debug mode by PSTR

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.h
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.h
@@ -35,7 +35,7 @@
 
 #ifdef DEBUG_ESP_HTTP_CLIENT
 #ifdef DEBUG_ESP_PORT
-#define DEBUG_HTTPCLIENT(...) DEBUG_ESP_PORT.printf( __VA_ARGS__ )
+#define DEBUG_HTTPCLIENT(fmt, ...) DEBUG_ESP_PORT.printf_P( (PGM_P)PSTR(fmt), ## __VA_ARGS__ )
 #endif
 #endif
 


### PR DESCRIPTION
Convert the HTTPClient debug macro to store strings in PROGMEM and
use the printf_P method to dump them.

Saves ~2.3KB heap when in debug mode.