### PR TITLE
emulation on host: fix nasty delay

### DIFF
--- a/tests/host/common/ArduinoMain.cpp
+++ b/tests/host/common/ArduinoMain.cpp
@@ -63,8 +63,16 @@ static int mock_start_uart(void)
 {
 	struct termios settings;
 
-	if (!isatty(STDIN)) return 0;
-	if (tcgetattr(STDIN, &initial_settings) < 0) return -1;
+	if (!isatty(STDIN))
+	{
+		perror("isatty(STDIN)");
+		return -1;
+	}
+	if (tcgetattr(STDIN, &initial_settings) < 0)
+	{
+		perror("tcgetattr(STDIN)");
+		return -1;
+	}
 	settings = initial_settings;
 	settings.c_lflag &= ~(ignore_sigint ? ISIG : 0);
 	settings.c_lflag &= ~(ECHO	| ICANON);
@@ -72,7 +80,11 @@ static int mock_start_uart(void)
 	settings.c_oflag |=	(ONLCR);
 	settings.c_cc[VMIN]	= 0;
 	settings.c_cc[VTIME] = 0;
-	if (tcsetattr(STDIN, TCSANOW, &settings) < 0) return -2;
+	if (tcsetattr(STDIN, TCSANOW, &settings) < 0)
+	{
+		perror("tcsetattr(STDIN)");
+		return -1;
+	}
 	restore_tty = true;
 	return 0;
 }
@@ -82,10 +94,13 @@ static int mock_stop_uart(void)
 	if (!restore_tty) return 0;
 	if (!isatty(STDIN)) {
 		perror("isatty(STDIN)");
-		//system("stty sane"); <- same error message "Inappropriate ioctl for device"
-		return 0;
+		return -1;
 	}
-	if (tcsetattr(STDIN, TCSANOW, &initial_settings) < 0) return -1;
+	if (tcsetattr(STDIN, TCSANOW, &initial_settings) < 0)
+	{
+		perror("tcsetattr(STDIN)");
+		return -1;
+	}
 	printf("\e[?25h"); // show cursor
 	return (0);
 }

--- a/tests/host/common/ArduinoMain.cpp
+++ b/tests/host/common/ArduinoMain.cpp
@@ -55,7 +55,7 @@ int mockverbose (const char* fmt, ...)
 	va_list ap;
 	va_start(ap, fmt);
 	if (mockdebug)
-		return fprintf(stderr, "MOCK: ") + vfprintf(stderr, fmt, ap);
+		return fprintf(stderr, MOCK) + vfprintf(stderr, fmt, ap);
 	return 0;
 }
 

--- a/tests/host/common/ArduinoMain.cpp
+++ b/tests/host/common/ArduinoMain.cpp
@@ -68,12 +68,12 @@ static int mock_start_uart(void)
 
 	if (!isatty(STDIN))
 	{
-		perror("isatty(STDIN)");
+		perror("setting tty in raw mode: isatty(STDIN)");
 		return -1;
 	}
 	if (tcgetattr(STDIN, &initial_settings) < 0)
 	{
-		perror("tcgetattr(STDIN)");
+		perror("setting tty in raw mode: tcgetattr(STDIN)");
 		return -1;
 	}
 	settings = initial_settings;
@@ -85,7 +85,7 @@ static int mock_start_uart(void)
 	settings.c_cc[VTIME] = 0;
 	if (tcsetattr(STDIN, TCSANOW, &settings) < 0)
 	{
-		perror("tcsetattr(STDIN)");
+		perror("setting tty in raw mode: tcsetattr(STDIN)");
 		return -1;
 	}
 	restore_tty = true;
@@ -96,12 +96,12 @@ static int mock_stop_uart(void)
 {
 	if (!restore_tty) return 0;
 	if (!isatty(STDIN)) {
-		perror("isatty(STDIN)");
+		perror("restoring tty: isatty(STDIN)");
 		return -1;
 	}
 	if (tcsetattr(STDIN, TCSANOW, &initial_settings) < 0)
 	{
-		perror("tcsetattr(STDIN)");
+		perror("restoring tty: tcsetattr(STDIN)");
 		return -1;
 	}
 	printf("\e[?25h"); // show cursor
@@ -158,7 +158,7 @@ void control_c (int sig)
 
 	if (user_exit)
 	{
-		mockverbose("stuck, killing\n");
+		fprintf(stderr, MOCK "stuck, killing\n");
 		cleanup();
 		exit(1);
 	}

--- a/tests/host/common/ArduinoMainUdp.cpp
+++ b/tests/host/common/ArduinoMainUdp.cpp
@@ -58,7 +58,7 @@ void check_incoming_udp ()
 		p.events = POLLIN;
 		if (poll(&p, 1, 0) && p.revents == POLLIN)
 		{
-			fprintf(stderr, MOCK "UDP poll(%d) -> cb\r", p.fd);
+			mockverbose("UDP poll(%d) -> cb\r", p.fd);
 			udp.second->mock_cb();
 		}
 	}

--- a/tests/host/common/ClientContextSocket.cpp
+++ b/tests/host/common/ClientContextSocket.cpp
@@ -43,7 +43,7 @@ int mockSockSetup (int sock)
 {
 	if (fcntl(sock, F_SETFL, O_NONBLOCK) == -1)
 	{
-		fprintf(stderr, MOCK "socket fcntl(O_NONBLOCK): %s\n", strerror(errno));
+		mockverbose("socket fcntl(O_NONBLOCK): %s\n", strerror(errno));
 		close(sock);
 		return -1;
 	}
@@ -52,7 +52,7 @@ int mockSockSetup (int sock)
 	int i = 1;
 	if (setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, &i, sizeof i) == -1)
 	{
-		fprintf(stderr, MOCK "sockopt(SO_NOSIGPIPE)(macOS): %s\n", strerror(errno));
+		mockverbose("sockopt(SO_NOSIGPIPE)(macOS): %s\n", strerror(errno));
 		close(sock);
 		return -1;
 	}
