### PR TITLE
Bugfix: attach interrupt (#6049)

### DIFF
--- a/cores/esp8266/Arduino.h
+++ b/cores/esp8266/Arduino.h
@@ -218,6 +218,7 @@ uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder);
 
 void attachInterrupt(uint8_t pin, void (*)(void), int mode);
 void detachInterrupt(uint8_t pin);
+void attachInterruptArg(uint8_t pin, void (*)(void*), void* arg, int mode);
 
 void preinit(void);
 void setup(void);

--- a/cores/esp8266/FunctionalInterrupt.cpp
+++ b/cores/esp8266/FunctionalInterrupt.cpp
@@ -47,7 +47,7 @@ void attachInterrupt(uint8_t pin, std::function<void(void)> intRoutine, int mode
 	as->interruptInfo = ii;
 	as->functionInfo = fi;
 
-    __attachInterruptFunctionalArg(pin, (voidFuncPtr)interruptFunctional, as, mode, true);
+	__attachInterruptFunctionalArg(pin, (voidFuncPtr)interruptFunctional, as, mode, true);
 }
 
 void attachScheduledInterrupt(uint8_t pin, std::function<void(InterruptInfo)> scheduledIntRoutine, int mode)
@@ -61,5 +61,5 @@ void attachScheduledInterrupt(uint8_t pin, std::function<void(InterruptInfo)> sc
 	as->interruptInfo = ii;
 	as->functionInfo = fi;
 
-    __attachInterruptFunctionalArg(pin, (voidFuncPtr)interruptFunctional, as, mode, true);
+	__attachInterruptFunctionalArg(pin, (voidFuncPtr)interruptFunctional, as, mode, true);
 }

--- a/cores/esp8266/FunctionalInterrupt.cpp
+++ b/cores/esp8266/FunctionalInterrupt.cpp
@@ -7,7 +7,7 @@ typedef void (*voidFuncPtr)(void);
 typedef void (*voidFuncPtrArg)(void*);
 
 // Helper functions for Functional interrupt routines
-extern "C" void ICACHE_RAM_ATTR __attachInterruptArg(uint8_t pin, voidFuncPtr userFunc, void*fp , int mode);
+extern "C" void __attachInterruptFunctionalArg(uint8_t pin, voidFuncPtr userFunc, void*fp, int mode, bool functional);
 
 
 void ICACHE_RAM_ATTR interruptFunctional(void* arg)
@@ -47,7 +47,7 @@ void attachInterrupt(uint8_t pin, std::function<void(void)> intRoutine, int mode
 	as->interruptInfo = ii;
 	as->functionInfo = fi;
 
-	__attachInterruptArg (pin, (voidFuncPtr)interruptFunctional, as, mode);
+    __attachInterruptFunctionalArg(pin, (voidFuncPtr)interruptFunctional, as, mode, true);
 }
 
 void attachScheduledInterrupt(uint8_t pin, std::function<void(InterruptInfo)> scheduledIntRoutine, int mode)
@@ -61,5 +61,5 @@ void attachScheduledInterrupt(uint8_t pin, std::function<void(InterruptInfo)> sc
 	as->interruptInfo = ii;
 	as->functionInfo = fi;
 
-	__attachInterruptArg (pin, (voidFuncPtr)interruptFunctional, as, mode);
+    __attachInterruptFunctionalArg(pin, (voidFuncPtr)interruptFunctional, as, mode, true);
 }

--- a/cores/esp8266/core_esp8266_wiring_digital.cpp
+++ b/cores/esp8266/core_esp8266_wiring_digital.cpp
@@ -210,13 +210,7 @@ extern void __attachInterruptArg(uint8_t pin, voidFuncPtrArg userFunc, void* arg
     __attachInterruptFunctionalArg(pin, userFunc, arg, mode, false);
 }
 
