### PR TITLE
Move exceptions back out of IRAM

### DIFF
--- a/tools/sdk/ld/eagle.app.v6.common.ld.h
+++ b/tools/sdk/ld/eagle.app.v6.common.ld.h
@@ -111,7 +111,7 @@ SECTIONS
     *libgcc.a:_umoddi3.o(.literal .text)
     *libgcc.a:_udivdi3.o(.literal .text)
     *libstdc++.a:( .literal .text .literal.* .text.*)
-    *libstdc++-nox.a:( .literal .text .literal.* .text.*)
+    *libstdc++-exc.a:( .literal .text .literal.* .text.*)
     *libsmartconfig.a:(.literal .text .literal.* .text.*)
     *liblwip_gcc.a:(.literal .text .literal.* .text.*)
     *liblwip_src.a:(.literal .text .literal.* .text.*)


### PR DESCRIPTION
PR #5538 made exceptiond disabled by default and changed some file names
which not get updated in the linker file, resultin in exceptions ending up
back in IRAM.