### PR TITLE
MDNS: fix legacy unicast responses

### DIFF
--- a/libraries/ESP8266mDNS/src/LEAmDNS_Control.cpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS_Control.cpp
@@ -245,7 +245,7 @@ bool MDNSResponder::_parseQuery(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHea
                          ((wifi_get_ip_info(STATION_IF, &IPInfo_Local)) &&
                           (ip4_addr_netcmp(&IPInfo_Remote.ip, &IPInfo_Local.ip, &IPInfo_Local.netmask))))) { // Remote IP in STATION's subnet
 
-                        DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Legacy query from local host %s!\n"), IPAddress(m_pUDPContext->getRemoteAddress()).toString().c_str()););
+                        DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _parseQuery: Legacy query from local host %s, id %u!\n"), IPAddress(m_pUDPContext->getRemoteAddress()).toString().c_str(), p_MsgHeader.m_u16ID););
 
                         sendParameter.m_u16ID = p_MsgHeader.m_u16ID;
                         sendParameter.m_bLegacyQuery = true;

--- a/libraries/ESP8266mDNS/src/LEAmDNS_Transfer.cpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS_Transfer.cpp
@@ -141,7 +141,7 @@ bool MDNSResponder::_prepareMDNSMessage(MDNSResponder::stcMDNSSendParameter& p_r
     bool    bResult = true;
     
     // Prepare header; count answers
-    stcMDNS_MsgHeader  msgHeader(0, p_rSendParameter.m_bResponse, 0, p_rSendParameter.m_bAuthorative);
+    stcMDNS_MsgHeader  msgHeader(p_rSendParameter.m_u16ID, p_rSendParameter.m_bResponse, 0, p_rSendParameter.m_bAuthorative);
     // If this is a response, the answers are anwers,
     // else this is a query or probe and the answers go into auth section
     uint16_t&           ru16Answers = (p_rSendParameter.m_bResponse


### PR DESCRIPTION
When trying to resolve mdns hostname using lwip built-in resolver (`WiFi.hostByName("something.local")`), LeaMDNS responder does not construct a response that lwip expects. While it does preserve the request ID here:
https://github.com/esp8266/Arduino/blob/48ca7cfce3de99f1d906e95938a67895e73f7f4a/libraries/ESP8266mDNS/src/LEAmDNS_Control.cpp#L248-L250
This ID is never set when preparing the message:
```
[MDNSResponder] _parseQuery: Legacy query from local host 10.0.0.22, id 30!
...
[MDNSResponder] _prepareMDNSMessage: ID:0 QR:1 OP:0 AA:1 TC:0 RD:0 RA:0 R:0 QD:1 AN:1 NS:0 AR:0
...
```
(debugging message could be improved though)