### PR TITLE
mDNS: Add support for String arg to begin()

### DIFF
--- a/libraries/ESP8266mDNS/src/ESP8266mDNS_Legacy.h
+++ b/libraries/ESP8266mDNS/src/ESP8266mDNS_Legacy.h
@@ -66,11 +66,17 @@ public:
   MDNSResponder();
   ~MDNSResponder();
   bool begin(const char* hostName);
+  bool begin(const String& hostName) {
+    return begin(hostName.c_str());
+  }
   //for compatibility
   bool begin(const char* hostName, IPAddress ip, uint32_t ttl=120){
     (void) ip;
     (void) ttl;
     return begin(hostName);
+  }
+  bool begin(const String& hostName, IPAddress ip, uint32_t ttl=120) {
+    return begin(hostName.c_str(), ip, ttl);
   }
   /* Application should call this whenever AP is configured/disabled */
   void notifyAPChange();

--- a/libraries/ESP8266mDNS/src/LEAmDNS.h
+++ b/libraries/ESP8266mDNS/src/LEAmDNS.h
@@ -173,10 +173,16 @@ public:
     // Later call MDNS::update() in every 'loop' to run the process loop
     // (probing, announcing, responding, ...)
     bool begin(const char* p_pcHostname);
+    bool begin(const String& p_strHostname) {return begin(p_strHostname.c_str());}
         // for compatibility
         bool begin(const char* p_pcHostname,
                    IPAddress p_IPAddress,       // ignored
                    uint32_t p_u32TTL = 120);    // ignored
+        bool begin(const String& p_strHostname,
+                   IPAddress p_IPAddress,       // ignored
+                   uint32_t p_u32TTL = 120) {   // ignored
+            return begin(p_strHostname.c_str(), p_IPAddress, p_u32TTL);
+        }
     // Finish MDNS processing
     bool close(void);
 


### PR DESCRIPTION
#5295 should be applied to mDNS::begin() I guess :)