### PR TITLE
Fix copy constructors to BearSSL server/client and axTLS compat wrappers

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
@@ -34,6 +34,7 @@ namespace BearSSL {
 class WiFiClientSecure : public WiFiClient {
   public:
     WiFiClientSecure();
+    WiFiClientSecure(const WiFiClientSecure &rhs);
     ~WiFiClientSecure() override;
 
     int connect(CONST IPAddress& ip, uint16_t port) override;
@@ -206,6 +207,14 @@ class WiFiClientSecure : public WiFiClient {
     bool _handshake_done;
     bool _oom_err;
 
+    // AXTLS compatibility shim elements:
+    // AXTLS managed memory for certs and keys, while BearSSL assumes
+    // the app manages these.  Use this local storage for holding the
+    // BearSSL created objects in a shared form.
+    std::shared_ptr<X509List>   _axtls_ta;
+    std::shared_ptr<X509List>   _axtls_chain;
+    std::shared_ptr<PrivateKey> _axtls_sk;
+
     // Optional storage space pointer for session parameters
     // Will be used on connect and updated on close
     Session *_session;
@@ -218,7 +227,7 @@ class WiFiClientSecure : public WiFiClient {
     unsigned _knownkey_usages;
 
     // Custom cipher list pointer or NULL if default
-    uint16_t *_cipher_list;
+    std::shared_ptr<uint16_t> _cipher_list;
     uint8_t _cipher_cnt;
 
     unsigned char *_recvapp_buf;
@@ -255,9 +264,6 @@ class WiFiClientSecure : public WiFiClient {
     bool _installServerX509Validator(const X509List *client_CA_ta); // Setup X509 client cert validation, if supplied
 
     uint8_t *_streamLoad(Stream& stream, size_t size);
-
-    // AXTLS compatible mode needs to delete the stored certs and keys on destruction
-    bool _deleteChainKeyTA;
 };
 
 };

--- a/libraries/ESP8266WiFi/src/WiFiServerSecureBearSSL.h
+++ b/libraries/ESP8266WiFi/src/WiFiServerSecureBearSSL.h
@@ -33,6 +33,7 @@ class WiFiServerSecure : public WiFiServer {
   public:
     WiFiServerSecure(IPAddress addr, uint16_t port);
     WiFiServerSecure(uint16_t port);
+    WiFiServerSecure(const WiFiServerSecure &rhs);
     virtual ~WiFiServerSecure();
 
     // Override the default buffer sizes, if you know what you're doing...
@@ -68,7 +69,11 @@ class WiFiServerSecure : public WiFiServer {
     int _iobuf_in_size = BR_SSL_BUFSIZE_INPUT;
     int _iobuf_out_size = 837;
     const X509List *_client_CA_ta = nullptr;
-    bool _deleteChainAndKey = false;
+
+    // axTLS compat
+    std::shared_ptr<X509List>   _axtls_chain;
+    std::shared_ptr<PrivateKey> _axtls_sk;
+
 };
 
 };


### PR DESCRIPTION
Because the constructors of the BSSL client and server add a reference
count to the stack_thunk, if there is no copy constructor defined then
the stack thunk reference count can get out of sync causing the stack
thunk memory to be freed while still in use.  That could cause random
crashes or hangs.

Add a very basic copy constructor to the WiFiClientSecure and
WiFiServerSecure objects, using the default operator= to duplicate
simple types and shared_ptr classes.