### PR TITLE
ArduinoOTA: Fix insecure nonce generation

### DIFF
--- a/libraries/ArduinoOTA/ArduinoOTA.h
+++ b/libraries/ArduinoOTA/ArduinoOTA.h
@@ -94,6 +94,7 @@ class ArduinoOTAClass
     void _onRx(void);
     int parseInt(void);
     String readStringUntil(char end);
+    String generateNonce(void);
 };
 
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_ARDUINOOTA)


### PR DESCRIPTION
**Issue:** Currently, ArduinoOTA library generates authentication nonce using the value obtained from `micros()` function which is not secure I suppose (correct me if I'm wrong, please).

**Brief PR description**: This PR defines a new private `ArduinoOTAClass::generateNonce()` function which generates random MD5 hash using MCU HWRNG (compatible with ESP8266 / ESP32) or with the `micros()` fallback in case of non-ESP environment. Nonce generation in `ArduinoOTAClass::_onRx` replaced with the call of this function.