### PR TITLE
Update CaptivePortal.ino

### DIFF
--- a/libraries/DNSServer/examples/CaptivePortal/CaptivePortal.ino
+++ b/libraries/DNSServer/examples/CaptivePortal/CaptivePortal.ino
@@ -3,7 +3,7 @@
 #include <ESP8266WebServer.h>
 
 const byte DNS_PORT = 53;
-IPAddress apIP(192, 168, 1, 1);
+IPAddress apIP(172, 217, 28, 1);
 DNSServer dnsServer;
 ESP8266WebServer webServer(80);
 


### PR DESCRIPTION
Android devices have a feature that opens a captive portal right after connecting to an accesspoint. to trigger this feature the target IP Adress cant be in the 192.168.x.x range.

After testing this on three devices and all of them work with the new ip adress and not the old i propose to change it

Tested on:
Xiamoi Redmi Note 4 (Android 7)
Samsung Galaxy A7  (Android 8)
Amazon Fire 7 (Android 5)