### PR TITLE
Prepare signing before sketch is compiled

### DIFF
--- a/package/build_boards_manager_package.sh
+++ b/package/build_boards_manager_package.sh
@@ -82,7 +82,7 @@ $SED 's/^tools.esptool.network_cmd=.*//g' | \
 $SED 's/^#tools.esptool.cmd=/tools.esptool.cmd=/g' | \
 $SED 's/^#tools.esptool.network_cmd=/tools.esptool.network_cmd=/g' | \
 $SED 's/tools.mkspiffs.path={runtime.platform.path}\/tools\/mkspiffs/tools.mkspiffs.path=\{runtime.tools.mkspiffs.path\}/g' |\
-$SED 's/recipe.hooks.core.prebuild.2.pattern.*//g' |\
+$SED 's/recipe.hooks.core.prebuild.pattern.*//g' |\
 $SED "s/version=.*/version=$ver/g" |\
 $SED -E "s/name=([a-zA-Z0-9\ -]+).*/name=\1($ver)/g"\
  > $outdir/platform.txt

--- a/platform.txt
+++ b/platform.txt
@@ -83,8 +83,8 @@ compiler.elf2hex.extra_flags=
 
 ## generate file with git version number
 ## needs bash, git, and echo
-recipe.hooks.sketch.prebuild.1.pattern="{runtime.tools.python.path}/python" "{runtime.tools.signing}" --mode header --publickey "{build.source.path}/public.key" --out "{build.path}/core/Updater_Signing.h"
-recipe.hooks.core.prebuild.1.pattern="{runtime.tools.python.path}/python" "{runtime.tools.makecorever}" --build_path "{build.path}" --platform_path "{runtime.platform.path}" --version "unix-{version}"
+recipe.hooks.sketch.prebuild.pattern="{runtime.tools.python.path}/python" "{runtime.tools.signing}" --mode header --publickey "{build.source.path}/public.key" --out "{build.path}/core/Updater_Signing.h"
+recipe.hooks.core.prebuild.pattern="{runtime.tools.python.path}/python" "{runtime.tools.makecorever}" --build_path "{build.path}" --platform_path "{runtime.platform.path}" --version "unix-{version}"
 
 ## Build the app.ld linker file
 recipe.hooks.linking.prelink.1.pattern="{compiler.path}{compiler.c.cmd}" -CC -E -P {build.vtable_flags} "{runtime.platform.path}/tools/sdk/ld/eagle.app.v6.common.ld.h" -o "{build.path}/local.eagle.app.v6.common.ld"

--- a/platform.txt
+++ b/platform.txt
@@ -83,8 +83,8 @@ compiler.elf2hex.extra_flags=
 
 ## generate file with git version number
 ## needs bash, git, and echo
-recipe.hooks.core.prebuild.1.pattern="{runtime.tools.python.path}/python" "{runtime.tools.signing}" --mode header --publickey "{build.source.path}/public.key" --out "{build.path}/core/Updater_Signing.h"
-recipe.hooks.core.prebuild.2.pattern="{runtime.tools.python.path}/python" "{runtime.tools.makecorever}" --build_path "{build.path}" --platform_path "{runtime.platform.path}" --version "unix-{version}"
+recipe.hooks.sketch.prebuild.1.pattern="{runtime.tools.python.path}/python" "{runtime.tools.signing}" --mode header --publickey "{build.source.path}/public.key" --out "{build.path}/core/Updater_Signing.h"
+recipe.hooks.core.prebuild.1.pattern="{runtime.tools.python.path}/python" "{runtime.tools.makecorever}" --build_path "{build.path}" --platform_path "{runtime.platform.path}" --version "unix-{version}"
 
 ## Build the app.ld linker file
 recipe.hooks.linking.prelink.1.pattern="{compiler.path}{compiler.c.cmd}" -CC -E -P {build.vtable_flags} "{runtime.platform.path}/tools/sdk/ld/eagle.app.v6.common.ld.h" -o "{build.path}/local.eagle.app.v6.common.ld"


### PR DESCRIPTION
This makes the right value available in ARDUINO_SIGNING in the sketch.

The order of compilation makes the actual value of the define `ARUDINO_SINGING` inconsistently available to users. It might come in handy to check from user code if signature validation is enabled. This PR changes the moment in the build process the `Updater_Signing.h` file is updated.

Old order of build process:
1. The core contains a place holder file "Updater_Signing.h" with `#define ARDUINO_SIGNING 0`, this file is always readily available.
2. **Compile sketch**
3. Compile libraries
4. **Enabling binary signing** - generates "Updater_Signing.h" with `#define ARDUINO_SIGNING 1`.
5. Compile core

If the sketch is build and no cache is available, `ARDUINO_SIGNING` will be `0` during sketch compilation (step 2). However, if the sketch is build again and a cache of the core is available, `ARDUINO_SIGNING` will be `1`. This makes the resulting binary inconsistent, even though nothing's changed in the code.

Order after this PR:
1. The core contains a place holder file "Updater_Signing.h" with `#define ARDUINO_SIGNING 0`, this file is always readily available.
2. **Enabling binary signing** - generates "Updater_Signing.h" with `#define ARDUINO_SIGNING 1`.
3. **Compile sketch**
4. Compile libraries
5. Compile core

Now the `ARDUINO_SIGNING` is already set to `1` in step 2, before compilation of the sketch.

[Example sketch demonstrating ARDUINO_SIGNING usage](https://github.com/esp8266/Arduino/files/3382829/ESP8266_PR_Sample.txt).

**Essential part of the example**
```
  server.on("/", HTTP_GET, [&]() {
    String content;
    content += F("<html><body>");
    content += F("Signing is ");
    content += (ARDUINO_SIGNING ? F("enabled") : F("disabled"));
    content += F("<br/>");

    if(ARDUINO_SIGNING) {
      content += F("<a href=\"/pubkey\">Public key</a>");
    }

    content += F("</body></html>");
    server.send(200, PSTR("text/html"), content);
  });

  #if ARDUINO_SIGNING
  server.on("/pubkey", HTTP_GET, [&]() {
    server.send_P(200, PSTR("text/plain"), signing_pubkey, sizeof(signing_pubkey));
  });
  #endif
```
