### PR TITLE
Fix GCC 9.1 warnings (except Ticker.h)

### DIFF
--- a/cores/esp8266/AddrList.h
+++ b/cores/esp8266/AddrList.h
@@ -167,8 +167,6 @@ public:
     bool operator== (AddressListIterator& o) { return netIf.equal(*o); }
     bool operator!= (AddressListIterator& o) { return !netIf.equal(*o); }
 
-    AddressListIterator& operator= (const AddressListIterator& o) { netIf = o.netIf; return *this; }
-
     AddressListIterator operator++ (int)
     {
         AddressListIterator ret = *this;

--- a/cores/esp8266/IPAddress.h
+++ b/cores/esp8266/IPAddress.h
@@ -136,6 +136,7 @@ class IPAddress: public Printable {
         // Overloaded copy operators to allow initialisation of IPAddress objects from other types
         IPAddress& operator=(const uint8_t *address);
         IPAddress& operator=(uint32_t address);
+        IPAddress& operator=(const IPAddress&) = default;
 
         virtual size_t printTo(Print& p) const;
         String toString() const;

--- a/cores/esp8266/core_esp8266_wiring_digital.cpp
+++ b/cores/esp8266/core_esp8266_wiring_digital.cpp
@@ -252,7 +252,7 @@ extern void initPins() {
 
 extern void pinMode(uint8_t pin, uint8_t mode) __attribute__ ((weak, alias("__pinMode")));
 extern void digitalWrite(uint8_t pin, uint8_t val) __attribute__ ((weak, alias("__digitalWrite")));
-extern int digitalRead(uint8_t pin) __attribute__ ((weak, alias("__digitalRead")));
+extern int digitalRead(uint8_t pin) __attribute__ ((weak, alias("__digitalRead"), nothrow));
 extern void attachInterrupt(uint8_t pin, voidFuncPtr handler, int mode) __attribute__ ((weak, alias("__attachInterrupt")));
 extern void attachInterruptArg(uint8_t pin, voidFuncPtrArg handler, void* arg, int mode) __attribute__((weak, alias("__attachInterruptArg")));
 extern void detachInterrupt(uint8_t pin) __attribute__ ((weak, alias("__detachInterrupt")));

--- a/cores/esp8266/gdb_hooks.cpp
+++ b/cores/esp8266/gdb_hooks.cpp
@@ -31,6 +31,11 @@ static bool ICACHE_RAM_ATTR __gdb_no_op()
     return false;
 }
 
+// To save space, don't create a dummy no-op for each GCC, just point to the no-op
+// Need to turn off GCC's checking of parameter types or we'll get many warnings
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattribute-alias"
+#pragma GCC diagnostic ignored "-Wmissing-attributes"
 void gdb_init(void) __attribute__ ((weak, alias("__gdb_no_op")));
 void gdb_do_break(void) __attribute__ ((weak, alias("__gdb_no_op")));
 bool gdb_present(void) __attribute__ ((weak, alias("__gdb_no_op")));
@@ -40,5 +45,6 @@ bool gdbstub_has_uart_isr_control(void) __attribute__ ((weak, alias("__gdb_no_op
 void gdbstub_set_uart_isr_callback(void (*func)(void*, uint8_t), void* arg) __attribute__ ((weak, alias("__gdb_no_op")));
 void gdbstub_write_char(char c) __attribute__ ((weak, alias("__gdb_no_op")));
 void gdbstub_write(const char* buf, size_t size) __attribute__ ((weak, alias("__gdb_no_op")));
+#pragma GCC diagnostic pop
 
 };

--- a/cores/esp8266/gdb_hooks.cpp
+++ b/cores/esp8266/gdb_hooks.cpp
@@ -31,11 +31,6 @@ static bool ICACHE_RAM_ATTR __gdb_no_op()
     return false;
 }
 
-// To save space, don't create a dummy no-op for each GCC, just point to the no-op
-// Need to turn off GCC's checking of parameter types or we'll get many warnings
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wattribute-alias"
-#pragma GCC diagnostic ignored "-Wmissing-attributes"
 void gdb_init(void) __attribute__ ((weak, alias("__gdb_no_op")));
 void gdb_do_break(void) __attribute__ ((weak, alias("__gdb_no_op")));
 bool gdb_present(void) __attribute__ ((weak, alias("__gdb_no_op")));
@@ -45,6 +40,5 @@ bool gdbstub_has_uart_isr_control(void) __attribute__ ((weak, alias("__gdb_no_op
 void gdbstub_set_uart_isr_callback(void (*func)(void*, uint8_t), void* arg) __attribute__ ((weak, alias("__gdb_no_op")));
 void gdbstub_write_char(char c) __attribute__ ((weak, alias("__gdb_no_op")));
 void gdbstub_write(const char* buf, size_t size) __attribute__ ((weak, alias("__gdb_no_op")));
-#pragma GCC diagnostic pop
 
 };

--- a/cores/esp8266/umm_malloc/umm_malloc_cfg.h
+++ b/cores/esp8266/umm_malloc/umm_malloc_cfg.h
@@ -91,7 +91,7 @@ void* realloc_loc (void* p, size_t s, const char* file, int line);
  #define UMM_BEST_FIT
 
 /* Start addresses and the size of the heap */
-extern char _heap_start;
+extern char _heap_start[];
 #define UMM_MALLOC_CFG__HEAP_ADDR   ((uint32_t)&_heap_start)
 #define UMM_MALLOC_CFG__HEAP_SIZE   ((size_t)(0x3fffc000 - UMM_MALLOC_CFG__HEAP_ADDR))
 

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureAxTLS.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureAxTLS.cpp
@@ -473,7 +473,7 @@ extern "C" int __ax_port_read(int fd, uint8_t* buffer, size_t count)
     }
     return cb;
 }
-extern "C" void ax_port_read() __attribute__ ((weak, alias("__ax_port_read")));
+extern "C" int ax_port_read(int fd, uint8_t* buffer, size_t count) __attribute__ ((weak, alias("__ax_port_read")));
 
 extern "C" int __ax_port_write(int fd, uint8_t* buffer, size_t count)
 {
@@ -489,7 +489,7 @@ extern "C" int __ax_port_write(int fd, uint8_t* buffer, size_t count)
     }
     return cb;
 }
-extern "C" void ax_port_write() __attribute__ ((weak, alias("__ax_port_write")));
+extern "C" int ax_port_write(int fd, uint8_t* buffer, size_t count) __attribute__ ((weak, alias("__ax_port_write")));
 
 extern "C" int __ax_get_file(const char *filename, uint8_t **buf)
 {
@@ -497,7 +497,7 @@ extern "C" int __ax_get_file(const char *filename, uint8_t **buf)
     *buf = 0;
     return 0;
 }
-extern "C" void ax_get_file() __attribute__ ((weak, alias("__ax_get_file")));
+extern "C" int ax_get_file(const char *filename, uint8_t **buf) __attribute__ ((weak, alias("__ax_get_file")));
 
 extern "C" void __ax_wdt_feed()
 {

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
@@ -37,6 +37,8 @@ class WiFiClientSecure : public WiFiClient {
     WiFiClientSecure(const WiFiClientSecure &rhs);
     ~WiFiClientSecure() override;
 
+    WiFiClientSecure& operator=(const WiFiClientSecure&) = default; // The shared-ptrs handle themselves automatically
+
     int connect(IPAddress ip, uint16_t port) override;
     int connect(const String& host, uint16_t port) override;
     int connect(const char* name, uint16_t port) override;

--- a/libraries/ESP8266WiFi/src/WiFiServerSecureBearSSL.h
+++ b/libraries/ESP8266WiFi/src/WiFiServerSecureBearSSL.h
@@ -62,6 +62,8 @@ class WiFiServerSecure : public WiFiServer {
     void setServerKeyAndCert(const uint8_t *key, int keyLen, const uint8_t *cert, int certLen);
     void setServerKeyAndCert_P(const uint8_t *key, int keyLen, const uint8_t *cert, int certLen);
 
+    WiFiServerSecure& operator=(const WiFiServerSecure&) = default;
+
   using ClientType = WiFiClientSecure;
 
   private:

--- a/libraries/GDBStub/src/internal/gdbstub.c
+++ b/libraries/GDBStub/src/internal/gdbstub.c
@@ -900,7 +900,7 @@ void ATTR_GDBINIT gdbstub_set_uart_isr_callback(void (*func)(void*, uint8_t), vo
 
 
 //gdbstub initialization routine.
-void ATTR_GDBINIT gdbstub_init() {
+void gdbstub_init() {
 #if GDBSTUB_REDIRECT_CONSOLE_OUTPUT
 	os_install_putc1(gdbstub_semihost_putchar1);
 #endif
@@ -923,4 +923,4 @@ bool ATTR_GDBEXTERNFN gdb_present() {
 }
 
 void ATTR_GDBFN gdb_do_break() { gdbstub_do_break(); }
-void ATTR_GDBINIT gdb_init() __attribute__((alias("gdbstub_init")));
+void gdb_init() __attribute__((alias("gdbstub_init")));

--- a/tools/sdk/ld/eagle.app.v6.common.ld.h
+++ b/tools/sdk/ld/eagle.app.v6.common.ld.h
@@ -129,6 +129,8 @@ SECTIONS
 
     *(.text.app_entry*)  /* The main startup code */
 
+    *(.text.gdbstub*, .text.gdb_init)    /* Any GDB hooks */
+
     /* all functional callers are placed in IRAM (including SPI/IRQ callbacks/etc) here */
     *(.text._ZNKSt8functionIF*EE*)  /* std::function<any(...)>::operator()() const */
   } >iram1_0_seg :iram1_0_phdr

--- a/tools/sdk/libc/xtensa-lx106-elf/include/sys/reent.h
+++ b/tools/sdk/libc/xtensa-lx106-elf/include/sys/reent.h
@@ -402,7 +402,7 @@ struct _reent
   char *_asctime_buf;
 
   /* signal info */
-  void (**(_sig_func))(int);
+  void (**_sig_func)(int);
 
 # ifndef _REENT_GLOBAL_ATEXIT
   /* atexit stuff */


### PR DESCRIPTION
Cleans up all warnings seen w/GCC 9.1 to allow it to track the main
branch more easily until 3.x.

Does not include Ticker.h "fix" of pragmas around a function cast we're
doing that GCC9 doesn't like, that will be addressed separately and
maybe only in the 3.0 branch.