### PR TITLE
Fail if generated JSON file cannot be read

### DIFF
--- a/package/build_boards_manager_package.sh
+++ b/package/build_boards_manager_package.sh
@@ -158,6 +158,10 @@ set +e
 # Merge the old and new, then drop any obsolete package versions
 python ../../merge_packages.py $new_json $old_json | python ../../drop_versions.py - platforms 1.6.5-947-g39819f0 2.5.0-beta1 2.5.0-beta2 2.5.0-beta3 2.4.0-rc1 2.4.0-rc2 >tmp && mv tmp $new_json && rm $old_json
 
+# Verify the JSON file can be read, fail if it's not OK
+set -e
+cat $new_json | jq empty
+
 popd
 popd
 


### PR DESCRIPTION
To avoid issues as seen in 2.5.1 release where an invalid JSON was
published for a few hours, fail the board script if JQ can't parse the
generated output file.