### PR TITLE
EspSoftwareSerial release 5.2.1

### DIFF
--- a/libraries/esp8266/examples/SerialStress/SerialStress.ino
+++ b/libraries/esp8266/examples/SerialStress/SerialStress.ino
@@ -72,8 +72,8 @@ void setup() {
 
   // using HardwareSerial0 pins,
   // so we can still log to the regular usbserial chips
-  SoftwareSerial* ss = new SoftwareSerial;
-  ss->begin(SSBAUD, 3, 1);
+  SoftwareSerial* ss = new SoftwareSerial(3, 1);
+  ss->begin(SSBAUD);
   ss->enableIntTx(false);
   logger = ss;
   logger->println();

--- a/libraries/esp8266/examples/SerialStress/SerialStress.ino
+++ b/libraries/esp8266/examples/SerialStress/SerialStress.ino
@@ -72,8 +72,8 @@ void setup() {
 
   // using HardwareSerial0 pins,
   // so we can still log to the regular usbserial chips
-  SoftwareSerial* ss = new SoftwareSerial(3, 1);
-  ss->begin(SSBAUD);
+  SoftwareSerial* ss = new SoftwareSerial;
+  ss->begin(SSBAUD, 3, 1);
   ss->enableIntTx(false);
   logger = ss;
   logger->println();


### PR DESCRIPTION
Using the std::bind workaround via FunctionInterrupt while attachInterruptArg is pending.