@@ -96,7 +96,7 @@ ssize_t mockFillInBuf (int sock, char* ccinbuf, size_t& ccinbufsize)
 	{
 		if (errno != EAGAIN)
 		{
-			fprintf(stderr, MOCK "ClientContext::(read/peek fd=%i): filling buffer for %zd bytes: %s\n", sock, maxread, strerror(errno));
+			mockverbose("ClientContext::(read/peek fd=%i): filling buffer for %zd bytes: %s\n", sock, maxread, strerror(errno));
 			return -1;
 		}
 		ret = 0;
@@ -108,7 +108,7 @@ ssize_t mockFillInBuf (int sock, char* ccinbuf, size_t& ccinbufsize)
 ssize_t mockPeekBytes (int sock, char* dst, size_t usersize, int timeout_ms, char* ccinbuf, size_t& ccinbufsize)
 {
 	if (usersize > CCBUFSIZE)
-		fprintf(stderr, MOCK "CCBUFSIZE(%d) should be increased by %zd bytes (-> %zd)\n", CCBUFSIZE, usersize - CCBUFSIZE, usersize);
+		mockverbose("CCBUFSIZE(%d) should be increased by %zd bytes (-> %zd)\n", CCBUFSIZE, usersize - CCBUFSIZE, usersize);
 
 	struct pollfd p;
 	size_t retsize = 0;
@@ -159,7 +159,7 @@ ssize_t mockWrite (int sock, const uint8_t* data, size_t size, int timeout_ms)
 	int ret = poll(&p, 1, timeout_ms);
 	if (ret == -1)
 	{
-		fprintf(stderr, MOCK "ClientContext::write: poll(%d): %s\n", sock, strerror(errno));
+		mockverbose("ClientContext::write: poll(%d): %s\n", sock, strerror(errno));
 		return 0;
 	}
 	if (ret)
@@ -171,12 +171,12 @@ ssize_t mockWrite (int sock, const uint8_t* data, size_t size, int timeout_ms)
 #endif
 		if (ret == -1)
 		{
-			fprintf(stderr, MOCK "ClientContext::write(%d): %s\n", sock, strerror(errno));
+			mockverbose("ClientContext::write(%d): %s\n", sock, strerror(errno));
 			return -1;
 		}
 		if (ret != (int)size)
 		{
-			fprintf(stderr, MOCK "ClientContext::write: short write (%d < %zd) (TODO)\n", ret, size);
+			mockverbose("ClientContext::write: short write (%d < %zd) (TODO)\n", ret, size);
 			exit(EXIT_FAILURE);
 		}
 	}

--- a/tests/host/common/ClientContextSocket.cpp
+++ b/tests/host/common/ClientContextSocket.cpp
@@ -52,7 +52,8 @@ int mockSockSetup (int sock)
 	int i = 1;
 	if (setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, &i, sizeof i) == -1)
 	{
-		fprintf(stderr, MOCK "sockopt( SO_NOSIGPIPE)(macOS): %s\n", strerror(errno));
+		fprintf(stderr, MOCK "sockopt(SO_NOSIGPIPE)(macOS): %s\n", strerror(errno));
+		close(sock);
 		return -1;
 	}
 #endif
@@ -84,6 +85,13 @@ ssize_t mockFillInBuf (int sock, char* ccinbuf, size_t& ccinbufsize)
 {
 	size_t maxread = CCBUFSIZE - ccinbufsize;
 	ssize_t ret = ::read(sock, ccinbuf + ccinbufsize, maxread);
+
+	if (ret == 0)
+	{
+		// connection closed
+		return -1;
+	}
+
 	if (ret == -1)
 	{
 		if (errno != EAGAIN)
@@ -163,7 +171,7 @@ ssize_t mockWrite (int sock, const uint8_t* data, size_t size, int timeout_ms)
 #endif
 		if (ret == -1)
 		{
-			fprintf(stderr, MOCK "ClientContext::read: write(%d): %s\n", sock, strerror(errno));
+			fprintf(stderr, MOCK "ClientContext::write(%d): %s\n", sock, strerror(errno));
 			return -1;
 		}
 		if (ret != (int)size)

--- a/tests/host/common/ClientContextSocket.cpp
+++ b/tests/host/common/ClientContextSocket.cpp
@@ -43,7 +43,7 @@ int mockSockSetup (int sock)
 {
 	if (fcntl(sock, F_SETFL, O_NONBLOCK) == -1)
 	{
-		mockverbose("socket fcntl(O_NONBLOCK): %s\n", strerror(errno));
+		perror("socket fcntl(O_NONBLOCK)");
 		close(sock);
 		return -1;
 	}
@@ -52,7 +52,7 @@ int mockSockSetup (int sock)
 	int i = 1;
 	if (setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, &i, sizeof i) == -1)
 	{
-		mockverbose("sockopt(SO_NOSIGPIPE)(macOS): %s\n", strerror(errno));
+		perror("sockopt(SO_NOSIGPIPE)(macOS)");
 		close(sock);
 		return -1;
 	}
@@ -96,7 +96,7 @@ ssize_t mockFillInBuf (int sock, char* ccinbuf, size_t& ccinbufsize)
 	{
 		if (errno != EAGAIN)
 		{
-			mockverbose("ClientContext::(read/peek fd=%i): filling buffer for %zd bytes: %s\n", sock, maxread, strerror(errno));
+			fprintf(stderr, MOCK "ClientContext::(read/peek fd=%i): filling buffer for %zd bytes: %s\n", sock, maxread, strerror(errno));
 			return -1;
 		}
 		ret = 0;
@@ -159,7 +159,7 @@ ssize_t mockWrite (int sock, const uint8_t* data, size_t size, int timeout_ms)
 	int ret = poll(&p, 1, timeout_ms);
 	if (ret == -1)
 	{
-		mockverbose("ClientContext::write: poll(%d): %s\n", sock, strerror(errno));
+		fprintf(stderr, MOCK "ClientContext::write: poll(%d): %s\n", sock, strerror(errno));
 		return 0;
 	}
 	if (ret)
@@ -171,12 +171,12 @@ ssize_t mockWrite (int sock, const uint8_t* data, size_t size, int timeout_ms)
 #endif
 		if (ret == -1)
 		{
-			mockverbose("ClientContext::write(%d): %s\n", sock, strerror(errno));
+			fprintf(stderr, MOCK "ClientContext::write(%d): %s\n", sock, strerror(errno));
 			return -1;
 		}
 		if (ret != (int)size)
 		{
-			mockverbose("ClientContext::write: short write (%d < %zd) (TODO)\n", ret, size);
+			fprintf(stderr, MOCK "ClientContext::write: short write (%d < %zd) (FIXME poll loop TODO)\n", ret, size);
 			exit(EXIT_FAILURE);
 		}
 	}

--- a/tests/host/common/HostWiring.cpp
+++ b/tests/host/common/HostWiring.cpp
@@ -47,21 +47,21 @@ void pinMode (uint8_t pin, uint8_t mode)
 	default: m="(special)";
 	}
 #ifdef DEBUG_ESP_CORE
-	fprintf(stderr, MOCK "gpio%d: mode='%s'\n", pin, m);
+	mockverbose("gpio%d: mode='%s'\n", pin, m);
 #endif
 }
 
 void digitalWrite(uint8_t pin, uint8_t val)
 {
 #ifdef DEBUG_ESP_CORE
-	fprintf(stderr, MOCK "digitalWrite(pin=%d val=%d)\n", pin, val);
+	mockverbose("digitalWrite(pin=%d val=%d)\n", pin, val);
 #endif
 }
 
 void analogWrite(uint8_t pin, int val)
 {
 #ifdef DEBUG_ESP_CORE
-	fprintf(stderr, MOCK "analogWrite(pin=%d, val=%d\n", pin, val);
+	mockverbose("analogWrite(pin=%d, val=%d\n", pin, val);
 #endif
 }
 
