### PR TITLE
Add simple RLE compression for ArduinoOTA

### DIFF
--- a/libraries/ArduinoOTA/ArduinoOTA.h
+++ b/libraries/ArduinoOTA/ArduinoOTA.h
@@ -75,6 +75,7 @@ class ArduinoOTAClass
     String _nonce;
     UdpContext *_udp_ota;
     bool _initialized;
+    bool _useCompression;
     bool _rebootOnSuccess;
     bool _useMDNS;
     ota_state_t _state;


### PR DESCRIPTION
When uploading large, sparse filesystems, there are often many repeated,
empty sectors.  These take a long time to transmit, even over WiFi.

Implement a basic RLE compression in espota.py (and only use it if it
actually saves upload size), and a simple decompressor in ArduinoOTA.

The actual flash update image is decompressed as received to the staging
location, so the bootloader/etc. do not need to be aware of it (i.e. a
1MB filesystem still takes 1MB of flash in the update area, even if it
only took 100KB to upload it).

Fixes #4277
