### PR TITLE
Put InterruptLock (from interrupts.h) into namespace esp8266

### DIFF
--- a/cores/esp8266/Esp.cpp
+++ b/cores/esp8266/Esp.cpp
@@ -200,7 +200,7 @@ void EspClass::restart(void)
 
 uint16_t EspClass::getVcc(void)
 {
-    InterruptLock lock;
+    esp8266::InterruptLock lock;
     (void)lock;
     return system_get_vdd33();
 }

--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -56,7 +56,7 @@ bool schedule_function_us(std::function<bool(void)>&& fn, uint32_t repeat_us, sc
 {
     assert(repeat_us < decltype(scheduled_fn_t::callNow)::neverExpires); //~26800000us (26.8s)
 
-    InterruptLock lockAllInterruptsInThisScope;
+    esp8266::InterruptLock lockAllInterruptsInThisScope;
 
     scheduled_fn_t* item = get_fn_unsafe();
     if (!item)
@@ -104,7 +104,7 @@ void run_scheduled_functions(schedule_e policy)
 
     static bool fence = false;
     {
-        InterruptLock lockAllInterruptsInThisScope;
+        esp8266::InterruptLock lockAllInterruptsInThisScope;
         if (fence)
             // prevent recursive calls from yield()
             return;
@@ -136,7 +136,7 @@ void run_scheduled_functions(schedule_e policy)
             else
             {
                 // function removed from list
-                InterruptLock lockAllInterruptsInThisScope;
+                esp8266::InterruptLock lockAllInterruptsInThisScope;
 
                 if (sFirst == toCall)
                     sFirst = sFirst->mNext;

--- a/cores/esp8266/Updater.cpp
+++ b/cores/esp8266/Updater.cpp
@@ -1,7 +1,6 @@
 #include "Updater.h"
 #include "Arduino.h"
 #include "eboot_command.h"
-#include <interrupts.h>
 #include <esp8266_peri.h>
 
 //#define DEBUG_UPDATER Serial

--- a/cores/esp8266/interrupts.h
+++ b/cores/esp8266/interrupts.h
@@ -16,6 +16,9 @@
 //}
 //
 
+namespace esp8266
+{
+
 class InterruptLock {
 public:
     InterruptLock() {
@@ -53,5 +56,7 @@ private: \
     uint32_t _savedPS; \
     }; \
 _AutoDisableIntr _autoDisableIntr 
+
+} // esp8266
 
 #endif //INTERRUPTS_H


### PR DESCRIPTION
Fix now and future collisions with 3rd party Arduino libraries (currently Adafruit DHT has this issue).