### PR TITLE
Added memory fence to xt_rsil(). Without this the compiler may use

### DIFF
--- a/cores/esp8266/Arduino.h
+++ b/cores/esp8266/Arduino.h
@@ -159,7 +159,7 @@ void ets_intr_unlock();
 // level 15 will disable ALL interrupts,
 // level 0 will enable ALL interrupts,
 //
-#define xt_rsil(level) (__extension__({uint32_t state; __asm__ __volatile__("rsil %0," __STRINGIFY(level) : "=a" (state)); state;}))
+#define xt_rsil(level) (__extension__({uint32_t state; __asm__ __volatile__("rsil %0," __STRINGIFY(level) : "=a" (state) :: "memory"); state;}))
 #define xt_wsr_ps(state)  __asm__ __volatile__("wsr %0,ps; isync" :: "a" (state) : "memory")
 
 #define interrupts() xt_rsil(0)


### PR DESCRIPTION
memory references loaded to registers before the fence, in computation
within the fence. These values could have changed before xt_rsil()
(critical section start) was called.

addresses: https://github.com/esp8266/Arduino/pull/6274#issuecomment-511173751
