### PR TITLE
Fixes issue #5744

### DIFF
--- a/libraries/ESP8266WiFi/src/include/UdpContext.h
+++ b/libraries/ESP8266WiFi/src/include/UdpContext.h
@@ -51,6 +51,12 @@ public:
     , _tx_buf_offset(0)
     {
         _pcb = udp_new();
+// Defaults to IPADDR_TYPE_V4 (_pcb initialized with all zeroes)
+#if LWIP_IPV4 && LWIP_IPV6
+        _pcb->local_ip.type = IPADDR_TYPE_ANY;
+#elif LWIP_IPV6
+        _pcb->local_ip.type = IPADDR_TYPE_V6;
+#endif
 #ifdef LWIP_MAYBE_XCC
         _mcast_ttl = 1;
 #endif


### PR DESCRIPTION
Initialize UdpContext `_pcb->local_ip.type` with `IPADDR_TYPE_ANY` in dual-stack mode.

### MCVE output before patch (release 2.5.0)
```
17:21:12.024205 IP 10.79.2.187.52506 > 8.8.8.8.18888: UDP, length 7
17:21:23.032132 IP 10.79.2.187.52506 > 8.8.8.8.18888: UDP, length 7
```

```
SDK:3.0.0-dev(c0f7b44)/Core:2.5.0=20500000/lwIP:IPv6+STABLE-2_1_2_RELEASE/glue:1.1/BearSSL:6778687

sta config unchangedscandone
.scandone
state: 0 -> 2 (b0)
state: 2 -> 3 (0)
state: 3 -> 5 (10)
add 0
aid 6
cnt 

connected with Solvang, channel 6
dhcp client start...
ip:10.79.2.187,mask:255.255.252.0,gw:10.79.0.1
Connected! IP address: 10.79.2.187
----------------------------------
Sending UDP packet to 8.8.8.8 port 18888
Udp.beginPacket: 1
Udp.write: 7
Udp.endPacket: 1
----------------------------------
ip:10.79.2.187,mask:255.255.252.0,gw:10.79.0.1
ip:10.79.2.187,mask:255.255.252.0,gw:10.79.0.1
Sending UDP packet to 2001:4860:4860::8888 port 18888
Udp.beginPacket: 1
Udp.write: 7
Udp.endPacket: :ust rc=-6
0
ip:10.79.2.187,mask:255.255.252.0,gw:10.79.0.1
ip:10.79.2.187,mask:255.255.252.0,gw:10.79.0.1
ip:10.79.2.187,mask:255.255.252.0,gw:10.79.0.1
pm open,type:2 0
----------------------------------
Sending UDP packet to 8.8.8.8 port 18888
Udp.beginPacket: 1
Udp.write: 7
Udp.endPacket: 1
----------------------------------
Sending UDP packet to 2001:4860:4860::8888 port 18888
Udp.beginPacket: 1
Udp.write: 7
Udp.endPacket: :ust rc=-6
0
----------------------------------
Sending UDP packet to 8.8.8.8 port 18888
Udp.beginPacket: 1
Udp.write: 7
Udp.endPacket: 1
----------------------------------
Sending UDP packet to 2001:4860:4860::8888 port 18888
Udp.beginPacket: 1
Udp.write: 7
Udp.endPacket: :ust rc=-6
0
----------------------------------
```

### MCVE output after patch
(one initial fail, due to no IPv6 yet)
```
17:30:26.970618 IP 10.79.2.187.61998 > 8.8.8.8.18888: UDP, length 7
17:30:37.976476 IP 10.79.2.187.61998 > 8.8.8.8.18888: UDP, length 7
17:30:38.974241 IP6 2a02:<snip>.61998 > 2001:4860:4860::8888.18888: UDP, length 7
17:30:48.981904 IP 10.79.2.187.61998 > 8.8.8.8.18888: UDP, length 7
17:30:49.980760 IP6 2a02:<snip>.61998 > 2001:4860:4860::8888.18888: UDP, length 7
```

```
SDK:3.0.0-dev(c0f7b44)/Core:2.5.0=20500000/lwIP:IPv6+STABLE-2_1_2_RELEASE/glue:1.1/BearSSL:6778687

sta config unchangedscandone
.scandone
state: 0 -> 2 (b0)
state: 2 -> 3 (0)
state: 3 -> 5 (10)
add 0
aid 6
cnt 

connected with Solvang, channel 6
dhcp client start...
ip:10.79.2.187,mask:255.255.252.0,gw:10.79.0.1
Connected! IP address: 10.79.2.187
----------------------------------
Sending UDP packet to 8.8.8.8 port 18888
Udp.beginPacket: 1
Udp.write: 7
Udp.endPacket: 1
----------------------------------
ip:10.79.2.187,mask:255.255.252.0,gw:10.79.0.1
ip:10.79.2.187,mask:255.255.252.0,gw:10.79.0.1
Sending UDP packet to 2001:4860:4860::8888 port 18888
Udp.beginPacket: 1
Udp.write: 7
Udp.endPacket: :ust rc=-4
0
ip:10.79.2.187,mask:255.255.252.0,gw:10.79.0.1
ip:10.79.2.187,mask:255.255.252.0,gw:10.79.0.1
ip:10.79.2.187,mask:255.255.252.0,gw:10.79.0.1
pm open,type:2 0
----------------------------------
Sending UDP packet to 8.8.8.8 port 18888
Udp.beginPacket: 1
Udp.write: 7
Udp.endPacket: 1
----------------------------------
Sending UDP packet to 2001:4860:4860::8888 port 18888
Udp.beginPacket: 1
Udp.write: 7
Udp.endPacket: 1
----------------------------------
Sending UDP packet to 8.8.8.8 port 18888
Udp.beginPacket: 1
Udp.write: 7
Udp.endPacket: 1
----------------------------------
Sending UDP packet to 2001:4860:4860::8888 port 18888
Udp.beginPacket: 1
Udp.write: 7
Udp.endPacket: 1
----------------------------------
```