### PR TITLE
Implement for ssid a similar approach as for passphrase

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp
@@ -187,7 +187,7 @@ bool ESP8266WiFiMulti::APlistAdd(const char* ssid, const char *passphrase) {
 
     WifiAPEntry newAP;
 
-    if(!ssid || *ssid == 0x00 || strlen(ssid) > 31) {
+    if(!ssid || *ssid == 0x00 || strlen(ssid) > 32) {
         // fail SSID too long or missing!
         DEBUG_WIFI_MULTI("[WIFI][APlistAdd] no ssid or ssid too long\n");
         return false;
@@ -230,7 +230,7 @@ bool ESP8266WiFiMulti::APlistAdd(const char* ssid, const char *passphrase) {
 }
 
 bool ESP8266WiFiMulti::APlistExists(const char* ssid, const char *passphrase) {
-    if(!ssid || *ssid == 0x00 || strlen(ssid) > 31) {
+    if(!ssid || *ssid == 0x00 || strlen(ssid) > 32) {
         // fail SSID too long or missing!
         DEBUG_WIFI_MULTI("[WIFI][APlistExists] no ssid or ssid too long\n");
         return false;

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
@@ -108,7 +108,7 @@ wl_status_t ESP8266WiFiSTAClass::begin(const char* ssid, const char *passphrase,
         return WL_CONNECT_FAILED;
     }
 
-    if(!ssid || *ssid == 0x00 || strlen(ssid) > 31) {
+    if(!ssid || *ssid == 0x00 || strlen(ssid) > 32) {
         // fail SSID too long or missing!
         return WL_CONNECT_FAILED;
     }
@@ -119,10 +119,12 @@ wl_status_t ESP8266WiFiSTAClass::begin(const char* ssid, const char *passphrase,
     }
 
     struct station_config conf;
-    strcpy(reinterpret_cast<char*>(conf.ssid), ssid);
+    if(strlen(ssid) == 32)
+        memcpy(reinterpret_cast<char*>(conf.ssid), ssid, 32); //copied in without null term
+    else
+        strcpy(reinterpret_cast<char*>(conf.ssid), ssid);
 
     conf.threshold.authmode = AUTH_OPEN;
-
     if(passphrase) {
         conf.threshold.authmode = _useInsecureWEP ? AUTH_WEP : AUTH_WPA_PSK;
         if (strlen(passphrase) == 64) // it's not a passphrase, is the PSK, which is copied into conf.password without null term
@@ -524,7 +526,10 @@ wl_status_t ESP8266WiFiSTAClass::status() {
 String ESP8266WiFiSTAClass::SSID() const {
     struct station_config conf;
     wifi_station_get_config(&conf);
-    return String(reinterpret_cast<char*>(conf.ssid));
+    char tmp[33]; //ssid can be up to 32chars, => plus null term
+    memcpy(tmp, conf.ssid, sizeof(conf.ssid));
+    tmp[32] = 0; //nullterm in case of 32 char ssid
+    return String(reinterpret_cast<char*>(tmp));
 }
 
 /**


### PR DESCRIPTION
Fixes #2200 (in theory).
This is not tested. The PR doesn't affect the pre-PR case (ssid up to 31chars). If the implementation doesn't work, and assuming no bug in the approach (same code as for passphrase with 64 bytes), then there is something broken in the SDK, and likely nothing can be done here.
