### PR TITLE
Remove redundant check for zero size SPIFFS partition

### DIFF
--- a/cores/esp8266/spiffs_api.h
+++ b/cores/esp8266/spiffs_api.h
@@ -126,10 +126,6 @@ public:
 
     bool begin() override
     {
-#if defined(ARDUINO) && !defined(CORE_MOCK)
-        if (&_SPIFFS_end <= &_SPIFFS_start)
-            return false;
-#endif
         if (SPIFFS_mounted(&_fs) != 0) {
             return true;
         }


### PR DESCRIPTION
The check if the end address of the SPIFFS partition is smaller or equal to the start of the partition breaks sketches that are linked with zero size SPIFFS linker scripts, but create their own SPIFFS partition later at arbitrary flash locations. But this check can safely be removed, because the check if the the SPIFFS partition is of size 0 is done a few lines further down anyway.