### PR TITLE
Update link in platform.txt

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -3,7 +3,7 @@
 # ------------------------------
 
 # For more info:
-# https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5---3rd-party-Hardware-specification
+# https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5-3rd-party-Hardware-specification
 
 name=ESP8266 Boards (2.6.0-dev)
 version=2.6.0-dev


### PR DESCRIPTION
The link to the Arduino-IDE-1.5-3rd-party-Hardware-specification has changed in the meantime,
from https://github.com/arduino/Arduino/wiki/Arduino-IDE---1.5-3rd-party-Hardware-specification
to https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5-3rd-party-Hardware-specification