### PR TITLE
small addons

### DIFF
--- a/cores/esp8266/core_esp8266_version.h
+++ b/cores/esp8266/core_esp8266_version.h
@@ -54,6 +54,20 @@ extern "C++"
 //     esp8266CoreVersionSubRevision() is 3   Numeric is: 20499903
 // case 2.5.0:
 //     esp8266CoreVersionSubRevision() is 0   Numeric is: 20500000
+//
+// Using esp8266::coreVersionNumeric() in a portable way:
+//
+//   #if HAS_ESP8266_VERSION_NUMERIC
+//       if (esp8266::coreVersionNumeric() >= 20500042)
+//       {
+//           // modern api can be used
+//       }
+//       else
+//   #endif
+//       {
+//           // code using older api
+//           // (will not be compiled in when newer api is usable)
+//       }
 
 namespace conststr {
 

--- a/cores/esp8266/core_esp8266_version.h
+++ b/cores/esp8266/core_esp8266_version.h
@@ -22,6 +22,8 @@
 #ifndef __CORE_ESP8266_VERSION_H
 #define __CORE_ESP8266_VERSION_H
 
+#define HAS_ESP8266_VERSION_NUMERIC 1
+
 #include <core_version.h>
 
 #define __STRHELPER(x) #x

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -625,7 +625,7 @@ void ESP8266WebServer::_finalizeResponse() {
   }
 }
 
-const String ESP8266WebServer::responseCodeToString(int code) {
+const String ESP8266WebServer::responseCodeToString(const int code) {
   switch (code) {
     case 100: return F("Continue");
     case 101: return F("Switching Protocols");

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.cpp
@@ -371,7 +371,7 @@ void ESP8266WebServer::_prepareHeader(String& response, int code, const char* co
     response = String(F("HTTP/1.")) + String(_currentVersion) + ' ';
     response += String(code);
     response += ' ';
-    response += _responseCodeToString(code);
+    response += responseCodeToString(code);
     response += "\r\n";
 
     using namespace mime;
@@ -625,7 +625,7 @@ void ESP8266WebServer::_finalizeResponse() {
   }
 }
 
-const String ESP8266WebServer::_responseCodeToString(int code) {
+const String ESP8266WebServer::responseCodeToString(int code) {
   switch (code) {
     case 100: return F("Continue");
     case 101: return F("Switching Protocols");

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -135,6 +135,8 @@ public:
     return _currentClient.write(file);
   }
 
+  static const String responseCodeToString(int code);
+
 protected:
   virtual size_t _currentClientWrite(const char* b, size_t l) { return _currentClient.write( b, l ); }
   virtual size_t _currentClientWrite_P(PGM_P b, size_t l) { return _currentClient.write_P( b, l ); }
@@ -144,7 +146,6 @@ protected:
   bool _parseRequest(WiFiClient& client);
   void _parseArguments(const String& data);
   int _parseArgumentsPrivate(const String& data, std::function<void(String&,String&,const String&,int,int,int,int)> handler);
-  static const String _responseCodeToString(int code);
   bool _parseForm(WiFiClient& client, const String& boundary, uint32_t len);
   bool _parseFormUploadAborted();
   void _uploadWriteByte(uint8_t b);

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -135,7 +135,7 @@ public:
     return _currentClient.write(file);
   }
 
-  static const String responseCodeToString(int code);
+  static const String responseCodeToString(const int code);
 
 protected:
   virtual size_t _currentClientWrite(const char* b, size_t l) { return _currentClient.write( b, l ); }

--- a/libraries/ESP8266mDNS/src/ESP8266mDNS.h
+++ b/libraries/ESP8266mDNS/src/ESP8266mDNS.h
@@ -45,12 +45,11 @@
 #include "ESP8266mDNS_Legacy.h"
 #include "LEAmDNS.h"
 
+// Maps the implementation to use to the global namespace type
+//using MDNSResponder = Legacy_MDNSResponder::MDNSResponder; //legacy
+using MDNSResponder = esp8266::MDNSImplementation::MDNSResponder; //new
 
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_MDNS)
-    // Maps the implementation to use to the global namespace type
-    //using MDNSResponder = Legacy_MDNSResponder::MDNSResponder; //legacy
-    using MDNSResponder = esp8266::MDNSImplementation::MDNSResponder; //new
-    
     extern MDNSResponder MDNS;
 #endif
 

--- a/libraries/ESP8266mDNS/src/ESP8266mDNS.h
+++ b/libraries/ESP8266mDNS/src/ESP8266mDNS.h
@@ -45,11 +45,12 @@
 #include "ESP8266mDNS_Legacy.h"
 #include "LEAmDNS.h"
 
-// Maps the implementation to use to the global namespace type
-//using MDNSResponder = Legacy_MDNSResponder::MDNSResponder; //legacy
-using MDNSResponder = esp8266::MDNSImplementation::MDNSResponder; //new
 
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_MDNS)
+    // Maps the implementation to use to the global namespace type
+    //using MDNSResponder = Legacy_MDNSResponder::MDNSResponder; //legacy
+    using MDNSResponder = esp8266::MDNSImplementation::MDNSResponder; //new
+    
     extern MDNSResponder MDNS;
 #endif
 


### PR DESCRIPTION
* make (static) `ESP8266WebServer::responseCodeToString` visible and usable
* esp8266:coreVersionNumeric(): add a define to check on its usability
```
#if HAS_ESP8266_VERSION_NUMERIC
    if (esp8266::coreVersionNumeric() >= 20500042)
    {
        // modern api
    }
    else
#endif
    {
        // older api
    }
```
