### PR TITLE
fix raise_exception()

### DIFF
--- a/cores/esp8266/core_esp8266_postmortem.cpp
+++ b/cores/esp8266/core_esp8266_postmortem.cpp
@@ -132,7 +132,7 @@ void __wrap_system_restart_local() {
         ets_printf_P(PSTR("\nSoft WDT reset\n"));
     }
     else {
-        ets_printf_P(PSTR("\nGeneric Soft Reset\n"));
+        ets_printf_P(PSTR("\nGeneric Reset\n"));
     }
 
     uint32_t cont_stack_start = (uint32_t) &(g_pcont->stack);

--- a/cores/esp8266/core_esp8266_postmortem.cpp
+++ b/cores/esp8266/core_esp8266_postmortem.cpp
@@ -230,6 +230,10 @@ static void uart1_write_char_d(char c) {
 
 static void raise_exception() {
     __asm__ __volatile__ ("syscall");
+    ets_printf_P(PSTR("exception from IRQ\n"));
+workaround=7; // last REASON_EXT_SYS_RST      = 6
+    __wrap_system_restart_local();
+    ets_printf_P(PSTR("beh\n"));
     while (1); // never reached, needed to satisfy "noreturn" attribute
 }
 

--- a/cores/esp8266/core_esp8266_postmortem.cpp
+++ b/cores/esp8266/core_esp8266_postmortem.cpp
@@ -83,7 +83,7 @@ static void ets_printf_P(const char *str, ...) {
 }
 
 #define FAKE_REASON_NONE 255
-#define FAKE_REASON_USER  254
+#define FAKE_REASON_USER 254
 static int fake_rst_reason = FAKE_REASON_NONE;
 
 void __wrap_system_restart_local() {
@@ -232,7 +232,7 @@ static void uart1_write_char_d(char c) {
 
 static void raise_exception() {
     __asm__ __volatile__ ("syscall"); // no effect?
-    ets_printf_P("\nsoftware exception");
+    ets_printf_P(PSTR("\nsoftware exception"));
     fake_rst_reason = FAKE_REASON_USER;
     __wrap_system_restart_local();
     while (1); // never reached, needed to satisfy "noreturn" attribute

--- a/cores/esp8266/core_esp8266_postmortem.cpp
+++ b/cores/esp8266/core_esp8266_postmortem.cpp
@@ -231,10 +231,13 @@ static void uart1_write_char_d(char c) {
 }
 
 static void raise_exception() {
+    //*((char*)0) = 0; // <- works but with a bad reason
     __asm__ __volatile__ ("syscall"); // no effect?
-    ets_printf_P(PSTR("\nsoftware exception"));
+
     fake_rst_reason = FAKE_REASON_USER;
+    ets_printf_P(PSTR("\nUser exception (panic/abort/assert)"));
     __wrap_system_restart_local();
+
     while (1); // never reached, needed to satisfy "noreturn" attribute
 }
 

--- a/cores/esp8266/core_esp8266_postmortem.cpp
+++ b/cores/esp8266/core_esp8266_postmortem.cpp
@@ -231,12 +231,21 @@ static void uart1_write_char_d(char c) {
 }
 
 static void raise_exception() {
-    //*((char*)0) = 0; // <- works but with a bad reason
+#if 0
+
+    // works but also showing
+    // "Fatal exception 29(StoreProhibitedCause)"
+    *((char*)0) = 0;
+
+#else
+
     __asm__ __volatile__ ("syscall"); // no effect?
 
     fake_rst_reason = FAKE_REASON_USER;
     ets_printf_P(PSTR("\nUser exception (panic/abort/assert)"));
     __wrap_system_restart_local();
+
+#endif
 
     while (1); // never reached, needed to satisfy "noreturn" attribute
 }

--- a/cores/esp8266/core_esp8266_postmortem.cpp
+++ b/cores/esp8266/core_esp8266_postmortem.cpp
@@ -90,6 +90,7 @@ void __wrap_system_restart_local() {
     register uint32_t sp asm("a1");
     uint32_t sp_dump = sp;
 
+#if 0
     if (gdb_present()) {
         /* When GDBStub is present, exceptions are handled by GDBStub,
            but Soft WDT will still call this function.
@@ -98,6 +99,7 @@ void __wrap_system_restart_local() {
            break into GDB here. */
         raise_exception();
     }
+#endif
 
     struct rst_info rst_info;
     memset(&rst_info, 0, sizeof(rst_info));
@@ -239,7 +241,9 @@ static void raise_exception() {
 
 #else
 
-    __asm__ __volatile__ ("syscall"); // no effect?
+    if (gdb_present())
+        //*((char*)0) = 0;
+        __asm__ __volatile__ ("syscall"); // triggers GDB when enabled
 
     fake_rst_reason = FAKE_REASON_USER;
     ets_printf_P(PSTR("\nUser exception (panic/abort/assert)"));


### PR DESCRIPTION
This is a proposal 

~It seems this has no *visible* effect:~
```
__asm__ __volatile__ ("syscall"); // triggers gdb or does nothing
```

On `panic`/`abort`/`assert` called from user context, WDT happens due to the following `while(1);` and finally produces an exception with the right message (after the WDT reason and delay).
On ISR context, only the WDT reason is visible.

This commit permits to avoid WDT and show the right message from both user or ISR context.

Before #4482, `*((int*)0)=0` was used to trigger an hardware exception (similar to the WDT exception we have now, also showing an additional message unrelated to the real cause).

On real hardware exception, `raise_exception()` is not called.

fixes #6283 (thanks @mhightower83)