### PR TITLE
stop lwIP dhcp client when WiFi goes off.

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -389,6 +389,11 @@ bool ESP8266WiFiGenericClass::mode(WiFiMode_t m) {
 
     bool ret = false;
 
+    if (m == WIFI_OFF)
+        // calls lwIP's dhcp_stop(),
+        // safe to call even if not started
+        wifi_station_dhcpc_stop();
+
     ETS_UART_INTR_DISABLE();
     if(_persistent) {
         ret = wifi_set_opmode(m);

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -389,7 +389,7 @@ bool ESP8266WiFiGenericClass::mode(WiFiMode_t m) {
 
     bool ret = false;
 
-    if (m == WIFI_OFF)
+    if (m != WIFI_STA && m != WIFI_AP_STA)
         // calls lwIP's dhcp_stop(),
         // safe to call even if not started
         wifi_station_dhcpc_stop();


### PR DESCRIPTION
fix #5667 

Bug is reproduced
This patch stops dhcp client when WiFi goes off,
dhcp client was anyway started by firmware when WiFi goes on.

Thanks @dalbert2 

*edit: bug no more appearing*