### PR TITLE
Add glob-style pattern matching to webserver uri handling

### DIFF
--- a/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
@@ -1,6 +1,7 @@
 #ifndef REQUESTHANDLERSIMPL_H
 #define REQUESTHANDLERSIMPL_H
 
+#include <fnmatch.h>
 #include "RequestHandler.h"
 #include "mimetable.h"
 #include "WString.h"
@@ -21,8 +22,8 @@ public:
         if (_method != HTTP_ANY && _method != requestMethod)
             return false;
 
-        if (requestUri != _uri)
-            return false;
+        if(fnmatch(_uri.c_str(), requestUri.c_str(), 0) != 0)
+          return false;
 
         return true;
     }


### PR DESCRIPTION
Fixes #2019 .
This is an alternate proposal to #5214 .

This adds glob-style pattern matching to the webserver uri handling. Glob patterns are what is used in command line. Examples:
- `server.on("/devices/*", devicesCB) ` would match any request that starts with /devices/ and call the devicesCB callback.
- `server.on("/led?", ...)` would match a request that starts with /led and is followed by one char, such as /led1 or /ledA.
- `server.on("*yomama*", ...)` would match a request that contains yomama anywhere in it.

For more details see `man glob` or `man fnmatch` under *nix.