### PR TITLE
Documentation: Correct 'git submodule' syntax

### DIFF
--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -106,7 +106,7 @@ Instructions - Windows 10
    .. code:: bash
 
        cd %USERPROFILE%\Documents\hardware\esp8266com\esp8266
-       git submodules update --init   
+       git submodule update --init   
   
   If error messages about missing files related to ``SoftwareSerial`` are encountered during the build process, it should be because this step was missed and is required.
   
@@ -180,7 +180,7 @@ Instructions - Other OS
    .. code:: bash
 
        cd esp8266
-       git submodules update --init   
+       git submodule update --init   
   
   If error messages about missing files related to ``SoftwareSerial`` are encountered during the build process, it should be because this step was missed and is required.
 


### PR DESCRIPTION
Should be singular, not plural (submodule, not submodules). 
```
git: 'submodules' is not a git command. See 'git --help'.

The most similar command is
	submodule
```