### PR TITLE
Remove duplication and incompatible declarations in sntp.h

### DIFF
--- a/libraries/esp8266/examples/NTP-TZ-DST/NTP-TZ-DST.ino
+++ b/libraries/esp8266/examples/NTP-TZ-DST/NTP-TZ-DST.ino
@@ -51,11 +51,7 @@
 #include <time.h>                       // time() ctime()
 #include <sys/time.h>                   // struct timeval
 
-#if LWIP_VERSION_MAJOR == 1
-#include <lwip/sntp.h>                  // sntp_servermode_dhcp()
-#else
-#include <lwip/apps/sntp.h>             // sntp_servermode_dhcp()
-#endif
+#include <sntp.h>                       // sntp_servermode_dhcp()
 
 // for testing purpose:
 extern "C" int clock_gettime(clockid_t unused, struct timespec *tp);

--- a/tools/sdk/include/sntp.h
+++ b/tools/sdk/include/sntp.h
@@ -5,11 +5,10 @@
 
 #include "lwip/init.h"
 #include "lwip/ip_addr.h"
-
 #if LWIP_VERSION_MAJOR == 1
-#define ipv4_addr_t ip_addr_t
+#include "lwip/sntp.h"
 #else
-typedef struct ip4_addr ipv4_addr_t;
+#include "lwip/apps/sntp.h"
 #endif
 
 #ifdef __cplusplus
@@ -32,48 +31,6 @@ sint8 sntp_get_timezone(void);
  * SNTP set time_zone (default GMT + 8)
  */
 bool sntp_set_timezone(sint8 timezone);
-/**
- * Initialize this module.
- * Send out request instantly or after SNTP_STARTUP_DELAY(_FUNC).
- */
-void sntp_init(void);
-/**
- * Stop this module.
- */
-void sntp_stop(void);
-/**
- * Initialize one of the NTP servers by IP address
- *
- * @param numdns the index of the NTP server to set must be < SNTP_MAX_SERVERS
- * @param dnsserver IP address of the NTP server to set
- */
-void sntp_setserver(unsigned char idx, ipv4_addr_t *addr);
-/**
- * Obtain one of the currently configured by IP address (or DHCP) NTP servers
- *
- * @param numdns the index of the NTP server
- * @return IP address of the indexed NTP server or "ipv4_addr_any" if the NTP
- *         server has not been configured by address (or at all).
- */
-ipv4_addr_t sntp_getserver(unsigned char idx);
-/**
- * Initialize one of the NTP servers by name
- *
- * @param numdns the index of the NTP server to set must be < SNTP_MAX_SERVERS,now sdk support SNTP_MAX_SERVERS = 3
- * @param dnsserver DNS name of the NTP server to set, to be resolved at contact time
- */
-void sntp_setservername(unsigned char idx, char *server);
-/**
- * Obtain one of the currently configured by name NTP servers.
- *
- * @param numdns the index of the NTP server
- * @return IP address of the indexed NTP server or NULL if the NTP
- *         server has not been configured by name (or at all)
- */
-char *sntp_getservername(unsigned char idx);
-
-#define sntp_servermode_dhcp(x)
-
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This removes definitions relating to the built-in SNTP client that
are LwIP v1 specific. Instead of duplicating these pull in the
LwIP header that correspond to the required functions depending on
the version of the stack being used.

Without this fix calls to sntp_getserver() work but return invalid
data and can lead to stack exhaustion.

Update the NTP-TZ-DST example to use the Arduino sntp.h header
rather than duplicate the conditional checks to use the LwIP header.

Tests:
 - Build against a simple SNTP API demonstratin app and all
   LwIP configurations. Verify that the app runs for an extended
   period and that the expected results are obtained.