### PR TITLE
Update EEPROM library documentation

### DIFF
--- a/doc/libraries.rst
+++ b/doc/libraries.rst
@@ -29,6 +29,8 @@ EEPROM library uses one sector of flash located just after the SPIFFS.
 
 `Three examples <https://github.com/esp8266/Arduino/tree/master/libraries/EEPROM>`__  included.
 
+Note that the sector needs to be re-flashed every time the changed EEPROM data needs to be saved, thus will wear out the flash memory very quickly even if small amounts of data are written. Consider using one of the EEPROM libraries mentioned down below.
+
 I2C (Wire library)
 ------------------
 
@@ -141,14 +143,6 @@ Servo
 
 This library exposes the ability to control RC (hobby) servo motors. It will support up to 24 servos on any available output pin. By default the first 12 servos will use Timer0 and currently this will not interfere with any other support. Servo counts above 12 will use Timer1 and features that use it will be affected. While many RC servo motors will accept the 3.3V IO data pin from a ESP8266, most will not be able to run off 3.3v and will require another power source that matches their specifications. Make sure to connect the grounds between the ESP8266 and the servo motor power supply.
 
-Improved EEPROM library for ESP (ESP_EEPROM)
---------------------------------------------
-
-An improved EEPROM library for ESPxxxx.  Uses flash memory as per the standard ESP EEPROM library but reduces reflash - so reducing wear and improving commit() performance.  
-
-As actions on the flash need to stop the interrupts, an EEPROM reflash could noticably affect anything using PWM, etc.
-
-
 Other libraries (not included with the IDE)
 -------------------------------------------
 
@@ -189,3 +183,4 @@ Libraries that don't rely on low-level access to AVR registers should work well.
 -  `MFRC522 <https://github.com/miguelbalboa/rfid>`__ - A library for using the Mifare RC522 RFID-tag reader/writer.
 -  `Ping <https://github.com/dancol90/ESP8266Ping>`__ - lets the ESP8266 ping a remote machine.
 -  `AsyncPing <https://github.com/akaJes/AsyncPing>`__ - fully asynchronous Ping library (have full ping statistic and hardware MAC address).
+-  `ESP_EEPROM <https://github.com/jwrw/ESP_EEPROM>`__ - This library writes a new copy of your data when you save (commit) it and keeps track of where in the sector the most recent copy is kept using a bitmap. The flash sector only needs to be erased when there is no more space for copies in the flash sector

--- a/doc/libraries.rst
+++ b/doc/libraries.rst
@@ -183,4 +183,5 @@ Libraries that don't rely on low-level access to AVR registers should work well.
 -  `MFRC522 <https://github.com/miguelbalboa/rfid>`__ - A library for using the Mifare RC522 RFID-tag reader/writer.
 -  `Ping <https://github.com/dancol90/ESP8266Ping>`__ - lets the ESP8266 ping a remote machine.
 -  `AsyncPing <https://github.com/akaJes/AsyncPing>`__ - fully asynchronous Ping library (have full ping statistic and hardware MAC address).
--  `ESP_EEPROM <https://github.com/jwrw/ESP_EEPROM>`__ - This library writes a new copy of your data when you save (commit) it and keeps track of where in the sector the most recent copy is kept using a bitmap. The flash sector only needs to be erased when there is no more space for copies in the flash sector
+-  `ESP_EEPROM <https://github.com/jwrw/ESP_EEPROM>`__ - This library writes a new copy of your data when you save (commit) it and keeps track of where in the sector the most recent copy is kept using a bitmap. The flash sector only needs to be erased when there is no more space for copies in the flash sector.
+-  `EEPROM Rotate <https://github.com/xoseperez/eeprom_rotate>`__ - Instead of using a single sector to persist the data from the emulated EEPROM, this library uses a number of sectors to do so: a sector pool.


### PR DESCRIPTION
As mentioned by @d-a-v https://github.com/esp8266/Arduino/pull/6537#issuecomment-533703771

> This rotate library was proposed here as a PR and instead moved to an arduino library #4493
> [doc](https://arduino-esp8266.readthedocs.io/en/latest/libraries.html#improved-eeprom-library-for-esp-esp-eeprom) (should be moved to the 'Other libraries' paragraph below?)
> https://github.com/jwrw/ESP_EEPROM

Update EEPROM description with mention of current implementation limitations
Move ESP_EEPROM to Other Libraries, update description from upstream README
Add https://github.com/xoseperez/eeprom_rotate to Other Libraries as an alternative

Note:
Both libraries depend on #6543 
ESP_EEPROM is reimplementing EEPROM class, so the default address would be different from the original library when upgrading to 2.6.0 (for example, using 4m 1m spiffs address is shifted by 1 sector)
Rotate library only uses it for automatic calculation, which user can override. Default ("last") sector is calculated by subtracting 5 sectors from ESP::getFlashChipSize()