### PR TITLE
UdpContext::setMulticastInterface(): fix for IPv6

### DIFF
--- a/cores/esp8266/AddrList.h
+++ b/cores/esp8266/AddrList.h
@@ -118,6 +118,7 @@ struct netifWrapper
     String toString() const         { return addr().toString(); }
 
     // related to legacy address (_num=0, ipv4)
+    IPAddress ipv4 () const         { return _netif->ip_addr; }
     IPAddress netmask () const      { return _netif->netmask; }
     IPAddress gw () const           { return _netif->gw; }
 

--- a/libraries/ESP8266WiFi/src/include/UdpContext.h
+++ b/libraries/ESP8266WiFi/src/include/UdpContext.h
@@ -30,6 +30,8 @@ void esp_schedule();
 #include <assert.h>
 }
 
+#include <AddrList.h>
+
 #define GET_UDP_HDR(pb) (reinterpret_cast<udp_hdr*>(((uint8_t*)((pb)->payload)) - UDP_HLEN))
 
 class UdpContext
@@ -107,6 +109,33 @@ public:
         udp_disconnect(_pcb);
     }
 
+#if LWIP_IPV6
+
+    void setMulticastInterface(IPAddress addr)
+    {
+        // Per 'udp_set_multicast_netif_addr()' signature and comments
+        // in lwIP sources:
+        // An IPv4 address designating a specific interface must be used.
+        // When an IPv6 address is given, the matching IPv4 in the same
+        // interface must be selected.
+
+        if (!addr.isV4())
+        {
+            for (auto a: addrList)
+                if (a.addr() == addr)
+                {
+                    // found the IPv6 address,
+                    // redirect parameter to IPv4 address in this interface
+                    addr = a.ipv4();
+                    break;
+                }
+            assert(addr.isV4());
+        }
+        udp_set_multicast_netif_addr(_pcb, ip_2_ip4((const ip_addr_t*)addr));
+    }
+
+#else // !LWIP_IPV6
+
     void setMulticastInterface(const IPAddress& addr)
     {
 #if LWIP_VERSION_MAJOR == 1
@@ -115,6 +144,8 @@ public:
         udp_set_multicast_netif_addr(_pcb, ip_2_ip4((const ip_addr_t*)addr));
 #endif
     }
+
+#endif // !LWIP_IPV6
 
     void setMulticastTTL(int ttl)
     {


### PR DESCRIPTION
Per 'udp_set_multicast_netif_addr()' signature and comments in lwIP sources:
An IPv4 address designating a specific interface must be used.
When an IPv6 address is given, the matching IPv4 in the same interface must be selected.

fix https://github.com/esp8266/Arduino/commit/e3bc3c226b4789f30e6f6a77a5522776b01f83bc#r32235572