### PR TITLE
Fix <sys/syslimits.h> for <climits>

### DIFF
--- a/tools/sdk/libc/xtensa-lx106-elf/include/sys/syslimits.h
+++ b/tools/sdk/libc/xtensa-lx106-elf/include/sys/syslimits.h
@@ -37,7 +37,9 @@
 #ifndef _SYS_SYSLIMITS_H_
 #define _SYS_SYSLIMITS_H_
 
+#ifndef ARG_MAX
 #define	ARG_MAX			65536	/* max bytes for an exec function */
+#endif
 #ifndef CHILD_MAX
 #define	CHILD_MAX		   40	/* max simultaneous processes */
 #endif
@@ -49,7 +51,9 @@
 #ifndef OPEN_MAX
 #define	OPEN_MAX		   64	/* max open files per process */
 #endif
+#ifndef PATH_MAX
 #define	PATH_MAX		 1024	/* max bytes in pathname */
+#endif
 #define	PIPE_BUF		  512	/* max bytes for atomic pipe writes */
 #define	IOV_MAX			 1024	/* max elements in i/o vector */
 


### PR DESCRIPTION
It's not possible to compile a file containing only `#include <climits>`
because `ARG_MAX` and `PATH_MAX` are defined by `<limits.h>` and then
`<sys/syslimits.h>` attempts to redefine them.