### PR TITLE
Correct out of bounds condition and remove an unnecessary cast

### DIFF
--- a/doc/esp8266wifi/udp-examples.rst
+++ b/doc/esp8266wifi/udp-examples.rst
@@ -35,7 +35,7 @@ Once we have libraries in place we need to create a ``WiFiUDP`` object. Then we 
 
     WiFiUDP Udp;
     unsigned int localUdpPort = 4210;
-    char incomingPacket[255];
+    char incomingPacket[256];
     char replyPacket[] = "Hi there! Got the message :-)";
 
 Wi-Fi Connection
@@ -68,7 +68,7 @@ Waiting for incoming UDP packed is done by the following code:
       int len = Udp.read(incomingPacket, 255);
       if (len > 0)
       {
-        incomingPacket[len] = 0;
+        incomingPacket[len] = '\0';
       }
       Serial.printf("UDP packet contents: %s\n", incomingPacket);
 


### PR DESCRIPTION
C arrays are 0 indexed, accordingly writing to array[255] actually writes to the 256th position, which is naturally out of bounds of a 255 item array. increasing the size of the array to 256 corrects that error. Also, 0 is an int and requires a cast into a char, '\0' is just a cleaner (a more syntactically pedantic) way to achieve the same end.