### PR TITLE
Expand NTP-TZ-DST example to list SNTP servers

### DIFF
--- a/libraries/esp8266/examples/NTP-TZ-DST/NTP-TZ-DST.ino
+++ b/libraries/esp8266/examples/NTP-TZ-DST/NTP-TZ-DST.ino
@@ -134,6 +134,25 @@ void showTime() {
   Serial.print("ctime:     ");
   Serial.print(ctime(&now));
 
+#if LWIP_VERSION_MAJOR > 1
+  // LwIP v2 is able to list more details about the currently configured SNTP servers
+  for (int i = 0; i < SNTP_MAX_SERVERS; i++) {
+    IPAddress sntp = *sntp_getserver(i);
+    const char* name = sntp_getservername(i);
+    if (sntp.isSet()) {
+      Serial.printf("sntp%d:     ", i);
+      if (name) {
+        Serial.printf("%s (%s) ", name, sntp.toString().c_str());
+      } else {
+        Serial.printf("%s ", sntp.toString().c_str());
+      }
+      Serial.printf("IPv6: %s Reachability: %o\n",
+                    sntp.isV6() ? "Yes" : "No",
+                    sntp_getreachability(i));
+    }
+  }
+#endif
+
   Serial.println();
 }
 


### PR DESCRIPTION
This change expands the NTP-TZ-DST example to list the active
SNTP servers. It lists the IP address server name (if used) and
reachability in ntpq style octal format.

Tests:
 - Build against all LwIP stack configurations and correct
   operation with a single SNTP server
 - Vary connectivity to an SNTP server and check reachability
   updates
 - Configure 3 SNTP servers by name
 - With a patched LwIP stack that supports simultaneous DHCP
   and DHCPv6 SNTP servers check that all server details are
   listed and update correctly during operation