### PR TITLE
Unrelated includes, but necessary Arduino.h missing

### DIFF
--- a/cores/esp8266/interrupts.h
+++ b/cores/esp8266/interrupts.h
@@ -1,12 +1,7 @@
 #ifndef INTERRUPTS_H
 #define INTERRUPTS_H
 
-#include <stddef.h>
-#include <stdint.h>
-extern "C" {
-#include "c_types.h"
-#include "ets_sys.h"
-}
+#include <Arduino.h>
 
 // these auto classes wrap up xt_rsil so your code can be simplier, but can only be
 // used in an ino or cpp files. 


### PR DESCRIPTION
The interrupts.h header includes a few headers that are not strictly needed, but the xt_rsil xt_wsr_ps are in Arduino.h, and that was not included.
Master compiles fine after cleanup.

For instance in EspSoftwareSerial, the unfixed interrupts.h forced inclusion of Arduino.h before interrupts.h, that's confusing to the human reader, this PR fixes that hidden prerequisite.