### PR TITLE
Inline ESP::getCycleCount() to make it safe to call from ISRs

### DIFF
--- a/cores/esp8266/Esp.h
+++ b/cores/esp8266/Esp.h
@@ -201,9 +201,10 @@ class EspClass {
         bool eraseConfig();
 
 #ifndef CORE_MOCK
-        inline
-#endif
+        inline uint32_t getCycleCount() __attribute__((always_inline));
+#else
         uint32_t getCycleCount();
+#endif
 };
 
 #ifndef CORE_MOCK

--- a/cores/esp8266/core_esp8266_features.h
+++ b/cores/esp8266/core_esp8266_features.h
@@ -85,6 +85,7 @@ namespace arduino
 #define xt_rsil(level) (__extension__({uint32_t state; __asm__ __volatile__("rsil %0," __STRINGIFY(level) : "=a" (state) :: "memory"); state;}))
 #define xt_wsr_ps(state)  __asm__ __volatile__("wsr %0,ps; isync" :: "a" (state) : "memory")
 
+inline uint32_t esp_get_cycle_count() __attribute__((always_inline));
 inline uint32_t esp_get_cycle_count() {
   uint32_t ccount;
   __asm__ __volatile__("rsr %0,ccount":"=a"(ccount));


### PR DESCRIPTION
Someone found out that on the ESP32, ESP::getCycleCount() is not ISR safe.
While the fix, inlining the machine code, is taken from ESP8266, on this platform I suggest additionally adding
`__attribute__((always_inline))`
to the respective functions to force the GCC to inline, no matter what compiler options are used by the build process.

This is a port of the fixing PR https://github.com/espressif/arduino-esp32/pull/3165.