### PR TITLE
Add fix to ESP8266HTTPClient sendHeader()

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -1085,7 +1085,7 @@ bool HTTPClient::sendHeader(const char * type)
         return false;
     }
 
-    String header = String(type) + " " + (_uri.length() ? _uri : F("/")) + F(" HTTP/1.");
+    String header = String(type) + F(" ") + (_uri.length() ? _uri : F("/")) + F(" HTTP/1.");
 
     if(_useHTTP10) {
         header += "0";


### PR DESCRIPTION
Fixed a part of code that lead - for me - to successive HTTP-Requests failing.
Logfile for first request read in apache like:
"GET /smtdata.php HTTP/1.1"
but after the first request turned deterministicly into:
"GET/smtdata.php HTTP/1.1"