### PR TITLE
fix bug. in sta mode, empty passphrase should not use secure auth mode

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
@@ -113,14 +113,14 @@ wl_status_t ESP8266WiFiSTAClass::begin(const char* ssid, const char *passphrase,
         return WL_CONNECT_FAILED;
     }
 
-    int passphrase_len = passphrase == NULL ? 0 : strlen(passphrase);
-    if(passphrase_len > 64) {
+    int passphraseLen = passphrase == nullptr ? 0 : strlen(passphrase);
+    if(passphraseLen > 64) {
         // fail passphrase too long!
         return WL_CONNECT_FAILED;
     }
 
     struct station_config conf;
-    conf.threshold.authmode = passphrase_len == 0 ? AUTH_OPEN : _useInsecureWEP ? AUTH_WEP : AUTH_WPA_PSK;
+    conf.threshold.authmode = (passphraseLen == 0) ? AUTH_OPEN : (_useInsecureWEP ? AUTH_WEP : AUTH_WPA_PSK);
 
     if(strlen(ssid) == 32)
         memcpy(reinterpret_cast<char*>(conf.ssid), ssid, 32); //copied in without null term
@@ -128,7 +128,7 @@ wl_status_t ESP8266WiFiSTAClass::begin(const char* ssid, const char *passphrase,
         strcpy(reinterpret_cast<char*>(conf.ssid), ssid);
 
     if(passphrase) {
-        if (passphrase_len == 64) // it's not a passphrase, is the PSK, which is copied into conf.password without null term
+        if (passphraseLen == 64) // it's not a passphrase, is the PSK, which is copied into conf.password without null term
             memcpy(reinterpret_cast<char*>(conf.password), passphrase, 64);
         else
             strcpy(reinterpret_cast<char*>(conf.password), passphrase);

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
@@ -113,21 +113,22 @@ wl_status_t ESP8266WiFiSTAClass::begin(const char* ssid, const char *passphrase,
         return WL_CONNECT_FAILED;
     }
 
-    if(passphrase && strlen(passphrase) > 64) {
+    int passphrase_len = passphrase == NULL ? 0 : strlen(passphrase);
+    if(passphrase_len > 64) {
         // fail passphrase too long!
         return WL_CONNECT_FAILED;
     }
 
     struct station_config conf;
+    conf.threshold.authmode = passphrase_len == 0 ? AUTH_OPEN : _useInsecureWEP ? AUTH_WEP : AUTH_WPA_PSK;
+
     if(strlen(ssid) == 32)
         memcpy(reinterpret_cast<char*>(conf.ssid), ssid, 32); //copied in without null term
     else
         strcpy(reinterpret_cast<char*>(conf.ssid), ssid);
 
-    conf.threshold.authmode = AUTH_OPEN;
     if(passphrase) {
-        conf.threshold.authmode = _useInsecureWEP ? AUTH_WEP : AUTH_WPA_PSK;
-        if (strlen(passphrase) == 64) // it's not a passphrase, is the PSK, which is copied into conf.password without null term
+        if (passphrase_len == 64) // it's not a passphrase, is the PSK, which is copied into conf.password without null term
             memcpy(reinterpret_cast<char*>(conf.password), passphrase, 64);
         else
             strcpy(reinterpret_cast<char*>(conf.password), passphrase);


### PR DESCRIPTION
if the passphrase is empty, use secure auth mode could not connect to wifi.