### PR TITLE
Update mklittlefs to match library

### DIFF
--- a/package/package_esp8266com_index.template.json
+++ b/package/package_esp8266com_index.template.json
@@ -121,7 +121,7 @@
                   },
                   {
                      "packager": "esp8266",
-                     "version": "2.5.1-1",
+                     "version": "2.5.1-2",
                      "name": "mklittlefs"
                   },
                   {
@@ -302,50 +302,50 @@
                ]
             },
             {
-               "version": "2.5.1-1",
+               "version": "2.5.1-2",
                "name": "mklittlefs",
                "systems": [
                   {
                     "host": "aarch64-linux-gnu",
-                    "url": "https://github.com/earlephilhower/mklittlefs/releases/download/2.5.1-1/aarch64-linux-gnu-mklittlefs-47e8167.tar.gz",
-                    "archiveFileName": "aarch64-linux-gnu-mklittlefs-47e8167.tar.gz",
-                    "checksum": "SHA-256:f5951f0f5c0649992cccbed0146e5ec91dd0a2294f391956bf65c32404a98e96",
-                    "size": "44128"
+                    "url": "https://github.com/earlephilhower/mklittlefs/releases/download/2.5.1-2/aarch64-linux-gnu-mklittlefs-1c43629.tar.gz",
+                    "archiveFileName": "aarch64-linux-gnu-mklittlefs-1c43629.tar.gz",
+                    "checksum": "SHA-256:1d51ab0e5abc9dd243829353a411fccb76e0ce70e3d106d51fb0d3a29dc1b1a7",
+                    "size": "44058"
                   },
                   {
                     "host": "arm-linux-gnueabihf",
-                    "url": "https://github.com/earlephilhower/mklittlefs/releases/download/2.5.1-1/arm-linux-gnueabihf-mklittlefs-47e8167.tar.gz",
-                    "archiveFileName": "arm-linux-gnueabihf-mklittlefs-47e8167.tar.gz",
-                    "checksum": "SHA-256:c5252ce0ae177238efecfa6835950ae12b3cb9dbb7f6d04caedf90afcf0b27b6",
-                    "size": "36590"
+                    "url": "https://github.com/earlephilhower/mklittlefs/releases/download/2.5.1-2/arm-linux-gnueabihf-mklittlefs-1c43629.tar.gz",
+                    "archiveFileName": "arm-linux-gnueabihf-mklittlefs-1c43629.tar.gz",
+                    "checksum": "SHA-256:f316d7638ae41c15d82d7f8ca0815dbdfcd5ab323a84ff0d22420e683841150a",
+                    "size": "36566"
                   },
                   {
                     "host": "i686-mingw32",
-                    "url": "https://github.com/earlephilhower/mklittlefs/releases/download/2.5.1-1/i686-w64-mingw32-mklittlefs-47e8167.zip",
-                    "archiveFileName": "i686-w64-mingw32-mklittlefs-47e8167.zip",
-                    "checksum": "SHA-256:85b2dccc9c00ab2747ffbcee8b949c2dc88747f7a7e14cd0bac5b8a8afe19a4b",
-                    "size": "332150"
+                    "url": "https://github.com/earlephilhower/mklittlefs/releases/download/2.5.1-2/i686-w64-mingw32-mklittlefs-1c43629.zip",
+                    "archiveFileName": "i686-w64-mingw32-mklittlefs-1c43629.zip",
+                    "checksum": "SHA-256:4a926f3c282aefe7895d353797f43ac988a9542f2ba7bfcd6ef98fbe1455569c",
+                    "size": "332058"
                   },
                   {
                     "host": "x86_64-apple-darwin",
-                    "url": "https://github.com/earlephilhower/mklittlefs/releases/download/2.5.1-1/x86_64-apple-darwin14-mklittlefs-47e8167.tar.gz",
-                    "archiveFileName": "x86_64-apple-darwin14-mklittlefs-47e8167.tar.gz",
-                    "checksum": "SHA-256:47ba021a929d62b1f5f85f61c935b23fdc3a07bdf01eb3d5f36f064ff4e42154",
-                    "size": "362031"
+                    "url": "https://github.com/earlephilhower/mklittlefs/releases/download/2.5.1-2/x86_64-apple-darwin14-mklittlefs-1c43629.tar.gz",
+                    "archiveFileName": "x86_64-apple-darwin14-mklittlefs-1c43629.tar.gz",
+                    "checksum": "SHA-256:b3e62af202f0c93a3f6ccacaaaa133afc0dd1c65a8ea492690d02345212bf535",
+                    "size": "362016"
                   },
                   {
                     "host": "x86_64-pc-linux-gnu",
-                    "url": "https://github.com/earlephilhower/mklittlefs/releases/download/2.5.1-1/x86_64-linux-gnu-mklittlefs-47e8167.tar.gz",
-                    "archiveFileName": "x86_64-linux-gnu-mklittlefs-47e8167.tar.gz",
-                    "checksum": "SHA-256:1e93a62cd550aa2fdb874820ead827880b964bea845a6fa053d12ddb8e39f8f0",
-                    "size": "46226"
+                    "url": "https://github.com/earlephilhower/mklittlefs/releases/download/2.5.1-2/x86_64-linux-gnu-mklittlefs-1c43629.tar.gz",
+                    "archiveFileName": "x86_64-linux-gnu-mklittlefs-1c43629.tar.gz",
+                    "checksum": "SHA-256:b5222d220e9396807d736d16ef63983f80dc1d8d1e02fa9736f3b4a3e224cc63",
+                    "size": "46162"
                   },
                   {
                     "host": "x86_64-mingw32",
-                    "url": "https://github.com/earlephilhower/mklittlefs/releases/download/2.5.1-1/x86_64-w64-mingw32-mklittlefs-47e8167.zip",
-                    "archiveFileName": "x86_64-w64-mingw32-mklittlefs-47e8167.zip",
-                    "checksum": "SHA-256:0136c76a710c90b0f47d9f01ab4bf46e93daba9935dd498eb9d8b52f23550626",
-                    "size": "344669"
+                    "url": "https://github.com/earlephilhower/mklittlefs/releases/download/2.5.1-2/x86_64-w64-mingw32-mklittlefs-1c43629.zip",
+                    "archiveFileName": "x86_64-w64-mingw32-mklittlefs-1c43629.zip",
+                    "checksum": "SHA-256:175cdd13a046d6ed06d1ee9eb535100821d8f59adbe16a117d8f80c252e7e62f",
+                    "size": "344578"
                   }
                ]
             }


### PR DESCRIPTION
Fixes #6220

MklittleFS had different configuration options which affected small
files and could result in crashes or corruption on upload.

Update mklittlefs tool to one that matches the config of the current
library.

You will need to re-run tools/get.py to get the new tool version if you
are running from Git.