### PR TITLE
Move cont_run/cont_yield out of IRAM

### DIFF
--- a/cores/esp8266/cont.S
+++ b/cores/esp8266/cont.S
@@ -18,7 +18,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-    .text
+    .section .irom0.text
     .align    4
     .literal_position
     .global   cont_yield
@@ -84,7 +84,7 @@ cont_wrapper:
 
 ////////////////////////////////////////////////////
 
-    .text
+    .section .irom0.text
     .align   4
     .literal_position
     .global  cont_run


### PR DESCRIPTION
cont_run is only called by loop_task(), which is not going to execute
during an IRQ and is stored, itself, in flash.

cont_yield cannot be called from an IRQ (since it's illegal to yield
inside IRQs), so move it out of IRAM, too.

Saves ~71 bytes of IRAM