### PR TITLE
scheduled function: replacing new by malloc needs to initialize complex members

### DIFF
--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -41,12 +41,12 @@ static scheduled_fn_t* get_fn_unsafe ()
     {
         result = sUnused;
         sUnused = sUnused->mNext;
-        result->mNext = nullptr;
     }
     // if no unused items, and count not too high, allocate a new one
     else if (sCount < SCHEDULED_FN_MAX_COUNT)
     {
         result = (scheduled_fn_t*)malloc(sizeof(scheduled_fn_t));
+        new (&result->mFunc) decltype(result->mFunc)();
         if (result)
             ++sCount;
     }
@@ -70,6 +70,7 @@ bool schedule_function (const std::function<void(void)>& fn)
         return false;
 
     item->mFunc = fn;
+    item->mNext = nullptr;
 
     if (sFirst)
         sLast->mNext = item;

--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -48,9 +48,11 @@ static scheduled_fn_t* get_fn_unsafe ()
         // calling malloc instead of new to avoid exception raising while in ISR
         // construct complex members in place (never raises exceptions)
         result = (scheduled_fn_t*)malloc(sizeof(scheduled_fn_t));
-        new (&result->mFunc) decltype(result->mFunc)();
         if (result)
+        {
+            new (&result->mFunc) decltype(result->mFunc)();
             ++sCount;
+        }
     }
     return result;
 }

--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -45,6 +45,8 @@ static scheduled_fn_t* get_fn_unsafe ()
     // if no unused items, and count not too high, allocate a new one
     else if (sCount < SCHEDULED_FN_MAX_COUNT)
     {
+        // calling malloc instead of new to avoid exception raising while in ISR
+        // construct complex members in place (never raises exceptions)
         result = (scheduled_fn_t*)malloc(sizeof(scheduled_fn_t));
         new (&result->mFunc) decltype(result->mFunc)();
         if (result)


### PR DESCRIPTION

Functional was not initialized because of `malloc()` instead of `new`.
First assignment calls destructor on initial value which was not constructed (->frozen,wdt)