### PR TITLE
Move umm_malloc back to IRAM

### DIFF
--- a/tools/sdk/ld/eagle.app.v6.common.ld.h
+++ b/tools/sdk/ld/eagle.app.v6.common.ld.h
@@ -135,8 +135,8 @@ SECTIONS
   {
     _irom0_text_start = ABSOLUTE(.);
     *(.ver_number)
-    *.c.o( EXCLUDE_FILE (umm_malloc.c.o) .literal*, EXCLUDE_FILE (umm_malloc.c.o) .text* )
-    *.cpp.o(.literal*, .text*)
+    *.c.o(.literal*, .text*)
+    *.cpp.o(EXCLUDE_FILE (umm_malloc.cpp.o) .literal*, EXCLUDE_FILE (umm_malloc.cpp.o) .text*)
     *.cc.o(.literal*, .text*)
 #ifdef VTABLES_IN_FLASH
     *(.rodata._ZTV*) /* C++ vtables */


### PR DESCRIPTION
As found by @mhightower83, umm_malloc was placed in flash during the
.c->.cpp conversion because of a missed linker change.

Adjust the link script to the new name .cpp