### PR TITLE
Refactor HardwareSerial.cpp for consistent use of PolledTimeout

### DIFF
--- a/cores/esp8266/HardwareSerial.cpp
+++ b/cores/esp8266/HardwareSerial.cpp
@@ -121,9 +121,9 @@ unsigned long HardwareSerial::testBaudrate()
 
 unsigned long HardwareSerial::detectBaudrate(time_t timeoutMillis)
 {
-    time_t startMillis = millis();
+    esp8266::polledTimeout::oneShotFastMs timeOut(timeoutMillis);
     unsigned long detectedBaudrate;
-    while ((time_t) millis() - startMillis < timeoutMillis) {
+    while (!timeOut) {
         if ((detectedBaudrate = testBaudrate())) {
           break;
         }


### PR DESCRIPTION
After quick review comment, both of the two places in HardwareSerial.cpp shall use PolledTimeout - fixed by this PR.