### PR TITLE
Move libstdc++-nox out of IRAM

### DIFF
--- a/tools/sdk/ld/eagle.app.v6.common.ld.h
+++ b/tools/sdk/ld/eagle.app.v6.common.ld.h
@@ -111,6 +111,7 @@ SECTIONS
     *libgcc.a:_umoddi3.o(.literal .text)
     *libgcc.a:_udivdi3.o(.literal .text)
     *libstdc++.a:( .literal .text .literal.* .text.*)
+    *libstdc++-nox.a:( .literal .text .literal.* .text.*)
     *libsmartconfig.a:(.literal .text .literal.* .text.*)
     *liblwip_gcc.a:(.literal .text .literal.* .text.*)
     *liblwip_src.a:(.literal .text .literal.* .text.*)


### PR DESCRIPTION
The new non-exception libstdc++ was not referenced in the linker script,
allowing it to end up in IRAM when not needed.  Add the line to match
and move it into IROM where it belongs.