### PR TITLE
Add EEPROM debug printouts, error check to example

### DIFF
--- a/libraries/EEPROM/EEPROM.cpp
+++ b/libraries/EEPROM/EEPROM.cpp
@@ -21,6 +21,7 @@
 
 #include "Arduino.h"
 #include "EEPROM.h"
+#include "debug.h"
 
 extern "C" {
 #include "c_types.h"
@@ -49,10 +50,14 @@ EEPROMClass::EEPROMClass(void)
 }
 
 void EEPROMClass::begin(size_t size) {
-  if (size <= 0)
+  if (size <= 0) {
+    DEBUGV("EEPROMClass::begin error, size == 0\n");
     return;
-  if (size > SPI_FLASH_SEC_SIZE)
+  }
+  if (size > SPI_FLASH_SEC_SIZE) {
+    DEBUGV("EEPROMClass::begin error, %d > %d\n", size, SPI_FLASH_SEC_SIZE);
     size = SPI_FLASH_SEC_SIZE;
+  }
 
   size = (size + 3) & (~3);
 
@@ -67,8 +72,11 @@ void EEPROMClass::begin(size_t size) {
   _size = size;
 
   noInterrupts();
-  spi_flash_read(_sector * SPI_FLASH_SEC_SIZE, reinterpret_cast<uint32_t*>(_data), _size);
+  auto ret = spi_flash_read(_sector * SPI_FLASH_SEC_SIZE, reinterpret_cast<uint32_t*>(_data), _size);
   interrupts();
+  if (ret != SPI_FLASH_RESULT_OK) {
+    DEBUGV("EEPROMClass::begin spi_flash_read failed,  %d\n", (int)ret);
+  }
 
   _dirty = false; //make sure dirty is cleared in case begin() is called 2nd+ time
 }
@@ -88,19 +96,27 @@ void EEPROMClass::end() {
 
 
 uint8_t EEPROMClass::read(int const address) {
-  if (address < 0 || (size_t)address >= _size)
+  if (address < 0 || (size_t)address >= _size) {
+    DEBUGV("EEPROMClass::read error, address %d > %d or %d < 0\n", address, _size, address);
     return 0;
-  if(!_data)
+  }
+  if (!_data) {
+    DEBUGV("EEPROMClass::read without ::begin\n");
     return 0;
+  }
 
   return _data[address];
 }
 
 void EEPROMClass::write(int const address, uint8_t const value) {
-  if (address < 0 || (size_t)address >= _size)
+  if (address < 0 || (size_t)address >= _size) {
+    DEBUGV("EEPROMClass::write error, address %d > %d or %d < 0\n", address, _size, address);
     return;
-  if(!_data)
+  }
+  if(!_data) {
+    DEBUGV("EEPROMClass::read without ::begin\n");
     return;
+  }
 
   // Optimise _dirty. Only flagged if data written is different.
   uint8_t* pData = &_data[address];
@@ -121,13 +137,19 @@ bool EEPROMClass::commit() {
     return false;
 
   noInterrupts();
-  if(spi_flash_erase_sector(_sector) == SPI_FLASH_RESULT_OK) {
-    if(spi_flash_write(_sector * SPI_FLASH_SEC_SIZE, reinterpret_cast<uint32_t*>(_data), _size) == SPI_FLASH_RESULT_OK) {
+  auto flashret = spi_flash_erase_sector(_sector);
+  if (flashret == SPI_FLASH_RESULT_OK) {
+    flashret = spi_flash_write(_sector * SPI_FLASH_SEC_SIZE, reinterpret_cast<uint32_t*>(_data), _size);
+    if (flashret == SPI_FLASH_RESULT_OK) {
       _dirty = false;
       ret = true;
     }
   }
   interrupts();
+
+  if (flashret != SPI_FLASH_RESULT_OK) {
+    DEBUGV("EEPROMClass::commit failed,  %d\n", (int)flashret);
+  }
 
   return ret;
 }

--- a/libraries/EEPROM/examples/eeprom_read/eeprom_read.ino
+++ b/libraries/EEPROM/examples/eeprom_read/eeprom_read.ino
@@ -14,7 +14,7 @@ byte value;
 
 void setup() {
   // initialize serial and wait for port to open:
-  Serial.begin(9600);
+  Serial.begin(115200);
   while (!Serial) {
     ; // wait for serial port to connect. Needed for Leonardo only
   }

--- a/libraries/EEPROM/examples/eeprom_write/eeprom_write.ino
+++ b/libraries/EEPROM/examples/eeprom_write/eeprom_write.ino
@@ -13,6 +13,7 @@
 int addr = 0;
 
 void setup() {
+  Serial.begin(115200);
   EEPROM.begin(512);
 }
 
@@ -33,7 +34,11 @@ void loop() {
   addr = addr + 1;
   if (addr == 512) {
     addr = 0;
-    EEPROM.commit();
+    if (EEPROM.commit()) {
+      Serial.println("EEPROM successfully written");
+    } else {
+      Serial.println("ERROR!  EEPROM write failed");
+    }
   }
 
   delay(100);

--- a/libraries/EEPROM/examples/eeprom_write/eeprom_write.ino
+++ b/libraries/EEPROM/examples/eeprom_write/eeprom_write.ino
@@ -35,9 +35,9 @@ void loop() {
   if (addr == 512) {
     addr = 0;
     if (EEPROM.commit()) {
-      Serial.println("EEPROM successfully written");
+      Serial.println("EEPROM successfully committed");
     } else {
-      Serial.println("ERROR!  EEPROM write failed");
+      Serial.println("ERROR! EEPROM commit failed");
     }
   }
 


### PR DESCRIPTION
Add debug printouts when EEPROM calls fail, even if the API doesn't
allow returning a success/failure code.

Adds error checking to the example to make it explicit that when you
call EEPROM::commit(), you need to look at the result code in your code.

Fixes #6551 , or would fix it if there was error checking in the MCVE.