### PR TITLE
Wakeup delayed scheduling

### DIFF
--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -24,7 +24,7 @@ struct recurrent_fn_t
     recurrent_fn_t* mNext = nullptr;
     mRecFuncT mFunc;
     esp8266::polledTimeout::periodicFastUs callNow;
-    std::function<bool()> alarm = nullptr;
+    std::function<bool(void)> alarm = nullptr;
     recurrent_fn_t(esp8266::polledTimeout::periodicFastUs interval) : callNow(interval) { }
 };
 
@@ -86,7 +86,7 @@ bool schedule_function (const std::function<void(void)>& fn)
 }
 
 bool schedule_recurrent_function_us(const std::function<bool(void)>& fn,
-    uint32_t repeat_us, std::function<bool()> alarm)
+    uint32_t repeat_us, std::function<bool(void)> alarm)
 {
     assert(repeat_us < decltype(recurrent_fn_t::callNow)::neverExpires); //~26800000us (26.8s)
 

--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -36,7 +36,7 @@ static recurrent_fn_t* rLast = &rFirst;
 // or if none are available allocates a new one,
 // or nullptr if limit is reached
 IRAM_ATTR // called from ISR
-static scheduled_fn_t* get_fn_unsafe()
+static scheduled_fn_t* get_fn_unsafe ()
 {
     scheduled_fn_t* result = nullptr;
     // try to get an item from unused items list
@@ -55,7 +55,7 @@ static scheduled_fn_t* get_fn_unsafe()
     return result;
 }
 
-static void recycle_fn_unsafe(scheduled_fn_t* fn)
+static void recycle_fn_unsafe (scheduled_fn_t* fn)
 {
     fn->mFunc = nullptr; // special overload in c++ std lib
     fn->mNext = sUnused;
@@ -63,7 +63,7 @@ static void recycle_fn_unsafe(scheduled_fn_t* fn)
 }
 
 IRAM_ATTR // (not only) called from ISR
-bool schedule_function(const std::function<void(void)>& fn)
+bool schedule_function (const std::function<void(void)>& fn)
 {
     if (!fn)
         return false;
@@ -111,7 +111,7 @@ bool schedule_recurrent_function_us(const std::function<bool(void)>& fn, uint32_
     return true;
 }
 
-void run_scheduled_functions()
+void run_scheduled_functions ()
 {
     esp8266::polledTimeout::periodicFastMs yieldNow(100); // yield every 100ms
 
@@ -186,10 +186,11 @@ void run_scheduled_recurrent_functions()
 
             auto to_ditch = current;
 
+            // removing rLast
+            if (rLast == current) rLast = prev;
+
             current = current->mNext;
             prev->mNext = current;
-            // removing rLast
-            if (!current) rLast = prev;
 
             delete(to_ditch);
         }

--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -169,8 +169,9 @@ void run_scheduled_recurrent_functions ()
         const bool wakeupToken = current->wakeupToken && current->wakeupToken->load();
         const bool wakeup = current->wakeupTokenCmp != wakeupToken;
         if (wakeup) current->wakeupTokenCmp = wakeupToken;
+        bool callNow = current->callNow;
 
-        if ((wakeup || current->callNow) && !current->mFunc())
+        if ((wakeup || callNow) && !current->mFunc())
         {
             // remove function from stack
             esp8266::InterruptLock lockAllInterruptsInThisScope;

--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -62,6 +62,9 @@ static void recycle_fn_unsafe (scheduled_fn_t* fn)
 IRAM_ATTR // (not only) called from ISR
 bool schedule_function (const std::function<void(void)>& fn)
 {
+    if (!fn)
+        return false;
+
     esp8266::InterruptLock lockAllInterruptsInThisScope;
 
     scheduled_fn_t* item = get_fn_unsafe();
@@ -83,6 +86,9 @@ bool schedule_function (const std::function<void(void)>& fn)
 bool schedule_recurrent_function_us (const std::function<bool(void)>& fn, uint32_t repeat_us)
 {
     assert(repeat_us < decltype(recurrent_fn_t::callNow)::neverExpires); //~26800000us (26.8s)
+
+    if (!fn)
+        return false;
 
     esp8266::InterruptLock lockAllInterruptsInThisScope;
 

--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -86,7 +86,7 @@ bool schedule_function(const std::function<void(void)>& fn)
 }
 
 bool schedule_recurrent_function_us(const std::function<bool(void)>& fn,
-    uint32_t repeat_us, std::function<bool(void)> alarm)
+    uint32_t repeat_us, const std::function<bool(void)>& alarm)
 {
     assert(repeat_us < decltype(recurrent_fn_t::callNow)::neverExpires); //~26800000us (26.8s)
 
@@ -98,7 +98,7 @@ bool schedule_recurrent_function_us(const std::function<bool(void)>& fn,
         return false;
 
     item->mFunc = fn;
-    item->alarm = std::move(alarm);
+    item->alarm = alarm;
 
     esp8266::InterruptLock lockAllInterruptsInThisScope;
 

--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -202,7 +202,7 @@ void run_scheduled_recurrent_functions()
 
         if (yieldNow)
         {
-            // because scheduled function might last too long for watchdog etc,
+            // because scheduled functions might last too long for watchdog etc,
             // this is yield() in cont stack:
             esp_schedule();
             cont_yield(g_pcont);

--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -176,8 +176,6 @@ void run_scheduled_recurrent_functions()
         done = current == stop;
         const bool wakeupToken = current->wakeupToken && current->wakeupToken->load();
         const bool wakeup = current->wakeupTokenCmp != wakeupToken;
-        if (wakeup)
-            current->wakeupTokenCmp = wakeupToken;
         bool callNow = current->callNow;
 
         if ((wakeup || callNow) && !current->mFunc())

--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -176,7 +176,8 @@ void run_scheduled_recurrent_functions()
         done = current == stop;
         const bool wakeupToken = current->wakeupToken && current->wakeupToken->load();
         const bool wakeup = current->wakeupTokenCmp != wakeupToken;
-        if (wakeup) current->wakeupTokenCmp = wakeupToken;
+        if (wakeup)
+            current->wakeupTokenCmp = wakeupToken;
         bool callNow = current->callNow;
 
         if ((wakeup || callNow) && !current->mFunc())
@@ -187,7 +188,8 @@ void run_scheduled_recurrent_functions()
             auto to_ditch = current;
 
             // removing rLast
-            if (rLast == current) rLast = prev;
+            if (rLast == current)
+                rLast = prev;
 
             current = current->mNext;
             prev->mNext = current;

--- a/cores/esp8266/Schedule.h
+++ b/cores/esp8266/Schedule.h
@@ -2,7 +2,6 @@
 #define ESP_SCHEDULE_H
 
 #include <functional>
-#include <atomic>
 
 #define SCHEDULED_FN_MAX_COUNT 32
 
@@ -62,7 +61,7 @@ void run_scheduled_functions();
 // * If alarm is used, anytime during scheduling when it returns true,
 //   any remaining delay from repeat_us is disregarded, and fn is executed.
 bool schedule_recurrent_function_us(const std::function<bool(void)>& fn,
-    uint32_t repeat_us, std::function<bool()> alarm = nullptr);
+    uint32_t repeat_us, std::function<bool(void)> alarm = nullptr);
 
 // Test recurrence and run recurrent scheduled functions.
 // (internally called at every `yield()` and `loop()`)

--- a/cores/esp8266/Schedule.h
+++ b/cores/esp8266/Schedule.h
@@ -59,11 +59,10 @@ void run_scheduled_functions();
 //   functions.  However a user function returning false will cancel itself.
 // * Long running operations or yield() or delay() are not allowed in the
 //   recurrent function.
-// * If a wakeupToken is used, anytime during scheduling when its value differs
-//   from the original one in this call, any remaining delay from repeat_us is
-//   disregarded, and fn is executed.
+// * If alarm is used, anytime during scheduling when it returns true,
+//   any remaining delay from repeat_us is disregarded, and fn is executed.
 bool schedule_recurrent_function_us(const std::function<bool(void)>& fn,
-    uint32_t repeat_us, const std::atomic<bool>* wakeupToken = nullptr);
+    uint32_t repeat_us, std::function<bool()> alarm = nullptr);
 
 // Test recurrence and run recurrent scheduled functions.
 // (internally called at every `yield()` and `loop()`)

--- a/cores/esp8266/Schedule.h
+++ b/cores/esp8266/Schedule.h
@@ -37,7 +37,7 @@
 // * Run the lambda only once next time.
 // * A scheduled function can schedule a function.
 
-bool schedule_function(const std::function<void(void)> & fn);
+bool schedule_function (const std::function<void(void)>& fn);
 
 // Run all scheduled functions.
 // Use this function if your are not using `loop`,

--- a/cores/esp8266/Schedule.h
+++ b/cores/esp8266/Schedule.h
@@ -59,8 +59,8 @@ void run_scheduled_functions();
 //   functions.  However a user function returning false will cancel itself.
 // * Long running operations or yield() or delay() are not allowed in the
 //   recurrent function.
-// * If a wakeupToken is used, if its value toggles, any remaining
-//   delay is disregarded, and the lambda runs on the next scheduler iteration.
+// * If a wakeupToken is used, anytime during scheduling when its value differs from that
+//   during this call, any remaining delay from repeat_us is disregarded, and fn is executed.
 bool schedule_recurrent_function_us(const std::function<bool(void)>& fn, uint32_t repeat_us,
     const std::atomic<bool>* wakeupToken = nullptr);
 

--- a/cores/esp8266/Schedule.h
+++ b/cores/esp8266/Schedule.h
@@ -2,6 +2,7 @@
 #define ESP_SCHEDULE_H
 
 #include <functional>
+#include <atomic>
 
 #define SCHEDULED_FN_MAX_COUNT 32
 
@@ -60,8 +61,10 @@ void run_scheduled_functions();
 //   recurrent function.
 // * A recurrent function currently must not schedule another recurrent
 //   functions.
-
-bool schedule_recurrent_function_us (const std::function<bool(void)>& fn, uint32_t repeat_us);
+// * If a wakeupToken is used, if its value toggles, any remaining
+//   delay is disregarded, and the lambda runs on the next scheduler iteration.
+bool schedule_recurrent_function_us (const std::function<bool(void)>& fn, uint32_t repeat_us,
+    const std::atomic<bool>* wakeupToken = nullptr);
 
 // Test recurrence and run recurrent scheduled functions.
 // (internally called at every `yield()` and `loop()`)

--- a/cores/esp8266/Schedule.h
+++ b/cores/esp8266/Schedule.h
@@ -61,7 +61,7 @@ void run_scheduled_functions();
 // * If alarm is used, anytime during scheduling when it returns true,
 //   any remaining delay from repeat_us is disregarded, and fn is executed.
 bool schedule_recurrent_function_us(const std::function<bool(void)>& fn,
-    uint32_t repeat_us, std::function<bool(void)> alarm = nullptr);
+    uint32_t repeat_us, const std::function<bool(void)>& alarm = nullptr);
 
 // Test recurrence and run recurrent scheduled functions.
 // (internally called at every `yield()` and `loop()`)

--- a/cores/esp8266/Schedule.h
+++ b/cores/esp8266/Schedule.h
@@ -11,7 +11,7 @@
 // in user stack (called CONT stack) without the common restrictions from
 // system context.  Details are below.
 
-// The purpose of recurrent scheduled function is to independantly execute
+// The purpose of recurrent scheduled function is to independently execute
 // user code in CONT stack on a regular basis.
 // It has been introduced with ethernet service in mind, it can also be used
 // for all libraries in the need of a regular `libdaemon_handlestuff()`.
@@ -37,7 +37,7 @@
 // * Run the lambda only once next time.
 // * A scheduled function can schedule a function.
 
-bool schedule_function (const std::function<void(void)>& fn);
+bool schedule_function(const std::function<void(void)> & fn);
 
 // Run all scheduled functions.
 // Use this function if your are not using `loop`,
@@ -59,16 +59,14 @@ void run_scheduled_functions();
 //   functions.  However a user function returning false will cancel itself.
 // * Long running operations or yield() or delay() are not allowed in the
 //   recurrent function.
-// * A recurrent function currently must not schedule another recurrent
-//   functions.
 // * If a wakeupToken is used, if its value toggles, any remaining
 //   delay is disregarded, and the lambda runs on the next scheduler iteration.
-bool schedule_recurrent_function_us (const std::function<bool(void)>& fn, uint32_t repeat_us,
+bool schedule_recurrent_function_us(const std::function<bool(void)>& fn, uint32_t repeat_us,
     const std::atomic<bool>* wakeupToken = nullptr);
 
 // Test recurrence and run recurrent scheduled functions.
 // (internally called at every `yield()` and `loop()`)
 
-void run_scheduled_recurrent_functions ();
+void run_scheduled_recurrent_functions();
 
 #endif // ESP_SCHEDULE_H

--- a/cores/esp8266/Schedule.h
+++ b/cores/esp8266/Schedule.h
@@ -59,10 +59,11 @@ void run_scheduled_functions();
 //   functions.  However a user function returning false will cancel itself.
 // * Long running operations or yield() or delay() are not allowed in the
 //   recurrent function.
-// * If a wakeupToken is used, anytime during scheduling when its value differs from that
-//   during this call, any remaining delay from repeat_us is disregarded, and fn is executed.
-bool schedule_recurrent_function_us(const std::function<bool(void)>& fn, uint32_t repeat_us,
-    const std::atomic<bool>* wakeupToken = nullptr);
+// * If a wakeupToken is used, anytime during scheduling when its value differs
+//   from the original one in this call, any remaining delay from repeat_us is
+//   disregarded, and fn is executed.
+bool schedule_recurrent_function_us(const std::function<bool(void)>& fn,
+    uint32_t repeat_us, const std::atomic<bool>* wakeupToken = nullptr);
 
 // Test recurrence and run recurrent scheduled functions.
 // (internally called at every `yield()` and `loop()`)


### PR DESCRIPTION
I have a use case for the ESP8266 core schedule class that needs the capability to let recurrent, delayed functions run immediately on the next iteration of the scheduler without taking into account a remaining delay or repeat timeout.
This PR [originally added] an optional parameter `const std::atomic<bool>* wakeupToken` to `schedule_recurrent_function_us()`. This was changed, after review comments, into a `std::function<bool(void)>` alarm polling callback.
The remaining delay or the logic by which the scheduled function return value determines whether to keep scheduling for execution or to be removed from scheduling is unaltered by the alarm.

[CoopTask release 2.0.0](https://github.com/dok-net/CoopTask/releases/tag/2.0.0) depends on this PR for it's new Semaphore with milliseconds timeout.