@@ -74,14 +74,14 @@ int analogRead(uint8_t pin)
 void analogWriteRange(uint32_t range)
 {
 #ifdef DEBUG_ESP_CORE
-	fprintf(stderr, MOCK "analogWriteRange(range=%d)\n", range);
+	mockverbose("analogWriteRange(range=%d)\n", range);
 #endif
 }
 
 int digitalRead(uint8_t pin)
 {
 #ifdef DEBUG_ESP_CORE
-	fprintf(stderr, MOCK "digitalRead(%d)\n", pin);
+	mockverbose("digitalRead(%d)\n", pin);
 #endif
 
 	// pin 0 is most likely a low active input

--- a/tests/host/common/HostWiring.cpp
+++ b/tests/host/common/HostWiring.cpp
@@ -31,6 +31,12 @@
 
 #include <Arduino.h>
 
+#ifdef DEBUG_ESP_CORE
+#define VERBOSE(x...) fprintf(stderr, MOCK x)
+#else
+#define VERBOSE(x...) mockverbose(x)
+#endif
+
 void pinMode (uint8_t pin, uint8_t mode)
 {
 	#define xxx(mode) case mode: m=STRHELPER(mode); break
@@ -46,23 +52,17 @@ void pinMode (uint8_t pin, uint8_t mode)
 	case WAKEUP_PULLDOWN: m="WAKEUP_PULLDOWN"; break;
 	default: m="(special)";
 	}
-#ifdef DEBUG_ESP_CORE
-	mockverbose("gpio%d: mode='%s'\n", pin, m);
-#endif
+	VERBOSE("gpio%d: mode='%s'\n", pin, m);
 }
 
 void digitalWrite(uint8_t pin, uint8_t val)
 {
-#ifdef DEBUG_ESP_CORE
-	mockverbose("digitalWrite(pin=%d val=%d)\n", pin, val);
-#endif
+	VERBOSE("digitalWrite(pin=%d val=%d)\n", pin, val);
 }
 
 void analogWrite(uint8_t pin, int val)
 {
-#ifdef DEBUG_ESP_CORE
-	mockverbose("analogWrite(pin=%d, val=%d\n", pin, val);
-#endif
+	VERBOSE("analogWrite(pin=%d, val=%d\n", pin, val);
 }
 
 int analogRead(uint8_t pin)
@@ -73,16 +73,12 @@ int analogRead(uint8_t pin)
 
 void analogWriteRange(uint32_t range)
 {
-#ifdef DEBUG_ESP_CORE
-	mockverbose("analogWriteRange(range=%d)\n", range);
-#endif
+	VERBOSE("analogWriteRange(range=%d)\n", range);
 }
 
 int digitalRead(uint8_t pin)
 {
-#ifdef DEBUG_ESP_CORE
-	mockverbose("digitalRead(%d)\n", pin);
-#endif
+	VERBOSE("digitalRead(%d)\n", pin);
 
 	// pin 0 is most likely a low active input
 	return pin ? 0 : 1;

--- a/tests/host/common/MockEEPROM.cpp
+++ b/tests/host/common/MockEEPROM.cpp
@@ -58,7 +58,7 @@ void EEPROMClass::begin(size_t size)
 	if (   (_fd = open(EEPROM_FILE_NAME, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)) == -1
 	    || ftruncate(_fd, size) == -1)
 	{
-		fprintf(stderr, MOCK "EEPROM: cannot open/create '%s' for r/w: %s\n\r", EEPROM_FILE_NAME, strerror(errno));
+		mockverbose("EEPROM: cannot open/create '%s' for r/w: %s\n\r", EEPROM_FILE_NAME, strerror(errno));
 		_fd = -1;
 	}
 }
