### PR TITLE
Added BR_OPT_NO_RENEGOTIATION flag to forbid TLS renegociation

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
@@ -827,6 +827,7 @@ extern "C" {
     uint16_t suites[cipher_cnt];
     memcpy_P(suites, cipher_list, cipher_cnt * sizeof(cipher_list[0]));
     br_ssl_client_zero(cc);
+    br_ssl_engine_add_flags(&cc->eng, BR_OPT_NO_RENEGOTIATION);  // forbid SSL renegociation, as we free the Private Key after handshake
     br_ssl_engine_set_versions(&cc->eng, BR_TLS10, BR_TLS12);
     br_ssl_engine_set_suites(&cc->eng, suites, (sizeof suites) / (sizeof suites[0]));
     br_ssl_client_set_default_rsapub(cc);


### PR DESCRIPTION
Since PR #6065 x509 memory structure are dropped after succesful handshake. This is ok as long as there is no TLS renegociation, otherwise it will crash.

Adding this flag to avoid any TLS renego, as described here: https://bearssl.org/x509.html