### PR TITLE
Run makecorever.py before specific prebuild hooks.

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -85,7 +85,7 @@ compiler.elf2hex.extra_flags=
 ## generate file with git version number
 ## needs git
 recipe.hooks.sketch.prebuild.pattern="{runtime.tools.python3.path}/python3" "{runtime.tools.signing}" --mode header --publickey "{build.source.path}/public.key" --out "{build.path}/core/Updater_Signing.h"
-recipe.hooks.core.prebuild.pattern="{runtime.tools.python3.path}/python3" "{runtime.tools.makecorever}" --build_path "{build.path}" --platform_path "{runtime.platform.path}" --version "unix-{version}"
+recipe.hooks.prebuild.10.pattern="{runtime.tools.python3.path}/python3" "{runtime.tools.makecorever}" --build_path "{build.path}" --platform_path "{runtime.platform.path}" --version "unix-{version}"
 
 ## Build the app.ld linker file
 recipe.hooks.linking.prelink.1.pattern="{compiler.path}{compiler.c.cmd}" -CC -E -P {build.vtable_flags} "{runtime.platform.path}/tools/sdk/ld/eagle.app.v6.common.ld.h" -o "{build.path}/local.eagle.app.v6.common.ld"


### PR DESCRIPTION
When a sketch needs information that is in `core_version.h`, you
have to build a dummy sketch 1st to get `core_version.h` created.
Since `core_version.h` is created after the sketch is compiled.

Moved rebuild recipe hook for running `makecorever.py` core to run
before all _specific_ prebuild hooks. While this form of prebuild hook
is not explicitly listed, it seems like an intuitive expectation and works.

Recipie hooks of this form:
```
recipe.hooks.prebuild.NUMBER.pattern=...
```
build before recipies of this form:
```
recipe.hooks.SPECIFIC.prebuild.NUMBER.pattern=...
```
where `SPECIFIC` would be: sketch, libraries, core, linking, ...