### PR TITLE
Clean up uploader.py, use implied paths

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -137,7 +137,7 @@ tools.esptool.upload.params.quiet=
 # First, potentially perform an erase or nothing
 # Next, do the binary upload
 # Combined in one rule because Arduino doesn't suport upload.1.pattern/upload.3.pattern
-tools.esptool.upload.pattern="{cmd}" "{runtime.platform.path}/tools/upload.py" "{runtime.platform.path}/tools/pyserial" "{runtime.platform.path}/tools/esptool" --chip esp8266 --port "{serial.port}" --baud "{upload.speed}" "{upload.verbose}" {upload.erase_cmd} --end  --chip esp8266 --port "{serial.port}" --baud "{upload.speed}" "{upload.verbose}" write_flash 0x0 "{build.path}/{build.project_name}.bin" --end
+tools.esptool.upload.pattern="{cmd}" "{runtime.platform.path}/tools/upload.py" --chip esp8266 --port "{serial.port}" --baud "{upload.speed}" "{upload.verbose}" {upload.erase_cmd} --end --chip esp8266 --port "{serial.port}" --baud "{upload.speed}" "{upload.verbose}" write_flash 0x0 "{build.path}/{build.project_name}.bin" --end
 
 tools.esptool.upload.network_pattern="{network_cmd}" "{runtime.platform.path}/tools/espota.py" -i "{serial.port}" -p "{network.port}" "--auth={network.password}" -f "{build.path}/{build.project_name}.bin"
 

--- a/tools/upload.py
+++ b/tools/upload.py
@@ -7,11 +7,13 @@
 # i.e. upload.py tools/pyserial tools/esptool erase_flash --end write_flash file 0x0 --end
 
 import sys
+import os
 
 sys.argv.pop(0) # Remove executable name
+toolspath = os.path.dirname(os.path.realpath(__file__)).replace('\\', '/') # CWD in UNIX format
 try:
-    sys.path.append(sys.argv.pop(0).replace('\\', '/')) # Add pyserial dir to search path, in UNIX format
-    sys.path.append(sys.argv.pop(0).replace('\\', '/')) # Add esptool dir to search path, in UNIX format
+    sys.path.append(toolspath + "/pyserial") # Add pyserial dir to search path
+    sys.path.append(toolspath + "/esptool") # Add esptool dir to search path
     import esptool # If this fails, we can't continue and will bomb below
 except:
     sys.stderr.write("Error in command line, need pyserial path as 1st arg and esptool path as 2nd.\n")


### PR DESCRIPTION
No need to explicitly send in full paths for esptool and pyserial Python
libs because they're in well known locations relative to upload.py.

Make upload.py calculate these on-the-fly and clean up platform.txt.