### PR TITLE
Fix Ticker callback casting.

### DIFF
--- a/libraries/Ticker/Ticker.h
+++ b/libraries/Ticker/Ticker.h
@@ -32,7 +32,7 @@ public:
 	Ticker();
 	~Ticker();
 
-	typedef void (*callback_with_arg_t)(void*);
+	typedef void (*callback_with_arg_t)(void *);
 	typedef std::function<void(void)> callback_function_t;
 
 	void attach_scheduled(float seconds, callback_function_t callback)
@@ -64,14 +64,14 @@ public:
 		// C-cast serves two purposes:
 		// static_cast for smaller integer types,
 		// reinterpret_cast + const_cast for pointer types
-		_attach_s(seconds, true, reinterpret_cast<callback_with_arg_t>(callback), (void*)arg);
+		_attach_s(seconds, true, reinterpret_cast<callback_with_arg_t>(callback), reinterpret_cast<void *>(arg));
 	}
 
 	template<typename TArg>
 	void attach_ms(uint32_t milliseconds, void (*callback)(TArg), TArg arg)
 	{
 		static_assert(sizeof(TArg) <= sizeof(void*), "attach() callback argument size must be <= sizeof(void*)");
-		_attach_ms(milliseconds, true, reinterpret_cast<callback_with_arg_t>(callback), (void*)arg);
+		_attach_ms(milliseconds, true, reinterpret_cast<callback_with_arg_t>(callback), reinterpret_cast<void *>(arg));
 	}
 
 	void once_scheduled(float seconds, callback_function_t callback)
@@ -100,14 +100,14 @@ public:
 	void once(float seconds, void (*callback)(TArg), TArg arg)
 	{
 		static_assert(sizeof(TArg) <= sizeof(void*), "attach() callback argument size must be <= sizeof(void*)");
-		_attach_s(seconds, false, reinterpret_cast<callback_with_arg_t>(callback), (void*)arg);
+		_attach_s(seconds, false, reinterpret_cast<callback_with_arg_t>(callback), reinterpret_cast<void *>(arg));
 	}
 
 	template<typename TArg>
 	void once_ms(uint32_t milliseconds, void (*callback)(TArg), TArg arg)
 	{
 		static_assert(sizeof(TArg) <= sizeof(void*), "attach() callback argument size must be <= sizeof(void*)");
-		_attach_ms(milliseconds, false, reinterpret_cast<callback_with_arg_t>(callback), (void*)arg);
+		_attach_ms(milliseconds, false, reinterpret_cast<callback_with_arg_t>(callback), reinterpret_cast<void *>(arg));
 	}
 
 	void detach();
@@ -122,7 +122,6 @@ protected:
 
 private:
 	void _attach_s(float seconds, bool repeat, callback_with_arg_t callback, void* arg);
-	//char _etsTimerMem[sizeof(ETSTimer)];
 	ETSTimer _etsTimer;
 };
 

--- a/libraries/Ticker/examples/TickerParameter/TickerParameter.ino
+++ b/libraries/Ticker/examples/TickerParameter/TickerParameter.ino
@@ -14,9 +14,14 @@
 #include <Ticker.h>
 
 Ticker tickerSetHigh;
+Ticker tickerSetAnalog;
 Ticker tickerSetLow;
 
 void setPin(int state) {
+  digitalWrite(LED_BUILTIN, state);
+}
+
+void setPinChar(char state) {
   digitalWrite(LED_BUILTIN, state);
 }
 
@@ -27,8 +32,9 @@ void setup() {
   // every 25 ms, call setPin(0)
   tickerSetLow.attach_ms(25, setPin, 0);
 
-  // every 26 ms, call setPin(1)
-  tickerSetHigh.attach_ms(26, setPin, 1);
+  // every 26 ms, call setPinChar(1)
+  tickerSetHigh.attach_ms(26, setPinChar, (char)1);
+
 }
 
 void loop() {


### PR DESCRIPTION
Fixes errors seen in #6281 and adds a slight test case to the examples
to ensure no compiler errors.