### PR TITLE
Add basic canary check to BSSL stack thunk

### DIFF
--- a/cores/esp8266/StackThunk.cpp
+++ b/cores/esp8266/StackThunk.cpp
@@ -36,7 +36,7 @@ uint32_t *stack_thunk_top = NULL;
 uint32_t *stack_thunk_save = NULL;  /* Saved A1 while in BearSSL */
 uint32_t stack_thunk_refcnt = 0;
 
-#define _stackSize (5750/4)
+#define _stackSize (5748/4)
 #define _stackPaint 0xdeadbeef
 
 /* Add a reference, and allocate the stack if necessary */
@@ -122,6 +122,13 @@ void stack_thunk_dump_stack()
     pos += 4;
   }
   ets_printf("<<<stack<<<\n");
+}
+
+/* Called when the stack overflow is detected by a thunk.  Main memory is corrupted at this point.  Do not return. */
+void stack_thunk_fatal_overflow()
+{
+    ets_printf("FATAL ERROR: BSSL stack overflow\n");
+    abort();
 }
 
 };

--- a/cores/esp8266/StackThunk.h
+++ b/cores/esp8266/StackThunk.h
@@ -41,6 +41,7 @@ extern uint32_t stack_thunk_get_stack_bot();
 extern uint32_t stack_thunk_get_cont_sp();
 extern uint32_t stack_thunk_get_max_usage();
 extern void stack_thunk_dump_stack();
+extern void stack_thunk_fatal_overflow();
 
 // Globals required for thunking operation
 extern uint32_t *stack_thunk_ptr;
@@ -53,6 +54,7 @@ extern uint32_t stack_thunk_refcnt;
 __asm("\n\
 .text\n\
 .literal_position\n\
+.literal .LC_STACK_VALUE"#fcnToThunk", 0xdeadbeef\n\
 \n\
 .text\n\
 .global thunk_"#fcnToThunk"\n\
@@ -67,6 +69,14 @@ thunk_"#fcnToThunk":\n\
   movi a15, stack_thunk_top   /* Load A1(SP) with thunk stack */\n\
   l32i.n a1, a15, 0\n\
   call0 "#fcnToThunk"      /* Do the call */\n\
+  /* Check the stack canary wasn't overwritten */\n\
+  movi a15, stack_thunk_ptr\n\
+  l32i.n a15, a15, 0    /* A15 now has the pointer to stack end*/ \n\
+  l32i.n a15, a15, 0    /* A15 now has contents of last stack entry */\n\
+  l32r a0, .LC_STACK_VALUE"#fcnToThunk" /* A0 now has the check value */\n\
+  beq a0, a15, .L1"#fcnToThunk"\n\
+  call0 stack_thunk_fatal_overflow\n\
+.L1"#fcnToThunk":\n\
   movi a15, stack_thunk_save  /* Restore A1(SP) */\n\
   l32i.n a1, a15, 0\n\
   l32i.n a15, a1, 8     /* Restore the saved registers */\n\


### PR DESCRIPTION
On return from a BSSL call, check that the last element of the stack is
still untouched.  If it is modified, print an error and abort().

Will catch problems like #6143 many times with an informative error
message instead of corrupting the heap and having a random crash
sometime later.