@@ -78,16 +78,16 @@ uint8_t EEPROMClass::read (int x)
 {
 	char c = 0;
 	if (pread(_fd, &c, 1, x) != 1)
-		fprintf(stderr, MOCK "eeprom: %s\n\r", strerror(errno));
+		mockverbose("eeprom: %s\n\r", strerror(errno));
 	return c;
 }
 
 void EEPROMClass::write (int x, uint8_t c)
 {
 	if (x > (int)_size)
-		fprintf(stderr, MOCK "### eeprom beyond\r\n");
+		mockverbose("### eeprom beyond\r\n");
 	else if (pwrite(_fd, &c, 1, x) != 1)
-		fprintf(stderr, MOCK "eeprom: %s\n\r", strerror(errno));
+		mockverbose("eeprom: %s\n\r", strerror(errno));
 }
 
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_EEPROM)

--- a/tests/host/common/MockEEPROM.cpp
+++ b/tests/host/common/MockEEPROM.cpp
@@ -58,7 +58,7 @@ void EEPROMClass::begin(size_t size)
 	if (   (_fd = open(EEPROM_FILE_NAME, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)) == -1
 	    || ftruncate(_fd, size) == -1)
 	{
-		mockverbose("EEPROM: cannot open/create '%s' for r/w: %s\n\r", EEPROM_FILE_NAME, strerror(errno));
+		fprintf(stderr, MOCK "EEPROM: cannot open/create '%s' for r/w: %s\n\r", EEPROM_FILE_NAME, strerror(errno));
 		_fd = -1;
 	}
 }
@@ -78,16 +78,16 @@ uint8_t EEPROMClass::read (int x)
 {
 	char c = 0;
 	if (pread(_fd, &c, 1, x) != 1)
-		mockverbose("eeprom: %s\n\r", strerror(errno));
+		fprintf(stderr, MOCK "eeprom: %s\n\r", strerror(errno));
 	return c;
 }
 
 void EEPROMClass::write (int x, uint8_t c)
 {
 	if (x > (int)_size)
-		mockverbose("### eeprom beyond\r\n");
+		fprintf(stderr, MOCK "### eeprom beyond\r\n");
 	else if (pwrite(_fd, &c, 1, x) != 1)
-		mockverbose("eeprom: %s\n\r", strerror(errno));
+		fprintf(stderr, MOCK "eeprom: %s\n\r", strerror(errno));
 }
 
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_EEPROM)

--- a/tests/host/common/MockEsp.cpp
+++ b/tests/host/common/MockEsp.cpp
@@ -81,7 +81,7 @@ EspClass ESP;
 
 void EspClass::restart ()
 {
-	fprintf(stderr, MOCK "Esp.restart(): exiting\n");
+	mockverbose("Esp.restart(): exiting\n");
 	exit(EXIT_SUCCESS);
 }
 

--- a/tests/host/common/MockTools.cpp
+++ b/tests/host/common/MockTools.cpp
@@ -59,7 +59,7 @@ extern "C" void configTime(long timezone, int daylightOffset_sec,
 	(void)server2;
 	(void)server3;
 
-	fprintf(stderr, MOCK "configTime: TODO (tz=%ldH offset=%dS) (time will be host's)\n", timezone, daylightOffset_sec);
+	mockverbose("configTime: TODO (tz=%ldH offset=%dS) (time will be host's)\n", timezone, daylightOffset_sec);
 }
 
 void stack_thunk_add_ref() { }

--- a/tests/host/common/MockWiFiServer.cpp
+++ b/tests/host/common/MockWiFiServer.cpp
@@ -47,23 +47,11 @@ extern "C" const ip_addr_t ip_addr_any = IPADDR4_INIT(IPADDR_ANY);
 WiFiServer::WiFiServer (const IPAddress& addr, uint16_t port)
 {
 	(void)addr;
-	if (port < 1024)
-	{
-		int newport = port + 9000;
-		mockverbose("WiFiServer port: %d -> %d\n", port, newport);
-		port = newport;
-	}
 	_port = port;
 }
 
 WiFiServer::WiFiServer (uint16_t port)
 {
-	if (port < 1024)
-	{
-		int newport = port + 9000;
-		mockverbose("WiFiServer port: %d -> %d\n", port, newport);
-		port = newport;
-	}
 	_port = port;
 }
 

--- a/tests/host/common/MockWiFiServer.cpp
+++ b/tests/host/common/MockWiFiServer.cpp
@@ -50,7 +50,7 @@ WiFiServer::WiFiServer (const IPAddress& addr, uint16_t port)
 	if (port < 1024)
 	{
 		int newport = port + 9000;
-		fprintf(stderr, MOCK "WiFiServer port: %d -> %d\n", port, newport);
+		mockverbose("WiFiServer port: %d -> %d\n", port, newport);
 		port = newport;
 	}
 	_port = port;
@@ -61,7 +61,7 @@ WiFiServer::WiFiServer (uint16_t port)
 	if (port < 1024)
 	{
 		int newport = port + 9000;
-		fprintf(stderr, MOCK "WiFiServer port: %d -> %d\n", port, newport);
+		mockverbose("WiFiServer port: %d -> %d\n", port, newport);
 		port = newport;
 	}
 	_port = port;

--- a/tests/host/common/MockWiFiServerSocket.cpp
+++ b/tests/host/common/MockWiFiServerSocket.cpp
@@ -127,7 +127,8 @@ size_t WiFiServer::write (uint8_t c)
 
 size_t WiFiServer::write (const uint8_t *buf, size_t size)
 {
-	mockverbose("todo: WiFiServer::write(%p, %zd)\n", buf, size);
+	fprintf(stderr, MOCK "todo: WiFiServer::write(%p, %zd)\n", buf, size);
+	exit(EXIT_FAILURE);
 	return 0;
 }
 

