### PR TITLE
Add `using fs::SPIFFSConfig` to FS.h

### DIFF
--- a/cores/esp8266/FS.h
+++ b/cores/esp8266/FS.h
@@ -241,6 +241,7 @@ using fs::SeekCur;
 using fs::SeekEnd;
 using fs::FSInfo;
 using fs::FSConfig;
+using fs::SPIFFSConfig;
 #endif //FS_NO_GLOBALS
 
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SPIFFS)


### PR DESCRIPTION
The SPIFFS config object was defined in FS.h in its own namespace, but
is not made easily available like other SPIFFS and FS objects because of
a missing `using` statement.  Add it in FS.h

Fixes #6322