### PR TITLE
Fix APConfig DHCP IP start in debug

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiAP.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiAP.cpp
@@ -229,7 +229,7 @@ bool ESP8266WiFiAPClass::softAPConfig(IPAddress local_ip, IPAddress gateway, IPA
 
     struct dhcps_lease dhcp_lease;
     IPAddress ip = local_ip;
-    ip[3] += 99;
+    ip[3] += 1;
     dhcp_lease.start_ip.addr = ip.v4();
     DEBUG_WIFI("[APConfig] DHCP IP start: %s\n", ip.toString().c_str());
 


### PR DESCRIPTION
Debug tells the " [APConfig] DHCP IP start: 192.168.1.100 " but the real start ip is 192.168.1.2