### PR TITLE
Moved 'Dropping' print from stdout to stderr in drop_versions.py

### DIFF
--- a/package/drop_versions.py
+++ b/package/drop_versions.py
@@ -20,7 +20,10 @@ def drop_version(todrop, obj):
     for o in obj:
         version = o['version'].encode('ascii')
         if version == todrop:
-            print("Dropping version {0}".format(todrop))
+            # removing the print, as it is writing to stdout, which in turn writes to json, which makes it invalid
+            # thus shifting to error stream
+            # alternatively, it can be removed
+            print("Dropping version {0}".format(todrop), file=sys.stderr)
         else:
             out.append(o)
     return out


### PR DESCRIPTION
Printing 'Dropping' debug strings to stdout leads to write in package json.
This moved that to stderr stream.
Alternatively it can be removed.