### PR TITLE
Make delay() as overridable as yield() already is, and add overridable loop_end()

### DIFF
--- a/cores/esp8266/core_esp8266_main.cpp
+++ b/cores/esp8266/core_esp8266_main.cpp
@@ -121,6 +121,14 @@ extern "C" void optimistic_yield(uint32_t interval_us) {
     }
 }
 
+extern "C" void __loop_end (void)
+{
+    run_scheduled_functions();
+    run_scheduled_recurrent_functions();
+}
+
+extern "C" void loop_end (void) __attribute__ ((weak, alias("__loop_end")));
+
 static void loop_wrapper() {
     static bool setup_done = false;
     preloop_update_frequency();
@@ -129,8 +137,7 @@ static void loop_wrapper() {
         setup_done = true;
     }
     loop();
-    run_scheduled_functions();
-    run_scheduled_recurrent_functions();
+    loop_end();
     esp_schedule();
 }
 

--- a/cores/esp8266/core_esp8266_wiring.cpp
+++ b/cores/esp8266/core_esp8266_wiring.cpp
@@ -43,7 +43,7 @@ void delay_end(void* arg) {
     esp_schedule();
 }
 
-void delay(unsigned long ms) {
+void __delay(unsigned long ms) {
     if(ms) {
         os_timer_setfn(&delay_timer, (os_timer_func_t*) &delay_end, 0);
         os_timer_arm(&delay_timer, ms, ONCE);
@@ -55,6 +55,8 @@ void delay(unsigned long ms) {
         os_timer_disarm(&delay_timer);
     }
 }
+
+void delay(unsigned long ms) __attribute__ ((weak, alias("__delay"))); 
 
 void micros_overflow_tick(void* arg) {
     (void) arg;


### PR DESCRIPTION
The Arduino delay() (at least on AVR) cyclically calls yield(), whereas on Espressif SOCs the delay scheduling is quite different. In order to implement cooperative scheduling in a portable fashion, with global yield() and delay() in large sketches upholding the principle of least surprise, the delay() function must be supplanted. This patch allows that by the usual weak linkage approach.
Additionally, a weakly-linked loop_end() is added, that allows libraries to add special main-loop functionality, in case the Schedule recurrent et cetera functionality is not appropriate.

(EspSoftwareSerial is updated to 5.2.3, containing review results for circular_queue and minor internals)