### PR TITLE
emulation on host: fix wrong tty_restore instead of restore_tty variable

### DIFF
--- a/tests/host/common/ArduinoMain.cpp
+++ b/tests/host/common/ArduinoMain.cpp
@@ -63,7 +63,7 @@ static int mock_start_uart(void)
 	settings.c_cc[VMIN]	= 0;
 	settings.c_cc[VTIME] = 0;
 	if (tcsetattr(STDIN, TCSANOW, &settings) < 0) return -2;
-	tty_restore = true;
+	restore_tty = true;
 	return 0;
 }
 


### PR DESCRIPTION
I don't know how this happened, sorry for the slip-up. :-/