### PR TITLE
Document ISRs need ICACHE_RAM_ATTR before them

### DIFF
--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -32,7 +32,8 @@ pins 9 and 11. These may be used as IO if flash chip works in DIO mode
 Pin interrupts are supported through ``attachInterrupt``,
 ``detachInterrupt`` functions. Interrupts may be attached to any GPIO
 pin, except GPIO16. Standard Arduino interrupt types are supported:
-``CHANGE``, ``RISING``, ``FALLING``.
+``CHANGE``, ``RISING``, ``FALLING``. ISRs need to have
+``ICACHE_RAM_ATTR`` before the function definition.
 
 Analog input
 ------------


### PR DESCRIPTION
Since v2.5.1, ISRs are required to have ICACHE_RAM_ATTR before them, this pull request adds this info to the documentation.