### PR TITLE
Correct link to Arduino Board Manager info

### DIFF
--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -35,7 +35,7 @@ might be broken.
 
 For more information on the Arduino Board Manager, see:
 
-- https://www.arduino.cc/en/Guide/Libraries
+- https://www.arduino.cc/en/guide/cores
 
 Using git version
 -----------------


### PR DESCRIPTION
The link is pointing to Arduino Libraries Manager info and not to Arduino Board Manager info.