### PR TITLE
Reimplement SD.h write methods exactly in File

### DIFF
--- a/cores/esp8266/FS.h
+++ b/cores/esp8266/FS.h
@@ -54,6 +54,11 @@ public:
     // Print methods:
     size_t write(uint8_t) override;
     size_t write(const uint8_t *buf, size_t size) override;
+    size_t write(int8_t t) { return write((uint8_t)t); }
+    size_t write(int16_t t) { return write((uint8_t)(t & 0xff)); }
+    size_t write(int32_t t) { return write((uint8_t)(t & 0xff)); }
+    size_t write(uint16_t t) { return write((uint8_t)(t & 0xff)); }
+    size_t write(uint32_t t) { return write((uint8_t)(t & 0xff)); }
 
     // Stream methods:
     int available() override;

--- a/cores/esp8266/FS.h
+++ b/cores/esp8266/FS.h
@@ -54,6 +54,7 @@ public:
     // Print methods:
     size_t write(uint8_t) override;
     size_t write(const uint8_t *buf, size_t size) override;
+    // These handle ambiguity for write(0) case
     size_t write(int8_t t) { return write((uint8_t)t); }
     size_t write(int16_t t) { return write((uint8_t)(t & 0xff)); }
     size_t write(int32_t t) { return write((uint8_t)(t & 0xff)); }
