### PR TITLE
enable PUYA flash chips support by default 

### DIFF
--- a/cores/esp8266/Arduino.h
+++ b/cores/esp8266/Arduino.h
@@ -303,6 +303,10 @@ extern "C" void configTime(long timezone, int daylightOffset_sec,
 
 #include "pins_arduino.h"
 
+#ifndef PUYA_SUPPORT
+#define PUYA_SUPPORT 1
+#endif
+
 #endif
 
 #ifdef DEBUG_ESP_OOM


### PR DESCRIPTION
It can be disabled with` -DPUYA_SUPPORT=0`.

closes #6359 