### PR TITLE
Fix for scheduling recurrent functions while inside scheduled function

### DIFF
--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -62,6 +62,9 @@ static void recycle_fn_unsafe (scheduled_fn_t* fn)
 IRAM_ATTR // (not only) called from ISR
 bool schedule_function (const std::function<void(void)>& fn)
 {
+    if (!fn)
+        return false;
+
     esp8266::InterruptLock lockAllInterruptsInThisScope;
 
     scheduled_fn_t* item = get_fn_unsafe();
@@ -83,6 +86,9 @@ bool schedule_function (const std::function<void(void)>& fn)
 bool schedule_recurrent_function_us (const std::function<bool(void)>& fn, uint32_t repeat_us)
 {
     assert(repeat_us < decltype(recurrent_fn_t::callNow)::neverExpires); //~26800000us (26.8s)
+
+    if (!fn)
+        return false;
 
     esp8266::InterruptLock lockAllInterruptsInThisScope;
 


### PR DESCRIPTION
Dear @d-a-v,
I hope to have come up with a relatively small fix to Schedule that allows scheduling from inside already scheduled functions. I am using this with my CoopTask scheduling, without this patch, the sketch crashed, with it, it performs correctly. I don't see any reason for side-effects, like poorer performance. Memory use is minimally increased by the use of a recurrent_fn_t instance for rFirst instead of the previous pointer, but the logic looked cleaner to me when I began the patch, and I'd rather not change it back if there's no compelling reason.
Could you please review this?