### PR TITLE
emulation on host: Make non essential ARDUINO LIBS optional.

### DIFF
--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -215,56 +215,60 @@ ARDUINO_LIBS := \
 		Updater.cpp \
 		base64.cpp \
 	) \
-	$(addprefix ../../libraries/,\
-		$(addprefix ESP8266WiFi/src/,\
-			ESP8266WiFi.cpp \
-			ESP8266WiFiAP.cpp \
-			ESP8266WiFiGeneric.cpp \
-			ESP8266WiFiMulti.cpp \
-			ESP8266WiFiSTA-WPS.cpp \
-			ESP8266WiFiSTA.cpp \
-			ESP8266WiFiScan.cpp \
-			WiFiClient.cpp \
-			WiFiUdp.cpp \
-			WiFiClientSecureBearSSL.cpp \
-			WiFiServerSecureBearSSL.cpp \
-			BearSSLHelpers.cpp \
-			CertStoreBearSSL.cpp \
-		) \
-		$(addprefix ESP8266WebServer/src/,\
-			ESP8266WebServer.cpp \
-			Parsing.cpp \
-			detail/mimetable.cpp \
-		) \
-		ESP8266mDNS/src/LEAmDNS.cpp \
-		ESP8266mDNS/src/LEAmDNS_Control.cpp \
-		ESP8266mDNS/src/LEAmDNS_Helpers.cpp \
-		ESP8266mDNS/src/LEAmDNS_Structs.cpp \
-		ESP8266mDNS/src/LEAmDNS_Transfer.cpp \
-		ESP8266mDNS/src/ESP8266mDNS.cpp \
-		ArduinoOTA/ArduinoOTA.cpp \
-		DNSServer/src/DNSServer.cpp \
-		ESP8266AVRISP/src/ESP8266AVRISP.cpp \
-		ESP8266HTTPClient/src/ESP8266HTTPClient.cpp \
+	$(addprefix ../../libraries/ESP8266WiFi/src/,\
+		ESP8266WiFi.cpp \
+		ESP8266WiFiAP.cpp \
+		ESP8266WiFiGeneric.cpp \
+		ESP8266WiFiMulti.cpp \
+		ESP8266WiFiSTA-WPS.cpp \
+		ESP8266WiFiSTA.cpp \
+		ESP8266WiFiScan.cpp \
+		WiFiClient.cpp \
+		WiFiUdp.cpp \
+		WiFiClientSecureBearSSL.cpp \
+		WiFiServerSecureBearSSL.cpp \
+		BearSSLHelpers.cpp \
+		CertStoreBearSSL.cpp \
 	) \
 
-MOCK_ARDUINO_LIBS := \
-	common/ClientContextSocket.cpp \
-	common/ClientContextTools.cpp \
-	common/MockWiFiServerSocket.cpp \
-	common/MockWiFiServer.cpp \
-	common/UdpContextSocket.cpp \
-	common/HostWiring.cpp \
-	common/MockEsp.cpp \
-	common/MockEEPROM.cpp \
-	common/MockSPI.cpp \
+OPT_ARDUINO_LIBS ?= $(addprefix ../../libraries/,\
+	$(addprefix ESP8266WebServer/src/,\
+		ESP8266WebServer.cpp \
+		Parsing.cpp \
+		detail/mimetable.cpp \
+	) \
+	$(addprefix ESP8266mDNS/src/,\
+		LEAmDNS.cpp \
+		LEAmDNS_Control.cpp \
+		LEAmDNS_Helpers.cpp \
+		LEAmDNS_Structs.cpp \
+		LEAmDNS_Transfer.cpp \
+		ESP8266mDNS.cpp \
+	) \
+	ArduinoOTA/ArduinoOTA.cpp \
+	DNSServer/src/DNSServer.cpp \
+	ESP8266AVRISP/src/ESP8266AVRISP.cpp \
+	ESP8266HTTPClient/src/ESP8266HTTPClient.cpp \
+) \
+
+MOCK_ARDUINO_LIBS := $(addprefix common/,\
+	ClientContextSocket.cpp \
+	ClientContextTools.cpp \
+	MockWiFiServerSocket.cpp \
+	MockWiFiServer.cpp \
+	UdpContextSocket.cpp \
+	HostWiring.cpp \
+	MockEsp.cpp \
+	MockEEPROM.cpp \
+	MockSPI.cpp \
+) \
 
 CPP_SOURCES_CORE_EMU = \
 	$(MOCK_CPP_FILES_EMU) \
 	$(CORE_CPP_FILES) \
 	$(MOCK_ARDUINO_LIBS) \
+	$(OPT_ARDUINO_LIBS) \
 	$(ARDUINO_LIBS) \
-
 
 LIBSSLFILE = ../../tools/sdk/ssl/bearssl/build$(N32)/libbearssl.a
 ifeq (,$(wildcard $(LIBSSLFILE)))
@@ -339,3 +343,4 @@ help:
 	@echo ""
 	@sed -rne 's,([^: \t]*):[^=#]*#[\t ]*(.*),\1 - \2,p' $(MAKEFILE)
 	@echo ""
+	


### PR DESCRIPTION
This patch splits ARDUINO_LIBS into two variables. The second variable is called OPT_ARDUINO_LIBS and can be overridden by the caller as it uses the ?= assignment operator. Additionally it unifies and simplifies collecting the files in common/ by using the addprefix macro. All changes should be 100% backwards compatible.