### PR TITLE
Clean up remaining non-LeaMDNS diffs from gcc4.8 to gcc7.2

### DIFF
--- a/cores/esp8266/IPAddress.h
+++ b/cores/esp8266/IPAddress.h
@@ -36,7 +36,7 @@
 #define IP_SET_TYPE_VAL(x,y) do { (void)0; } while (0)
 #define IP_ANY_TYPE (&ip_addr_any)
 #define IP4_ADDR_ANY IPADDR_ANY
-#define IP4_ADDR_ANY4 IPADDR_ANY
+#define IP4_ADDR_ANY4 IP_ADDR_ANY
 #define IPADDR4_INIT(x) { x }
 #define CONST /* nothing: lwIP-v1 does not use const */
 #define ip4_addr_netcmp ip_addr_netcmp

--- a/libraries/ESP8266NetBIOS/ESP8266NetBIOS.cpp
+++ b/libraries/ESP8266NetBIOS/ESP8266NetBIOS.cpp
@@ -156,7 +156,7 @@ bool ESP8266NetBIOS::begin(const char *name)
     }
     _pcb = udp_new();
     udp_recv(_pcb, &_s_recv, (void *) this);
-    err_t err = udp_bind(_pcb, INADDR_ANY, NBNS_PORT);
+    err_t err = udp_bind(_pcb, (ip_addr_t*)INADDR_ANY, NBNS_PORT);
     if(err != ERR_OK) {
         end();
         return false;


### PR DESCRIPTION
With this change plus the leamdns change, the core will compile
unmodified on GCC 4.8 and GCC 7.2, making keeping the two in sync for
3.0 much easier.