### PR TITLE
Move __PRETTY_FUNCTION__ to progmem

### DIFF
--- a/tools/sdk/ld/eagle.app.v6.common.ld.h
+++ b/tools/sdk/ld/eagle.app.v6.common.ld.h
@@ -140,6 +140,7 @@ SECTIONS
 
     /* __FUNCTION__ locals */
     *(.rodata._ZZ*__FUNCTION__)
+    *(.rodata._ZZ*__PRETTY_FUNCTION__)
 
     /* std::* exception strings, in their own section to allow string coalescing */
     *(.irom.exceptiontext)

--- a/tools/sdk/ld/eagle.app.v6.common.ld.h
+++ b/tools/sdk/ld/eagle.app.v6.common.ld.h
@@ -141,6 +141,7 @@ SECTIONS
     /* __FUNCTION__ locals */
     *(.rodata._ZZ*__FUNCTION__)
     *(.rodata._ZZ*__PRETTY_FUNCTION__)
+    *(.rodata._ZZ*__func__)
 
     /* std::* exception strings, in their own section to allow string coalescing */
     *(.irom.exceptiontext)


### PR DESCRIPTION
Match `__FUNCTION__` linking, keep C++ function names out of rodata/heap.