### PR TITLE
dynamic WiFi.hostname("newname")

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
@@ -467,7 +467,7 @@ IPAddress ESP8266WiFiSTAClass::dnsIP(uint8_t dns_no) {
  * Get ESP8266 station DHCP hostname
  * @return hostname
  */
-const char* ESP8266WiFiSTAClass::hostname(void) {
+String ESP8266WiFiSTAClass::hostname(void) {
     return wifi_station_get_hostname();
 }
 

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
@@ -70,7 +70,8 @@ class ESP8266WiFiSTAClass {
         IPAddress dnsIP(uint8_t dns_no = 0);
 
         String hostname();
-        bool hostname(String aHostname);
+        bool hostname(const String& aHostname) { return hostname(aHostname.c_str()); }
+        bool hostname(const char* aHostname);
 
         // STA WiFi info
         wl_status_t status();

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
@@ -69,10 +69,8 @@ class ESP8266WiFiSTAClass {
         IPAddress gatewayIP();
         IPAddress dnsIP(uint8_t dns_no = 0);
 
-        String hostname();
-        bool hostname(char* aHostname);
-        bool hostname(const char* aHostname);
-        bool hostname(const String& aHostname);
+        const char* hostname();
+        bool hostname(String aHostname);
 
         // STA WiFi info
         wl_status_t status();

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
@@ -69,7 +69,7 @@ class ESP8266WiFiSTAClass {
         IPAddress gatewayIP();
         IPAddress dnsIP(uint8_t dns_no = 0);
 
-        const char* hostname();
+        String hostname();
         bool hostname(String aHostname);
 
         // STA WiFi info

--- a/tools/sdk/include/user_interface.h
+++ b/tools/sdk/include/user_interface.h
@@ -328,8 +328,8 @@ bool wifi_station_dhcpc_stop(void);
 enum dhcp_status wifi_station_dhcpc_status(void);
 bool wifi_station_dhcpc_set_maxtry(uint8 num);
 
-char* wifi_station_get_hostname(void);
-bool wifi_station_set_hostname(char *name);
+const char* wifi_station_get_hostname(void);
+bool wifi_station_set_hostname(const char *name);
 
 int wifi_station_set_cert_key(uint8 *client_cert, int client_cert_len,
     uint8 *private_key, int private_key_len,


### PR DESCRIPTION
Effect of `WiFi.hostname("new name")` on the network:

![hostname](https://user-images.githubusercontent.com/4800356/51606889-720ff980-1f13-11e9-958f-d27b4fb5da30.png)

My AP runs `openwrt` with `dnsmasq`, and I can ping the new hostname as soon as `Wifi.hostname("name")` is called on the esp.

Sketch:
```

#include <ESP8266WiFi.h>
#include <PolledTimeout.h>

#ifndef STASSID
#define STASSID "your-ssid"
#define STAPSK  "your-password"
#endif

const char* ssid     = STASSID;
const char* password = STAPSK;

void connect ()
{
  WiFi.mode(WIFI_STA);
  WiFi.begin(ssid, password);

  while (WiFi.status() != WL_CONNECTED) {
    delay(500);
    Serial.print(".");
  }

  Serial.println("");
  Serial.println("WiFi connected");
  Serial.println("IP address: ");
  Serial.println(WiFi.localIP());
}

void setup() {
  Serial.begin(115200);
  Serial.println();
  Serial.println();
  Serial.print("Connecting to ");
  Serial.println(ssid);

  WiFi.persistent(false);
  connect();
  WiFi.hostname("chameleon");
  Serial.printf("host name is %s, will change every 20 seconds, ping me !\n", WiFi.hostname().c_str());
}

esp8266::polledTimeout::periodic renew(20000);
int count = 0;

void loop()
{
  if (renew)
  {
    String name = String(++count) + "chameleonchameleonchameleon";
    Serial.printf("setting hostname to: %s\n", name.c_str());
    Serial.printf("ret=%d\n", WiFi.hostname(name));
    Serial.printf("hostname=%s\n", WiFi.hostname().c_str());
  }
}
```

Logs:
```
...
setting hostname to: 17chameleonchameleonchameleon
hostname '17chameleonchameleonchameleon' is not compliant with RFC952
ret=0
...
```
(but esp name stays "nicely" responding to name `17chameleonchameleonchameleon`)