### PR TITLE
ISR code must be in ICACHE_RAM - the check was commited in ab125162bf

### DIFF
--- a/cores/esp8266/FunctionalInterrupt.cpp
+++ b/cores/esp8266/FunctionalInterrupt.cpp
@@ -11,7 +11,7 @@ typedef void (*voidFuncPtrArg)(void*);
 extern "C" void ICACHE_RAM_ATTR __attachInterruptArg(uint8_t pin, voidFuncPtr userFunc, void*fp , int mode);
 
 
-void interruptFunctional(void* arg)
+void ICACHE_RAM_ATTR interruptFunctional(void* arg)
 {
     ArgStructure* localArg = (ArgStructure*)arg;
 	if (localArg->functionInfo->reqScheduledFunction)


### PR DESCRIPTION
#5995 hasn't actually merged any PR - the minimum to get actual code working is in this PR.
Caveat: I don't know how to check if ICACHE_RAM_ATTR has the desired effect on lambda expressions, if it does not, there will still be an adverse performance (no real-time behavior!) impact over the standard Arduino attachInterrupt() usage.
Q: why not implement void attachInterruptArg(uint8_t pin, void (*)(void*), void * arg, int mode) like the ESP32 has already?