### PR TITLE
Fix Serial.write(0) overloading

### DIFF
--- a/cores/esp8266/HardwareSerial.h
+++ b/cores/esp8266/HardwareSerial.h
@@ -156,10 +156,7 @@ public:
     {
         return uart_write(_uart, (const char*)buffer, size);
     }
-    size_t write(const char *buffer)
-    {
-        return buffer? uart_write(_uart, buffer, strlen(buffer)): 0;
-    }
+    using Print::write; // Import other write() methods to support things like write(0) properly
     operator bool() const
     {
         return _uart != 0;


### PR DESCRIPTION
Add missing "using Print::write" to the HWSerial class to get the proper
overrides to make Serial.write(0) and Serial1.write(0) work as expected.

Fixes #5846 