### PR TITLE
Uncouple uart from GDBStub library

### DIFF
--- a/cores/esp8266/uart.cpp
+++ b/cores/esp8266/uart.cpp
@@ -42,7 +42,7 @@
  */
 #include "Arduino.h"
 #include <pgmspace.h>
-#include "../../libraries/GDBStub/src/GDBStub.h"
+#include "gdb_hooks.h"
 #include "uart.h"
 #include "esp8266_peri.h"
 #include "user_interface.h"


### PR DESCRIPTION
The core should never reference a library. This uses the pre-existing header file in the core to get the GDB function prototypes instead of referencing an external library with a hard-coded relative path.