### PR TITLE
Fix OTA in AP mode

### DIFF
--- a/libraries/ESP8266mDNS/src/LEAmDNS_Control.cpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS_Control.cpp
@@ -79,9 +79,10 @@ bool MDNSResponder::_process(bool p_bUserContext) {
         }
     }
     else {
-        bResult = ((WiFi.isConnected()) &&          // Has connection?
-                   (_updateProbeStatus()) &&        // Probing
-                   (_checkServiceQueryCache()));    // Service query cache check
+        bResult = ((WiFi.isConnected() ||               // Either station is connected
+                    WiFi.softAPgetStationNum()>0) &&    // Or AP has stations connected
+                   (_updateProbeStatus()) &&            // Probing
+                   (_checkServiceQueryCache()));        // Service query cache check
     }
     return bResult;
 }


### PR DESCRIPTION
OTA is broken in AP mode because ESP8266mDNS is checking whether the station is connected before processing. Change the logic to WiFi.isConnected() OR WiFi.softAPgetStationNum()>0 fixes the issue.