### PR TITLE
usn and udn differences cause issues with smarthings

### DIFF
--- a/libraries/ESP8266SSDP/ESP8266SSDP.cpp
+++ b/libraries/ESP8266SSDP/ESP8266SSDP.cpp
@@ -99,7 +99,7 @@ static const char _ssdp_schema_template[] PROGMEM =
   "<modelURL>%s</modelURL>"
   "<manufacturer>%s</manufacturer>"
   "<manufacturerURL>%s</manufacturerURL>"
-  "<UDN>UUID: %s</UDN>"
+  "<UDN>uuid:%s</UDN>"
   "</device>"
  //"<iconList>"	
  //"<icon>"	


### PR DESCRIPTION
I recently starting playing around with a few esp8266-01s and tried to use the SSDP libraries to work with Smarthings discovery:

https://docs.smartthings.com/en/latest/cloud-and-lan-connected-device-types-developers-guide/building-lan-connected-device-types/building-the-service-manager.html

on the docs there are example grovy files that do simple service discovery, i was not able to get SSDP to work correctly, though i was able to find some other projects that did (python fauxmo works for alexa, but with modifications i was able to make it work for custom devices in ST).

after digging to figure out why the python code was working and the ESP SSDP lib was not i noticed there is a string comparison in the grovy file and it was failing to match the udn with the original usn device id. The ST groovy code could be changed to remedy this problem but i wonder if it should be fixed here, because so many other examples of SSDP discovery take care in ensuring the usn and udn match exactly.

___________

Summary, I think the USN and UDN values should match exactly. This will fix issues, allowing for much easier integration with smart hubs that need the device  ids to match. Allowing me to use these libraries and not need to roll a custom SSDP handler.