--- a/tests/host/common/MockWiFiServerSocket.cpp
+++ b/tests/host/common/MockWiFiServerSocket.cpp
@@ -117,7 +117,7 @@ size_t WiFiServer::write (uint8_t c)
 
 size_t WiFiServer::write (const uint8_t *buf, size_t size)
 {
-	fprintf(stderr, MOCK "todo: WiFiServer::write(%p, %zd)\n", buf, size);
+	mockverbose("todo: WiFiServer::write(%p, %zd)\n", buf, size);
 	return 0;
 }
 

--- a/tests/host/common/MockWiFiServerSocket.cpp
+++ b/tests/host/common/MockWiFiServerSocket.cpp
@@ -67,7 +67,17 @@ void WiFiServer::begin (uint16_t port)
 void WiFiServer::begin ()
 {
 	int sock;
+	int mockport;
 	struct sockaddr_in server;
+
+	mockport = _port;
+	if (mockport < 1024 && mock_port_shifter)
+	{
+		mockport += mock_port_shifter;
+		fprintf(stderr, MOCK "=====> WiFiServer port: %d shifted to %d (use option -s) <=====\n", _port, mockport);
+	}
+	else
+		fprintf(stderr, MOCK "=====> WiFiServer port: %d <=====\n", mockport);
 
 	if ((sock = socket(AF_INET, SOCK_STREAM, 0)) == -1)
 	{
@@ -83,7 +93,7 @@ void WiFiServer::begin ()
 	}
 
     	server.sin_family = AF_INET;
-	server.sin_port = htons(_port);
+	server.sin_port = htons(mockport);
 	server.sin_addr.s_addr = htonl(INADDR_ANY);
 	if (bind(sock, (struct sockaddr*)&server, sizeof(server)) == -1)
 	{

--- a/tests/host/common/UdpContextSocket.cpp
+++ b/tests/host/common/UdpContextSocket.cpp
@@ -44,7 +44,7 @@ int mockUDPSocket ()
 	int s;
 	if ((s = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) == -1 || fcntl(s, F_SETFL, O_NONBLOCK) == -1)
 	{
-		fprintf(stderr, MOCK "UDP socket: %s", strerror(errno));
+		mockverbose("UDP socket: %s", strerror(errno));
 		exit(EXIT_FAILURE);
 	}
 	return s;
@@ -54,10 +54,10 @@ bool mockUDPListen (int sock, uint32_t dstaddr, uint16_t port, uint32_t mcast)
 {
 	int optval = 1;
 	if (setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval)) == -1)
-		fprintf(stderr, MOCK "SO_REUSEPORT failed\n");
+		mockverbose("SO_REUSEPORT failed\n");
 	optval = 1;
 	if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) == -1)
-		fprintf(stderr, MOCK "SO_REUSEADDR failed\n");
+		mockverbose("SO_REUSEADDR failed\n");
 
 	struct sockaddr_in servaddr;
 	memset(&servaddr, 0, sizeof(servaddr));
@@ -71,11 +71,11 @@ bool mockUDPListen (int sock, uint32_t dstaddr, uint16_t port, uint32_t mcast)
 	// Bind the socket with the server address
 	if (bind(sock, (const struct sockaddr *)&servaddr, sizeof(servaddr)) < 0)
 	{
-		fprintf(stderr, MOCK "UDP bind on port %d failed: %s\n", port, strerror(errno));
+		mockverbose("UDP bind on port %d failed: %s\n", port, strerror(errno));
 		return false;
 	}
 	else
-		fprintf(stderr, MOCK "UDP server on port %d (sock=%d)\n", (int)port, sock);
+		mockverbose("UDP server on port %d (sock=%d)\n", (int)port, sock);
 
 	if (mcast)
 	{
@@ -94,14 +94,14 @@ bool mockUDPListen (int sock, uint32_t dstaddr, uint16_t port, uint32_t mcast)
 #else
 			if (setsockopt(sock, SOL_SOCKET, SO_BINDTODEVICE, host_interface, strlen(host_interface)) == -1)
 #endif
-				fprintf(stderr, MOCK "UDP multicast: can't setup bind/output on interface %s: %s\n", host_interface, strerror(errno));
+				mockverbose("UDP multicast: can't setup bind/output on interface %s: %s\n", host_interface, strerror(errno));
 			if (setsockopt(sock, IPPROTO_IP, IP_MULTICAST_IF, &mreq.imr_interface, sizeof(struct in_addr)) == -1)
-				fprintf(stderr, MOCK "UDP multicast: can't setup bind/input on interface %s: %s\n", host_interface, strerror(errno));
+				mockverbose("UDP multicast: can't setup bind/input on interface %s: %s\n", host_interface, strerror(errno));
 		}
 
 		if (setsockopt(sock, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq)) < 0)
 		{
-			fprintf(stderr, MOCK "can't join multicast group addr %08x\n", (int)mcast);
+			mockverbose("can't join multicast group addr %08x\n", (int)mcast);
 			return false;
 		}
 	}
