### PR TITLE
tools/python is missing from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 tools/dist/
 tools/xtensa-lx106-elf/
 tools/mkspiffs/
+tools/python/
 package/versions/
 exclude.txt
 tools/sdk/lib/liblwip_src.a


### PR DESCRIPTION
git clean honors .gitignore, leaving the build tools downloaded by tools/get.py in place.