-extern void __attachInterrupt(uint8_t pin, voidFuncPtr userFunc, int mode)
-{
-    __attachInterruptFunctionalArg(pin, (voidFuncPtrArg)userFunc, 0, mode, false);
-}
-
-extern void ICACHE_RAM_ATTR __detachInterrupt(uint8_t pin)
-{
+extern void ICACHE_RAM_ATTR __detachInterrupt(uint8_t pin) {
     if (pin < 16)
     {
         ETS_GPIO_INTR_DISABLE();
@@ -237,6 +231,11 @@ extern void ICACHE_RAM_ATTR __detachInterrupt(uint8_t pin)
             ETS_GPIO_INTR_ENABLE();
         }
     }
+}
+
+extern void __attachInterrupt(uint8_t pin, voidFuncPtr userFunc, int mode)
+{
+    __attachInterruptFunctionalArg(pin, (voidFuncPtrArg)userFunc, 0, mode, false);
 }
 
 void initPins() {

--- a/cores/esp8266/core_esp8266_wiring_digital.cpp
+++ b/cores/esp8266/core_esp8266_wiring_digital.cpp
@@ -109,8 +109,9 @@ typedef void (*voidFuncPtrArg)(void*);
 
 typedef struct {
   uint8_t mode;
-  void (*fn)(void);
+  voidFuncPtr fn;
   void * arg;
+  bool functional;
 } interrupt_handler_t;
 
 //duplicate from functionalInterrupt.h keep in sync
@@ -125,11 +126,11 @@ typedef struct {
 	void* functionInfo;
 } ArgStructure;
 
-static interrupt_handler_t interrupt_handlers[16];
+static interrupt_handler_t interrupt_handlers[16] = { {0, 0, 0, 0}, };
 static uint32_t interrupt_reg = 0;
 
-void ICACHE_RAM_ATTR interrupt_handler(void *arg) {
-  (void) arg;
+void ICACHE_RAM_ATTR interrupt_handler(void*)
+{
   uint32_t status = GPIE;
   GPIEC = status;//clear them interrupts
   uint32_t levels = GPI;
@@ -144,34 +145,37 @@ void ICACHE_RAM_ATTR interrupt_handler(void *arg) {
     if (handler->fn && 
         (handler->mode == CHANGE || 
          (handler->mode & 1) == !!(levels & (1 << i)))) {
-      // to make ISR compatible to Arduino AVR model where interrupts are disabled
-      // we disable them before we call the client ISR
-      uint32_t savedPS = xt_rsil(15); // stop other interrupts
-      ArgStructure* localArg = (ArgStructure*)handler->arg;
-      if (localArg && localArg->interruptInfo)
-      {
-         localArg->interruptInfo->pin = i;
-         localArg->interruptInfo->value = __digitalRead(i);
-         localArg->interruptInfo->micro = micros();
+          // to make ISR compatible to Arduino AVR model where interrupts are disabled
+          // we disable them before we call the client ISR
+          uint32_t savedPS = xt_rsil(15); // stop other interrupts
+          if (handler->functional)
+          {
+              ArgStructure* localArg = (ArgStructure*)handler->arg;
+              if (localArg && localArg->interruptInfo)
+              {
+                  localArg->interruptInfo->pin = i;
+                  localArg->interruptInfo->value = __digitalRead(i);
+                  localArg->interruptInfo->micro = micros();
+              }
+          }
+          if (handler->arg)
+          {
+              ((voidFuncPtrArg)handler->fn)(handler->arg);
+          }
+          else
+          {
+              handler->fn();
+          }
+          xt_wsr_ps(savedPS);
       }
-      if (handler->arg)
-      {
-    	  ((voidFuncPtrArg)handler->fn)(handler->arg);
-      }
-      else
-      {
-    	  handler->fn();
-      }
-       xt_wsr_ps(savedPS);
-    }
   }
   ETS_GPIO_INTR_ENABLE();
 }
 
 extern void cleanupFunctional(void* arg);
 
-extern void ICACHE_RAM_ATTR __attachInterruptArg(uint8_t pin, voidFuncPtr userFunc, void *arg, int mode) {
-
+extern void __attachInterruptFunctionalArg(uint8_t pin, voidFuncPtrArg userFunc, void* arg, int mode, bool functional)
+{
   // #5780
   // https://github.com/esp8266/esp8266-wiki/wiki/Memory-Map
   if ((uint32_t)userFunc >= 0x40200000)
@@ -183,14 +187,15 @@ extern void ICACHE_RAM_ATTR __attachInterruptArg(uint8_t pin, voidFuncPtr userFu
 
   if(pin < 16) {
     ETS_GPIO_INTR_DISABLE();
-    interrupt_handler_t *handler = &interrupt_handlers[pin];
+    interrupt_handler_t* handler = &interrupt_handlers[pin];
     handler->mode = mode;
-    handler->fn = userFunc;
-    if (handler->arg)  // Clean when new attach without detach
-	{
-	  cleanupFunctional(handler->arg);
-	}
+    handler->fn = (voidFuncPtr)userFunc;
+    if (handler->functional && handler->arg)  // Clean when new attach without detach
+    {
+        cleanupFunctional(handler->arg);
+    }
     handler->arg = arg;
+    handler->functional = functional;
     interrupt_reg |= (1 << pin);
     GPC(pin) &= ~(0xF << GPCI);//INT mode disabled
     GPIEC = (1 << pin); //Clear Interrupt for this pin
@@ -200,28 +205,38 @@ extern void ICACHE_RAM_ATTR __attachInterruptArg(uint8_t pin, voidFuncPtr userFu
   }
 }
 
-extern void ICACHE_RAM_ATTR __attachInterrupt(uint8_t pin, voidFuncPtr userFunc, int mode )
+extern void __attachInterruptArg(uint8_t pin, voidFuncPtrArg userFunc, void* arg, int mode)
 {
-	__attachInterruptArg (pin, userFunc, 0, mode);
+    __attachInterruptFunctionalArg(pin, userFunc, arg, mode, false);
 }
 
-extern void ICACHE_RAM_ATTR __detachInterrupt(uint8_t pin) {
-  if(pin < 16) {
-    ETS_GPIO_INTR_DISABLE();
-    GPC(pin) &= ~(0xF << GPCI);//INT mode disabled
-    GPIEC = (1 << pin); //Clear Interrupt for this pin
-    interrupt_reg &= ~(1 << pin);
-    interrupt_handler_t *handler = &interrupt_handlers[pin];
-    handler->mode = 0;
-    handler->fn = 0;
-    if (handler->arg)
-		{
-		  cleanupFunctional(handler->arg);
-		}
-    handler->arg = 0;
-    if (interrupt_reg)
-      ETS_GPIO_INTR_ENABLE();
-  }
+extern void __attachInterrupt(uint8_t pin, voidFuncPtr userFunc, int mode)
+{
+    __attachInterruptFunctionalArg(pin, (voidFuncPtrArg)userFunc, 0, mode, false);
+}
+
+extern void ICACHE_RAM_ATTR __detachInterrupt(uint8_t pin)
+{
+    if (pin < 16)
+    {
+        ETS_GPIO_INTR_DISABLE();
+        GPC(pin) &= ~(0xF << GPCI);//INT mode disabled
+        GPIEC = (1 << pin); //Clear Interrupt for this pin
+        interrupt_reg &= ~(1 << pin);
+        interrupt_handler_t* handler = &interrupt_handlers[pin];
+        handler->mode = 0;
+        handler->fn = 0;
+        if (handler->functional && handler->arg)
+        {
+            cleanupFunctional(handler->arg);
+        }
+        handler->arg = 0;
+        handler->functional = false;
+        if (interrupt_reg)
+        {
+            ETS_GPIO_INTR_ENABLE();
+        }
+    }
 }
 
 void initPins() {
@@ -243,6 +258,7 @@ extern void pinMode(uint8_t pin, uint8_t mode) __attribute__ ((weak, alias("__pi
 extern void digitalWrite(uint8_t pin, uint8_t val) __attribute__ ((weak, alias("__digitalWrite")));
 extern int digitalRead(uint8_t pin) __attribute__ ((weak, alias("__digitalRead")));
 extern void attachInterrupt(uint8_t pin, voidFuncPtr handler, int mode) __attribute__ ((weak, alias("__attachInterrupt")));
+extern void attachInterruptArg(uint8_t pin, voidFuncPtrArg handler, void* arg, int mode) __attribute__((weak, alias("__attachInterruptArg")));
 extern void detachInterrupt(uint8_t pin) __attribute__ ((weak, alias("__detachInterrupt")));
 
 };

--- a/cores/esp8266/core_esp8266_wiring_digital.cpp
+++ b/cores/esp8266/core_esp8266_wiring_digital.cpp
@@ -174,7 +174,7 @@ void ICACHE_RAM_ATTR interrupt_handler(void*)
 
 extern void cleanupFunctional(void* arg);
 
-void set_interrupt_handlers(uint8_t pin, voidFuncPtr userFunc, void* arg, uint8_t mode, bool functional)
+static void set_interrupt_handlers(uint8_t pin, voidFuncPtr userFunc, void* arg, uint8_t mode, bool functional)
 {
   interrupt_handler_t* handler = &interrupt_handlers[pin];
   handler->mode = mode;
@@ -235,7 +235,7 @@ extern void __attachInterrupt(uint8_t pin, voidFuncPtr userFunc, int mode)
     __attachInterruptFunctionalArg(pin, (voidFuncPtrArg)userFunc, 0, mode, false);
 }
 
-void initPins() {
+extern void initPins() {
   //Disable UART interrupts
   system_set_os_print(0);
   U0IE = 0;

--- a/cores/esp8266/core_esp8266_wiring_digital.cpp
+++ b/cores/esp8266/core_esp8266_wiring_digital.cpp
@@ -26,6 +26,7 @@
 #include "ets_sys.h"
 #include "user_interface.h"
 #include "core_esp8266_waveform.h"
+#include "interrupts.h"
 
 extern "C" {
 
@@ -147,7 +148,7 @@ void ICACHE_RAM_ATTR interrupt_handler(void*)
          (handler->mode & 1) == !!(levels & (1 << i)))) {
           // to make ISR compatible to Arduino AVR model where interrupts are disabled
           // we disable them before we call the client ISR
-          uint32_t savedPS = xt_rsil(15); // stop other interrupts
+          esp8266::InterruptLock irqLock; // stop other interrupts
           if (handler->functional)
           {
               ArgStructure* localArg = (ArgStructure*)handler->arg;
@@ -166,7 +167,6 @@ void ICACHE_RAM_ATTR interrupt_handler(void*)
           {
               handler->fn();
           }
-          xt_wsr_ps(savedPS);
       }
   }
   ETS_GPIO_INTR_ENABLE();


### PR DESCRIPTION
Fixes: #6049 

- BUG FIX: __attachInterruptArg is known in the field, but it's use fails due to incorrect delete of arg pointer via cleanupFunctional. This PR guards against this case.
- Original author commented that ScheduledFunctions.(h|cpp) were added by mistake, and should be removed.
- ICACHE_RAM_ATTR was previously applied to attachInterrupt() / detachInterrupt() functions, but reviewer of #6003 commented that this can be reverted to save some precious IRAM, as attaching / detachInterrupt from inside ISR are corner cases.
- Properly expose attachInterruptArg() via Arduino.h

(Reference: PR #6047 implement all-C++ functional based interrupt service routine handling. Caveat: ICACHE_RAM_ATTR attributes maybe don't quite work on functional instances, like lambdas, yet)