### PR TITLE
Clean up code to build under GCC7, fix pgm_read_unaligned

### DIFF
--- a/cores/esp8266/Arduino.h
+++ b/cores/esp8266/Arduino.h
@@ -256,6 +256,7 @@ const int TIM_DIV265 __attribute__((deprecated, weak)) = TIM_DIV256;
 #ifdef __cplusplus
 
 #include <algorithm>
+#include <cmath>
 #include <pgmspace.h>
 
 #include "WCharacter.h"

--- a/cores/esp8266/core_esp8266_app_entry_noextra4k.cpp
+++ b/cores/esp8266/core_esp8266_app_entry_noextra4k.cpp
@@ -27,7 +27,7 @@ extern "C" void call_user_start();
 /* this is the default NONOS-SDK user's heap location */
 static cont_t g_cont __attribute__ ((aligned (16)));
 
-extern "C" void ICACHE_RAM_ATTR app_entry_redefinable(void)
+extern "C" void app_entry_redefinable(void)
 {
     g_pcont = &g_cont;
 

--- a/cores/esp8266/core_esp8266_main.cpp
+++ b/cores/esp8266/core_esp8266_main.cpp
@@ -236,8 +236,8 @@ void init_done() {
 
 */
 
-extern "C" void ICACHE_RAM_ATTR app_entry_redefinable(void) __attribute__((weak));
-extern "C" void ICACHE_RAM_ATTR app_entry_redefinable(void)
+extern "C" void app_entry_redefinable(void) __attribute__((weak));
+extern "C" void app_entry_redefinable(void)
 {
     /* Allocate continuation context on this SYS stack,
        and save pointer to it. */
@@ -248,9 +248,9 @@ extern "C" void ICACHE_RAM_ATTR app_entry_redefinable(void)
     call_user_start();
 }
 
-static void ICACHE_RAM_ATTR app_entry_custom (void) __attribute__((weakref("app_entry_redefinable")));
+static void app_entry_custom (void) __attribute__((weakref("app_entry_redefinable")));
 
-extern "C" void ICACHE_RAM_ATTR app_entry (void)
+extern "C" void app_entry (void)
 {
     return app_entry_custom();
 }

--- a/libraries/ESP8266WiFi/src/include/UdpContext.h
+++ b/libraries/ESP8266WiFi/src/include/UdpContext.h
@@ -84,11 +84,9 @@ public:
 
     void unref()
     {
-        if(this != 0) {
-            DEBUGV(":ur %d\r\n", _refcnt);
-            if(--_refcnt == 0) {
-                delete this;
-            }
+        DEBUGV(":ur %d\r\n", _refcnt);
+        if(--_refcnt == 0) {
+            delete this;
         }
     }
 

--- a/tools/sdk/ld/eagle.app.v6.common.ld.h
+++ b/tools/sdk/ld/eagle.app.v6.common.ld.h
@@ -127,6 +127,8 @@ SECTIONS
     *(.init.literal)
     *(.init)
 
+    *(.text.app_entry*)  /* The main startup code */
+
     /* all functional callers are placed in IRAM (including SPI/IRQ callbacks/etc) here */
     *(.text._ZNKSt8functionIF*EE*)  /* std::function<any(...)>::operator()() const */
   } >iram1_0_seg :iram1_0_phdr


### PR DESCRIPTION
Apply most compatible changes needed to get the core compiling under GCC
7.2 to the main gcc 4.8 tree to ease porting for 3.0.0.

Update pgmspace.h with corrected and optimized unaligned pgm_read
macros.  Now pgm_read_dword in the unaligned case gives proper results
even if optimization is enabled and is also written in assembly and only
1 instruction longer than the pgm_read_byte macro (which also has been
optimized to reduce 1 instruction).  These changes should marginally
shrink code and speed up flash reads accordingly.

The toolchain should/will be rebuilt at a later time with this
optimization to ensure it's used in the libc.a/etc. files.