### PR TITLE
Expand BSSL stack to 5750 bytes

### DIFF
--- a/cores/esp8266/StackThunk.cpp
+++ b/cores/esp8266/StackThunk.cpp
@@ -36,7 +36,7 @@ uint32_t *stack_thunk_top = NULL;
 uint32_t *stack_thunk_save = NULL;  /* Saved A1 while in BearSSL */
 uint32_t stack_thunk_refcnt = 0;
 
-#define _stackSize (5600/4)
+#define _stackSize (5750/4)
 #define _stackPaint 0xdeadbeef
 
 /* Add a reference, and allocate the stack if necessary */


### PR DESCRIPTION
Fix #6143 which found a cipher combination which overran the old limit
of 5600 bytes (it required 5700 bytes).