### PR TITLE
Fix: WebServer: Digest authentication failed for some clients

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -38,6 +38,7 @@
 
 static const char AUTHORIZATION_HEADER[] PROGMEM = "Authorization";
 static const char qop_auth[] PROGMEM = "qop=auth";
+static const char qop_auth_quoted[] PROGMEM = "qop=\"auth\"";
 static const char WWW_Authenticate[] PROGMEM = "WWW-Authenticate";
 static const char Content_Length[] PROGMEM = "Content-Length";
 
@@ -165,7 +166,7 @@ bool ESP8266WebServer::authenticate(const char * username, const char * password
       }
       // parameters for the RFC 2617 newer Digest
       String _nc,_cnonce;
-      if(authReq.indexOf(FPSTR(qop_auth)) != -1) {
+      if(authReq.indexOf(FPSTR(qop_auth)) != -1 || authReq.indexOf(FPSTR(qop_auth_quoted)) != -1) {
         _nc = _extractParam(authReq, F("nc="), ',');
         _cnonce = _extractParam(authReq, F("cnonce=\""));
       }
@@ -195,7 +196,7 @@ bool ESP8266WebServer::authenticate(const char * username, const char * password
       DEBUG_OUTPUT.println("Hash of GET:uri=" + _H2);
       #endif
       md5.begin();
-      if(authReq.indexOf(FPSTR(qop_auth)) != -1) {
+      if(authReq.indexOf(FPSTR(qop_auth)) != -1 || authReq.indexOf(FPSTR(qop_auth_quoted)) != -1) {
         md5.add(_H1 + ':' + _nonce + ':' + _nc + ':' + _cnonce + F(":auth:") + _H2);
       } else {
         md5.add(_H1 + ':' + _nonce + ':' + _H2);


### PR DESCRIPTION
This PR fixes Issue #4717.

As stated in the issue, some devices send `qop="auth"` in the authorization header, but the server only accepts `qop=auth`. This apparently affects IPhone/IPad devices, but also python-requests.

The PR fixes it by accepting both header versions, even if one might violate the RFC standard.