### PR TITLE
emulation on host: Add base64 decode library to mock files

### DIFF
--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -63,6 +63,7 @@ CORE_CPP_FILES := $(addprefix $(CORE_PATH)/,\
 	spiffs/spiffs_hydrogen.cpp \
 	spiffs/spiffs_nucleus.cpp \
 	libb64/cencode.cpp \
+	libb64/cdecode.cpp \
 	Schedule.cpp \
 )
 


### PR DESCRIPTION
Fixes missing symbols during linking of sketches that use them.