### PR TITLE
fix random(min,max) in WMath.cpp

### DIFF
--- a/cores/esp8266/WMath.cpp
+++ b/cores/esp8266/WMath.cpp
@@ -51,7 +51,7 @@ long random(long howsmall, long howbig) {
         return howsmall;
     }
     long diff = howbig - howsmall;
-    return random(diff) + howsmall;
+    return random(diff + 1) + howsmall;
 }
 
 long secureRandom(long howbig) {
@@ -66,7 +66,7 @@ long secureRandom(long howsmall, long howbig) {
         return howsmall;
     }
     long diff = howbig - howsmall;
-    return secureRandom(diff) + howsmall;
+    return secureRandom(diff + 1) + howsmall;
 }
 
 long map(long x, long in_min, long in_max, long out_min, long out_max) {


### PR DESCRIPTION
Update WMath.cpp function
`long random(long howsmall, long howbig)`
`secureRandom(long howsmall, long howbig)`
The previous code is inclusive of argument howsmall, but exclusive of argument howbig. E.g. => random(1, 3) will return only [1 or 2].