### PR TITLE
ClientContext: rework an assert

### DIFF
--- a/libraries/ESP8266WiFi/src/include/ClientContext.h
+++ b/libraries/ESP8266WiFi/src/include/ClientContext.h
@@ -609,9 +609,10 @@ protected:
         (void) err;
         (void) pcb;
         assert(pcb == _pcb);
-        assert(_delaying);
-        _delaying = false;
-        esp_schedule(); // break current delay()
+        if (_delaying) {
+            _delaying = false;
+            esp_schedule(); // break current delay()
+        }
         return ERR_OK;
     }
 


### PR DESCRIPTION
... and standardizes processing of `_delaying` over lwIP callbacks
fixes #6459 
