### PR TITLE
use static_assert to check on fw structure changes over updates (fix)

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
@@ -64,7 +64,11 @@ static bool sta_config_equal(const station_config& lhs, const station_config& rh
  */
 static bool sta_config_equal(const station_config& lhs, const station_config& rhs) {
 
+#ifdef NONOSDK3V0
+    static_assert(sizeof(station_config) == 116, "struct station_config has changed, please update comparison function");
+#else
     static_assert(sizeof(station_config) == 112, "struct station_config has changed, please update comparison function");
+#endif
 
     if(strncmp(reinterpret_cast<const char*>(lhs.ssid), reinterpret_cast<const char*>(rhs.ssid), sizeof(lhs.ssid)) != 0) {
         return false;


### PR DESCRIPTION
fix https://github.com/esp8266/Arduino/commit/ca79f2ce39724527052319717a731b3501d5f0b2#commitcomment-33018667
fix #5945