### PR TITLE
Fix PIO toolchain by ensuring IRQ vectors in link

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -51,10 +51,10 @@ compiler.c.flags=-c {compiler.warning_flags} -Os -g -Wpointer-arith -Wno-implici
 compiler.S.cmd=xtensa-lx106-elf-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp -MMD -mlongcalls
 
-compiler.c.elf.flags=-g {compiler.warning_flags} -Os -nostdlib -Wl,--no-check-sections -u app_entry {build.float} -Wl,-static "-L{compiler.sdk.path}/lib" "-L{compiler.sdk.path}/lib/{build.sdk}" "-L{compiler.sdk.path}/ld" "-L{compiler.libc.path}/lib" "-T{build.flash_ld}" -Wl,--gc-sections -Wl,-wrap,system_restart_local -Wl,-wrap,spi_flash_read
+compiler.c.elf.flags=-g {compiler.warning_flags} -Os -nostdlib -Wl,--no-check-sections -u app_entry {build.float} -Wl,-static "-L{compiler.sdk.path}/lib" "-L{compiler.sdk.path}/lib/{build.sdk}" "-L{compiler.sdk.path}/ld" "-L{compiler.libc.path}/lib" "-Wl,-T{build.flash_ld}" -Wl,--gc-sections -Wl,-wrap,system_restart_local -Wl,-wrap,spi_flash_read
 
 compiler.c.elf.cmd=xtensa-lx106-elf-gcc
-compiler.c.elf.libs=-lhal -lphy -lpp -lnet80211 {build.lwip_lib} -lwpa -lcrypto -lmain -lwps -lbearssl -laxtls -lespnow -lsmartconfig -lairkiss -lwpa2 {build.stdcpp_lib} -lm -lc -lgcc
+compiler.c.elf.libs=-lhal -lphy -lpp -lnet80211 {build.lwip_lib} -lwpa -lcrypto -Wl,--whole-archive -lmain -Wl,--no-whole-archive -lwps -lbearssl -laxtls -lespnow -lsmartconfig -lairkiss -lwpa2 {build.stdcpp_lib} -lm -lc -lgcc
 
 compiler.cpp.cmd=xtensa-lx106-elf-g++
 compiler.cpp.flags=-c {compiler.warning_flags} -Os -g -mlongcalls -mtext-section-literals -fno-rtti -falign-functions=4 -std=c++11 -MMD -ffunction-sections -fdata-sections {build.exception_flags} {build.sslflags}

--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -90,6 +90,10 @@ env.Append(
         "-Wl,--gc-sections",
         "-Wl,-wrap,system_restart_local",
         "-Wl,-wrap,spi_flash_read",
+        # Ensure IRQ handler stuff linked in properly
+        "-Wl,--whole-archive",
+        "-lmain",
+        "-Wl,--no-whole-archive",
         "-u", "app_entry",
         "-u", "_printf_float",
         "-u", "_scanf_float"
@@ -120,7 +124,7 @@ env.Append(
     ],
 
     LIBS=[
-        "hal", "phy", "pp", "net80211", "wpa", "crypto", "main",
+        "hal", "phy", "pp", "net80211", "wpa", "crypto",
         "wps", "bearssl", "axtls", "espnow", "smartconfig", "airkiss", "wpa2",
         "stdc++", "m", "c", "gcc"
     ],


### PR DESCRIPTION
PIO uses GCC in a way that causes the compiler to optimize away the IRQ
vectors (since they're not used in our code itself) in the final build
stage.

We can avoid this by forcing all of libmain to be included in the final
object.  This is a small file, and almost completely related to IRQs, so
space impact is minimal.

Fixes #6087 and
https://github.com/platformio/platform-espressif8266/issues/147