### PR TITLE
Release 2.5.2

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -5,8 +5,8 @@
 # For more info:
 # https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5-3rd-party-Hardware-specification
 
-name=ESP8266 Boards (2.6.0-dev)
-version=2.6.0-dev
+name=ESP8266 Boards (2.5.2)
+version=2.5.2
 
 # These will be removed by the packager script when doing a JSON release
 runtime.tools.xtensa-lx106-elf-gcc.path={runtime.platform.path}/tools/xtensa-lx106-elf


### PR DESCRIPTION
Changes since 2.5.1 (to 2.5.2)

Core
----
* Add explicit Print::write(char) (#6101)

Build system
----
* Fix typo in elf2bin for QOUT binary generation (#6116)
* Support PIO Wl-T and Arduino -T linking properly (#6095)
* Allow *.cc files to be linked into flash by default (#6100)
* Use custom "ElfToBin" builder for PIO (#6091)
* Fail if generated JSON file cannot be read (#6076)
* Moved 'Dropping' print from stdout to stderr in drop_versions.py (#6071)
* Fix PIO issue when build environment contains spaces (#6119)

Libraries
----
* Remove deadlock when server is not acking our data (#6107)
* Bugfix for stuck in write method of WiFiClient and WiFiClientSecure until the remote peer closed connection (#6104)
* Re-add original SD FAT info access methods (#6092)
* Make FILE_WRITE append in SD.h wrapper (#6106)
* Drop X509 after connection, avoid hang on TLS broken (#6065)