### PR TITLE
polledTimeout: ensures timeType is unsigned

### DIFF
--- a/cores/esp8266/PolledTimeout.h
+++ b/cores/esp8266/PolledTimeout.h
@@ -142,6 +142,7 @@ class timeoutTemplate
 {
 public:
   using timeType = typename TimePolicyT::timeType;
+  static_assert(std::is_unsigned<timeType>::value == true, "timeType must be unsigned");
 
   static constexpr timeType alwaysExpired   = 0;
   static constexpr timeType neverExpires    = std::numeric_limits<timeType>::max();


### PR DESCRIPTION
closes #5964 