### PR TITLE
Fix tool name to point to proper JSON entry

### DIFF
--- a/package/package_esp8266com_index.template.json
+++ b/package/package_esp8266com_index.template.json
@@ -138,7 +138,7 @@
          "tools": [
             {
                "version": "3.7.2-post1",
-               "name": "python",
+               "name": "python3",
                "systems": [
                   {
                      "host": "x86_64-mingw32",


### PR DESCRIPTION
Python renamed to python3, but not in package JSON.