### PR TITLE
Convert to standard PSTR/PROGMEM macros

### DIFF
--- a/libraries/ESP8266mDNS/src/LEAmDNS.cpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS.cpp
@@ -98,7 +98,7 @@ bool MDNSResponder::begin(const char* p_pcHostname) {
             
         bResult = _restart();
     }
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] begin: FAILED for '%s'!\n"), (p_pcHostname ?: "-")); } );
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] begin: FAILED for '%s'!\n"), (p_pcHostname ?: "-")); } );
     return bResult;
 }
 
@@ -157,7 +157,7 @@ bool MDNSResponder::setHostname(const char* p_pcHostname) {
             }
         }
     }
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] setHostname: FAILED for '%s'!\n"), (p_pcHostname ?: "-")); } );
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] setHostname: FAILED for '%s'!\n"), (p_pcHostname ?: "-")); } );
     return bResult;
 }
 
@@ -205,7 +205,7 @@ MDNSResponder::hMDNSService MDNSResponder::addService(const char* p_pcName,
           }
         }
     }   // else: bad arguments
-    DEBUG_EX_ERR(if (!hResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] addService: FAILED to add '%s.%s.%s'!\n"), (p_pcName ?: "-"), p_pcService, p_pcProtocol); } );
+    DEBUG_EX_ERR(if (!hResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] addService: FAILED to add '%s.%s.%s'!\n"), (p_pcName ?: "-"), p_pcService, p_pcProtocol); } );
     return hResult;
 }
 
@@ -222,7 +222,7 @@ bool MDNSResponder::removeService(const MDNSResponder::hMDNSService p_hService) 
     bool    bResult = (((pService = _findService(p_hService))) &&
                        (_announceService(*pService, false)) &&
                        (_releaseService(pService)));
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] removeService: FAILED!\n")); } );
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] removeService: FAILED!\n")); } );
     return bResult;
 }
 
@@ -258,7 +258,7 @@ bool MDNSResponder::setServiceName(const MDNSResponder::hMDNSService p_hService,
                        ((pService = _findService(p_hService))) &&
                        (pService->setName(p_pcInstanceName)) &&
                        ((pService->m_ProbeInformation.m_ProbingStatus = ProbingStatus_ReadyToStart)));
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] setServiceName: FAILED for '%s'!\n"), (p_pcInstanceName ?: "-")); } );
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] setServiceName: FAILED for '%s'!\n"), (p_pcInstanceName ?: "-")); } );
     return bResult;
 }
 
@@ -281,7 +281,7 @@ MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSS
     if (pService) {
         hTxt = (hMDNSTxt)_addServiceTxt(pService, p_pcKey, p_pcValue, false);
     }
-    DEBUG_EX_ERR(if (!hTxt) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] addServiceTxt: FAILED for '%s=%s'!\n"), (p_pcKey ?: "-"), (p_pcValue ?: "-")); } );
+    DEBUG_EX_ERR(if (!hTxt) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] addServiceTxt: FAILED for '%s=%s'!\n"), (p_pcKey ?: "-"), (p_pcValue ?: "-")); } );
     return hTxt;
 }
 
@@ -376,7 +376,7 @@ bool MDNSResponder::removeServiceTxt(const MDNSResponder::hMDNSService p_hServic
             bResult = _releaseServiceTxt(pService, pTxt);
         }
     }
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] removeServiceTxt: FAILED!\n")); } );
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] removeServiceTxt: FAILED!\n")); } );
     return bResult;
 }
 
@@ -395,7 +395,7 @@ bool MDNSResponder::removeServiceTxt(const MDNSResponder::hMDNSService p_hServic
             bResult = _releaseServiceTxt(pService, pTxt);
         }
     }
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] removeServiceTxt: FAILED for '%s'!\n"), (p_pcKey ?: "-")); } );
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] removeServiceTxt: FAILED for '%s'!\n"), (p_pcKey ?: "-")); } );
     return bResult;
 }
 
@@ -477,7 +477,7 @@ bool MDNSResponder::setDynamicServiceTxtCallback(MDNSResponder::hMDNSService p_h
         
         bResult = true;
     }   
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] setDynamicServiceTxtCallback: FAILED!\n")); } );
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] setDynamicServiceTxtCallback: FAILED!\n")); } );
     return bResult;
 }
 
@@ -487,7 +487,7 @@ bool MDNSResponder::setDynamicServiceTxtCallback(MDNSResponder::hMDNSService p_h
 MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(MDNSResponder::hMDNSService p_hService,
                                                             const char* p_pcKey,
                                                             const char* p_pcValue) {
-    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] addDynamicServiceTxt (%s=%s)\n"), p_pcKey, p_pcValue););
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] addDynamicServiceTxt (%s=%s)\n"), p_pcKey, p_pcValue););
     
     hMDNSTxt        hTxt = 0;
 
@@ -495,7 +495,7 @@ MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(MDNSResponder::hMDNS
     if (pService) {
         hTxt = _addServiceTxt(pService, p_pcKey, p_pcValue, true);
     }
-    DEBUG_EX_ERR(if (!hTxt) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] addDynamicServiceTxt: FAILED for '%s=%s'!\n"), (p_pcKey ?: "-"), (p_pcValue ?: "-")); } );
+    DEBUG_EX_ERR(if (!hTxt) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] addDynamicServiceTxt: FAILED for '%s=%s'!\n"), (p_pcKey ?: "-"), (p_pcValue ?: "-")); } );
     return hTxt;
 }
 
@@ -595,7 +595,7 @@ MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(MDNSResponder::hMDNS
 uint32_t MDNSResponder::queryService(const char* p_pcService,
                                      const char* p_pcProtocol,
                                      const uint16_t p_u16Timeout /*= MDNS_QUERYSERVICES_WAIT_TIME*/) {
-    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] queryService '%s.%s'\n"), p_pcService, p_pcProtocol););
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] queryService '%s.%s'\n"), p_pcService, p_pcProtocol););
     
     uint32_t    u32Result = 0;
 
@@ -613,7 +613,7 @@ uint32_t MDNSResponder::queryService(const char* p_pcService,
         
         if (_sendMDNSServiceQuery(*pServiceQuery)) {
             // Wait for answers to arrive
-            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] queryService: Waiting %u ms for answers...\n"), p_u16Timeout););
+            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] queryService: Waiting %u ms for answers...\n"), p_u16Timeout););
             delay(p_u16Timeout);
 
             // All answers should have arrived by now -> stop adding new answers
@@ -625,7 +625,7 @@ uint32_t MDNSResponder::queryService(const char* p_pcService,
         }
     }
     else {
-        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] queryService: INVALID input data!\n"), p_pcService, p_pcProtocol););
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] queryService: INVALID input data!\n"), p_pcService, p_pcProtocol););
     }
     return u32Result;
 }
@@ -774,7 +774,7 @@ MDNSResponder::hMDNSServiceQuery MDNSResponder::installServiceQuery(const char* 
             _removeServiceQuery(pServiceQuery);
         }
     }
-    DEBUG_EX_ERR(if (!hResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] installServiceQuery: FAILED for '%s.%s'!\n"), (p_pcService ?: "-"), (p_pcProtocol ?: "-")); } );
+    DEBUG_EX_ERR(if (!hResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] installServiceQuery: FAILED for '%s.%s'!\n"), (p_pcService ?: "-"), (p_pcProtocol ?: "-")); } );
     return hResult;
 }
 
@@ -789,7 +789,7 @@ bool MDNSResponder::removeServiceQuery(MDNSResponder::hMDNSServiceQuery p_hServi
     stcMDNSServiceQuery*    pServiceQuery = 0;
     bool    bResult = (((pServiceQuery = _findServiceQuery(p_hServiceQuery))) &&
                        (_removeServiceQuery(pServiceQuery)));
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] removeServiceQuery: FAILED!\n")); } );
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] removeServiceQuery: FAILED!\n")); } );
     return bResult;
 }
 

