### PR TITLE
BearSSL CertStore Example: Fix the changed structure of the input file

### DIFF
--- a/libraries/ESP8266WiFi/examples/BearSSL_CertStore/certs-from-mozilla.py
+++ b/libraries/ESP8266WiFi/examples/BearSSL_CertStore/certs-from-mozilla.py
@@ -30,7 +30,7 @@ csvData = response.read()
 csvReader = csv.reader(StringIO(csvData))
 for row in csvReader:
     names.append(row[0]+":"+row[1]+":"+row[2])
-    pems.append(row[28])
+    pems.append(row[30])
 del names[0] # Remove headers
 del pems[0] # Remove headers
 


### PR DESCRIPTION
The input file containing certificates has changed, certificates (the column PEM_INFO) are now at position 31.