### PR TITLE
Base64::encode : const correctness / String by reference passing

### DIFF
--- a/cores/esp8266/base64.cpp
+++ b/cores/esp8266/base64.cpp
@@ -31,11 +31,11 @@ extern "C" {
 
 /**
  * convert input data to base64
- * @param data uint8_t *
+ * @param data const uint8_t *
  * @param length size_t
  * @return String
  */
-String base64::encode(uint8_t * data, size_t length, bool doNewLines) {
+String base64::encode(const uint8_t * data, size_t length, bool doNewLines) {
     // base64 needs more size then the source data, use cencode.h macros
     size_t size = ((doNewLines ? base64_encode_expected_len(length)
                                : base64_encode_expected_len_nonewlines(length)) + 1);
@@ -62,10 +62,10 @@ String base64::encode(uint8_t * data, size_t length, bool doNewLines) {
 
 /**
  * convert input data to base64
- * @param text String
+ * @param text const String&
  * @return String
  */
-String base64::encode(String text, bool doNewLines) {
-    return base64::encode((uint8_t *) text.c_str(), text.length(), doNewLines);
+String base64::encode(const String& text, bool doNewLines) {
+    return base64::encode((const uint8_t *) text.c_str(), text.length(), doNewLines);
 }
 

--- a/cores/esp8266/base64.h
+++ b/cores/esp8266/base64.h
@@ -30,8 +30,8 @@ class base64 {
         // NOTE: The default behaviour of backend (lib64)
         // is to add a newline every 72 (encoded) characters output.
         // This may 'break' longer uris and json variables
-        static String encode(uint8_t * data, size_t length, bool doNewLines = true);
-        static String encode(String text, bool doNewLines = true);
+        static String encode(const uint8_t * data, size_t length, bool doNewLines = true);
+        static String encode(const String& text, bool doNewLines = true);
     private:
 };
 


### PR DESCRIPTION
This is another instance in the core library where we pass in read-only
parameters as pass-by-value, where in the case of String() that
is inefficient as it involves copy-constructor/temp string creations.