--- a/libraries/ESP8266mDNS/src/LEAmDNS_Control.cpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS_Control.cpp
@@ -68,13 +68,13 @@ bool MDNSResponder::_process(bool p_bUserContext) {
     
     if ((m_pUDPContext) &&          // UDPContext available AND
         (m_pUDPContext->next())) {  // has content
-        //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _update: Calling _parseMessage\n")););
+        //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _update: Calling _parseMessage\n")););
         
         bResult = _parseMessage();
         if (p_bUserContext) {
             esp_yield();
         }
-        //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parsePacket %s\n"), (bResult ? "succeeded" : "FAILED")););
+        //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parsePacket %s\n"), (bResult ? "succeeded" : "FAILED")););
     }
     else if (p_bUserContext) {
         if (bResult) {              // Probing
@@ -108,7 +108,7 @@ bool MDNSResponder::_parseMessage(void) {
     DEBUG_EX_INFO(
             unsigned long   ulStartTime = millis();
             unsigned        uStartMemory = ESP.getFreeHeap();
-            DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseMessage (Time: %lu ms, heap: %u bytes, from %s(%u), to %s(%u))\n"), ulStartTime, uStartMemory,
+            DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseMessage (Time: %lu ms, heap: %u bytes, from %s(%u), to %s(%u))\n"), ulStartTime, uStartMemory,
                                     IPAddress(m_pUDPContext->getRemoteAddress()).toString().c_str(), m_pUDPContext->getRemotePort(),
                                     IPAddress(m_pUDPContext->getDestAddress()).toString().c_str(), m_pUDPContext->getLocalPort());
     );
@@ -120,26 +120,26 @@ bool MDNSResponder::_parseMessage(void) {
     if (_readMDNSMsgHeader(header)) {
         if (0 == header.m_4bOpcode) {   // A standard query
             if (header.m_1bQR) {        // Received a response -> answers to a query
-                //DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseMessage: Reading answers: ID:%u, Q:%u, A:%u, NS:%u, AR:%u\n"), header.m_u16ID, header.m_u16QDCount, header.m_u16ANCount, header.m_u16NSCount, header.m_u16ARCount););
+                //DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseMessage: Reading answers: ID:%u, Q:%u, A:%u, NS:%u, AR:%u\n"), header.m_u16ID, header.m_u16QDCount, header.m_u16ANCount, header.m_u16NSCount, header.m_u16ARCount););
                 bResult = _parseResponse(header);
             }
             else {                      // Received a query (Questions)
-                //DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseMessage: Reading query: ID:%u, Q:%u, A:%u, NS:%u, AR:%u\n"), header.m_u16ID, header.m_u16QDCount, header.m_u16ANCount, header.m_u16NSCount, header.m_u16ARCount););
+                //DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseMessage: Reading query: ID:%u, Q:%u, A:%u, NS:%u, AR:%u\n"), header.m_u16ID, header.m_u16QDCount, header.m_u16ANCount, header.m_u16NSCount, header.m_u16ARCount););
                 bResult = _parseQuery(header);
             }
         }
         else {
-            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseMessage: Received UNEXPECTED opcode:%u. Ignoring message!\n"), header.m_4bOpcode););
+            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseMessage: Received UNEXPECTED opcode:%u. Ignoring message!\n"), header.m_4bOpcode););
             m_pUDPContext->flush();
         }
     }
     else {
-        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseMessage: FAILED to read header\n")););
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseMessage: FAILED to read header\n")););
         m_pUDPContext->flush();
     }
     DEBUG_EX_INFO(
             unsigned    uFreeHeap = ESP.getFreeHeap();
-            DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseMessage: Done (%s after %lu ms, ate %i bytes, remaining %u)\n\n"), (bResult ? "Succeeded" : "FAILED"), (millis() - ulStartTime), (uStartMemory - uFreeHeap), uFreeHeap);
+            DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseMessage: Done (%s after %lu ms, ate %i bytes, remaining %u)\n\n"), (bResult ? "Succeeded" : "FAILED"), (millis() - ulStartTime), (uStartMemory - uFreeHeap), uFreeHeap);
     );
     return bResult;
 }
@@ -176,7 +176,7 @@ bool MDNSResponder::_parseQuery(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHea
             sendParameter.m_u8HostReplyMask = ((ProbingStatus_Done == m_HostProbeInformation.m_ProbingStatus)
                                                 ? _replyMaskForHost(questionRR.m_Header, 0)
                                                 : 0);
-            DEBUG_EX_INFO(if (u8HostOrServiceReplies) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Host reply needed %u\n"), u8HostOrServiceReplies); });
+            DEBUG_EX_INFO(if (u8HostOrServiceReplies) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Host reply needed %u\n"), u8HostOrServiceReplies); });
 
             // Check tiebreak need for host domain
             if (ProbingStatus_InProgress == m_HostProbeInformation.m_ProbingStatus) {
@@ -187,8 +187,8 @@ bool MDNSResponder::_parseQuery(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHea
                     // a race-condition: Two host with the same domain names try simutanously to probe their domains
                     // See: RFC 6762, 8.2 (Tiebraking)
                     // However, we're using a max. reduced approach for tiebreaking here: The higher IP-address wins!
-                    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Possible race-condition for host domain detected while probing.\n")););
-                    Serial.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Possible race-condition for host domain detected while probing.\n"));
+                    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Possible race-condition for host domain detected while probing.\n")););
+                    Serial.printf_P(PSTR("[MDNSResponder] _parseQuery: Possible race-condition for host domain detected while probing.\n"));
 
                     m_HostProbeInformation.m_bTiebreakNeeded = true;
                 }
@@ -201,10 +201,10 @@ bool MDNSResponder::_parseQuery(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHea
                                                     ? _replyMaskForService(questionRR.m_Header, *pService, 0)
                                                     : 0);
                 u8HostOrServiceReplies |= (pService->m_u8ReplyMask |= u8ReplyMaskForQuestion);
-                DEBUG_EX_INFO(if (u8ReplyMaskForQuestion) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Service reply needed for (%s.%s.%s): %u (%s)\n"), (pService->m_pcName ?: m_pcHostname), pService->m_pcService, pService->m_pcProtocol, u8ReplyMaskForQuestion, IPAddress(m_pUDPContext->getRemoteAddress()).toString().c_str()); } );
+                DEBUG_EX_INFO(if (u8ReplyMaskForQuestion) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Service reply needed for (%s.%s.%s): %u (%s)\n"), (pService->m_pcName ?: m_pcHostname), pService->m_pcService, pService->m_pcProtocol, u8ReplyMaskForQuestion, IPAddress(m_pUDPContext->getRemoteAddress()).toString().c_str()); } );
                 /*if ((u8ReplyMaskForQuestion) &&
                     (0 == os_strcmp("hap", pService->m_pcService))) {
-                    DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Service reply needed for (%s.%s.%s): %u (%s)\n"), (pService->m_pcName ?: m_pcHostname), pService->m_pcService, pService->m_pcProtocol, u8ReplyMaskForQuestion, IPAddress(m_pUDPContext->getRemoteAddress()).toString().c_str());
+                    DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Service reply needed for (%s.%s.%s): %u (%s)\n"), (pService->m_pcName ?: m_pcHostname), pService->m_pcService, pService->m_pcProtocol, u8ReplyMaskForQuestion, IPAddress(m_pUDPContext->getRemoteAddress()).toString().c_str());
                 }*/
 
                 // Check tiebreak need for service domain
@@ -216,8 +216,8 @@ bool MDNSResponder::_parseQuery(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHea
                         // a race-condition: Two services with the same domain names try simutanously to probe their domains
                         // See: RFC 6762, 8.2 (Tiebraking)
                         // However, we're using a max. reduced approach for tiebreaking here: The 'higher' SRV host wins!
-                        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Possible race-condition for service domain %s.%s.%s detected while probing.\n"), (pService->m_pcName ?: m_pcHostname), pService->m_pcService, pService->m_pcProtocol););
-                        Serial.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Possible race-condition for service domain %s.%s.%s detected while probing.\n"), (pService->m_pcName ?: m_pcHostname), pService->m_pcService, pService->m_pcProtocol);
+                        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Possible race-condition for service domain %s.%s.%s detected while probing.\n"), (pService->m_pcName ?: m_pcHostname), pService->m_pcService, pService->m_pcProtocol););
+                        Serial.printf_P(PSTR("[MDNSResponder] _parseQuery: Possible race-condition for service domain %s.%s.%s detected while probing.\n"), (pService->m_pcName ?: m_pcHostname), pService->m_pcService, pService->m_pcProtocol);
 
                         pService->m_ProbeInformation.m_bTiebreakNeeded = true;
                     }
@@ -232,7 +232,7 @@ bool MDNSResponder::_parseQuery(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHea
 
                 sendParameter.m_bUnicast = true;
                 sendParameter.m_bCacheFlush = false;
-                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Unicast response for %s!\n"), IPAddress(m_pUDPContext->getRemoteAddress()).toString().c_str()););
+                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Unicast response for %s!\n"), IPAddress(m_pUDPContext->getRemoteAddress()).toString().c_str()););
                 
                 if ((DNS_MQUERY_PORT != m_pUDPContext->getRemotePort()) &&  // Unicast (maybe legacy) query AND
                     (1 == p_MsgHeader.m_u16QDCount) &&                          // Only one question AND
@@ -248,7 +248,7 @@ bool MDNSResponder::_parseQuery(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHea
                          ((wifi_get_ip_info(STATION_IF, &IPInfo_Local)) &&
                           (ip_addr_netcmp(&IPInfo_Remote.ip, &IPInfo_Local.ip, &IPInfo_Local.netmask))))) { // Remote IP in STATION's subnet
 
-                        DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Legacy query from local host %s!\n"), IPAddress(m_pUDPContext->getRemoteAddress()).toString().c_str()););
+                        DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Legacy query from local host %s!\n"), IPAddress(m_pUDPContext->getRemoteAddress()).toString().c_str()););
 
                         sendParameter.m_u16ID = p_MsgHeader.m_u16ID;
                         sendParameter.m_bLegacyQuery = true;
@@ -259,27 +259,27 @@ bool MDNSResponder::_parseQuery(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHea
                             sendParameter.m_pQuestions->m_Header.m_Attributes.m_u16Class = questionRR.m_Header.m_Attributes.m_u16Class;
                         }
                         else {
-                            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: FAILED to add legacy question!\n")););
+                            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: FAILED to add legacy question!\n")););
                         }
                     }
                     else {
-                        DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Legacy query from NON-LOCAL host!\n")););
+                        DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Legacy query from NON-LOCAL host!\n")););
                         bResult = false;
                     }
                 }
             }
         }
         else {
-            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: FAILED to read question!\n")););
+            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: FAILED to read question!\n")););
         }
         //*esp_yield();
     }   // for questions
 
-    //DEBUG_EX_INFO(if (u8HostOrServiceReplies) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Reply needed: %u (%s: %s->%s)\n"), u8HostOrServiceReplies, clsTimeSyncer::timestr(), IPAddress(m_pUDPContext->getRemoteAddress()).toString().c_str(), IPAddress(m_pUDPContext->getDestAddress()).toString().c_str()); } );
+    //DEBUG_EX_INFO(if (u8HostOrServiceReplies) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Reply needed: %u (%s: %s->%s)\n"), u8HostOrServiceReplies, clsTimeSyncer::timestr(), IPAddress(m_pUDPContext->getRemoteAddress()).toString().c_str(), IPAddress(m_pUDPContext->getDestAddress()).toString().c_str()); } );
 
     // Handle known answers
     uint32_t    u32Answers = (p_MsgHeader.m_u16ANCount + p_MsgHeader.m_u16NSCount + p_MsgHeader.m_u16ARCount);
-    DEBUG_EX_INFO(if ((u8HostOrServiceReplies) && (u32Answers)) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Known answers(%u):\n"), u32Answers); } );
+    DEBUG_EX_INFO(if ((u8HostOrServiceReplies) && (u32Answers)) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Known answers(%u):\n"), u32Answers); } );
 
     for (uint32_t an=0; ((bResult) && (an<u32Answers)); ++an) {
         stcMDNS_RRAnswer*   pKnownRRAnswer = 0;
@@ -303,14 +303,14 @@ bool MDNSResponder::_parseQuery(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHea
 #ifdef MDNS_IP4_SUPPORT
                             if (u8HostMatchMask & ContentFlag_PTR_IP4) {
                                 // IP4 PTR was asked for, but is already known -> skipping
-                                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: IP4 PTR already known... skipping!\n")););
+                                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: IP4 PTR already known... skipping!\n")););
                                 sendParameter.m_u8HostReplyMask &= ~ContentFlag_PTR_IP4;
                             }
 #endif
 #ifdef MDNS_IP6_SUPPORT
                             if (u8HostMatchMask & ContentFlag_PTR_IP6) {
                                 // IP6 PTR was asked for, but is already known -> skipping
-                                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: IP6 PTR already known... skipping!\n")););
+                                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: IP6 PTR already known... skipping!\n")););
                                 sendParameter.m_u8HostReplyMask &= ~ContentFlag_PTR_IP6;
                             }
 #endif
@@ -322,7 +322,7 @@ bool MDNSResponder::_parseQuery(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHea
                         if ((AnswerType_A == pKnownRRAnswer->answerType()) &&
                             (((stcMDNS_RRAnswerA*)pKnownRRAnswer)->m_IPAddress == _getResponseMulticastInterface(SOFTAP_MODE | STATION_MODE))) {
 
-                            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: IP4 address already known... skipping!\n")););
+                            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: IP4 address already known... skipping!\n")););
                             sendParameter.m_u8HostReplyMask &= ~ContentFlag_A;
                         }   // else: RData NOT IP4 length !!
 #endif
@@ -333,7 +333,7 @@ bool MDNSResponder::_parseQuery(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHea
                         if ((AnswerType_AAAA == pAnswerRR->answerType()) &&
                             (((stcMDNS_RRAnswerAAAA*)pAnswerRR)->m_IPAddress == _getResponseMulticastInterface(SOFTAP_MODE | STATION_MODE))) {
 
-                            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: IP6 address already known... skipping!\n")););
+                            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: IP6 address already known... skipping!\n")););
                             sendParameter.m_u8HostReplyMask &= ~ContentFlag_AAAA;
                         }   // else: RData NOT IP6 length !!
 #endif
@@ -352,19 +352,19 @@ bool MDNSResponder::_parseQuery(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHea
                             IPAddress   localIPAddress(_getResponseMulticastInterface(SOFTAP_MODE | STATION_MODE));
                             if (((stcMDNS_RRAnswerA*)pKnownRRAnswer)->m_IPAddress == localIPAddress) {
                                 // SAME IP address -> We've received an old message from ourselfs (same IP)
-                                DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Tiebreak (IP4) WON (was an old message)!\n")););
+                                DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Tiebreak (IP4) WON (was an old message)!\n")););
                                 m_HostProbeInformation.m_bTiebreakNeeded = false;
                             }
                             else {
                                 if ((uint32_t)(((stcMDNS_RRAnswerA*)pKnownRRAnswer)->m_IPAddress) > (uint32_t)localIPAddress) { // The OTHER IP is 'higher' -> LOST
                                     // LOST tiebreak
-                                    DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Tiebreak (IP4) LOST (lower)!\n")););
+                                    DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Tiebreak (IP4) LOST (lower)!\n")););
                                     _cancelProbingForHost();
                                     m_HostProbeInformation.m_bTiebreakNeeded = false;
                                 }
                                 else {  // WON tiebreak
                                     //TiebreakState = TiebreakState_Won;    // We received an 'old' message from ourselfs -> Just ignore
-                                    DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Tiebreak (IP4) WON (higher IP)!\n")););
+                                    DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Tiebreak (IP4) WON (higher IP)!\n")););
                                     m_HostProbeInformation.m_bTiebreakNeeded = false;
                                 }
                             }
@@ -387,7 +387,7 @@ bool MDNSResponder::_parseQuery(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHea
                         ((MDNS_SERVICE_TTL / 2) <= pKnownRRAnswer->m_u32TTL)) { // The TTL of the known answer is longer than half of the new service TTL (4500s)
 
                         /*if ((0 == os_strcmp("hap", pService->m_pcService))) {
-                            DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Known answer for (%s.%s.%s): %u (%s) %u\n"), (pService->m_pcName ?: m_pcHostname), pService->m_pcService, pService->m_pcProtocol, pKnownRRAnswer->answerType(), IPAddress(m_pUDPContext->getRemoteAddress()).toString().c_str(), pKnownRRAnswer->m_u32TTL);
+                            DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Known answer for (%s.%s.%s): %u (%s) %u\n"), (pService->m_pcName ?: m_pcHostname), pService->m_pcService, pService->m_pcProtocol, pKnownRRAnswer->answerType(), IPAddress(m_pUDPContext->getRemoteAddress()).toString().c_str(), pKnownRRAnswer->m_u32TTL);
                         }*/
                         
                         if (AnswerType_PTR == pKnownRRAnswer->answerType()) {
@@ -395,18 +395,18 @@ bool MDNSResponder::_parseQuery(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHea
                             if ((u8ServiceMatchMask & ContentFlag_PTR_TYPE) &&
                                 (_buildDomainForService(*pService, false, serviceDomain)) &&
                                 (serviceDomain == ((stcMDNS_RRAnswerPTR*)pKnownRRAnswer)->m_PTRDomain)) {
-                                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Service type PTR already known... skipping!\n")););
+                                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Service type PTR already known... skipping!\n")););
                                 pService->m_u8ReplyMask &= ~ContentFlag_PTR_TYPE;
                             }
                             if ((u8ServiceMatchMask & ContentFlag_PTR_NAME) &&
                                 (_buildDomainForService(*pService, true, serviceDomain)) &&
                                 (serviceDomain == ((stcMDNS_RRAnswerPTR*)pKnownRRAnswer)->m_PTRDomain)) {
-                                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Service name PTR already known... skipping!\n")););
+                                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Service name PTR already known... skipping!\n")););
                                 pService->m_u8ReplyMask &= ~ContentFlag_PTR_NAME;
                             }
                         }
                         else if (u8ServiceMatchMask & ContentFlag_SRV) {
-                            DEBUG_EX_ERR(if (AnswerType_SRV != pKnownRRAnswer->answerType()) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: ERROR! INVALID answer type (SRV)!\n")););
+                            DEBUG_EX_ERR(if (AnswerType_SRV != pKnownRRAnswer->answerType()) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: ERROR! INVALID answer type (SRV)!\n")););
                             stcMDNS_RRDomain    hostDomain;
                             if ((_buildDomainForHost(m_pcHostname, hostDomain)) &&
                                 (hostDomain == ((stcMDNS_RRAnswerSRV*)pKnownRRAnswer)->m_SRVDomain)) {  // Host domain match
@@ -415,16 +415,16 @@ bool MDNSResponder::_parseQuery(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHea
                                         (MDNS_SRV_WEIGHT == ((stcMDNS_RRAnswerSRV*)pKnownRRAnswer)->m_u16Weight) &&
                                         (pService->m_u16Port == ((stcMDNS_RRAnswerSRV*)pKnownRRAnswer)->m_u16Port)) {
 
-                                    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Service SRV answer already known... skipping!\n")););
+                                    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Service SRV answer already known... skipping!\n")););
                                     pService->m_u8ReplyMask &= ~ContentFlag_SRV;
                                 }   // else: Small differences -> send update message
                             }
                         }
                         else if (u8ServiceMatchMask & ContentFlag_TXT) {
-                            DEBUG_EX_ERR(if (AnswerType_TXT != pKnownRRAnswer->answerType()) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: ERROR! INVALID answer type (TXT)!\n")););
+                            DEBUG_EX_ERR(if (AnswerType_TXT != pKnownRRAnswer->answerType()) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: ERROR! INVALID answer type (TXT)!\n")););
                             _collectServiceTxts(*pService);
                             if (pService->m_Txts == ((stcMDNS_RRAnswerTXT*)pKnownRRAnswer)->m_Txts) {
-                                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Service TXT answer already known... skipping!\n")););
+                                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Service TXT answer already known... skipping!\n")););
                                 pService->m_u8ReplyMask &= ~ContentFlag_TXT;
                             }
                             _releaseTempServiceTxts(*pService);
@@ -444,19 +444,19 @@ bool MDNSResponder::_parseQuery(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHea
                                     (hostDomain == ((stcMDNS_RRAnswerSRV*)pKnownRRAnswer)->m_SRVDomain)) {  // Host domain match
 
                                     // We've received an old message from ourselfs (same SRV)
-                                    DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Tiebreak (SRV) won (was an old message)!\n")););
+                                    DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Tiebreak (SRV) won (was an old message)!\n")););
                                     pService->m_ProbeInformation.m_bTiebreakNeeded = false;
                                 }
                                 else {
                                     if (((stcMDNS_RRAnswerSRV*)pKnownRRAnswer)->m_SRVDomain > hostDomain) { // The OTHER domain is 'higher' -> LOST
                                         // LOST tiebreak
-                                        DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Tiebreak (SRV) LOST (lower)!\n")););
+                                        DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Tiebreak (SRV) LOST (lower)!\n")););
                                         _cancelProbingForService(*pService);
                                         pService->m_ProbeInformation.m_bTiebreakNeeded = false;
                                     }
                                     else {  // WON tiebreak
                                         //TiebreakState = TiebreakState_Won;    // We received an 'old' message from ourselfs -> Just ignore
-                                        DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Tiebreak (SRV) won (higher)!\n")););
+                                        DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Tiebreak (SRV) won (higher)!\n")););
                                         pService->m_ProbeInformation.m_bTiebreakNeeded = false;
                                     }
                                 }
@@ -467,7 +467,7 @@ bool MDNSResponder::_parseQuery(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHea
             }   // ANY answers
         }
         else {
-            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: FAILED to read known answer!\n")););
+            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: FAILED to read known answer!\n")););
         }
 
         if (pKnownRRAnswer) {
@@ -485,38 +485,38 @@ bool MDNSResponder::_parseQuery(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHea
 
             if ((u8ReplyNeeded) &&
                 (0 == os_strcmp("hap", pService->m_pcService))) {
-                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Sending service reply for (%s.%s.%s): %u (%s)\n"), (pService->m_pcName ?: m_pcHostname), pService->m_pcService, pService->m_pcProtocol, u8ReplyNeeded, IPAddress(m_pUDPContext->getRemoteAddress()).toString().c_str()););
+                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Sending service reply for (%s.%s.%s): %u (%s)\n"), (pService->m_pcName ?: m_pcHostname), pService->m_pcService, pService->m_pcProtocol, u8ReplyNeeded, IPAddress(m_pUDPContext->getRemoteAddress()).toString().c_str()););
             }
         }
 
         if (u8ReplyNeeded) {
-            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Sending answer(%u)...\n"), u8ReplyNeeded););
+            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Sending answer(%u)...\n"), u8ReplyNeeded););
             sendParameter.m_bResponse = true;
             sendParameter.m_bAuthorative = true;
             bResult = _sendMDNSMessage(sendParameter);
         }
         else {
-            //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: No reply needed\n")););
+            //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: No reply needed\n")););
         }
     }
     else {
-        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: Something FAILED!\n")););
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Something FAILED!\n")););
         m_pUDPContext->flush();
     }
 
     //
     // Check and reset tiebreak-states
     if (m_HostProbeInformation.m_bTiebreakNeeded) {
-        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: UNSOLVED tiebreak-need for host domain!\n")););
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: UNSOLVED tiebreak-need for host domain!\n")););
         m_HostProbeInformation.m_bTiebreakNeeded = false;
     }
     for (stcMDNSService* pService=m_pServices; pService; pService=pService->m_pNext) {
         if (pService->m_ProbeInformation.m_bTiebreakNeeded) {
-            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: UNSOLVED tiebreak-need for service domain (%s.%s.%s)\n"), (pService->m_pcName ?: m_pcHostname), pService->m_pcService, pService->m_pcProtocol););
+            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: UNSOLVED tiebreak-need for service domain (%s.%s.%s)\n"), (pService->m_pcName ?: m_pcHostname), pService->m_pcService, pService->m_pcProtocol););
             pService->m_ProbeInformation.m_bTiebreakNeeded = false;
         }
     }
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseQuery: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: FAILED!\n")); });
     return bResult;
 }
 
@@ -548,7 +548,7 @@ bool MDNSResponder::_parseQuery(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHea
  *    Level 3: A/AAAA - links the host domain to an IP address
  */
 bool MDNSResponder::_parseResponse(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHeader) {
-    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseResponse\n")););
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseResponse\n")););
     //DEBUG_EX_INFO(_udpDump(););
     
     bool    bResult = false;
@@ -558,7 +558,7 @@ bool MDNSResponder::_parseResponse(const MDNSResponder::stcMDNS_MsgHeader& p_Msg
         (_hasProbesWaitingForAnswers())) {                  // Probe responses
 
        DEBUG_EX_INFO(
-                DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseResponse: Received a response\n"));
+                DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseResponse: Received a response\n"));
                 //_udpDump();
         );
 
@@ -567,7 +567,7 @@ bool MDNSResponder::_parseResponse(const MDNSResponder::stcMDNS_MsgHeader& p_Msg
         // Ignore questions here
         stcMDNS_RRQuestion  dummyRRQ;
         for (uint16_t qd=0; ((bResult) && (qd<p_MsgHeader.m_u16QDCount)); ++qd) {
-            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseResponse: Received a response containing a question... ignoring!\n")););
+            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseResponse: Received a response containing a question... ignoring!\n")););
             bResult = _readRRQuestion(dummyRRQ);
             //*esp_yield();
         }   // for queries
@@ -580,12 +580,12 @@ bool MDNSResponder::_parseResponse(const MDNSResponder::stcMDNS_MsgHeader& p_Msg
             stcMDNS_RRAnswer*   pRRAnswer = 0;
             if (((bResult = _readRRAnswer(pRRAnswer))) &&
                 (pRRAnswer)) {
-                //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseResponse: ADDING answer!\n")););
+                //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseResponse: ADDING answer!\n")););
                 pRRAnswer->m_pNext = pCollectedRRAnswers;
                 pCollectedRRAnswers = pRRAnswer;
             }
             else {
-                DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseResponse: FAILED to read answer!\n")););
+                DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseResponse: FAILED to read answer!\n")););
                 if (pRRAnswer) {
                     delete pRRAnswer;
                     pRRAnswer = 0;
@@ -602,13 +602,13 @@ bool MDNSResponder::_parseResponse(const MDNSResponder::stcMDNS_MsgHeader& p_Msg
                        (_processAnswers(pCollectedRRAnswers)));
         }
         else {  // Some failure while reading answers
-            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseResponse: FAILED to read answers!\n")););
+            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseResponse: FAILED to read answers!\n")););
             m_pUDPContext->flush();
         }
         
         // Delete collected answers
         while (pCollectedRRAnswers) {
-            //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseResponse: DELETING answer!\n")););
+            //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseResponse: DELETING answer!\n")););
             stcMDNS_RRAnswer*   pNextAnswer = pCollectedRRAnswers->m_pNext;
             delete pCollectedRRAnswers;
             pCollectedRRAnswers = pNextAnswer;
@@ -616,7 +616,7 @@ bool MDNSResponder::_parseResponse(const MDNSResponder::stcMDNS_MsgHeader& p_Msg
     }
     else {  // Received an unexpected response -> ignore
         /*DEBUG_EX_INFO(
-                DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseResponse: Received an unexpected response... ignoring!\nDUMP:\n"));
+                DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseResponse: Received an unexpected response... ignoring!\nDUMP:\n"));
                 bool    bDumpResult = true;
                 for (uint16_t qd=0; ((bDumpResult) && (qd<p_MsgHeader.m_u16QDCount)); ++qd) {
                     stcMDNS_RRQuestion  questionRR;
@@ -638,7 +638,7 @@ bool MDNSResponder::_parseResponse(const MDNSResponder::stcMDNS_MsgHeader& p_Msg
         m_pUDPContext->flush();
         bResult = true;
     }
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _parseResponse: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseResponse: FAILED!\n")); });
     return bResult;
 }
 
@@ -661,7 +661,7 @@ bool MDNSResponder::_processAnswers(const MDNSResponder::stcMDNS_RRAnswer* p_pAn
     bool    bResult = false;
     
     if (p_pAnswers) {
-        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _processAnswers: Processing answers...\n")););
+        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _processAnswers: Processing answers...\n")););
         bResult = true;
         
         // Answers may arrive in an unexpected order. So we loop our answers as long, as we
@@ -715,7 +715,7 @@ bool MDNSResponder::_processAnswers(const MDNSResponder::stcMDNS_RRAnswer* p_pAn
                     if ((_buildDomainForHost(m_pcHostname, hostDomain)) &&
                         (pRRAnswer->m_Header.m_Domain == hostDomain)) {
 
-                        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _processAnswers: Probing CONFLICT found with: %s.local\n"), m_pcHostname););
+                        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _processAnswers: Probing CONFLICT found with: %s.local\n"), m_pcHostname););
                         _cancelProbingForHost();
                     }
                 }
@@ -729,7 +729,7 @@ bool MDNSResponder::_processAnswers(const MDNSResponder::stcMDNS_RRAnswer* p_pAn
                         if ((_buildDomainForService(*pService, true, serviceDomain)) &&
                             (pRRAnswer->m_Header.m_Domain == serviceDomain)) {
 
-                            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _processAnswers: Probing CONFLICT found with: %s.%s.%s\n"), (pService->m_pcName ?: m_pcHostname), pService->m_pcService, pService->m_pcProtocol););
+                            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _processAnswers: Probing CONFLICT found with: %s.%s.%s\n"), (pService->m_pcName ?: m_pcHostname), pService->m_pcService, pService->m_pcProtocol););
                             _cancelProbingForService(*pService);
                         }
                     }
@@ -741,7 +741,7 @@ bool MDNSResponder::_processAnswers(const MDNSResponder::stcMDNS_RRAnswer* p_pAn
         } while ((bFoundNewKeyAnswer) &&
                  (bResult));
     }   // else: No answers provided
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _processAnswers: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _processAnswers: FAILED!\n")); });
     return bResult;
 }
 
@@ -754,7 +754,7 @@ bool MDNSResponder::_processPTRAnswer(const MDNSResponder::stcMDNS_RRAnswerPTR* 
     bool    bResult = false;
     
     if ((bResult = (0 != p_pPTRAnswer))) {
-        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _processPTRAnswer: Processing PTR answers...\n")););
+        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _processPTRAnswer: Processing PTR answers...\n")););
         // eg. _http._tcp.local PTR xxxx xx MyESP._http._tcp.local
         // Check pending service queries for '_http._tcp'
         
@@ -767,18 +767,18 @@ bool MDNSResponder::_processPTRAnswer(const MDNSResponder::stcMDNS_RRAnswerPTR* 
                     if (p_pPTRAnswer->m_u32TTL) {   // Received update message
                         pSQAnswer->m_TTLServiceDomain.set(p_pPTRAnswer->m_u32TTL);    // Update TTL tag
                         DEBUG_EX_INFO(
-                                DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _processPTRAnswer: Updated TTL for "));
+                                DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _processPTRAnswer: Updated TTL for "));
                                 _printRRDomain(pSQAnswer->m_ServiceDomain);
-                                DEBUG_OUTPUT.printf_P(PSTR_LEA("\n"));
+                                DEBUG_OUTPUT.printf_P(PSTR("\n"));
                         );
                     }
                     else {                      // received goodbye-message
                         pSQAnswer->m_TTLServiceDomain.set(1);             // See RFC 6762, 10.1
                         pSQAnswer->m_TTLServiceDomain.m_bUpdateScheduled = true;    // Avoid 'cache update' query
                         DEBUG_EX_INFO(
-                                DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _processPTRAnswer: 'Goodbye' received for "));
+                                DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _processPTRAnswer: 'Goodbye' received for "));
                                 _printRRDomain(pSQAnswer->m_ServiceDomain);
-                                DEBUG_OUTPUT.printf_P(PSTR_LEA("\n"));
+                                DEBUG_OUTPUT.printf_P(PSTR("\n"));
                         );
                     }
                 }
@@ -800,7 +800,7 @@ bool MDNSResponder::_processPTRAnswer(const MDNSResponder::stcMDNS_RRAnswerPTR* 
             pServiceQuery = _findNextServiceQueryByServiceType(p_pPTRAnswer->m_Header.m_Domain, pServiceQuery);
         }
     }   // else: No p_pPTRAnswer
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _processPTRAnswer: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _processPTRAnswer: FAILED!\n")); });
     return bResult;
 }
 
@@ -822,9 +822,9 @@ bool MDNSResponder::_processSRVAnswer(const MDNSResponder::stcMDNS_RRAnswerSRV* 
                 if (p_pSRVAnswer->m_u32TTL) {   // First or update message (TTL != 0)
                     pSQAnswer->m_TTLHostDomainAndPort.set(p_pSRVAnswer->m_u32TTL);    // Update TTL tag
                     DEBUG_EX_INFO(
-                            DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _processSRVAnswer: Updated TTL for "));
+                            DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _processSRVAnswer: Updated TTL for "));
                             _printRRDomain(pSQAnswer->m_ServiceDomain);
-                            DEBUG_OUTPUT.printf_P(PSTR_LEA(" host domain and port\n"));
+                            DEBUG_OUTPUT.printf_P(PSTR(" host domain and port\n"));
                     );
                     // Host domain & Port
                     if ((pSQAnswer->m_HostDomain != p_pSRVAnswer->m_SRVDomain) ||
@@ -845,16 +845,16 @@ bool MDNSResponder::_processSRVAnswer(const MDNSResponder::stcMDNS_RRAnswerSRV* 
                     pSQAnswer->m_TTLHostDomainAndPort.set(1);             // See RFC 6762, 10.1
                     pSQAnswer->m_TTLHostDomainAndPort.m_bUpdateScheduled = true;    // Avoid 'cache update' query
                     DEBUG_EX_INFO(
-                            DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _processSRVAnswer: 'Goodbye' received for "));
+                            DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _processSRVAnswer: 'Goodbye' received for "));
                             _printRRDomain(pSQAnswer->m_ServiceDomain);
-                            DEBUG_OUTPUT.printf_P(PSTR_LEA(" host domain and port\n"));
+                            DEBUG_OUTPUT.printf_P(PSTR(" host domain and port\n"));
                     );
                 }
             }
             pServiceQuery = pServiceQuery->m_pNext;
         }   // while(service query)
     }   // else: No p_pSRVAnswer
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _processSRVAnswer: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _processSRVAnswer: FAILED!\n")); });
     return bResult;
 }
 
@@ -875,9 +875,9 @@ bool MDNSResponder::_processTXTAnswer(const MDNSResponder::stcMDNS_RRAnswerTXT* 
                 if (p_pTXTAnswer->m_u32TTL) {   // First or update message
                     pSQAnswer->m_TTLTxts.set(p_pTXTAnswer->m_u32TTL); // Update TTL tag
                     DEBUG_EX_INFO(
-                            DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _processTXTAnswer: Updated TTL for "));
+                            DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _processTXTAnswer: Updated TTL for "));
                             _printRRDomain(pSQAnswer->m_ServiceDomain);
-                            DEBUG_OUTPUT.printf_P(PSTR_LEA(" TXTs\n"));
+                            DEBUG_OUTPUT.printf_P(PSTR(" TXTs\n"));
                     );
                     if (!pSQAnswer->m_Txts.compare(p_pTXTAnswer->m_Txts)) {
                         pSQAnswer->m_Txts = p_pTXTAnswer->m_Txts;
@@ -893,16 +893,16 @@ bool MDNSResponder::_processTXTAnswer(const MDNSResponder::stcMDNS_RRAnswerTXT* 
                     pSQAnswer->m_TTLTxts.set(1);          // See RFC 6762, 10.1
                     pSQAnswer->m_TTLTxts.m_bUpdateScheduled = true; // Avoid 'cache update' query
                     DEBUG_EX_INFO(
-                            DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _processTXTAnswer: 'Goodbye' received for "));
+                            DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _processTXTAnswer: 'Goodbye' received for "));
                             _printRRDomain(pSQAnswer->m_ServiceDomain);
-                            DEBUG_OUTPUT.printf_P(PSTR_LEA(" TXTs\n"));
+                            DEBUG_OUTPUT.printf_P(PSTR(" TXTs\n"));
                     );
                 }
             }
             pServiceQuery = pServiceQuery->m_pNext;
         }   // while(service query)
     }   // else: No p_pTXTAnswer
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _processTXTAnswer: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _processTXTAnswer: FAILED!\n")); });
     return bResult;
 }
 
@@ -927,18 +927,18 @@ bool MDNSResponder::_processTXTAnswer(const MDNSResponder::stcMDNS_RRAnswerTXT* 
                         if (p_pAAnswer->m_u32TTL) { // Valid TTL -> Update answers TTL
                             pIP4Address->m_TTL.set(p_pAAnswer->m_u32TTL);
                             DEBUG_EX_INFO(
-                                    DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _processAAnswer: Updated TTL for "));
+                                    DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _processAAnswer: Updated TTL for "));
                                     _printRRDomain(pSQAnswer->m_ServiceDomain);
-                                    DEBUG_OUTPUT.printf_P(PSTR_LEA(" IP4Address (%s)\n"), pIP4Address->m_IPAddress.toString().c_str());
+                                    DEBUG_OUTPUT.printf_P(PSTR(" IP4Address (%s)\n"), pIP4Address->m_IPAddress.toString().c_str());
                             );
                         }
                         else {                      // 'Goodbye' message for known IP4 address
                             pIP4Address->m_TTL.set(1);            // See RFC 6762, 10.1
                             pIP4Address->m_TTL.m_bUpdateScheduled = true;   // Avoid 'cache update' query
                             DEBUG_EX_INFO(
-                                    DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _processAAnswer: 'Goodbye' received for "));
+                                    DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _processAAnswer: 'Goodbye' received for "));
                                     _printRRDomain(pSQAnswer->m_ServiceDomain);
-                                    DEBUG_OUTPUT.printf_P(PSTR_LEA(" IP4 address (%s)\n"), pIP4Address->m_IPAddress.toString().c_str());
+                                    DEBUG_OUTPUT.printf_P(PSTR(" IP4 address (%s)\n"), pIP4Address->m_IPAddress.toString().c_str());
                             );
                         }                                
                     }
@@ -956,7 +956,7 @@ bool MDNSResponder::_processTXTAnswer(const MDNSResponder::stcMDNS_RRAnswerTXT* 
                                 }
                             }
                             else {   
-                                DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _processAAnswer: FAILED to add IP4 address (%s)!\n"), p_pAAnswer->m_IPAddress.toString().c_str()););
+                                DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _processAAnswer: FAILED to add IP4 address (%s)!\n"), p_pAAnswer->m_IPAddress.toString().c_str()););
                             }
                         }
                     }
@@ -964,7 +964,7 @@ bool MDNSResponder::_processTXTAnswer(const MDNSResponder::stcMDNS_RRAnswerTXT* 
                 pServiceQuery = pServiceQuery->m_pNext;
             }   // while(service query)         
         }   // else: No p_pAAnswer
-        DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _processAAnswer: FAILED!\n")); });
+        DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _processAAnswer: FAILED!\n")); });
         return bResult;
     }
 #endif
@@ -990,18 +990,18 @@ bool MDNSResponder::_processTXTAnswer(const MDNSResponder::stcMDNS_RRAnswerTXT* 
                         if (p_pAAAAAnswer->m_u32TTL) { // Valid TTL -> Update answers TTL
                             pIP6Address->m_TTL.set(p_pAAAAAnswer->m_u32TTL);
                             DEBUG_EX_INFO(
-                                    DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _processAAnswer: Updated TTL for "));
+                                    DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _processAAnswer: Updated TTL for "));
                                     _printRRDomain(pSQAnswer->m_ServiceDomain);
-                                    DEBUG_OUTPUT.printf_P(PSTR_LEA(" IP6 address (%s)\n"), pIP6Address->m_IPAddress.toString().c_str());
+                                    DEBUG_OUTPUT.printf_P(PSTR(" IP6 address (%s)\n"), pIP6Address->m_IPAddress.toString().c_str());
                             );
                         }
                         else {                      // 'Goodbye' message for known IP6 address
                             pIP6Address->m_TTL.set(1);            // See RFC 6762, 10.1
                             pIP6Address->m_TTL.m_bUpdateScheduled = true;   // Avoid 'cache update' query
                             DEBUG_EX_INFO(
-                                    DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _processAAnswer: 'Goodbye' received for "));
+                                    DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _processAAnswer: 'Goodbye' received for "));
                                     _printRRDomain(pSQAnswer->m_ServiceDomain);
-                                    DEBUG_OUTPUT.printf_P(PSTR_LEA(" IP6 address (%s)\n"), pIP6Address->m_IPAddress.toString().c_str());
+                                    DEBUG_OUTPUT.printf_P(PSTR(" IP6 address (%s)\n"), pIP6Address->m_IPAddress.toString().c_str());
                             );
                         }                                
                     }
@@ -1019,7 +1019,7 @@ bool MDNSResponder::_processTXTAnswer(const MDNSResponder::stcMDNS_RRAnswerTXT* 
                                 }
                             }
                             else {   
-                                DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _processAAnswer: FAILED to add IP6 address (%s)!\n"), p_pAAAAAnswer->m_IPAddress.toString().c_str()););
+                                DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _processAAnswer: FAILED to add IP6 address (%s)!\n"), p_pAAAAAnswer->m_IPAddress.toString().c_str()););
                             }
                         }
                     }
@@ -1058,7 +1058,7 @@ bool MDNSResponder::_updateProbeStatus(void) {
     if ((ProbingStatus_ReadyToStart == m_HostProbeInformation.m_ProbingStatus) &&                   // Ready to get started AND
         //TODO: Fix the following to allow Ethernet shield or other interfaces
         (_getResponseMulticastInterface(SOFTAP_MODE | STATION_MODE) != IPAddress())) {              // Has IP address
-        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _updateProbeStatus: Starting host probing...\n")););
+        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _updateProbeStatus: Starting host probing...\n")););
 
         // First probe delay SHOULD be random 0-250 ms
         m_HostProbeInformation.m_NextProbeTimeFlag.restart(rand() % MDNS_PROBE_DELAY);
@@ -1069,13 +1069,13 @@ bool MDNSResponder::_updateProbeStatus(void) {
 
         if (MDNS_PROBE_COUNT > m_HostProbeInformation.m_u8ProbesSent) {                             // Send next probe
             if ((bResult = _sendHostProbe())) {
-                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _updateProbeStatus: Did sent host probe\n")););
+                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _updateProbeStatus: Did sent host probe\n")););
                 m_HostProbeInformation.m_NextProbeTimeFlag.restart(MDNS_PROBE_DELAY);
                 ++m_HostProbeInformation.m_u8ProbesSent;
             }
         }
         else {                                                                                      // Probing finished
-            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _updateProbeStatus: Done host probing.\n")););
+            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _updateProbeStatus: Done host probing.\n")););
             m_HostProbeInformation.m_ProbingStatus = ProbingStatus_Done;
             m_HostProbeInformation.m_NextProbeTimeFlag.reset();
 
@@ -1100,13 +1100,13 @@ bool MDNSResponder::_updateProbeStatus(void) {
 
             if (MDNS_PROBE_COUNT > pService->m_ProbeInformation.m_u8ProbesSent) {                           // Send next probe
                 if ((bResult = _sendServiceProbe(*pService))) {
-                    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _updateProbeStatus: Did sent service probe (%u)\n"), (pService->m_ProbeInformation.m_u8ProbesSent + 1)););
+                    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _updateProbeStatus: Did sent service probe (%u)\n"), (pService->m_ProbeInformation.m_u8ProbesSent + 1)););
                     pService->m_ProbeInformation.m_NextProbeTimeFlag.restart(MDNS_PROBE_DELAY);
                     ++pService->m_ProbeInformation.m_u8ProbesSent;
                 }
             }
             else {                                                                                      // Probing finished
-                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _updateProbeStatus: Done service probing %s.%s.%s\n"), (pService->m_pcName ?: m_pcHostname), pService->m_pcService, pService->m_pcProtocol););
+                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _updateProbeStatus: Done service probing %s.%s.%s\n"), (pService->m_pcName ?: m_pcHostname), pService->m_pcService, pService->m_pcProtocol););
                 pService->m_ProbeInformation.m_ProbingStatus = ProbingStatus_Done;
                 pService->m_ProbeInformation.m_NextProbeTimeFlag.reset();
 
@@ -1128,7 +1128,7 @@ bool MDNSResponder::_updateProbeStatus(void) {
             }
         }   // else: Probing already finished OR waiting for next time slot
     }
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _updateProbeStatus: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _updateProbeStatus: FAILED!\n")); });
     return bResult;
 }
 
@@ -1179,7 +1179,7 @@ bool MDNSResponder::_hasProbesWaitingForAnswers(void) const {
  * - A/AAAA (eg. esp8266.esp -> 192.168.2.120)
  */
 bool MDNSResponder::_sendHostProbe(void) {
-    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _sendHostProbe (%s, %lu)\n"), m_pcHostname, millis()););
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _sendHostProbe (%s, %lu)\n"), m_pcHostname, millis()););
     
     bool    bResult = true;
         
@@ -1204,13 +1204,13 @@ bool MDNSResponder::_sendHostProbe(void) {
 #endif
     }
     else {
-        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _sendHostProbe: FAILED to create host question!\n")););
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _sendHostProbe: FAILED to create host question!\n")););
         if (sendParameter.m_pQuestions) {
             delete sendParameter.m_pQuestions;
             sendParameter.m_pQuestions = 0;
         }
     }
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _sendHostProbe: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _sendHostProbe: FAILED!\n")); });
     return ((bResult) &&
             (_sendMDNSMessage(sendParameter)));
 }
@@ -1228,7 +1228,7 @@ bool MDNSResponder::_sendHostProbe(void) {
  * - PTR NAME (eg. _http._tcp.local -> MyESP._http._tcp.local) (TODO: Check if needed, maybe TXT is better)
  */
 bool MDNSResponder::_sendServiceProbe(stcMDNSService& p_rService) {
-    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _sendServiceProbe (%s.%s.%s, %lu)\n"), (p_rService.m_pcName ?: m_pcHostname), p_rService.m_pcService, p_rService.m_pcProtocol, millis()););
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _sendServiceProbe (%s.%s.%s, %lu)\n"), (p_rService.m_pcName ?: m_pcHostname), p_rService.m_pcService, p_rService.m_pcProtocol, millis()););
 
     bool    bResult = true;
 
@@ -1248,13 +1248,13 @@ bool MDNSResponder::_sendServiceProbe(stcMDNSService& p_rService) {
         p_rService.m_u8ReplyMask = (ContentFlag_SRV | ContentFlag_PTR_NAME);                // Add SRV and PTR NAME answers
     }
     else {
-        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _sendServiceProbe: FAILED to create service question!\n")););
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _sendServiceProbe: FAILED to create service question!\n")););
         if (sendParameter.m_pQuestions) {
             delete sendParameter.m_pQuestions;
             sendParameter.m_pQuestions = 0;
         }
     }
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _sendServiceProbe: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _sendServiceProbe: FAILED!\n")); });
     return ((bResult) &&
             (_sendMDNSMessage(sendParameter)));
 }
@@ -1355,24 +1355,24 @@ bool MDNSResponder::_announce(bool p_bAnnounce /*= true*/) {
         sendParameter.m_u8HostReplyMask |= ContentFlag_PTR_IP6;             // PTR_IP6 answer
     #endif
 
-        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _announce: Announcing host %s (%u)\n"), m_pcHostname, sendParameter.m_u8HostReplyMask););
+        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _announce: Announcing host %s (%u)\n"), m_pcHostname, sendParameter.m_u8HostReplyMask););
         //bResult = _sendMDNSMessage(sendParameter);
-        //DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _announceService: FAILED (A)!\n")); });
+        //DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _announceService: FAILED (A)!\n")); });
 
         // Announce services (service type, name, SRV (location) and TXTs)
         for (stcMDNSService* pService=m_pServices; ((bResult) && (pService)); pService=pService->m_pNext) {
             //bResult = _announceService(*pService, p_bAnnounce);
-            //DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _announceService: FAILED (B)!\n")); });
+            //DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _announceService: FAILED (B)!\n")); });
 
 
             if (ProbingStatus_Done == pService->m_ProbeInformation.m_ProbingStatus) {
                 pService->m_u8ReplyMask = (ContentFlag_PTR_TYPE | ContentFlag_PTR_NAME | ContentFlag_SRV | ContentFlag_TXT);
 
-                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _announce: Announcing service %s.%s.%s (%u)\n"), (pService->m_pcName ?: m_pcHostname), pService->m_pcService, pService->m_pcProtocol, pService->m_u8ReplyMask););
+                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _announce: Announcing service %s.%s.%s (%u)\n"), (pService->m_pcName ?: m_pcHostname), pService->m_pcService, pService->m_pcProtocol, pService->m_u8ReplyMask););
             }
         }
     }
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _announceService: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _announceService: FAILED!\n")); });
     return ((bResult) &&
             (_sendMDNSMessage(sendParameter)));
     //return bResult;
@@ -1398,11 +1398,11 @@ bool MDNSResponder::_announceService(stcMDNSService& p_rService,
 
         // Announce services (service type, name, SRV (location) and TXTs)
         p_rService.m_u8ReplyMask = (ContentFlag_PTR_TYPE | ContentFlag_PTR_NAME | ContentFlag_SRV | ContentFlag_TXT);
-        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _announceService: Announcing service %s.%s.%s (%u)\n"), (p_rService.m_pcName ?: m_pcHostname), p_rService.m_pcService, p_rService.m_pcProtocol, p_rService.m_u8ReplyMask););
+        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _announceService: Announcing service %s.%s.%s (%u)\n"), (p_rService.m_pcName ?: m_pcHostname), p_rService.m_pcService, p_rService.m_pcProtocol, p_rService.m_u8ReplyMask););
 
         bResult = true;
     }
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _announceService: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _announceService: FAILED!\n")); });
     return ((bResult) &&
             (_sendMDNSMessage(sendParameter)));
 }
@@ -1455,9 +1455,9 @@ bool MDNSResponder::_checkServiceQueryCache(void) {
                     bResult = ((_sendMDNSServiceQuery(*pServiceQuery)) &&
                                ((pSQAnswer->m_TTLServiceDomain.m_bUpdateScheduled = true)));
                     DEBUG_EX_INFO(
-                            DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _checkServiceQueryCache: Update scheduled for "));
+                            DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _checkServiceQueryCache: Update scheduled for "));
                             _printRRDomain(pSQAnswer->m_ServiceDomain);
-                            DEBUG_OUTPUT.printf_P(PSTR_LEA(" %s\n"), (bResult ? "OK" : "FAILURE"));
+                            DEBUG_OUTPUT.printf_P(PSTR(" %s\n"), (bResult ? "OK" : "FAILURE"));
                     );
                 }
                 else if ((bResult) &&
@@ -1480,9 +1480,9 @@ bool MDNSResponder::_checkServiceQueryCache(void) {
                     bResult = ((_sendMDNSQuery(pSQAnswer->m_ServiceDomain, DNS_RRTYPE_SRV)) &&
                                ((pSQAnswer->m_TTLHostDomainAndPort.m_bUpdateScheduled = true)));
                     DEBUG_EX_INFO(
-                            DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _checkServiceQueryCache: Update scheduled for "));
+                            DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _checkServiceQueryCache: Update scheduled for "));
                             _printRRDomain(pSQAnswer->m_ServiceDomain);
-                            DEBUG_OUTPUT.printf_P(PSTR_LEA(" host domain and port %s\n"), (bResult ? "OK" : "FAILURE"));
+                            DEBUG_OUTPUT.printf_P(PSTR(" host domain and port %s\n"), (bResult ? "OK" : "FAILURE"));
                     );
                 }
                 else if ((bResult) &&
@@ -1519,9 +1519,9 @@ bool MDNSResponder::_checkServiceQueryCache(void) {
                     bResult = ((_sendMDNSQuery(pSQAnswer->m_ServiceDomain, DNS_RRTYPE_TXT)) &&
                                ((pSQAnswer->m_TTLTxts.m_bUpdateScheduled = true)));
                     DEBUG_EX_INFO(
-                            DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _checkServiceQueryCache: Update scheduled for "));
+                            DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _checkServiceQueryCache: Update scheduled for "));
                             _printRRDomain(pSQAnswer->m_ServiceDomain);
-                            DEBUG_OUTPUT.printf_P(PSTR_LEA(" TXTs %s\n"), (bResult ? "OK" : "FAILURE"));
+                            DEBUG_OUTPUT.printf_P(PSTR(" TXTs %s\n"), (bResult ? "OK" : "FAILURE"));
                     );
                 }
                 else if ((bResult) &&
@@ -1557,9 +1557,9 @@ bool MDNSResponder::_checkServiceQueryCache(void) {
                             bAUpdateQuerySent = true;
                             
                             DEBUG_EX_INFO(
-                                    DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _checkServiceQueryCache: Update scheduled for "));
+                                    DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _checkServiceQueryCache: Update scheduled for "));
                                     _printRRDomain(pSQAnswer->m_ServiceDomain);
-                                    DEBUG_OUTPUT.printf_P(PSTR_LEA(" IP4 address (%s)\n"), (pIP4Address->m_IPAddress.toString().c_str()));
+                                    DEBUG_OUTPUT.printf_P(PSTR(" IP4 address (%s)\n"), (pIP4Address->m_IPAddress.toString().c_str()));
                             );
                         }
                     }
@@ -1594,9 +1594,9 @@ bool MDNSResponder::_checkServiceQueryCache(void) {
                             bAAAAUpdateQuerySent = true;
                             
                             DEBUG_EX_INFO(
-                                    DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _checkServiceQueryCache: Update scheduled for "));
+                                    DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _checkServiceQueryCache: Update scheduled for "));
                                     _printRRDomain(pSQAnswer->m_ServiceDomain);
-                                    DEBUG_OUTPUT.printf_P(PSTR_LEA(" IP6 address (%s)\n"), (pIP6Address->m_IPAddress.toString().c_str()));
+                                    DEBUG_OUTPUT.printf_P(PSTR(" IP6 address (%s)\n"), (pIP6Address->m_IPAddress.toString().c_str()));
                             );
                         }
                     }
@@ -1618,7 +1618,7 @@ bool MDNSResponder::_checkServiceQueryCache(void) {
             }
         }
     }
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _checkServiceQueryCache: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _checkServiceQueryCache: FAILED!\n")); });
     return bResult;
 }
 
@@ -1634,7 +1634,7 @@ bool MDNSResponder::_checkServiceQueryCache(void) {
  */
 uint8_t MDNSResponder::_replyMaskForHost(const MDNSResponder::stcMDNS_RRHeader& p_RRHeader,
                                          bool* p_pbFullNameMatch /*= 0*/) const {
-    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _replyMaskForHost\n")););
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _replyMaskForHost\n")););
     
     uint8_t u8ReplyMask = 0;
     (p_pbFullNameMatch ? *p_pbFullNameMatch = false : 0);
@@ -1681,9 +1681,9 @@ uint8_t MDNSResponder::_replyMaskForHost(const MDNSResponder::stcMDNS_RRHeader& 
         }
     }
     else {
-        //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _replyMaskForHost: INVALID RR-class (0x%04X)!\n"), p_RRHeader.m_Attributes.m_u16Class););
+        //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _replyMaskForHost: INVALID RR-class (0x%04X)!\n"), p_RRHeader.m_Attributes.m_u16Class););
     }
-    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _replyMaskForHost: %u\n"), u8ReplyMask););
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _replyMaskForHost: %u\n"), u8ReplyMask););
     return u8ReplyMask;
 }
 
@@ -1745,9 +1745,9 @@ uint8_t MDNSResponder::_replyMaskForService(const MDNSResponder::stcMDNS_RRHeade
         }
     }
     else {
-        //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _replyMaskForService: INVALID RR-class (0x%04X)!\n"), p_RRHeader.m_Attributes.m_u16Class););
+        //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _replyMaskForService: INVALID RR-class (0x%04X)!\n"), p_RRHeader.m_Attributes.m_u16Class););
     }
-    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _replyMaskForService(%s.%s.%s): %u\n"), p_Service.m_pcName, p_Service.m_pcService, p_Service.m_pcProtocol, u8ReplyMask););
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _replyMaskForService(%s.%s.%s): %u\n"), p_Service.m_pcName, p_Service.m_pcService, p_Service.m_pcProtocol, u8ReplyMask););
     return u8ReplyMask;
 }
 

--- a/libraries/ESP8266mDNS/src/LEAmDNS_Helpers.cpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS_Helpers.cpp
@@ -160,7 +160,7 @@ namespace MDNSImplementation {
             DEBUG_EX_ERR(DEBUG_OUTPUT.println(F("[MDNSResponder] indexDomain: FAILED to alloc new hostname!")););
         }
     }
-    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] indexDomain: %s\n"), p_rpcDomain););
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] indexDomain: %s\n"), p_rpcDomain););
     return bResult;
 }
 
@@ -357,7 +357,7 @@ MDNSResponder::stcMDNSServiceQuery* MDNSResponder::_findNextServiceQueryByServic
  * MDNSResponder::_setHostname
  */
 bool MDNSResponder::_setHostname(const char* p_pcHostname) {
-    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _allocHostname (%s)\n"), p_pcHostname););
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _allocHostname (%s)\n"), p_pcHostname););
     
     bool    bResult = false;
     
@@ -664,25 +664,25 @@ bool MDNSResponder::_releaseTempServiceTxts(MDNSResponder::stcMDNSService& p_rSe
      */
     bool MDNSResponder::_printRRDomain(const MDNSResponder::stcMDNS_RRDomain& p_RRDomain) const {
 
-        //DEBUG_OUTPUT.printf_P(PSTR_LEA("Domain: "));
+        //DEBUG_OUTPUT.printf_P(PSTR("Domain: "));
 
         const char* pCursor = p_RRDomain.m_acName;
         uint8_t     u8Length = *pCursor++;
         if (u8Length) {
             while (u8Length) {
                 for (uint8_t u=0; u<u8Length; ++u) {
-                    DEBUG_OUTPUT.printf_P(PSTR_LEA("%c"), *(pCursor++));
+                    DEBUG_OUTPUT.printf_P(PSTR("%c"), *(pCursor++));
                 }
                 u8Length = *pCursor++;
                 if (u8Length) {
-                    DEBUG_OUTPUT.printf_P(PSTR_LEA("."));
+                    DEBUG_OUTPUT.printf_P(PSTR("."));
                 }
             }
         }
         else {  // empty domain
-            DEBUG_OUTPUT.printf_P(PSTR_LEA("-empty-"));
+            DEBUG_OUTPUT.printf_P(PSTR("-empty-"));
         }
-        //DEBUG_OUTPUT.printf_P(PSTR_LEA("\n"));
+        //DEBUG_OUTPUT.printf_P(PSTR("\n"));
 
         return true;
     }
@@ -692,17 +692,17 @@ bool MDNSResponder::_releaseTempServiceTxts(MDNSResponder::stcMDNSService& p_rSe
      */
     bool MDNSResponder::_printRRAnswer(const MDNSResponder::stcMDNS_RRAnswer& p_RRAnswer) const {
 
-        DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] RRAnswer: "));
+        DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] RRAnswer: "));
         _printRRDomain(p_RRAnswer.m_Header.m_Domain);
-        DEBUG_OUTPUT.printf_P(PSTR_LEA(" Type:0x%04X Class:0x%04X TTL:%u, "), p_RRAnswer.m_Header.m_Attributes.m_u16Type, p_RRAnswer.m_Header.m_Attributes.m_u16Class, p_RRAnswer.m_u32TTL);
+        DEBUG_OUTPUT.printf_P(PSTR(" Type:0x%04X Class:0x%04X TTL:%u, "), p_RRAnswer.m_Header.m_Attributes.m_u16Type, p_RRAnswer.m_Header.m_Attributes.m_u16Class, p_RRAnswer.m_u32TTL);
         switch (p_RRAnswer.m_Header.m_Attributes.m_u16Type & (~0x8000)) {   // Topmost bit might carry 'cache flush' flag
 #ifdef MDNS_IP4_SUPPORT
         case DNS_RRTYPE_A:
-            DEBUG_OUTPUT.printf_P(PSTR_LEA("A IP:%s"), ((const stcMDNS_RRAnswerA*)&p_RRAnswer)->m_IPAddress.toString().c_str());
+            DEBUG_OUTPUT.printf_P(PSTR("A IP:%s"), ((const stcMDNS_RRAnswerA*)&p_RRAnswer)->m_IPAddress.toString().c_str());
             break;
 #endif
         case DNS_RRTYPE_PTR:
-            DEBUG_OUTPUT.printf_P(PSTR_LEA("PTR "));
+            DEBUG_OUTPUT.printf_P(PSTR("PTR "));
             _printRRDomain(((const stcMDNS_RRAnswerPTR*)&p_RRAnswer)->m_PTRDomain);
             break;
         case DNS_RRTYPE_TXT: {
@@ -710,25 +710,25 @@ bool MDNSResponder::_releaseTempServiceTxts(MDNSResponder::stcMDNSService& p_rSe
             char*   pTxts = new char[stTxtLength];
             if (pTxts) {
                 ((/*const c_str()!!*/stcMDNS_RRAnswerTXT*)&p_RRAnswer)->m_Txts.c_str(pTxts);
-                DEBUG_OUTPUT.printf_P(PSTR_LEA("TXT(%u) %s"), stTxtLength, pTxts);
+                DEBUG_OUTPUT.printf_P(PSTR("TXT(%u) %s"), stTxtLength, pTxts);
                 delete[] pTxts;
             }
             break;
         }
 #ifdef MDNS_IP6_SUPPORT
         case DNS_RRTYPE_AAAA:
-            DEBUG_OUTPUT.printf_P(PSTR_LEA("AAAA IP:%s"), ((stcMDNS_RRAnswerA*&)p_rpRRAnswer)->m_IPAddress.toString().c_str());
+            DEBUG_OUTPUT.printf_P(PSTR("AAAA IP:%s"), ((stcMDNS_RRAnswerA*&)p_rpRRAnswer)->m_IPAddress.toString().c_str());
             break;
 #endif
         case DNS_RRTYPE_SRV:
-            DEBUG_OUTPUT.printf_P(PSTR_LEA("SRV Port:%u "), ((const stcMDNS_RRAnswerSRV*)&p_RRAnswer)->m_u16Port);
+            DEBUG_OUTPUT.printf_P(PSTR("SRV Port:%u "), ((const stcMDNS_RRAnswerSRV*)&p_RRAnswer)->m_u16Port);
             _printRRDomain(((const stcMDNS_RRAnswerSRV*)&p_RRAnswer)->m_SRVDomain);
             break;
         default:
-            DEBUG_OUTPUT.printf_P(PSTR_LEA("generic "));
+            DEBUG_OUTPUT.printf_P(PSTR("generic "));
             break;
         }
-        DEBUG_OUTPUT.printf_P(PSTR_LEA("\n"));
+        DEBUG_OUTPUT.printf_P(PSTR("\n"));
 
         return true;
     }

--- a/libraries/ESP8266mDNS/src/LEAmDNS_Priv.h
+++ b/libraries/ESP8266mDNS/src/LEAmDNS_Priv.h
@@ -146,9 +146,6 @@ namespace MDNSImplementation {
 #define USE_PGM_PRINTF
 
 #ifdef USE_PGM_PRINTF
-// See: https://github.com/esp8266/Arduino/issues/3369
-#define PROGMEM_LEA __attribute__((section(".irom.text.LEA")))
-#define PSTR_LEA(s) (__extension__({static const char __c[] PROGMEM_LEA = (s); &__c[0];}))
 #else
     #ifdef F
         #undef F

--- a/libraries/ESP8266mDNS/src/LEAmDNS_Transfer.cpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS_Transfer.cpp
@@ -78,7 +78,7 @@ bool MDNSResponder::_sendMDNSMessage(MDNSResponder::stcMDNSSendParameter& p_rSen
     
     if (p_rSendParameter.m_bResponse) {
         if (p_rSendParameter.m_bUnicast) {  // Unicast response  -> Send to querier
-            DEBUG_EX_ERR(if (!m_pUDPContext->getRemoteAddress()) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _sendMDNSMessage: MISSING remote address for response!\n")); });
+            DEBUG_EX_ERR(if (!m_pUDPContext->getRemoteAddress()) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _sendMDNSMessage: MISSING remote address for response!\n")); });
             ip_addr_t   ipRemote;
             ipRemote.addr = m_pUDPContext->getRemoteAddress();
             bResult = ((_prepareMDNSMessage(p_rSendParameter, _getResponseMulticastInterface(SOFTAP_MODE | STATION_MODE))) &&
@@ -102,7 +102,7 @@ bool MDNSResponder::_sendMDNSMessage(MDNSResponder::stcMDNSSendParameter& p_rSen
         pService->m_u8ReplyMask = 0;
     }
 
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _sendMDNSMessage: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _sendMDNSMessage: FAILED!\n")); });
     return bResult;
 }
 
@@ -133,11 +133,11 @@ bool MDNSResponder::_sendMDNSMessage_Multicast(MDNSResponder::stcMDNSSendParamet
     //TODO: set multicast address
     toMulticastAddress.addr = DNS_MQUERY_IPV6_GROUP_INIT;
 #endif
-    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _sendMDNSMessage_Multicast: Will send to '%s'.\n"), IPAddress(toMulticastAddress.addr).toString().c_str()););
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _sendMDNSMessage_Multicast: Will send to '%s'.\n"), IPAddress(toMulticastAddress.addr).toString().c_str()););
     bResult = ((_prepareMDNSMessage(p_rSendParameter, fromIPAddress)) &&
                (m_pUDPContext->send(&toMulticastAddress, DNS_MQUERY_PORT)));
 
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _sendMDNSMessage_Multicast: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _sendMDNSMessage_Multicast: FAILED!\n")); });
     return bResult;
 }
 
@@ -152,7 +152,7 @@ bool MDNSResponder::_sendMDNSMessage_Multicast(MDNSResponder::stcMDNSSendParamet
  */
 bool MDNSResponder::_prepareMDNSMessage(MDNSResponder::stcMDNSSendParameter& p_rSendParameter,
                                         IPAddress p_IPAddress) {
-    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _prepareMDNSMessage\n")););
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _prepareMDNSMessage\n")););
     bool    bResult = true;
     
     // Prepare header; count answers
@@ -175,7 +175,7 @@ bool MDNSResponder::_prepareMDNSMessage(MDNSResponder::stcMDNSSendParameter& p_r
     for (uint32_t sequence=Sequence_Count; ((bResult) && (sequence<=Sequence_Send)); ++sequence) {
         DEBUG_EX_INFO(
             if (Sequence_Send == sequence) {
-                DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _prepareMDNSMessage: ID:%u QR:%u OP:%u AA:%u TC:%u RD:%u RA:%u R:%u QD:%u AN:%u NS:%u AR:%u\n"),
+                DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _prepareMDNSMessage: ID:%u QR:%u OP:%u AA:%u TC:%u RD:%u RA:%u R:%u QD:%u AN:%u NS:%u AR:%u\n"),
                 (unsigned)msgHeader.m_u16ID,
                 (unsigned)msgHeader.m_1bQR, (unsigned)msgHeader.m_4bOpcode, (unsigned)msgHeader.m_1bAA, (unsigned)msgHeader.m_1bTC, (unsigned)msgHeader.m_1bRD,
                 (unsigned)msgHeader.m_1bRA, (unsigned)msgHeader.m_4bRCode,
@@ -190,13 +190,13 @@ bool MDNSResponder::_prepareMDNSMessage(MDNSResponder::stcMDNSSendParameter& p_r
         bResult = ((Sequence_Count == sequence)
                     ? true
                     : _writeMDNSMsgHeader(msgHeader, p_rSendParameter));
-        DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _prepareMDNSMessage: _writeMDNSMsgHeader FAILED!\n")););
+        DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _prepareMDNSMessage: _writeMDNSMsgHeader FAILED!\n")););
         // Questions
         for (stcMDNS_RRQuestion* pQuestion=p_rSendParameter.m_pQuestions; ((bResult) && (pQuestion)); pQuestion=pQuestion->m_pNext) {
             ((Sequence_Count == sequence)
                 ? ++msgHeader.m_u16QDCount
                 : (bResult = _writeMDNSQuestion(*pQuestion, p_rSendParameter)));
-            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _prepareMDNSMessage: _writeMDNSQuestion FAILED!\n")););
+            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _prepareMDNSMessage: _writeMDNSQuestion FAILED!\n")););
         }
 
         // Answers and authorative answers
@@ -206,14 +206,14 @@ bool MDNSResponder::_prepareMDNSMessage(MDNSResponder::stcMDNSSendParameter& p_r
             ((Sequence_Count == sequence)
                 ? ++ru16Answers
                 : (bResult = _writeMDNSAnswer_A(p_IPAddress, p_rSendParameter)));
-            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_A(A) FAILED!\n")););
+            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_A(A) FAILED!\n")););
         }
         if ((bResult) &&
             (p_rSendParameter.m_u8HostReplyMask & ContentFlag_PTR_IP4)) {
             ((Sequence_Count == sequence)
                 ? ++ru16Answers
                 : (bResult = _writeMDNSAnswer_PTR_IP4(p_IPAddress, p_rSendParameter)));
-            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_PTR_IP4 FAILED!\n")););
+            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_PTR_IP4 FAILED!\n")););
         }
 #endif
 #ifdef MDNS_IP6_SUPPORT
@@ -222,14 +222,14 @@ bool MDNSResponder::_prepareMDNSMessage(MDNSResponder::stcMDNSSendParameter& p_r
             ((Sequence_Count == sequence)
                 ? ++ru16Answers
                 : (bResult = _writeMDNSAnswer_AAAA(p_IPAddress, p_rSendParameter)));
-            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_AAAA(A) FAILED!\n")););
+            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_AAAA(A) FAILED!\n")););
         }
         if ((bResult) &&
             (p_rSendParameter.m_u8HostReplyMask & ContentFlag_PTR_IP6)) {
             ((Sequence_Count == sequence)
                 ? ++ru16Answers
                 : (bResult = _writeMDNSAnswer_PTR_IP6(p_IPAddress, p_rSendParameter)));
-            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_PTR_IP6 FAILED!\n")););
+            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_PTR_IP6 FAILED!\n")););
         }
 #endif
 
@@ -239,28 +239,28 @@ bool MDNSResponder::_prepareMDNSMessage(MDNSResponder::stcMDNSSendParameter& p_r
                 ((Sequence_Count == sequence)
                     ? ++ru16Answers
                     : (bResult = _writeMDNSAnswer_PTR_TYPE(*pService, p_rSendParameter)));
-                DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_PTR_TYPE FAILED!\n")););
+                DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_PTR_TYPE FAILED!\n")););
             }
             if ((bResult) &&
                 (pService->m_u8ReplyMask & ContentFlag_PTR_NAME)) {
                 ((Sequence_Count == sequence)
                     ? ++ru16Answers
                     : (bResult = _writeMDNSAnswer_PTR_NAME(*pService, p_rSendParameter)));
-                DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_PTR_NAME FAILED!\n")););
+                DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_PTR_NAME FAILED!\n")););
             }
             if ((bResult) &&
                 (pService->m_u8ReplyMask & ContentFlag_SRV)) {
                 ((Sequence_Count == sequence)
                     ? ++ru16Answers
                     : (bResult = _writeMDNSAnswer_SRV(*pService, p_rSendParameter)));
-                DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_SRV(A) FAILED!\n")););
+                DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_SRV(A) FAILED!\n")););
             }
             if ((bResult) &&
                 (pService->m_u8ReplyMask & ContentFlag_TXT)) {
                 ((Sequence_Count == sequence)
                     ? ++ru16Answers
                     : (bResult = _writeMDNSAnswer_TXT(*pService, p_rSendParameter)));
-                DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_TXT(A) FAILED!\n")););
+                DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_TXT(A) FAILED!\n")););
             }
         }   // for services
         
@@ -278,7 +278,7 @@ bool MDNSResponder::_prepareMDNSMessage(MDNSResponder::stcMDNSSendParameter& p_r
                 ((Sequence_Count == sequence)
                     ? ++msgHeader.m_u16ARCount
                     : (bResult = _writeMDNSAnswer_SRV(*pService, p_rSendParameter)));
-                DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_SRV(B) FAILED!\n")););
+                DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_SRV(B) FAILED!\n")););
             }
             if ((bResult) &&
                 (pService->m_u8ReplyMask & ContentFlag_PTR_NAME) && // If PTR_NAME is requested, AND
@@ -286,7 +286,7 @@ bool MDNSResponder::_prepareMDNSMessage(MDNSResponder::stcMDNSSendParameter& p_r
                 ((Sequence_Count == sequence)
                     ? ++msgHeader.m_u16ARCount
                     : (bResult = _writeMDNSAnswer_TXT(*pService, p_rSendParameter)));
-                DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_TXT(B) FAILED!\n")););
+                DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_TXT(B) FAILED!\n")););
             }
             if ((pService->m_u8ReplyMask & (ContentFlag_PTR_NAME | ContentFlag_SRV)) ||         // If service instance name or SRV OR
                 (p_rSendParameter.m_u8HostReplyMask & (ContentFlag_A | ContentFlag_AAAA))) {    // any host IP address is requested
@@ -312,7 +312,7 @@ bool MDNSResponder::_prepareMDNSMessage(MDNSResponder::stcMDNSSendParameter& p_r
             ((Sequence_Count == sequence)
                 ? ++msgHeader.m_u16ARCount
                 : (bResult = _writeMDNSAnswer_A(p_IPAddress, p_rSendParameter)));
-            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_A(B) FAILED!\n")););
+            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_A(B) FAILED!\n")););
         }
 #endif
 #ifdef MDNS_IP6_SUPPORT
@@ -322,12 +322,12 @@ bool MDNSResponder::_prepareMDNSMessage(MDNSResponder::stcMDNSSendParameter& p_r
             ((Sequence_Count == sequence)
                 ? ++msgHeader.m_u16ARCount
                 : (bResult = _writeMDNSAnswer_AAAA(p_IPAddress, p_rSendParameter)));
-            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_AAAA(B) FAILED!\n")););
+            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _prepareMDNSMessage: _writeMDNSAnswer_AAAA(B) FAILED!\n")););
         }
 #endif
-        DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _prepareMDNSMessage: Loop %i FAILED!\n"), sequence););
+        DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _prepareMDNSMessage: Loop %i FAILED!\n"), sequence););
     }   // for sequence
-    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _prepareMDNSMessage: FAILED!\n")););
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _prepareMDNSMessage: FAILED!\n")););
     return bResult;
 }
 
@@ -363,7 +363,7 @@ bool MDNSResponder::_sendMDNSQuery(const MDNSResponder::stcMDNS_RRDomain& p_Quer
 
         bResult = _sendMDNSMessage(sendParameter);
     }   // else: FAILED to alloc question
-    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _sendMDNSQuery: FAILED to alloc question!\n")););
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _sendMDNSQuery: FAILED to alloc question!\n")););
     return bResult;
 }
 
@@ -383,7 +383,7 @@ IPAddress MDNSResponder::_getResponseMulticastInterface(int p_iWiFiOpModes) cons
     
     if ((p_iWiFiOpModes & SOFTAP_MODE) &&
         (wifi_get_opmode() & SOFTAP_MODE)) {
-        //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _getResponseMulticastInterface: SOFTAP_MODE\n")););
+        //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _getResponseMulticastInterface: SOFTAP_MODE\n")););
         // Get remote IP address
         ip_info IPInfo_Remote;
         IPInfo_Remote.ip.addr = m_pUDPContext->getRemoteAddress();
@@ -398,11 +398,11 @@ IPAddress MDNSResponder::_getResponseMulticastInterface(int p_iWiFiOpModes) cons
     if ((!bFoundMatch) &&
         (p_iWiFiOpModes & STATION_MODE) &&
         (wifi_get_opmode() & STATION_MODE)) {
-        //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _getResponseMulticastInterface: STATION_MODE\n")););
+        //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _getResponseMulticastInterface: STATION_MODE\n")););
         // Get local (STATION) IP address
         wifi_get_ip_info(STATION_IF, &IPInfo_Local);
     }
-    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _getResponseMulticastInterface(%i): %s\n"), p_iWiFiOpModes, IPAddress(IPInfo_Local.ip.addr).toString().c_str()););
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _getResponseMulticastInterface(%i): %s\n"), p_iWiFiOpModes, IPAddress(IPInfo_Local.ip.addr).toString().c_str()););
     return IPAddress(IPInfo_Local.ip.addr);
 }
 
@@ -422,7 +422,7 @@ IPAddress MDNSResponder::_getResponseMulticastInterface(int p_iWiFiOpModes) cons
  *
  */
 bool MDNSResponder::_readRRQuestion(MDNSResponder::stcMDNS_RRQuestion& p_rRRQuestion) {
-    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRQuestion\n")););
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRQuestion\n")););
     
     bool    bResult = false;
     
@@ -432,12 +432,12 @@ bool MDNSResponder::_readRRQuestion(MDNSResponder::stcMDNS_RRQuestion& p_rRRQues
         p_rRRQuestion.m_Header.m_Attributes.m_u16Class &= (~0x8000);
 
         DEBUG_EX_INFO(
-                DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRQuestion "));
+                DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRQuestion "));
                 _printRRDomain(p_rRRQuestion.m_Header.m_Domain);
-                DEBUG_OUTPUT.printf_P(PSTR_LEA(" Type:0x%04X Class:0x%04X %s\n"), (unsigned)p_rRRQuestion.m_Header.m_Attributes.m_u16Type, (unsigned)p_rRRQuestion.m_Header.m_Attributes.m_u16Class, (p_rRRQuestion.m_bUnicast ? "Unicast" : "Multicast"));
+                DEBUG_OUTPUT.printf_P(PSTR(" Type:0x%04X Class:0x%04X %s\n"), (unsigned)p_rRRQuestion.m_Header.m_Attributes.m_u16Type, (unsigned)p_rRRQuestion.m_Header.m_Attributes.m_u16Class, (p_rRRQuestion.m_bUnicast ? "Unicast" : "Multicast"));
                 );
     }
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRQuestion: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRQuestion: FAILED!\n")); });
     return bResult;
 }
 
@@ -453,7 +453,7 @@ bool MDNSResponder::_readRRQuestion(MDNSResponder::stcMDNS_RRQuestion& p_rRRQues
  *
  */
 bool MDNSResponder::_readRRAnswer(MDNSResponder::stcMDNS_RRAnswer*& p_rpRRAnswer) {
-    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRAnswer\n")););
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRAnswer\n")););
     
     bool    bResult = false;
     
@@ -465,9 +465,9 @@ bool MDNSResponder::_readRRAnswer(MDNSResponder::stcMDNS_RRAnswer*& p_rpRRAnswer
         (_udpRead16(u16RDLength))) {
 
         DEBUG_EX_INFO(
-                DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRAnswer: Reading 0x%04X answer (class:0x%04X, TTL:%u, RDLength:%u) for "), header.m_Attributes.m_u16Type, header.m_Attributes.m_u16Class, u32TTL, u16RDLength);
+                DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRAnswer: Reading 0x%04X answer (class:0x%04X, TTL:%u, RDLength:%u) for "), header.m_Attributes.m_u16Type, header.m_Attributes.m_u16Class, u32TTL, u16RDLength);
                 _printRRDomain(header.m_Domain);
-                DEBUG_OUTPUT.printf_P(PSTR_LEA("\n"));
+                DEBUG_OUTPUT.printf_P(PSTR("\n"));
                 );
         
         switch (header.m_Attributes.m_u16Type & (~0x8000)) {    // Topmost bit might carry 'cache flush' flag
@@ -503,17 +503,17 @@ bool MDNSResponder::_readRRAnswer(MDNSResponder::stcMDNS_RRAnswer*& p_rpRRAnswer
         DEBUG_EX_INFO(
                 if ((bResult) &&
                     (p_rpRRAnswer)) {
-                    DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRAnswer: "));
+                    DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRAnswer: "));
                     _printRRDomain(p_rpRRAnswer->m_Header.m_Domain);
-                    DEBUG_OUTPUT.printf_P(PSTR_LEA(" Type:0x%04X Class:0x%04X TTL:%u, RDLength:%u "), p_rpRRAnswer->m_Header.m_Attributes.m_u16Type, p_rpRRAnswer->m_Header.m_Attributes.m_u16Class, p_rpRRAnswer->m_u32TTL, u16RDLength);
+                    DEBUG_OUTPUT.printf_P(PSTR(" Type:0x%04X Class:0x%04X TTL:%u, RDLength:%u "), p_rpRRAnswer->m_Header.m_Attributes.m_u16Type, p_rpRRAnswer->m_Header.m_Attributes.m_u16Class, p_rpRRAnswer->m_u32TTL, u16RDLength);
                     switch (header.m_Attributes.m_u16Type & (~0x8000)) {    // Topmost bit might carry 'cache flush' flag
 #ifdef MDNS_IP4_SUPPORT
                     case DNS_RRTYPE_A:
-                        DEBUG_OUTPUT.printf_P(PSTR_LEA("A IP:%s"), ((stcMDNS_RRAnswerA*&)p_rpRRAnswer)->m_IPAddress.toString().c_str());
+                        DEBUG_OUTPUT.printf_P(PSTR("A IP:%s"), ((stcMDNS_RRAnswerA*&)p_rpRRAnswer)->m_IPAddress.toString().c_str());
                         break;
 #endif
                     case DNS_RRTYPE_PTR:
-                        DEBUG_OUTPUT.printf_P(PSTR_LEA("PTR "));
+                        DEBUG_OUTPUT.printf_P(PSTR("PTR "));
                         _printRRDomain(((stcMDNS_RRAnswerPTR*&)p_rpRRAnswer)->m_PTRDomain);
                         break;
                     case DNS_RRTYPE_TXT: {
@@ -521,32 +521,32 @@ bool MDNSResponder::_readRRAnswer(MDNSResponder::stcMDNS_RRAnswer*& p_rpRRAnswer
                         char*   pTxts = new char[stTxtLength];
                         if (pTxts) {
                             ((stcMDNS_RRAnswerTXT*&)p_rpRRAnswer)->m_Txts.c_str(pTxts);
-                            DEBUG_OUTPUT.printf_P(PSTR_LEA("TXT(%u) %s"), stTxtLength, pTxts);
+                            DEBUG_OUTPUT.printf_P(PSTR("TXT(%u) %s"), stTxtLength, pTxts);
                             delete[] pTxts;
                         }
                         break;
                     }
 #ifdef MDNS_IP6_SUPPORT
                     case DNS_RRTYPE_AAAA:
-                        DEBUG_OUTPUT.printf_P(PSTR_LEA("AAAA IP:%s"), ((stcMDNS_RRAnswerA*&)p_rpRRAnswer)->m_IPAddress.toString().c_str());
+                        DEBUG_OUTPUT.printf_P(PSTR("AAAA IP:%s"), ((stcMDNS_RRAnswerA*&)p_rpRRAnswer)->m_IPAddress.toString().c_str());
                         break;
 #endif
                     case DNS_RRTYPE_SRV:
-                        DEBUG_OUTPUT.printf_P(PSTR_LEA("SRV Port:%u "), ((stcMDNS_RRAnswerSRV*&)p_rpRRAnswer)->m_u16Port);
+                        DEBUG_OUTPUT.printf_P(PSTR("SRV Port:%u "), ((stcMDNS_RRAnswerSRV*&)p_rpRRAnswer)->m_u16Port);
                         _printRRDomain(((stcMDNS_RRAnswerSRV*&)p_rpRRAnswer)->m_SRVDomain);
                         break;
                     default:
-                        DEBUG_OUTPUT.printf_P(PSTR_LEA("generic "));
+                        DEBUG_OUTPUT.printf_P(PSTR("generic "));
                         break;
                     }
-                    DEBUG_OUTPUT.printf_P(PSTR_LEA("\n"));
+                    DEBUG_OUTPUT.printf_P(PSTR("\n"));
                 }
                 else {
-                    DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRAnswer: FAILED to read specific answer of type 0x%04X!\n"), p_rpRRAnswer->m_Header.m_Attributes.m_u16Type);
+                    DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRAnswer: FAILED to read specific answer of type 0x%04X!\n"), p_rpRRAnswer->m_Header.m_Attributes.m_u16Type);
                 }
         );  // DEBUG_EX_INFO
     }
-    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRAnswer: FAILED!\n")););
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRAnswer: FAILED!\n")););
     return bResult;
 }
 
@@ -561,7 +561,7 @@ bool MDNSResponder::_readRRAnswer(MDNSResponder::stcMDNS_RRAnswer*& p_rpRRAnswer
         bool        bResult = ((MDNS_IP4_SIZE == p_u16RDLength) &&
                                (_udpReadBuffer((unsigned char*)&u32IP4Address, MDNS_IP4_SIZE)) &&
                                ((p_rRRAnswerA.m_IPAddress = IPAddress(u32IP4Address))));
-        DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRAnswerA: FAILED!\n")););
+        DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRAnswerA: FAILED!\n")););
         return bResult;
     }
 #endif
@@ -574,7 +574,7 @@ bool MDNSResponder::_readRRAnswerPTR(MDNSResponder::stcMDNS_RRAnswerPTR& p_rRRAn
     
     bool    bResult = ((p_u16RDLength) &&
                        (_readRRDomain(p_rRRAnswerPTR.m_PTRDomain)));
-    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRAnswerPTR: FAILED!\n")););
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRAnswerPTR: FAILED!\n")););
     return bResult;
 }
 
@@ -585,7 +585,7 @@ bool MDNSResponder::_readRRAnswerPTR(MDNSResponder::stcMDNS_RRAnswerPTR& p_rRRAn
  */
 bool MDNSResponder::_readRRAnswerTXT(MDNSResponder::stcMDNS_RRAnswerTXT& p_rRRAnswerTXT,
                                      uint16_t p_u16RDLength) {
-    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRAnswerTXT: RDLength:%u\n"), p_u16RDLength););
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRAnswerTXT: RDLength:%u\n"), p_u16RDLength););
     bool    bResult = true;
     
     p_rRRAnswerTXT.clear();
@@ -609,7 +609,7 @@ bool MDNSResponder::_readRRAnswerTXT(MDNSResponder::stcMDNS_RRAnswerTXT& p_rRRAn
                                 static char sacBuffer[64]; *sacBuffer = 0;
                                 uint8_t u8MaxLength = ((ucLength > (sizeof(sacBuffer) - 1)) ? (sizeof(sacBuffer) - 1) : ucLength);
                                 os_strncpy(sacBuffer, (const char*)pucCursor, u8MaxLength); sacBuffer[u8MaxLength] = 0;
-                                DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRAnswerTXT: Item(%u): %s\n"), ucLength, sacBuffer);
+                                DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRAnswerTXT: Item(%u): %s\n"), ucLength, sacBuffer);
                                 );
 
                         unsigned char*  pucEqualSign = (unsigned char*)os_strchr((const char*)pucCursor, '=');  // Position of the '=' sign
@@ -622,12 +622,12 @@ bool MDNSResponder::_readRRAnswerTXT(MDNSResponder::stcMDNS_RRAnswerTXT& p_rRRAn
                                        (pTxt->setValue((const char*)(pucEqualSign + 1), ucValueLength)));
                         }
                         else {
-                            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRAnswerTXT: INVALID TXT format (No '=')!\n")););
+                            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRAnswerTXT: INVALID TXT format (No '=')!\n")););
                         }
                         pucCursor += ucLength;
                     }
                     else {  // no/zero length TXT
-                        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRAnswerTXT: TXT answer contains no items.\n")););
+                        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRAnswerTXT: TXT answer contains no items.\n")););
                         bResult = true;
                     }
                     
@@ -640,10 +640,10 @@ bool MDNSResponder::_readRRAnswerTXT(MDNSResponder::stcMDNS_RRAnswerTXT& p_rRRAn
                     else {          // At least no TXT (migth be OK, if length was 0) OR an error
                         if (!bResult) {
                             DEBUG_EX_ERR(
-                                    DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRAnswerTXT: FAILED to read TXT item!\n"));
-                                    DEBUG_OUTPUT.printf_P(PSTR_LEA("RData dump:\n"));
+                                    DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRAnswerTXT: FAILED to read TXT item!\n"));
+                                    DEBUG_OUTPUT.printf_P(PSTR("RData dump:\n"));
                                     _udpDump((m_pUDPContext->tell() - p_u16RDLength), p_u16RDLength);
-                                    DEBUG_OUTPUT.printf_P(PSTR_LEA("\n"));
+                                    DEBUG_OUTPUT.printf_P(PSTR("\n"));
                             );
                         }
                         if (pTxt) {
@@ -656,26 +656,26 @@ bool MDNSResponder::_readRRAnswerTXT(MDNSResponder::stcMDNS_RRAnswerTXT& p_rRRAn
                 
                 DEBUG_EX_ERR(
                     if (!bResult) { // Some failure
-                        DEBUG_OUTPUT.printf_P(PSTR_LEA("RData dump:\n"));
+                        DEBUG_OUTPUT.printf_P(PSTR("RData dump:\n"));
                         _udpDump((m_pUDPContext->tell() - p_u16RDLength), p_u16RDLength);
-                        DEBUG_OUTPUT.printf_P(PSTR_LEA("\n"));
+                        DEBUG_OUTPUT.printf_P(PSTR("\n"));
                     }
                 );
             }
             else {
-                DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRAnswerTXT: FAILED to read TXT content!\n")););
+                DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRAnswerTXT: FAILED to read TXT content!\n")););
             }
             // Clean up
             delete[] pucBuffer;
         }
         else {
-            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRAnswerTXT: FAILED to alloc buffer for TXT content!\n")););
+            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRAnswerTXT: FAILED to alloc buffer for TXT content!\n")););
         }
     }
     else {
-        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRAnswerTXT: WARNING! No content!\n")););
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRAnswerTXT: WARNING! No content!\n")););
     }
-    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRAnswerTXT: FAILED!\n")););
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRAnswerTXT: FAILED!\n")););
     return bResult;
 }
 
@@ -699,7 +699,7 @@ bool MDNSResponder::_readRRAnswerSRV(MDNSResponder::stcMDNS_RRAnswerSRV& p_rRRAn
                        (_udpRead16(p_rRRAnswerSRV.m_u16Weight)) &&
                        (_udpRead16(p_rRRAnswerSRV.m_u16Port)) &&
                        (_readRRDomain(p_rRRAnswerSRV.m_SRVDomain)));
-    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRAnswerSRV: FAILED!\n")););
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRAnswerSRV: FAILED!\n")););
     return bResult;
 }
 
@@ -716,7 +716,7 @@ bool MDNSResponder::_readRRAnswerGeneric(MDNSResponder::stcMDNS_RRAnswerGeneric&
 
         bResult = _udpReadBuffer(p_rRRAnswerGeneric.m_pu8RDData, p_rRRAnswerGeneric.m_u16RDLength);
     }
-    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRAnswerGeneric: FAILED!\n")););
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRAnswerGeneric: FAILED!\n")););
     return bResult;
 }
 
@@ -724,11 +724,11 @@ bool MDNSResponder::_readRRAnswerGeneric(MDNSResponder::stcMDNS_RRAnswerGeneric&
  * MDNSResponder::_readRRHeader
  */
 bool MDNSResponder::_readRRHeader(MDNSResponder::stcMDNS_RRHeader& p_rRRHeader) {
-    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRHeader\n")););
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRHeader\n")););
     
     bool    bResult = ((_readRRDomain(p_rRRHeader.m_Domain)) &&
                        (_readRRAttributes(p_rRRHeader.m_Attributes)));
-    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRHeader: FAILED!\n")););
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRHeader: FAILED!\n")););
     return bResult;
 }
 
@@ -739,11 +739,11 @@ bool MDNSResponder::_readRRHeader(MDNSResponder::stcMDNS_RRHeader& p_rRRHeader) 
  *
  */
 bool MDNSResponder::_readRRDomain(MDNSResponder::stcMDNS_RRDomain& p_rRRDomain) {
-    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRDomain\n")););
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRDomain\n")););
     
     bool    bResult = ((p_rRRDomain.clear()) &&
                        (_readRRDomain_Loop(p_rRRDomain, 0)));
-    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRDomain: FAILED!\n")););
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRDomain: FAILED!\n")););
     return bResult;
 }
 
@@ -757,7 +757,7 @@ bool MDNSResponder::_readRRDomain(MDNSResponder::stcMDNS_RRDomain& p_rRRDomain) 
  */
 bool MDNSResponder::_readRRDomain_Loop(MDNSResponder::stcMDNS_RRDomain& p_rRRDomain,
                                        uint8_t p_u8Depth) {
-    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRDomain_Loop(%u)\n"), p_u8Depth););
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRDomain_Loop(%u)\n"), p_u8Depth););
     
     bool    bResult = false;
     
@@ -766,7 +766,7 @@ bool MDNSResponder::_readRRDomain_Loop(MDNSResponder::stcMDNS_RRDomain& p_rRRDom
         
         uint8_t u8Len = 0;
         do {
-            //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRDomain_Loop(%u): Offset:%u p0:%02x\n"), p_u8Depth, m_pUDPContext->tell(), m_pUDPContext->peek()););
+            //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRDomain_Loop(%u): Offset:%u p0:%02x\n"), p_u8Depth, m_pUDPContext->tell(), m_pUDPContext->peek()););
             _udpRead8(u8Len);
             
             if (u8Len & MDNS_DOMAIN_COMPRESS_MARK) {
@@ -778,19 +778,19 @@ bool MDNSResponder::_readRRDomain_Loop(MDNSResponder::stcMDNS_RRDomain& p_rRRDom
                 if (m_pUDPContext->isValidOffset(u16Offset)) {
                     size_t  stCurrentPosition = m_pUDPContext->tell();      // Prepare return from recursion
                     
-                    //DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRDomain_Loop(%u): Redirecting from %u to %u!\n"), p_u8Depth, stCurrentPosition, u16Offset););
+                    //DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRDomain_Loop(%u): Redirecting from %u to %u!\n"), p_u8Depth, stCurrentPosition, u16Offset););
                     m_pUDPContext->seek(u16Offset);
                     if (_readRRDomain_Loop(p_rRRDomain, p_u8Depth + 1)) {   // Do recursion
-                        //DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRDomain_Loop(%u): Succeeded to read redirected label! Returning to %u\n"), p_u8Depth, stCurrentPosition););
+                        //DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRDomain_Loop(%u): Succeeded to read redirected label! Returning to %u\n"), p_u8Depth, stCurrentPosition););
                         m_pUDPContext->seek(stCurrentPosition);             // Restore after recursion
                     }
                     else {
-                        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRDomain_Loop(%u): FAILED to read redirected label!\n"), p_u8Depth););
+                        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRDomain_Loop(%u): FAILED to read redirected label!\n"), p_u8Depth););
                         bResult = false;
                     }
                 }
                 else {
-                    DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRDomain_Loop(%u): INVALID offset in redirection!\n"), p_u8Depth););
+                    DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRDomain_Loop(%u): INVALID offset in redirection!\n"), p_u8Depth););
                     bResult = false;
                 }
                 break;
@@ -805,16 +805,16 @@ bool MDNSResponder::_readRRDomain_Loop(MDNSResponder::stcMDNS_RRDomain& p_rRRDom
                         if ((bResult = _udpReadBuffer((unsigned char*)&(p_rRRDomain.m_acName[p_rRRDomain.m_u16NameLength]), u8Len))) {
                             /*DEBUG_EX_INFO(
                                     p_rRRDomain.m_acName[p_rRRDomain.m_u16NameLength + u8Len] = 0;  // Closing '\0' for printing
-                                    DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRDomain_Loop(%u): Domain label (%u): %s\n"), p_u8Depth, (unsigned)(p_rRRDomain.m_acName[p_rRRDomain.m_u16NameLength - 1]), &(p_rRRDomain.m_acName[p_rRRDomain.m_u16NameLength]));
+                                    DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRDomain_Loop(%u): Domain label (%u): %s\n"), p_u8Depth, (unsigned)(p_rRRDomain.m_acName[p_rRRDomain.m_u16NameLength - 1]), &(p_rRRDomain.m_acName[p_rRRDomain.m_u16NameLength]));
                                     );*/
 
                             p_rRRDomain.m_u16NameLength += u8Len;
                         }
                     }
-                    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRDomain_Loop(2) offset:%u p0:%x\n"), m_pUDPContext->tell(), m_pUDPContext->peek()););
+                    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRDomain_Loop(2) offset:%u p0:%x\n"), m_pUDPContext->tell(), m_pUDPContext->peek()););
                 }
                 else {
-                    DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRDomain_Loop(%u): ERROR! Domain name too long (%u + %u)!\n"), p_u8Depth, p_rRRDomain.m_u16NameLength, u8Len););
+                    DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRDomain_Loop(%u): ERROR! Domain name too long (%u + %u)!\n"), p_u8Depth, p_rRRDomain.m_u16NameLength, u8Len););
                     bResult = false;
                     break;
                 }
@@ -823,7 +823,7 @@ bool MDNSResponder::_readRRDomain_Loop(MDNSResponder::stcMDNS_RRDomain& p_rRRDom
                  (0 != u8Len));
     }
     else {
-        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRDomain_Loop(%u): ERROR! Too many redirections!\n"), p_u8Depth););
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRDomain_Loop(%u): ERROR! Too many redirections!\n"), p_u8Depth););
     }
     return bResult;
 }
@@ -832,11 +832,11 @@ bool MDNSResponder::_readRRDomain_Loop(MDNSResponder::stcMDNS_RRDomain& p_rRRDom
  * MDNSResponder::_readRRAttributes
  */
 bool MDNSResponder::_readRRAttributes(MDNSResponder::stcMDNS_RRAttributes& p_rRRAttributes) {
-    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRAttributes\n")););
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRAttributes\n")););
 
     bool    bResult = ((_udpRead16(p_rRRAttributes.m_u16Type)) &&
                        (_udpRead16(p_rRRAttributes.m_u16Class)));
-    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readRRAttributes: FAILED!\n")););
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readRRAttributes: FAILED!\n")););
     return bResult;
 }
 
@@ -860,7 +860,7 @@ bool MDNSResponder::_buildDomainForHost(const char* p_pcHostname,
                        (p_rHostDomain.addLabel(p_pcHostname)) &&
                        (p_rHostDomain.addLabel(scpcLocal)) &&
                        (p_rHostDomain.addLabel(0)));
-    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _buildDomainForHost: FAILED!\n")););
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _buildDomainForHost: FAILED!\n")););
     return bResult;
 }
 
@@ -879,7 +879,7 @@ bool MDNSResponder::_buildDomainForDNSSD(MDNSResponder::stcMDNS_RRDomain& p_rDNS
                        (p_rDNSSDDomain.addLabel(scpcUDP, true)) &&
                        (p_rDNSSDDomain.addLabel(scpcLocal)) &&
                        (p_rDNSSDDomain.addLabel(0)));
-    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _buildDomainForDNSSD: FAILED!\n")););
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _buildDomainForDNSSD: FAILED!\n")););
     return bResult;
 }
 
@@ -901,7 +901,7 @@ bool MDNSResponder::_buildDomainForService(const MDNSResponder::stcMDNSService& 
                        (p_rServiceDomain.addLabel(p_Service.m_pcProtocol, true)) &&
                        (p_rServiceDomain.addLabel(scpcLocal)) &&
                        (p_rServiceDomain.addLabel(0)));
-    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _buildDomainForService: FAILED!\n")););
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _buildDomainForService: FAILED!\n")););
     return bResult;
 }
 
@@ -923,7 +923,7 @@ bool MDNSResponder::_buildDomainForService(const char* p_pcService,
                        (p_rServiceDomain.addLabel(p_pcProtocol, ('_' != *p_pcProtocol))) &&
                        (p_rServiceDomain.addLabel(scpcLocal)) &&
                        (p_rServiceDomain.addLabel(0)));
-    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _buildDomainForService: FAILED for (%s.%s)!\n"), (p_pcService ?: "-"), (p_pcProtocol ?: "-")););
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _buildDomainForService: FAILED for (%s.%s)!\n"), (p_pcService ?: "-"), (p_pcProtocol ?: "-")););
     return bResult;
 }           
 
@@ -951,7 +951,7 @@ bool MDNSResponder::_buildDomainForService(const char* p_pcService,
                    (p_rReverseIP4Domain.addLabel(scpcReverseIP4Domain)) &&
                    (p_rReverseIP4Domain.addLabel(scpcReverseTopDomain)) &&
                    (p_rReverseIP4Domain.addLabel(0)));
-        DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _buildDomainForReverseIP4: FAILED!\n")););
+        DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _buildDomainForReverseIP4: FAILED!\n")););
         return bResult;
     }
 #endif
@@ -985,7 +985,7 @@ bool MDNSResponder::_udpReadBuffer(unsigned char* p_pBuffer,
                        (p_pBuffer) &&
                        (p_stLength) &&
                        ((p_stLength == m_pUDPContext->read((char*)p_pBuffer, p_stLength))));
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _udpReadBuffer: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _udpReadBuffer: FAILED!\n")); });
     return bResult;
 }
 
@@ -1035,7 +1035,7 @@ bool MDNSResponder::_udpAppendBuffer(const unsigned char* p_pcBuffer,
                    (p_pcBuffer) &&
                    (p_stLength) &&
                    (p_stLength == m_pUDPContext->append((const char*)p_pcBuffer, p_stLength)));
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _udpAppendBuffer: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _udpAppendBuffer: FAILED!\n")); });
     return bResult;
 }
 
@@ -1079,9 +1079,9 @@ bool MDNSResponder::_udpAppend32(uint32_t p_u32Value) {
         uint8_t     u8Byte = 0;
 
         while (_udpRead8(u8Byte)) {
-            DEBUG_OUTPUT.printf_P(PSTR_LEA("%02x %s"), u8Byte, ((++u32Counter % cu8BytesPerLine) ? "" : "\n"));
+            DEBUG_OUTPUT.printf_P(PSTR("%02x %s"), u8Byte, ((++u32Counter % cu8BytesPerLine) ? "" : "\n"));
         }
-        DEBUG_OUTPUT.printf_P(PSTR_LEA("%sDone: %u bytes\n"), (((u32Counter) && (u32Counter % cu8BytesPerLine)) ? "\n" : ""), u32Counter);
+        DEBUG_OUTPUT.printf_P(PSTR("%sDone: %u bytes\n"), (((u32Counter) && (u32Counter % cu8BytesPerLine)) ? "\n" : ""), u32Counter);
         
         if (!p_bMovePointer) {  // Restore
             m_pUDPContext->seek(u32StartPosition);
@@ -1102,7 +1102,7 @@ bool MDNSResponder::_udpAppend32(uint32_t p_u32Value) {
             m_pUDPContext->seek(p_uOffset);
             uint8_t u8Byte;
             for (unsigned u=0; ((u<p_uLength) && (_udpRead8(u8Byte))); ++u) {
-                DEBUG_OUTPUT.printf_P(PSTR_LEA("%02x "), u8Byte);
+                DEBUG_OUTPUT.printf_P(PSTR("%02x "), u8Byte);
             }
             // Return to start position
             m_pUDPContext->seek(uCurrentPosition);
@@ -1153,7 +1153,7 @@ bool MDNSResponder::_readMDNSMsgHeader(MDNSResponder::stcMDNS_MsgHeader& p_rMsgH
         p_rMsgHeader.m_3bZ      = (u8B2 & 0x70);    // Zero
         p_rMsgHeader.m_4bRCode  = (u8B2 & 0x0F);    // Response code
 
-        /*DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readMDNSMsgHeader: ID:%u QR:%u OP:%u AA:%u TC:%u RD:%u RA:%u R:%u QD:%u AN:%u NS:%u AR:%u\n"),
+        /*DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readMDNSMsgHeader: ID:%u QR:%u OP:%u AA:%u TC:%u RD:%u RA:%u R:%u QD:%u AN:%u NS:%u AR:%u\n"),
                 (unsigned)p_rMsgHeader.m_u16ID,
                 (unsigned)p_rMsgHeader.m_1bQR, (unsigned)p_rMsgHeader.m_4bOpcode, (unsigned)p_rMsgHeader.m_1bAA, (unsigned)p_rMsgHeader.m_1bTC, (unsigned)p_rMsgHeader.m_1bRD,
                 (unsigned)p_rMsgHeader.m_1bRA, (unsigned)p_rMsgHeader.m_4bRCode,
@@ -1163,7 +1163,7 @@ bool MDNSResponder::_readMDNSMsgHeader(MDNSResponder::stcMDNS_MsgHeader& p_rMsgH
                 (unsigned)p_rMsgHeader.m_u16ARCount););*/
         bResult = true;
     }
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _readMDNSMsgHeader: FAILED!\n")); } );
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _readMDNSMsgHeader: FAILED!\n")); } );
     return bResult;
 }
 
@@ -1208,7 +1208,7 @@ bool MDNSResponder::_write32(uint32_t p_u32Value,
  */
 bool MDNSResponder::_writeMDNSMsgHeader(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHeader,
                                         MDNSResponder::stcMDNSSendParameter& p_rSendParameter) {
-    /*DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSMsgHeader: ID:%u QR:%u OP:%u AA:%u TC:%u RD:%u RA:%u R:%u QD:%u AN:%u NS:%u AR:%u\n"),
+    /*DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSMsgHeader: ID:%u QR:%u OP:%u AA:%u TC:%u RD:%u RA:%u R:%u QD:%u AN:%u NS:%u AR:%u\n"),
             (unsigned)p_MsgHeader.m_u16ID,
             (unsigned)p_MsgHeader.m_1bQR, (unsigned)p_MsgHeader.m_4bOpcode, (unsigned)p_MsgHeader.m_1bAA, (unsigned)p_MsgHeader.m_1bTC, (unsigned)p_MsgHeader.m_1bRD,
             (unsigned)p_MsgHeader.m_1bRA, (unsigned)p_MsgHeader.m_4bRCode,
@@ -1227,7 +1227,7 @@ bool MDNSResponder::_writeMDNSMsgHeader(const MDNSResponder::stcMDNS_MsgHeader& 
                        (_write16(p_MsgHeader.m_u16NSCount, p_rSendParameter)) &&
                        (_write16(p_MsgHeader.m_u16ARCount, p_rSendParameter)));
 
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSMsgHeader: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSMsgHeader: FAILED!\n")); });
     return bResult;
 }
 
@@ -1240,7 +1240,7 @@ bool MDNSResponder::_writeMDNSRRAttributes(const MDNSResponder::stcMDNS_RRAttrib
     bool    bResult = ((_write16(p_Attributes.m_u16Type, p_rSendParameter)) &&
                        (_write16(p_Attributes.m_u16Class, p_rSendParameter)));
 
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSRRAttributes: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSRRAttributes: FAILED!\n")); });
     return bResult;
 }
 
@@ -1253,7 +1253,7 @@ bool MDNSResponder::_writeMDNSRRDomain(const MDNSResponder::stcMDNS_RRDomain& p_
     bool    bResult = ((_udpAppendBuffer((const unsigned char*)p_Domain.m_acName, p_Domain.m_u16NameLength)) &&
                        (p_rSendParameter.shiftOffset(p_Domain.m_u16NameLength)));
 
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSRRDomain: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSRRDomain: FAILED!\n")); });
     return bResult;
 }
 
@@ -1294,7 +1294,7 @@ bool MDNSResponder::_writeMDNSHostDomain(const char* p_pcHostname,
                            (p_rSendParameter.addDomainCacheItem((const void*)p_pcHostname, false, p_rSendParameter.m_u16Offset)) &&
                            (_writeMDNSRRDomain(hostDomain, p_rSendParameter))));
 
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSHostDomain: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSHostDomain: FAILED!\n")); });
     return bResult;
 
 }
@@ -1334,7 +1334,7 @@ bool MDNSResponder::_writeMDNSServiceDomain(const MDNSResponder::stcMDNSService&
                            (p_rSendParameter.addDomainCacheItem((const void*)&p_Service, p_bIncludeName, p_rSendParameter.m_u16Offset)) &&
                            (_writeMDNSRRDomain(serviceDomain, p_rSendParameter))));
 
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSServiceDomain: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSServiceDomain: FAILED!\n")); });
     return bResult;
 
 }
@@ -1351,12 +1351,12 @@ bool MDNSResponder::_writeMDNSServiceDomain(const MDNSResponder::stcMDNSService&
  */
 bool MDNSResponder::_writeMDNSQuestion(MDNSResponder::stcMDNS_RRQuestion& p_Question,
                                        MDNSResponder::stcMDNSSendParameter& p_rSendParameter) {
-    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSQuestion\n")););
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSQuestion\n")););
 
     bool    bResult = ((_writeMDNSRRDomain(p_Question.m_Header.m_Domain, p_rSendParameter)) &&
                        (_writeMDNSRRAttributes(p_Question.m_Header.m_Attributes, p_rSendParameter)));
 
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSQuestion: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSQuestion: FAILED!\n")); });
     return bResult;
 
 }
@@ -1380,7 +1380,7 @@ bool MDNSResponder::_writeMDNSQuestion(MDNSResponder::stcMDNS_RRQuestion& p_Ques
      */
     bool MDNSResponder::_writeMDNSAnswer_A(IPAddress p_IPAddress,
                                            MDNSResponder::stcMDNSSendParameter& p_rSendParameter) {
-        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSAnswer_A (%s)\n"), p_IPAddress.toString().c_str()););
+        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSAnswer_A (%s)\n"), p_IPAddress.toString().c_str()););
 
         stcMDNS_RRAttributes    attributes(DNS_RRTYPE_A,
                                            ((p_rSendParameter.m_bCacheFlush ? 0x8000 : 0) | DNS_RRCLASS_IN));   // Cache flush? & INternet
@@ -1392,7 +1392,7 @@ bool MDNSResponder::_writeMDNSQuestion(MDNSResponder::stcMDNS_RRQuestion& p_Ques
                            (_udpAppendBuffer(aucIPAddress, MDNS_IP4_SIZE)) &&               // RData
                            (p_rSendParameter.shiftOffset(MDNS_IP4_SIZE)));
 
-        DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSAnswer_A: FAILED!\n")); });
+        DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSAnswer_A: FAILED!\n")); });
         return bResult;
 
     }
@@ -1408,7 +1408,7 @@ bool MDNSResponder::_writeMDNSQuestion(MDNSResponder::stcMDNS_RRQuestion& p_Ques
      */
     bool MDNSResponder::_writeMDNSAnswer_PTR_IP4(IPAddress p_IPAddress,
                                                  MDNSResponder::stcMDNSSendParameter& p_rSendParameter) {
-        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSAnswer_PTR_IP4 (%s)\n"), p_IPAddress.toString().c_str()););
+        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSAnswer_PTR_IP4 (%s)\n"), p_IPAddress.toString().c_str()););
         
         stcMDNS_RRDomain        reverseIP4Domain;
         stcMDNS_RRAttributes    attributes(DNS_RRTYPE_PTR,
@@ -1420,7 +1420,7 @@ bool MDNSResponder::_writeMDNSQuestion(MDNSResponder::stcMDNS_RRQuestion& p_Ques
                            (_write32((p_rSendParameter.m_bUnannounce ? 0 : MDNS_HOST_TTL), p_rSendParameter)) &&    // TTL
                            (_writeMDNSHostDomain(m_pcHostname, true, p_rSendParameter)));   // RDLength & RData (host domain, eg. esp8266.local)
 
-        DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSAnswer_PTR_IP4: FAILED!\n")); });
+        DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSAnswer_PTR_IP4: FAILED!\n")); });
         return bResult;
     }
 #endif
@@ -1437,7 +1437,7 @@ bool MDNSResponder::_writeMDNSQuestion(MDNSResponder::stcMDNS_RRQuestion& p_Ques
  */
 bool MDNSResponder::_writeMDNSAnswer_PTR_TYPE(MDNSResponder::stcMDNSService& p_rService,
                                               MDNSResponder::stcMDNSSendParameter& p_rSendParameter) {
-    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSAnswer_PTR_TYPE\n")););
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSAnswer_PTR_TYPE\n")););
     
     stcMDNS_RRDomain        dnssdDomain;
     stcMDNS_RRDomain        serviceDomain;
@@ -1449,7 +1449,7 @@ bool MDNSResponder::_writeMDNSAnswer_PTR_TYPE(MDNSResponder::stcMDNSService& p_r
                        (_write32((p_rSendParameter.m_bUnannounce ? 0 : MDNS_SERVICE_TTL), p_rSendParameter)) && // TTL
                        (_writeMDNSServiceDomain(p_rService, false, true, p_rSendParameter)));   // RDLength & RData (service domain, eg. _http._tcp.local)
 
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSAnswer_PTR_TYPE: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSAnswer_PTR_TYPE: FAILED!\n")); });
     return bResult;
 }
 
@@ -1465,7 +1465,7 @@ bool MDNSResponder::_writeMDNSAnswer_PTR_TYPE(MDNSResponder::stcMDNSService& p_r
  */ 
 bool MDNSResponder::_writeMDNSAnswer_PTR_NAME(MDNSResponder::stcMDNSService& p_rService,
                                               MDNSResponder::stcMDNSSendParameter& p_rSendParameter) {
-    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSAnswer_PTR_NAME\n")););
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSAnswer_PTR_NAME\n")););
 
     stcMDNS_RRAttributes    attributes(DNS_RRTYPE_PTR,
                                        ((p_rSendParameter.m_bCacheFlush ? 0x8000 : 0) | DNS_RRCLASS_IN));   // Cache flush? & INternet
@@ -1474,7 +1474,7 @@ bool MDNSResponder::_writeMDNSAnswer_PTR_NAME(MDNSResponder::stcMDNSService& p_r
                        (_write32((p_rSendParameter.m_bUnannounce ? 0 : MDNS_SERVICE_TTL), p_rSendParameter)) && // TTL
                        (_writeMDNSServiceDomain(p_rService, true, true, p_rSendParameter)));        // RDLength & RData (service domain, eg. MyESP._http._tcp.local)
 
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSAnswer_PTR_NAME: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSAnswer_PTR_NAME: FAILED!\n")); });
     return bResult;
 }
 
@@ -1492,7 +1492,7 @@ bool MDNSResponder::_writeMDNSAnswer_PTR_NAME(MDNSResponder::stcMDNSService& p_r
  */
 bool MDNSResponder::_writeMDNSAnswer_TXT(MDNSResponder::stcMDNSService& p_rService,
                                          MDNSResponder::stcMDNSSendParameter& p_rSendParameter) {
-    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSAnswer_TXT\n")););
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSAnswer_TXT\n")););
     
     bool                    bResult = false;
 
@@ -1519,12 +1519,12 @@ bool MDNSResponder::_writeMDNSAnswer_TXT(MDNSResponder::stcMDNSService& p_rServi
                         (((size_t)os_strlen(pTxt->m_pcValue) == m_pUDPContext->append(pTxt->m_pcValue, os_strlen(pTxt->m_pcValue))) &&  // Value
                          (p_rSendParameter.shiftOffset((size_t)os_strlen(pTxt->m_pcValue))))));
 
-            DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSAnswer_TXT: FAILED to write %sTxt %s=%s!\n"), (pTxt->m_bTemp ? "temp. " : ""), (pTxt->m_pcKey ?: "?"), (pTxt->m_pcValue ?: "?")); });
+            DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSAnswer_TXT: FAILED to write %sTxt %s=%s!\n"), (pTxt->m_bTemp ? "temp. " : ""), (pTxt->m_pcKey ?: "?"), (pTxt->m_pcValue ?: "?")); });
         }
     }
     _releaseTempServiceTxts(p_rService);
     
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSAnswer_TXT: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSAnswer_TXT: FAILED!\n")); });
     return bResult;
 }
 
@@ -1540,7 +1540,7 @@ bool MDNSResponder::_writeMDNSAnswer_TXT(MDNSResponder::stcMDNSService& p_rServi
      */
     bool MDNSResponder::_writeMDNSAnswer_AAAA(IPAddress p_IPAddress,
                                               MDNSResponder::stcMDNSSendParameter& p_rSendParameter) {
-        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSAnswer_AAAA\n")););
+        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSAnswer_AAAA\n")););
 
         stcMDNS_RRAttributes    attributes(DNS_RRTYPE_AAAA,
                                            ((p_rSendParameter.m_bCacheFlush ? 0x8000 : 0) | DNS_RRCLASS_IN));   // Cache flush? & INternet
@@ -1550,7 +1550,7 @@ bool MDNSResponder::_writeMDNSAnswer_TXT(MDNSResponder::stcMDNSService& p_rServi
                            (_write16(MDNS_IP6_SIZE, p_rSendParameter)) &&                       // RDLength
                            (false /*TODO: IP6 version of: _udpAppendBuffer((uint32_t)p_IPAddress, MDNS_IP4_SIZE)*/));   // RData
 
-        DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSAnswer_AAAA: FAILED!\n")); });
+        DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSAnswer_AAAA: FAILED!\n")); });
         return bResult;
     }
     
@@ -1565,7 +1565,7 @@ bool MDNSResponder::_writeMDNSAnswer_TXT(MDNSResponder::stcMDNSService& p_rServi
      */
     bool MDNSResponder::_writeMDNSAnswer_PTR_IP6(IPAddress p_IPAddress,
                                                  MDNSResponder::stcMDNSSendParameter& p_rSendParameter) {
-        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSAnswer_PTR_IP6\n")););
+        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSAnswer_PTR_IP6\n")););
         
         stcMDNS_RRDomain        reverseIP6Domain;
         stcMDNS_RRAttributes    attributes(DNS_RRTYPE_PTR,
@@ -1576,7 +1576,7 @@ bool MDNSResponder::_writeMDNSAnswer_TXT(MDNSResponder::stcMDNSService& p_rServi
                            (_write32((p_rSendParameter.m_bUnannounce ? 0 : MDNS_HOST_TTL), p_rSendParameter)) &&    // TTL
                            (_writeMDNSHostDomain(m_pcHostname, true, p_rSendParameter)));       // RDLength & RData (host domain, eg. esp8266.local)
 
-        DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSAnswer_PTR_IP6: FAILED!\n")); });
+        DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSAnswer_PTR_IP6: FAILED!\n")); });
         return bResult;
     }
 #endif
@@ -1589,7 +1589,7 @@ bool MDNSResponder::_writeMDNSAnswer_TXT(MDNSResponder::stcMDNSService& p_rServi
  */
 bool MDNSResponder::_writeMDNSAnswer_SRV(MDNSResponder::stcMDNSService& p_rService,
                                          MDNSResponder::stcMDNSSendParameter& p_rSendParameter) {
-    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSAnswer_SRV\n")););
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSAnswer_SRV\n")););
 
     uint16_t                u16CachedDomainOffset = (p_rSendParameter.m_bLegacyQuery
                                                         ? 0
@@ -1625,7 +1625,7 @@ bool MDNSResponder::_writeMDNSAnswer_SRV(MDNSResponder::stcMDNSService& p_rServi
                                (_write8(((u16CachedDomainOffset >> 8) | MDNS_DOMAIN_COMPRESS_MARK), p_rSendParameter)) &&   // Compression mark (and offset)
                                (_write8((uint8_t)u16CachedDomainOffset, p_rSendParameter)))));  // Offset
 
-    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR_LEA("[MDNSResponder] _writeMDNSAnswer_SRV: FAILED!\n")); });
+    DEBUG_EX_ERR(if (!bResult) { DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _writeMDNSAnswer_SRV: FAILED!\n")); });
     return bResult;
 }
 


### PR DESCRIPTION
The bug referenced in the code that required a custom macro to enable
PSTR/PROGMEM compilation ( https://github.com/esp8266/Arduino/issues/3369 )
was fixed a while back and all PROGMEM references now live in their own
save .sections.

This patch simply is the output of `sed -i s/PSTR_LEA/PSTR/g *` and
`sed -i s/PROGMEM_LEA/PROGMEM/g *` on the codebase and the removal
of those defines.