### PR TITLE
Add .git to BearSSL repo reference

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/d-a-v/esp82xx-nonos-linklayer.git
 [submodule "tools/sdk/ssl/bearssl"]
 	path = tools/sdk/ssl/bearssl
-	url = https://github.com/earlephilhower/bearssl-esp8266
+	url = https://github.com/earlephilhower/bearssl-esp8266.git
 [submodule "libraries/SoftwareSerial"]
 	path = libraries/SoftwareSerial
 	url = https://github.com/plerup/espsoftwareserial.git


### PR DESCRIPTION
The BearSSL submodule reference is missing the .git extension on the
URL.  Add it, to match the rest of the repos.