### PR TITLE
Set method _connectSSL as protected

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
@@ -193,6 +193,9 @@ class WiFiClientSecure : public WiFiClient {
     // AxTLS API deprecated section end
     /////////////////////////////////////
 
+  protected:
+    bool _connectSSL(const char *hostName); // Do initial SSL handshake
+
   private:
     void _clear();
     void _clearAuthenticationSettings();
@@ -243,7 +246,6 @@ class WiFiClientSecure : public WiFiClient {
     size_t _recvapp_len;
 
     bool _clientConnected(); // Is the underlying socket alive?
-    bool _connectSSL(const char *hostName); // Do initial SSL handshake
     void _freeSSL();
     int _run_until(unsigned target, bool blocking = true);
     size_t _write(const uint8_t *buf, size_t size, bool pmem);


### PR DESCRIPTION
This commit makes it possible to create derived classes that connect to destination hosts through proxy servers (socks5 etc).