### PR TITLE
Fix minor warning w/Ubuntu18.04 in host test build

### DIFF
--- a/tests/host/common/MockUART.cpp
+++ b/tests/host/common/MockUART.cpp
@@ -64,7 +64,8 @@ static void
 uart_do_write_char(const int uart_nr, char c)
 {
 	if (uart_nr >= UART0 && uart_nr <= UART1)
-		write(uart_nr + 1, &c, 1);
+		if (1 != write(uart_nr + 1, &c, 1))
+			fprintf(stderr, "Unable to write character to emulated UART stream: %d\n", c);
 }
 
 // write a new byte into the RX FIFO buffer


### PR DESCRIPTION
GCC reports the following warning about ignoring the return value of
write() (to the console/UART in this instance).

````
common/MockUART.cpp: In function ‘void uart_do_write_char(int, char)’:
common/MockUART.cpp:67:8: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’, declared with attribute warn_unused_result [-Wunused-result]
   write(uart_nr + 1, &c, 1);
   ~~~~~^~~~~~~~~~~~~~~~~~~~
````

Add a simple warning printout to STDERR which may not be the same as the
UART stream and could succeed.