@@ -86,16 +87,16 @@ public:
 
     // Arduino "class SD" methods for compatibility
     template<typename T> size_t write(T &src){
-      uint8_t obuf[512];
+      uint8_t obuf[256];
       size_t doneLen = 0;
       size_t sentLen;
       int i;
 
-      while (src.available() > 512){
-        src.read(obuf, 512);
-        sentLen = write(obuf, 512);
+      while (src.available() > sizeof(obuf)){
+        src.read(obuf, sizeof(obuf));
+        sentLen = write(obuf, sizeof(obuf));
         doneLen = doneLen + sentLen;
-        if(sentLen != 512){
+        if(sentLen != sizeof(obuf)){
           return doneLen;
         }
       }

--- a/cores/esp8266/FS.h
+++ b/cores/esp8266/FS.h
@@ -80,7 +80,29 @@ public:
     bool isDirectory() const;
 
     // Arduino "class SD" methods for compatibility
-    size_t write(const char *str) { return write((const uint8_t*)str, strlen(str)); }
+    template<typename T> size_t write(T &src){
+      uint8_t obuf[512];
+      size_t doneLen = 0;
+      size_t sentLen;
+      int i;
+
+      while (src.available() > 512){
+        src.read(obuf, 512);
+        sentLen = write(obuf, 512);
+        doneLen = doneLen + sentLen;
+        if(sentLen != 512){
+          return doneLen;
+        }
+      }
+
+      size_t leftLen = src.available();
+      src.read(obuf, leftLen);
+      sentLen = write(obuf, leftLen);
+      doneLen = doneLen + sentLen;
+      return doneLen;
+    }
+    using Print::write;
+
     void rewindDirectory();
     File openNextFile();
 

--- a/cores/esp8266/FS.h
+++ b/cores/esp8266/FS.h
@@ -54,12 +54,6 @@ public:
     // Print methods:
     size_t write(uint8_t) override;
     size_t write(const uint8_t *buf, size_t size) override;
-    // These handle ambiguity for write(0) case
-    size_t write(int8_t t) { return write((uint8_t)t); }
-    size_t write(int16_t t) { return write((uint8_t)(t & 0xff)); }
-    size_t write(int32_t t) { return write((uint8_t)(t & 0xff)); }
-    size_t write(uint16_t t) { return write((uint8_t)(t & 0xff)); }
-    size_t write(uint32_t t) { return write((uint8_t)(t & 0xff)); }
 
     // Stream methods:
     int available() override;

--- a/cores/esp8266/HardwareSerial.h
+++ b/cores/esp8266/HardwareSerial.h
@@ -152,22 +152,6 @@ public:
     {
         return uart_write_char(_uart, c);
     }
-    inline size_t write(unsigned long n)
-    {
-        return write((uint8_t) n);
-    }
-    inline size_t write(long n)
-    {
-        return write((uint8_t) n);
-    }
-    inline size_t write(unsigned int n)
-    {
-        return write((uint8_t) n);
-    }
-    inline size_t write(int n)
-    {
-        return write((uint8_t) n);
-    }
     size_t write(const uint8_t *buffer, size_t size) override
     {
         return uart_write(_uart, (const char*)buffer, size);

--- a/cores/esp8266/Print.h
+++ b/cores/esp8266/Print.h
@@ -62,6 +62,13 @@ class Print {
         size_t write(const char *buffer, size_t size) {
             return write((const uint8_t *) buffer, size);
         }
+        // These handle ambiguity for write(0) case, because (0) can be a pointer or an integer
+        size_t write(short t) { return write((uint8_t)t); }
+        size_t write(unsigned short t) { return write((uint8_t)t); }
+        size_t write(int t) { return write((uint8_t)t); }
+        size_t write(unsigned int t) { return write((uint8_t)t); }
+        size_t write(long t) { return write((uint8_t)t); }
+        size_t write(unsigned long t) { return write((uint8_t)t); }
 
         size_t printf(const char * format, ...)  __attribute__ ((format (printf, 2, 3)));
         size_t printf_P(PGM_P format, ...) __attribute__((format(printf, 2, 3)));

--- a/tests/host/fs/test_fs.cpp
+++ b/tests/host/fs/test_fs.cpp
@@ -343,6 +343,11 @@ TEST_CASE("Multisplendored File::writes", "[fs]")
     f.write('a');
     f.write(65);
     f.write("bbcc");
+    f.write("theend", 6);
+    char block[3]={'x','y','z'};
+    f.write(block, 3);
+    uint32_t bigone = 0x40404040;
+    f.write((const uint8_t*)&bigone, 4);
     f.close();
-    REQUIRE(readFileSD("/file.txt") == "aAbbcc");
+    REQUIRE(readFileSD("/file.txt") == "aAbbcctheendxyz@@@@");
 }

--- a/tests/host/fs/test_fs.cpp
+++ b/tests/host/fs/test_fs.cpp
@@ -331,3 +331,18 @@ TEST_CASE("Listfiles.ino example", "[sd]")
     REQUIRE(readFileSD("/dir2/dir3/file4") == "bonjour");
 }
 
+TEST_CASE("Multisplendored File::writes", "[fs]")
+{
+    SDFS_MOCK_DECLARE();
+    SDFS.end();
+    SDFS.setConfig(SDFSConfig(0, SD_SCK_MHZ(1)));
+    REQUIRE(SDFS.format());
+    REQUIRE(SD.begin(4));
+
+    File f = SD.open("/file.txt", FILE_WRITE);
+    f.write('a');
+    f.write(65);
+    f.write("bbcc");
+    f.close();
+    REQUIRE(readFileSD("/file.txt") == "aAbbcc");
+}

--- a/tests/host/fs/test_fs.cpp
+++ b/tests/host/fs/test_fs.cpp
@@ -350,4 +350,12 @@ TEST_CASE("Multisplendored File::writes", "[fs]")
     f.write((const uint8_t*)&bigone, 4);
     f.close();
     REQUIRE(readFileSD("/file.txt") == "aAbbcctheendxyz@@@@");
+    File g = SD.open("/file.txt", FILE_WRITE);
+    g.write(0);
+    g.close();
+    g = SD.open("/file.txt", FILE_READ);
+    uint8_t u = 0x66;
+    g.read(&u, 1);
+    g.close();
+    REQUIRE(u == 0);
 }


### PR DESCRIPTION
Replace the individual override with the existing SD.h File's
implementation for all methods of File::write.

Fixes #5846