@@ -120,7 +120,7 @@ size_t mockUDPFillInBuf (int sock, char* ccinbuf, size_t& ccinbufsize, uint8_t& 
 	if (ret == -1)
 	{
 		if (errno != EAGAIN)
-			fprintf(stderr, MOCK "UDPContext::(read/peek): filling buffer for %zd bytes: %s\n", maxread, strerror(errno));
+			mockverbose("UDPContext::(read/peek): filling buffer for %zd bytes: %s\n", maxread, strerror(errno));
 		ret = 0;
 	}
 
@@ -131,7 +131,7 @@ size_t mockUDPFillInBuf (int sock, char* ccinbuf, size_t& ccinbufsize, uint8_t& 
 			memcpy(&addr[0], &(((sockaddr_in*)&addrbuf)->sin_addr.s_addr), addrsize = 4);
 		else
 		{
-			fprintf(stderr, MOCK "TODO UDP+IPv6\n");
+			mockverbose("TODO UDP+IPv6\n");
 			exit(EXIT_FAILURE);
 		}
 	}
@@ -142,7 +142,7 @@ size_t mockUDPFillInBuf (int sock, char* ccinbuf, size_t& ccinbufsize, uint8_t& 
 size_t mockUDPPeekBytes (int sock, char* dst, size_t usersize, int timeout_ms, char* ccinbuf, size_t& ccinbufsize)
 {
 	if (usersize > CCBUFSIZE)
-		fprintf(stderr, MOCK "CCBUFSIZE(%d) should be increased by %zd bytes (-> %zd)\n", CCBUFSIZE, usersize - CCBUFSIZE, usersize);
+		mockverbose("CCBUFSIZE(%d) should be increased by %zd bytes (-> %zd)\n", CCBUFSIZE, usersize - CCBUFSIZE, usersize);
 
 	size_t retsize = 0;
 	if (ccinbufsize)
@@ -180,12 +180,12 @@ size_t mockUDPWrite (int sock, const uint8_t* data, size_t size, int timeout_ms,
 	int ret = ::sendto(sock, data, size, 0/*flags*/, (const sockaddr*)&peer, sizeof(peer));
 	if (ret == -1)
 	{
-		fprintf(stderr, MOCK "UDPContext::write: write(%d): %s\n", sock, strerror(errno));
+		mockverbose("UDPContext::write: write(%d): %s\n", sock, strerror(errno));
 		return 0;
 	}
 	if (ret != (int)size)
 	{
-		fprintf(stderr, MOCK "UDPContext::write: short write (%d < %zd) (TODO)\n", ret, size);
+		mockverbose("UDPContext::write: short write (%d < %zd) (TODO)\n", ret, size);
 		exit(EXIT_FAILURE);
 	}
 

--- a/tests/host/common/UdpContextSocket.cpp
+++ b/tests/host/common/UdpContextSocket.cpp
@@ -52,7 +52,19 @@ int mockUDPSocket ()
 
 bool mockUDPListen (int sock, uint32_t dstaddr, uint16_t port, uint32_t mcast)
 {
-	int optval = 1;
+	int optval;
+	int mockport;
+
+	mockport = port;
+	if (mockport < 1024 && mock_port_shifter)
+	{
+		mockport += mock_port_shifter;
+		fprintf(stderr, MOCK "=====> UdpServer port: %d shifted to %d (use option -s) <=====\n", port, mockport);
+	}
+	else
+		fprintf(stderr, MOCK "=====> UdpServer port: %d <=====\n", mockport);
+
+	optval = 1;
 	if (setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval)) == -1)
 		mockverbose("SO_REUSEPORT failed\n");
 	optval = 1;

--- a/tests/host/common/UdpContextSocket.cpp
+++ b/tests/host/common/UdpContextSocket.cpp
@@ -44,7 +44,7 @@ int mockUDPSocket ()
 	int s;
 	if ((s = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) == -1 || fcntl(s, F_SETFL, O_NONBLOCK) == -1)
 	{
-		mockverbose("UDP socket: %s", strerror(errno));
+		fprintf(stderr, MOCK "UDP socket: %s", strerror(errno));
 		exit(EXIT_FAILURE);
 	}
 	return s;
@@ -66,10 +66,10 @@ bool mockUDPListen (int sock, uint32_t dstaddr, uint16_t port, uint32_t mcast)
 
 	optval = 1;
 	if (setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval)) == -1)
-		mockverbose("SO_REUSEPORT failed\n");
+		fprintf(stderr, MOCK "SO_REUSEPORT failed\n");
 	optval = 1;
 	if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) == -1)
-		mockverbose("SO_REUSEADDR failed\n");
+		fprintf(stderr, MOCK "SO_REUSEADDR failed\n");
 
 	struct sockaddr_in servaddr;
 	memset(&servaddr, 0, sizeof(servaddr));
@@ -78,16 +78,16 @@ bool mockUDPListen (int sock, uint32_t dstaddr, uint16_t port, uint32_t mcast)
 	servaddr.sin_family = AF_INET;
 	//servaddr.sin_addr.s_addr = global_ipv4_netfmt?: dstaddr;
 	servaddr.sin_addr.s_addr = htonl(INADDR_ANY);
-	servaddr.sin_port = htons(port);
+	servaddr.sin_port = htons(mockport);
 
 	// Bind the socket with the server address
 	if (bind(sock, (const struct sockaddr *)&servaddr, sizeof(servaddr)) < 0)
 	{
-		mockverbose("UDP bind on port %d failed: %s\n", port, strerror(errno));
+		fprintf(stderr, MOCK "UDP bind on port %d failed: %s\n", mockport, strerror(errno));
 		return false;
 	}
 	else
-		mockverbose("UDP server on port %d (sock=%d)\n", (int)port, sock);
+		mockverbose("UDP server on port %d (sock=%d)\n", mockport, sock);
 
 	if (mcast)
 	{
@@ -106,14 +106,14 @@ bool mockUDPListen (int sock, uint32_t dstaddr, uint16_t port, uint32_t mcast)
 #else
 			if (setsockopt(sock, SOL_SOCKET, SO_BINDTODEVICE, host_interface, strlen(host_interface)) == -1)
 #endif
-				mockverbose("UDP multicast: can't setup bind/output on interface %s: %s\n", host_interface, strerror(errno));
+				fprintf(stderr, MOCK "UDP multicast: can't setup bind/output on interface %s: %s\n", host_interface, strerror(errno));
 			if (setsockopt(sock, IPPROTO_IP, IP_MULTICAST_IF, &mreq.imr_interface, sizeof(struct in_addr)) == -1)
-				mockverbose("UDP multicast: can't setup bind/input on interface %s: %s\n", host_interface, strerror(errno));
+				fprintf(stderr, MOCK "UDP multicast: can't setup bind/input on interface %s: %s\n", host_interface, strerror(errno));
 		}
 
 		if (setsockopt(sock, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq)) < 0)
 		{
-			mockverbose("can't join multicast group addr %08x\n", (int)mcast);
+			fprintf(stderr, MOCK "can't join multicast group addr %08x\n", (int)mcast);
 			return false;
 		}
 	}
