### PR TITLE
Fix Small String Optimization misplaced 0 terminator

### DIFF
--- a/cores/esp8266/WString.cpp
+++ b/cores/esp8266/WString.cpp
@@ -129,6 +129,7 @@ String::~String() {
 // /*********************************************/
 
 inline void String::init(void) {
+    memset(sso_buf, 0, sizeof(sso_buf));
     setSSO(false);
     setCapacity(0);
     setLen(0);
@@ -161,11 +162,11 @@ unsigned char String::changeBuffer(unsigned int maxStrLen) {
             return 1;
         } else { // if bufptr && !sso()
             // Using bufptr, need to shrink into sso_buff
-            char temp[sizeof(sso_buf)];
+            char temp[sizeof(sso_buf)] = {0};
             memcpy(temp, buffer(), maxStrLen);
             free(wbuffer());
             setSSO(true);
-            memcpy(wbuffer(), temp, maxStrLen);
+            memcpy(wbuffer(), temp, sizeof(sso_buf));
             return 1;
         }
     }

--- a/tests/host/core/test_string.cpp
+++ b/tests/host/core/test_string.cpp
@@ -83,6 +83,12 @@ TEST_CASE("String constructors", "[core][String]")
     REQUIRE(ssh == "3.14159_abcd");
     String flash = (F("hello from flash"));
     REQUIRE(flash == "hello from flash");
+    const char textarray[6] = {'h', 'e', 'l', 'l', 'o', 0};
+    String hello(textarray);
+    REQUIRE(hello == "hello");
+    String hello2;
+    hello2 = textarray;
+    REQUIRE(hello2 == "hello");
 }
 
 TEST_CASE("String concantenation", "[core][String]")
@@ -360,4 +366,8 @@ TEST_CASE("String SSO works", "[core][String]")
     REQUIRE(s == "0123456789abcdefghijklmnopqrstu");
     REQUIRE(s.length() == 31);
   }
+  s = "0123456789abcde";
+  s = s.substring(s.indexOf('a'));
+  REQUIRE(s == "abcde");
+  REQUIRE(s.length() == 5);
 }


### PR DESCRIPTION
A fix for some issue introduced in PR #5690
See discussion in https://github.com/esp8266/Arduino/issues/5883