### PR TITLE
[ESP8266WiFiSTA] Add get broadcast IP address functionality

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
@@ -499,6 +499,23 @@ IPAddress ESP8266WiFiSTAClass::gatewayIP() {
 }
 
 /**
+ * Get the broadcast ip address.
+ * @return IPAddress broadcastIP
+ */
+IPAddress ESP8266WiFiSTAClass::broadcastIP() {
+    struct ip_info ip;
+    wifi_get_ip_info(STATION_IF, &ip);
+    IPAddress subnetMask(ip.netmask.addr);
+    IPAddress gatewayIP(ip.gw.addr);
+
+    IPAddress broadcastIp;
+    for (int i = 0; i < 4; i++)
+        broadcastIp[i] = ~subnetMask[i] | gatewayIP[i];
+    
+    return broadcastIp;
+}
+
+/**
  * Get the DNS ip address.
  * @param dns_no
  * @return IPAddress DNS Server IP

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
@@ -67,6 +67,7 @@ class ESP8266WiFiSTAClass {
 
         IPAddress subnetMask();
         IPAddress gatewayIP();
+        IPAddress broadcastIP();
         IPAddress dnsIP(uint8_t dns_no = 0);
 
         String hostname();


### PR DESCRIPTION
Calculate the broadcast IP address using the subnet mask and default gateway IP address.