### PR TITLE
emulation on host: Fix optimistic_yield(interval_us)

### DIFF
--- a/tests/host/common/user_interface.cpp
+++ b/tests/host/common/user_interface.cpp
@@ -424,9 +424,9 @@ void esp_schedule (void)
 {
 }
 
-void optimistic_yield (uint32_t ms)
+void optimistic_yield (uint32_t interval_us)
 {
-	usleep(ms * 1000);
+	usleep(interval_us);
 }
 
 void dns_setserver (u8_t numdns, ip_addr_t *dnsserver)


### PR DESCRIPTION
optimistic_yield() takes micro seconds not milliseconds as interval parameter