### PR TITLE
fix OTA

### DIFF
--- a/tools/espota.py
+++ b/tools/espota.py
@@ -144,6 +144,8 @@ def serve(remoteAddr, localAddr, remotePort, localPort, password, filename, comm
     sock.close()
     return 1
 
+  received_ok = False
+
   try:
     f = open(filename, "rb")
     if (PROGRESS):
@@ -160,7 +162,9 @@ def serve(remoteAddr, localAddr, remotePort, localPort, password, filename, comm
       connection.settimeout(10)
       try:
         connection.sendall(chunk)
-        res = connection.recv(4)
+        if connection.recv(32).decode().find('O') >= 0:
+          # connection will receive only digits or 'OK'
+          received_ok = True;
       except:
         sys.stderr.write('\n')
         logging.error('Error Uploading')
@@ -176,8 +180,10 @@ def serve(remoteAddr, localAddr, remotePort, localPort, password, filename, comm
     # the connection before receiving the 'O' of 'OK'
     try:
       connection.settimeout(60)
-      while True:
-        if connection.recv(32).decode().find('O') >= 0: break
+      while not received_ok:
+        if connection.recv(32).decode().find('O') >= 0:
+          # connection will receive only digits or 'OK'
+          received_ok = True;
       logging.info('Result: OK')
       connection.close()
       f.close()


### PR DESCRIPTION
https://github.com/esp8266/Arduino/issues/4283#issuecomment-445447030

@washcroft
- OTA protocol is old, it may not be changed or things would break on the user side
- OTA received multiple fixes
- You are right about the latest fix, it was too simple and didn't take into account this `res=connection.recv(4)` which is, apart from swallowing data without using them, useless
- OTA code is quite hairy to read, you are not a python dev but I surely could have proposed a fix

> [...] all the recent issues with OTA seems to be caused by the changes @d-a-v made to the espota.py

Well... Yes. I didn't change it for pleasure :) I was fixing some other issue.

> [...] but I can understand the logic and I am merely pointing out why so many people are having issues with OTA uploads. Take it or leave it.

I can't imagine finding this bug was easy, so a way to fix it might also have popped out from your research, that was @devyte's question.