@@ -132,7 +132,7 @@ size_t mockUDPFillInBuf (int sock, char* ccinbuf, size_t& ccinbufsize, uint8_t& 
 	if (ret == -1)
 	{
 		if (errno != EAGAIN)
-			mockverbose("UDPContext::(read/peek): filling buffer for %zd bytes: %s\n", maxread, strerror(errno));
+			fprintf(stderr, MOCK "UDPContext::(read/peek): filling buffer for %zd bytes: %s\n", maxread, strerror(errno));
 		ret = 0;
 	}
 
@@ -143,7 +143,7 @@ size_t mockUDPFillInBuf (int sock, char* ccinbuf, size_t& ccinbufsize, uint8_t& 
 			memcpy(&addr[0], &(((sockaddr_in*)&addrbuf)->sin_addr.s_addr), addrsize = 4);
 		else
 		{
-			mockverbose("TODO UDP+IPv6\n");
+			fprintf(stderr, MOCK "TODO UDP+IPv6\n");
 			exit(EXIT_FAILURE);
 		}
 	}
@@ -154,7 +154,7 @@ size_t mockUDPFillInBuf (int sock, char* ccinbuf, size_t& ccinbufsize, uint8_t& 
 size_t mockUDPPeekBytes (int sock, char* dst, size_t usersize, int timeout_ms, char* ccinbuf, size_t& ccinbufsize)
 {
 	if (usersize > CCBUFSIZE)
-		mockverbose("CCBUFSIZE(%d) should be increased by %zd bytes (-> %zd)\n", CCBUFSIZE, usersize - CCBUFSIZE, usersize);
+		fprintf(stderr, MOCK "CCBUFSIZE(%d) should be increased by %zd bytes (-> %zd)\n", CCBUFSIZE, usersize - CCBUFSIZE, usersize);
 
 	size_t retsize = 0;
 	if (ccinbufsize)
@@ -192,12 +192,12 @@ size_t mockUDPWrite (int sock, const uint8_t* data, size_t size, int timeout_ms,
 	int ret = ::sendto(sock, data, size, 0/*flags*/, (const sockaddr*)&peer, sizeof(peer));
 	if (ret == -1)
 	{
-		mockverbose("UDPContext::write: write(%d): %s\n", sock, strerror(errno));
+		fprintf(stderr, MOCK "UDPContext::write: write(%d): %s\n", sock, strerror(errno));
 		return 0;
 	}
 	if (ret != (int)size)
 	{
-		mockverbose("UDPContext::write: short write (%d < %zd) (TODO)\n", ret, size);
+		fprintf(stderr, MOCK "UDPContext::write: short write (%d < %zd) (TODO)\n", ret, size);
 		exit(EXIT_FAILURE);
 	}
 

--- a/tests/host/common/include/ClientContext.h
+++ b/tests/host/common/include/ClientContext.h
@@ -54,7 +54,7 @@ public:
         if (_sock >= 0)
         {
             ::close(_sock);
-	    printf(MOCK "socket %d closed\n", _sock);
+	    mockverbose("socket %d closed\n", _sock);
         }
         _sock = -1;
         return ERR_ABRT;
@@ -114,12 +114,12 @@ public:
 
     void setNoDelay(bool nodelay)
     {
-        fprintf(stderr, MOCK "TODO setNoDelay(%d)\n", (int)nodelay);
+        mockverbose("TODO setNoDelay(%d)\n", (int)nodelay);
     }
 
     bool getNoDelay() const
     {
-        fprintf(stderr, MOCK "TODO getNoDelay()\n");
+        mockverbose("TODO getNoDelay()\n");
         return false;
     }
 
@@ -135,25 +135,25 @@ public:
 
     uint32_t getRemoteAddress() const
     {
-        fprintf(stderr, MOCK "TODO getRemoteAddress()\n");
+        mockverbose("TODO getRemoteAddress()\n");
         return 0;
     }
 
     uint16_t getRemotePort() const
     {
-        fprintf(stderr, MOCK "TODO getRemotePort()\n");
+        mockverbose("TODO getRemotePort()\n");
         return 0;
     }
 
     uint32_t getLocalAddress() const
     {
-        fprintf(stderr, MOCK "TODO getLocalAddress()\n");
+        mockverbose("TODO getLocalAddress()\n");
         return 0;
     }
 
     uint16_t getLocalPort() const
     {
-        fprintf(stderr, MOCK "TODO getLocalPort()\n");
+        mockverbose("TODO getLocalPort()\n");
         return 0;
     }
 
@@ -208,7 +208,7 @@ public:
 
     void discard_received()
     {
-        fprintf(stderr, MOCK "TODO: ClientContext::discard_received()\n");
+        mockverbose("TODO: ClientContext::discard_received()\n");
     }
 
     bool wait_until_sent(int max_wait_ms = WIFICLIENT_MAX_FLUSH_WAIT_MS)
@@ -258,42 +258,42 @@ public:
 
     void keepAlive (uint16_t idle_sec = TCP_DEFAULT_KEEPALIVE_IDLE_SEC, uint16_t intv_sec = TCP_DEFAULT_KEEPALIVE_INTERVAL_SEC, uint8_t count = TCP_DEFAULT_KEEPALIVE_COUNT)
     {
-        fprintf(stderr, MOCK "TODO ClientContext::keepAlive()\n");
+        mockverbose("TODO ClientContext::keepAlive()\n");
     }
 
     bool isKeepAliveEnabled () const
     {
-        fprintf(stderr, MOCK "TODO ClientContext::isKeepAliveEnabled()\n");
+        mockverbose("TODO ClientContext::isKeepAliveEnabled()\n");
         return false;
     }
 
     uint16_t getKeepAliveIdle () const
     {
-        fprintf(stderr, MOCK "TODO ClientContext::getKeepAliveIdle()\n");
+        mockverbose("TODO ClientContext::getKeepAliveIdle()\n");
         return 0;
     }
 
     uint16_t getKeepAliveInterval () const
     {
-        fprintf(stderr, MOCK "TODO ClientContext::getKeepAliveInternal()\n");
+        mockverbose("TODO ClientContext::getKeepAliveInternal()\n");
         return 0;
     }
 
     uint8_t getKeepAliveCount () const
     {
-        fprintf(stderr, MOCK "TODO ClientContext::getKeepAliveCount()\n");
+        mockverbose("TODO ClientContext::getKeepAliveCount()\n");
         return 0;
     }
 
     bool getSync () const
     {
-        fprintf(stderr, MOCK "TODO ClientContext::getSync()\n");
+        mockverbose("TODO ClientContext::getSync()\n");
         return _sync;
     }
 
     void setSync (bool sync)
     {
-        fprintf(stderr, MOCK "TODO ClientContext::setSync()\n");
+        mockverbose("TODO ClientContext::setSync()\n");
         _sync = sync;
     }
 

--- a/tests/host/common/include/UdpContext.h
+++ b/tests/host/common/include/UdpContext.h
@@ -89,7 +89,7 @@ public:
     void setMulticastTTL(int ttl)
     {
         (void)ttl;
-        //fprintf(stderr, MOCK "TODO: UdpContext::setMulticastTTL\n");
+        //mockverbose("TODO: UdpContext::setMulticastTTL\n");
     }
 
     // warning: handler is called from tcp stack context
@@ -112,7 +112,7 @@ public:
     {
         if (!isValidOffset(pos))
         {
-            fprintf(stderr, MOCK "UDPContext::seek too far (%zd >= %zd)\n", pos, _inbufsize);
+            mockverbose("UDPContext::seek too far (%zd >= %zd)\n", pos, _inbufsize);
             exit(EXIT_FAILURE);
         }
         mockUDPSwallow(pos, _inbuf, _inbufsize);
@@ -134,13 +134,13 @@ public:
 
     uint32_t getDestAddress()
     {
-        fprintf(stderr, MOCK "TODO: implement UDP getDestAddress\n");
+        mockverbose("TODO: implement UDP getDestAddress\n");
         return 0; //ip_hdr* iphdr = GET_IP_HDR(_rx_buf);
     }
 
     uint16_t getLocalPort()
     {
-        fprintf(stderr, MOCK "TODO: implement UDP getLocalPort\n");
+        mockverbose("TODO: implement UDP getLocalPort\n");
         return 0; //
     }
 
@@ -175,7 +175,7 @@ public:
 
     void flush()
     {
-        //fprintf(stderr, MOCK "UdpContext::flush() does not follow arduino's flush concept\n");
+        //mockverbose("UdpContext::flush() does not follow arduino's flush concept\n");
         //exit(EXIT_FAILURE);
         // would be:
         _inbufsize = 0;
@@ -185,7 +185,7 @@ public:
     {
         if (size + _outbufsize > sizeof _outbuf)
         {
-            fprintf(stderr, MOCK "UdpContext::append: increase CCBUFSIZE (%d -> %zd)\n", CCBUFSIZE, (size + _outbufsize));
+            mockverbose("UdpContext::append: increase CCBUFSIZE (%d -> %zd)\n", CCBUFSIZE, (size + _outbufsize));
             exit(EXIT_FAILURE);
         }
 
@@ -225,7 +225,7 @@ private:
             //ip4_addr_set_u32(&ip_2_ip4(_dst), *(uint32_t*)addr);
         }
         else
-            fprintf(stderr, MOCK "TODO unhandled udp address of size %d\n", (int)addrsize);
+            mockverbose("TODO unhandled udp address of size %d\n", (int)addrsize);
     }
 
     int _sock = -1;

--- a/tests/host/common/mock.h
+++ b/tests/host/common/mock.h
@@ -81,6 +81,8 @@ int mockverbose (const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
 
 extern const char* host_interface; // cmdline parameter
 
+extern int mock_port_shifter;
+
 #define NO_GLOBAL_BINDING 0xffffffff
 extern uint32_t global_ipv4_netfmt; // selected interface addresse to bind to
 

--- a/tests/host/common/mock.h
+++ b/tests/host/common/mock.h
@@ -77,6 +77,8 @@ extern "C" {
 int ets_printf (const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
 #define os_printf_plus printf
 
+int mockverbose (const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
+
 extern const char* host_interface; // cmdline parameter
 
 #define NO_GLOBAL_BINDING 0xffffffff

--- a/tests/host/common/user_interface.cpp
+++ b/tests/host/common/user_interface.cpp
@@ -216,7 +216,7 @@ wifi_event_handler_cb_t wifi_event_handler_cb_emu = nullptr;
 void wifi_set_event_handler_cb (wifi_event_handler_cb_t cb)
 {
 	wifi_event_handler_cb_emu = cb;
-	fprintf(stderr, MOCK "TODO: wifi_set_event_handler_cb set\n");
+	mockverbose("TODO: wifi_set_event_handler_cb set\n");
 }
 
 bool wifi_set_ip_info (uint8 if_index, struct ip_info *info)


### PR DESCRIPTION
* uart emulation on tty: add cmdline `-b` debug option to disable raw tty 

* emulation with socket: fix nasty delay
  * properly check all return values (read() returning 0 indicates closed peer)
  * ClientContext::state() triggers read() to check for closed peer

* hide annoying MOCK messages, add cmdline `-v` option to show them

* uart emulation on tty: check more return values 

* emulation on host: tcp/udp port shifting: new cmdline `-s`(port Shift) option 