### PR TITLE
Fix negative SPIFFS size for 2M/4M (no SPIFFS) boards

### DIFF
--- a/tools/boards.txt.py
+++ b/tools/boards.txt.py
@@ -1206,6 +1206,7 @@ def flash_map (flashsize_kb, spiffs_kb = 0):
             sys.stdout = open(lddir + ld, 'w')
 
         if spiffs_kb == 0:
+            spiffs_start = spiffs_end
             page = 0
             block = 0
         elif spiffs_kb < 0x80000 / 1024:

--- a/tools/sdk/ld/eagle.flash.2m.ld
+++ b/tools/sdk/ld/eagle.flash.2m.ld
@@ -1,7 +1,7 @@
 /* Flash Split for 2M chips */
 /* sketch @0x40200000 (~1019KB) (1044464B) */
-/* empty  @0x402FEFF0 (~1028KB) (1052688B) */
-/* spiffs @0x40400000 (~-20KB) (-20480B) */
+/* empty  @0x402FEFF0 (~1008KB) (1032208B) */
+/* spiffs @0x403FB000 (~0KB) (0B) */
 /* eeprom @0x403FB000 (4KB) */
 /* rfcal  @0x403FC000 (4KB) */
 /* wifi   @0x403FD000 (12KB) */
@@ -14,7 +14,7 @@ MEMORY
   irom0_0_seg :                         org = 0x40201010, len = 0xfeff0
 }
 
-PROVIDE ( _SPIFFS_start = 0x40400000 );
+PROVIDE ( _SPIFFS_start = 0x403FB000 );
 PROVIDE ( _SPIFFS_end = 0x403FB000 );
 PROVIDE ( _SPIFFS_page = 0x0 );
 PROVIDE ( _SPIFFS_block = 0x0 );

--- a/tools/sdk/ld/eagle.flash.4m.ld
+++ b/tools/sdk/ld/eagle.flash.4m.ld
@@ -1,7 +1,7 @@
 /* Flash Split for 4M chips */
 /* sketch @0x40200000 (~1019KB) (1044464B) */
-/* empty  @0x402FEFF0 (~3076KB) (3149840B) */
-/* spiffs @0x40600000 (~-20KB) (-20480B) */
+/* empty  @0x402FEFF0 (~3056KB) (3129360B) */
+/* spiffs @0x405FB000 (~0KB) (0B) */
 /* eeprom @0x405FB000 (4KB) */
 /* rfcal  @0x405FC000 (4KB) */
 /* wifi   @0x405FD000 (12KB) */
@@ -14,7 +14,7 @@ MEMORY
   irom0_0_seg :                         org = 0x40201010, len = 0xfeff0
 }
 
-PROVIDE ( _SPIFFS_start = 0x40600000 );
+PROVIDE ( _SPIFFS_start = 0x405FB000 );
 PROVIDE ( _SPIFFS_end = 0x405FB000 );
 PROVIDE ( _SPIFFS_page = 0x0 );
 PROVIDE ( _SPIFFS_block = 0x0 );


### PR DESCRIPTION
Noticed by @arihantdaga in https://github.com/xoseperez/espurna/issues/1436

Same as <=1024 KiB boards, just make start=end