### PR TITLE
Expand gitignore to cover files created by Visual Micro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ boards.local.txt
 [Rr]elease*/
 .vs/
 __vm/
+*.vcxproj*

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ boards.local.txt
 *.gcda
 *.o
 *.a
+
+#Ignore files built by Visual Studio/Visual Micro
+[Dd]ebug*/
+[Rr]elease*/
+.vs/
+__vm/


### PR DESCRIPTION
The Arduino IDE for Visual Studio in part uses the standard MS Visual Studio project layout.