### PR TITLE
device tests: filter weird characters from esp output to python

### DIFF
--- a/tests/device/Makefile
+++ b/tests/device/Makefile
@@ -34,12 +34,18 @@ all: count tests test_report
 
 $(TEST_LIST): | virtualenv $(TEST_CONFIG) $(BUILD_DIR) $(HARDWARE_DIR)
 
-tests: $(TEST_LIST)
+tests: showtestlist $(TEST_LIST)
+
+showtestlist:
+	@echo "-------------------------------- test list:"
+	@echo $(TEST_LIST)
+	@echo "--------------------------------"
 
 $(TEST_LIST): LOCAL_BUILD_DIR=$(BUILD_DIR)/$(notdir $@)
 
 $(TEST_LIST):
-	@echo Running $(words $(TEST_LIST)) tests
+	@echo "--------------------------------"
+	@echo "Running test '$@' of $(words $(TEST_LIST)) tests"
 	$(SILENT)mkdir -p $(LOCAL_BUILD_DIR)
 ifneq ("$(NO_BUILD)","1")
 	@test -n "$(ARDUINO_IDE_PATH)" || (echo "Please export ARDUINO_IDE_PATH" && exit 1)
@@ -85,7 +91,7 @@ ifneq ("$(NO_RUN)","1")
 		--port $(UPLOAD_PORT) \
 		--baud $(UPLOAD_BAUD) \
 		read_flash_status # reset
-	@source $(BS_DIR)/virtualenv/bin/activate && \
+	$(SILENT)source $(BS_DIR)/virtualenv/bin/activate && \
 		$(PYTHON) $(BS_DIR)/runner.py \
 			$(RUNNER_DEBUG_FLAG) \
 			-p $(UPLOAD_PORT) \

--- a/tests/device/libraries/BSTest/runner.py
+++ b/tests/device/libraries/BSTest/runner.py
@@ -29,6 +29,7 @@ except:
 import mock_decorators
 
 debug = False
+#debug = True
 
 sys.path.append(os.path.abspath(__file__))
 
@@ -126,7 +127,7 @@ class BSTestRunner(object):
                 debug_print('test output was:')
                 debug_print(test_output.getvalue())
                 if result == BSTestRunner.SUCCESS:
-                    test_case.stdout = test_output.getvalue()
+                    test_case.stdout = filter(lambda c: ord(c) < 128, test_output.getvalue())
                     print('test "{}" passed'.format(name))
                 else:
                     print('test "{}" failed'.format(name))
@@ -269,7 +270,7 @@ def main():
         ts = run_tests(sp, name, mocks, env_vars)
         if args.output:
             with open(args.output, "w") as f:
-                TestSuite.to_file(f, [ts])
+                TestSuite.to_file(f, [ts], encoding='raw_unicode_escape')
         return 0
 
 if __name__ == '__main__':


### PR DESCRIPTION
this is an issue probably since we switched from esptool.exe to esptool.py.
