### PR TITLE
include submodules with git clone --recursive

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Documentation: [https://arduino-esp8266.readthedocs.io/en/2.5.0/](https://arduin
 cd hardware
 mkdir esp8266com
 cd esp8266com
-git clone https://github.com/esp8266/Arduino.git esp8266
+git clone --recursive https://github.com/esp8266/Arduino.git esp8266
 ```
 - Download binary tools (you need Python 2.7)
 ```bash

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ Documentation: [https://arduino-esp8266.readthedocs.io/en/2.5.0/](https://arduin
 cd hardware
 mkdir esp8266com
 cd esp8266com
-git clone --recursive https://github.com/esp8266/Arduino.git esp8266
+git clone https://github.com/esp8266/Arduino.git esp8266
+cd esp8266
+git submodule update --init
 ```
 - Download binary tools (you need Python 2.7)
 ```bash


### PR DESCRIPTION
Since we have some submodules it is recomended to include them while cloning the project.