### PR TITLE
ESP8266WiFi examples - 'traditional' WiFiWebClient example

### DIFF
--- a/libraries/ESP8266WiFi/examples/WiFiWebClient/WiFiWebClient.ino
+++ b/libraries/ESP8266WiFi/examples/WiFiWebClient/WiFiWebClient.ino
@@ -1,0 +1,77 @@
+/*
+  Web client
+
+  This sketch connects to a website (http://arduino.cc)
+  using the WiFi module.
+
+  created 13 July 2010
+  by dlf (Metodo2 srl)
+  modified 31 May 2012
+  by Tom Igoe
+*/
+
+#include <ESP8266WiFi.h>
+
+#ifndef STASSID
+#define STASSID "your-ssid"
+#define STAPSK  "your-password"
+#endif
+
+const char* ssid = STASSID;
+const char* pass = STAPSK;
+
+const char* server = "arduino.cc";
+
+WiFiClient client;
+
+void setup() {
+  Serial.begin(115200);
+  delay(10);
+
+  Serial.println();
+  Serial.print("Connecting to ");
+  Serial.println(ssid);
+
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(ssid, pass);
+
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println("");
+  Serial.println("WiFi connected");
+
+  Serial.println("Starting connection to server...");
+  if (client.connect(server, 80)) {
+    Serial.println("connected to server");
+    // Make a HTTP request:
+    client.println("GET /asciilogo.txt HTTP/1.1");
+    client.print("Host: ");
+    client.println(server);
+    client.println("Connection: close");
+    client.println();
+  }
+}
+
+void loop() {
+
+  // if there are incoming bytes available
+  // from the server, read them and print them:
+  while (client.available()) {
+    char c = client.read();
+    Serial.write(c);
+  }
+
+  // if the server's disconnected, stop the client:
+  if (!client.connected()) {
+    Serial.println();
+    Serial.println("disconnecting from server.");
+    client.stop();
+
+    // do nothing forevermore:
+    while (true) {
+      delay(100);
+    }
+  }
+}


### PR DESCRIPTION
some commits last year modified the WiFiClient example to a non HTTP example.

The (WiFi)WebClient example started in Arduino Ethernet library and most Arduino networking libraries have some modification of it. I modified the version from WiFiNINA library for ESP8266WiFi and used my favourite test address, the Arduino ASCII logo because it is readable on Serial Monitor. 
