### PR TITLE
Update EEPROM.cpp

### DIFF
--- a/libraries/EEPROM/EEPROM.cpp
+++ b/libraries/EEPROM/EEPROM.cpp
@@ -22,6 +22,7 @@
 #include "Arduino.h"
 #include "EEPROM.h"
 #include "debug.h"
+#include "interrupts.h"
 
 extern "C" {
 #include "c_types.h"

--- a/libraries/EEPROM/EEPROM.cpp
+++ b/libraries/EEPROM/EEPROM.cpp
@@ -134,7 +134,7 @@ bool EEPROMClass::commit() {
     return false;
 
   if (ESP.flashEraseSector(_sector)) {
-    if (ESP.flashWirite(_sector * SPI_FLASH_SEC_SIZE, reinterpret_cast<uint32_t*>(_data), _size)) {
+    if (ESP.flashWrite(_sector * SPI_FLASH_SEC_SIZE, reinterpret_cast<uint32_t*>(_data), _size)) {
       _dirty = false;
       return true;
     }

--- a/libraries/EEPROM/EEPROM.cpp
+++ b/libraries/EEPROM/EEPROM.cpp
@@ -22,7 +22,6 @@
 #include "Arduino.h"
 #include "EEPROM.h"
 #include "debug.h"
-#include "interrupts.h"
 
 extern "C" {
 #include "c_types.h"


### PR DESCRIPTION
use InterruptLock class for scoped interrupts instead of blindly disabling/enabling interrupts, which doesn't support nesting nor restore previous state.
Fixes #6589 