### PR TITLE
operator new: no exception without need for std::nothrow

### DIFF
--- a/cores/esp8266/Arduino.h
+++ b/cores/esp8266/Arduino.h
@@ -33,24 +33,32 @@ extern "C" {
 #include <string.h>
 #include <math.h>
 
-#if defined(__cplusplus) && !defined(__cpp_exceptions)
+#if defined(__cplusplus) \
+ && !defined(__cpp_exceptions) \
+ && !defined(_NEWHACK) \
+ && !defined(CORE_MOCK)
 // this is a hack working with gcc4.8
 // Overload operator new so it can return nullptr instead of throwing an
 // exception without (std::nothrow)`
-// Requirement (or the constructor is called even on nullptr)
+// Requirements: (or the constructor is called even on nullptr)
 // - "noexcept" is needed
 // - "#include <new>" must not be done *before* these definitions
+#define _NEWHACK
+#ifdef _NEW
+#error Arduino.h must be included before other c++ include files
+#endif
 #include <bits/c++config.h>
+extern "C" void* _malloc4newabi (size_t size);
 extern "C++" inline void* operator new (std::size_t size) noexcept
 {
-    return malloc(size);
+    return _malloc4newabi(size);
 }
 extern "C++" inline void* operator new [] (std::size_t size) noexcept
 {
-    return malloc(size);
+    return _malloc4newabi(size);
 }
 #include <new>
-#endif // new nothrow nullptr hack
+#endif // _NEWHACK
 
 #include "stdlib_noniso.h"
 #include "binary.h"

--- a/cores/esp8266/Arduino.h
+++ b/cores/esp8266/Arduino.h
@@ -33,6 +33,25 @@ extern "C" {
 #include <string.h>
 #include <math.h>
 
+#if defined(__cplusplus) && !defined(__cpp_exceptions)
+// this is a hack working with gcc4.8
+// Overload operator new so it can return nullptr instead of throwing an
+// exception without (std::nothrow)`
+// Requirement (or the constructor is called even on nullptr)
+// - "noexcept" is needed
+// - "#include <new>" must not be done *before* these definitions
+#include <bits/c++config.h>
+extern "C++" inline void* operator new (std::size_t size) noexcept
+{
+    return malloc(size);
+}
+extern "C++" inline void* operator new [] (std::size_t size) noexcept
+{
+    return malloc(size);
+}
+#include <new>
+#endif // new nothrow nullptr hack
+
 #include "stdlib_noniso.h"
 #include "binary.h"
 #include "esp8266_peri.h"

--- a/cores/esp8266/Arduino.h
+++ b/cores/esp8266/Arduino.h
@@ -44,7 +44,7 @@ extern "C" {
 // - "noexcept" is needed
 // - "#include <new>" must not be done *before* these definitions
 #define _NEWHACK
-#ifdef _NEW
+#if defined(_NEW) && !defined(_ARDUINO_HIDE_NEWHACK_WARNING)
 #warning Arduino.h must be included before other c++ include files
 #endif
 #include <bits/c++config.h>

--- a/cores/esp8266/Arduino.h
+++ b/cores/esp8266/Arduino.h
@@ -45,7 +45,7 @@ extern "C" {
 // - "#include <new>" must not be done *before* these definitions
 #define _NEWHACK
 #ifdef _NEW
-#error Arduino.h must be included before other c++ include files
+#warning Arduino.h must be included before other c++ include files
 #endif
 #include <bits/c++config.h>
 extern "C" void* _malloc4newabi (size_t size);

--- a/cores/esp8266/FS.cpp
+++ b/cores/esp8266/FS.cpp
@@ -18,6 +18,7 @@
  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include "Arduino.h"
 #include "FS.h"
 #include "FSImpl.h"
 

--- a/cores/esp8266/FunctionalInterrupt.cpp
+++ b/cores/esp8266/FunctionalInterrupt.cpp
@@ -1,6 +1,6 @@
+#include <Arduino.h>
 #include <FunctionalInterrupt.h>
 #include <Schedule.h>
-#include "Arduino.h"
 
 // Duplicate typedefs from core_esp8266_wiring_digital_c
 typedef void (*voidFuncPtr)(void);

--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -1,6 +1,7 @@
 
 #include <assert.h>
 
+#include "Arduino.h"
 #include "Schedule.h"
 #include "PolledTimeout.h"
 #include "interrupts.h"

--- a/cores/esp8266/Schedule.h
+++ b/cores/esp8266/Schedule.h
@@ -1,6 +1,7 @@
 #ifndef ESP_SCHEDULE_H
 #define ESP_SCHEDULE_H
 
+#include <Arduino.h>
 #include <functional>
 
 #define SCHEDULED_FN_MAX_COUNT 32

--- a/cores/esp8266/abi.cpp
+++ b/cores/esp8266/abi.cpp
@@ -68,5 +68,19 @@ extern "C" void __cxa_guard_abort(__guard* pg)
     xt_wsr_ps(reinterpret_cast<guard_t*>(pg)->ps);
 }
 
+// Debugging helper, last allocation which returned NULL
+extern void *umm_last_fail_alloc_addr;
+extern int umm_last_fail_alloc_size;
+
+void* _malloc4newabi (size_t size)
+{
+    void* ret = malloc(size);
+    if (0 != size && 0 == ret) {
+        umm_last_fail_alloc_addr = __builtin_return_address(0);
+        umm_last_fail_alloc_size = size;
+    }
+    return ret;
+}
+
 // TODO: rebuild windows toolchain to make this unnecessary:
 void* __dso_handle;

--- a/cores/esp8266/spiffs_api.cpp
+++ b/cores/esp8266/spiffs_api.cpp
@@ -21,6 +21,7 @@
  License along with this library; if not, write to the Free Software
  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
+#include "Arduino.h"
 #include "spiffs_api.h"
 
 using namespace fs;

--- a/libraries/ArduinoOTA/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/ArduinoOTA.cpp
@@ -1,6 +1,7 @@
 #ifndef LWIP_OPEN_SRC
 #define LWIP_OPEN_SRC
 #endif
+#include <Arduino.h>
 #include <functional>
 #include <WiFiUdp.h>
 #include "ArduinoOTA.h"

--- a/libraries/ESP8266LLMNR/ESP8266LLMNR.cpp
+++ b/libraries/ESP8266LLMNR/ESP8266LLMNR.cpp
@@ -36,8 +36,8 @@
  */
 
 #include <debug.h>
-#include <functional>
 #include <ESP8266LLMNR.h>
+#include <functional>
 #include <WiFiUdp.h>
 
 extern "C" {

--- a/libraries/ESP8266WiFi/src/BearSSLHelpers.cpp
+++ b/libraries/ESP8266WiFi/src/BearSSLHelpers.cpp
@@ -20,13 +20,14 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#include <Arduino.h>
+
 #include <memory>
 #include <vector>
 #include <bearssl/bearssl.h>
 #include <pgmspace.h>
 #include <stdlib.h>
 #include <string.h>
-#include <Arduino.h>
 #include <StackThunk.h>
 #include "BearSSLHelpers.h"
 

--- a/libraries/ESP8266WiFi/src/ESP8266WiFi.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFi.h
@@ -22,6 +22,8 @@
 #ifndef WiFi_h
 #define WiFi_h
 
+#include <Arduino.h>
+
 #include <stdint.h>
 
 extern "C" {

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiAP.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiAP.cpp
@@ -22,6 +22,7 @@
 
  */
 
+#include <Arduino.h>
 #include "ESP8266WiFi.h"
 #include "ESP8266WiFiGeneric.h"
 #include "ESP8266WiFiAP.h"

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -22,6 +22,8 @@
 
  */
 
+#include <Arduino.h>
+
 #include <list>
 #include <string.h>
 #include "ESP8266WiFi.h"

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA-WPS.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA-WPS.cpp
@@ -22,6 +22,7 @@
 
  */
 
+#include <Arduino.h>
 
 #include "ESP8266WiFi.h"
 #include "ESP8266WiFiGeneric.h"

--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -22,6 +22,8 @@
 
 #define LWIP_INTERNAL
 
+#include <Arduino.h>
+
 extern "C"
 {
     #include "include/wl_definitions.h"

--- a/libraries/ESP8266WiFi/src/WiFiClient.h
+++ b/libraries/ESP8266WiFi/src/WiFiClient.h
@@ -21,8 +21,8 @@
 
 #ifndef wificlient_h
 #define wificlient_h
-#include <memory>
 #include "Arduino.h"
+#include <memory>
 #include "Print.h"
 #include "Client.h"
 #include "IPAddress.h"

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureAxTLS.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureAxTLS.cpp
@@ -22,6 +22,8 @@
 
 #define LWIP_INTERNAL
 
+#include <Arduino.h>
+
 #include "debug.h"
 #include "ESP8266WiFi.h"
 #include "WiFiClientSecure.h"

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
@@ -22,6 +22,8 @@
 
 #define LWIP_INTERNAL
 
+#include <Arduino.h>
+
 #include <list>
 #include <errno.h>
 #include <algorithm>

--- a/libraries/ESP8266WiFi/src/WiFiServer.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiServer.cpp
@@ -28,6 +28,8 @@ extern "C" {
     #include "ets_sys.h"
 }
 
+#include <Arduino.h>
+
 #include "debug.h"
 #include "ESP8266WiFi.h"
 #include "WiFiClient.h"

--- a/libraries/ESP8266WiFi/src/WiFiServerSecureBearSSL.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiServerSecureBearSSL.cpp
@@ -26,6 +26,8 @@ extern "C" {
 #include "ets_sys.h"
 }
 
+#include <Arduino.h>
+
 #include <StackThunk.h>
 #include "debug.h"
 #include "ESP8266WiFi.h"

--- a/libraries/ESP8266WiFi/src/WiFiUdp.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiUdp.cpp
@@ -21,6 +21,8 @@
 */
 
 #define LWIP_INTERNAL
+
+#include <Arduino.h>
 #include <functional>
 
 extern "C"

--- a/libraries/ESP8266WiFi/src/WiFiUdp.h
+++ b/libraries/ESP8266WiFi/src/WiFiUdp.h
@@ -22,8 +22,13 @@
 #ifndef WIFIUDP_H
 #define WIFIUDP_H
 
+#include <Arduino.h>
+
+#include <functional>
+
 #include <Udp.h>
 #include <include/slist.h>
+
 
 #define UDP_TX_PACKET_MAX_SIZE 8192
 

--- a/libraries/ESP8266mDNS/src/LEAmDNS.h
+++ b/libraries/ESP8266mDNS/src/LEAmDNS.h
@@ -102,7 +102,6 @@
 #ifndef MDNS_H
 #define MDNS_H
 
-#include <functional>   // for UdpContext.h
 #include "WiFiUdp.h"
 #include "lwip/udp.h"
 #include "debug.h"


### PR DESCRIPTION
Overloads `operator new` so it can return `nullptr` instead of throwing an exception without need for `(std::nothrow)`.

Requirement: `<Arduino.h>` must be included prior to any c++ header file

addresses #6269 @mcspr @mhightower83 