### PR TITLE
Fix setURL() handling of path-only parameters

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -536,8 +536,8 @@ void HTTPClient::setTimeout(uint16_t timeout)
 bool HTTPClient::setURL(String url)
 {
     // if the new location is only a path then only update the URI
-    if (_location.startsWith("/")) {
-        _uri = _location;
+    if (url && url[0] == '/') {
+        _uri = url;
         clear();
         return true;
     }


### PR DESCRIPTION
The function accidentally compared the current location instead
of the passed in (new) location, which didn't match intended
logic and the code comment.