### PR TITLE
Bugfix for stuck in write method of WiFiClient and WiFiClientSecure until the remote peer closed connection

### DIFF
--- a/libraries/ESP8266WiFi/src/include/ClientContext.h
+++ b/libraries/ESP8266WiFi/src/include/ClientContext.h
@@ -455,7 +455,7 @@ protected:
                 break;
             }
 
-            ++_send_waiting;
+            _send_waiting = 1;
             esp_yield();
         } while(true);
         _send_waiting = 0;

--- a/libraries/ESP8266WiFi/src/include/ClientContext.h
+++ b/libraries/ESP8266WiFi/src/include/ClientContext.h
@@ -437,7 +437,7 @@ protected:
     size_t _write_from_source(DataSource* ds)
     {
         assert(_datasource == nullptr);
-        assert(_send_waiting == 0);
+        assert(!_send_waiting);
         _datasource = ds;
         _written = 0;
         _op_start_time = millis();
@@ -455,10 +455,10 @@ protected:
                 break;
             }
 
-            _send_waiting = 1;
+            _send_waiting = true;
             esp_yield();
         } while(true);
-        _send_waiting = 0;
+        _send_waiting = false;
 
         if (_sync)
             wait_until_sent();
@@ -525,8 +525,8 @@ protected:
 
     void _write_some_from_cb()
     {
-        if (_send_waiting == 1) {
-            _send_waiting--;
+        if (_send_waiting) {
+            _send_waiting = false;
             esp_schedule();
         }
     }
@@ -650,7 +650,7 @@ private:
     size_t _written = 0;
     uint32_t _timeout_ms = 5000;
     uint32_t _op_start_time = 0;
-    uint8_t _send_waiting = 0;
+    bool _send_waiting = false;
     uint8_t _connect_pending = 0;
 
     int8_t _refcnt;


### PR DESCRIPTION
Couple of days I was troubleshooting strange behavior with stability of components built on top of WiFiClient and WiFiClientSecure. Finally, I found the root cause of these issues. From time to time it happened that call of write method get stuck until the remote peer closed connection. It seems that root cause bug is present for quite long time in the code. 

When tcp send buffer is full, ClientContext::_write_from_source increments _send_waiting and switch context to NONOS using esp_yield. If something else call esp_schedule (not _write_some_from_cb method in the same instance of ClientContext), the cycle in  _write_from_source is repeated, send buffer is still full and value of _send_waiting is incremented again (thus from this moment _send_waiting>1). Any successful ack on the relevant connection never call esp_schedule because of condition in _write_some_from_cb where _send_waiting is decremented only if it is equal to 1. 

One example when something else can call esp_schedule method is when there are two or more ClientContext instances (e.g. two client connections). Ack on other client context cause esp_schedule and thus resume of write this client context while there is still no space in tcp send buffer.

The simplest solution is set _send_waiting to 1 instead of its increment. As _send_waiting is one Byte it has no sense to change it to bool. 