### PR TITLE
Puyafix

### DIFF
--- a/cores/esp8266/Arduino.h
+++ b/cores/esp8266/Arduino.h
@@ -285,10 +285,6 @@ void configTime(const char* tz, const char* server1,
 
 #include "pins_arduino.h"
 
-#ifndef PUYA_SUPPORT
-#define PUYA_SUPPORT 1
-#endif
-
 #endif
 
 #ifdef DEBUG_ESP_OOM

--- a/cores/esp8266/Esp.h
+++ b/cores/esp8266/Esp.h
@@ -23,15 +23,6 @@
 
 #include <Arduino.h>
 
-#ifndef PUYA_SUPPORT
-  #define PUYA_SUPPORT 0
-#endif
-#ifndef PUYA_BUFFER_SIZE
-  // Good alternative for buffer size is: SPI_FLASH_SEC_SIZE (= 4k)
-  // Always use a multiple of flash page size (256 bytes)
-  #define PUYA_BUFFER_SIZE 256
-#endif
-
 // Vendor IDs taken from Flashrom project
 // https://review.coreboot.org/cgit/flashrom.git/tree/flashchips.h?h=1.0.x
 typedef enum {


### PR DESCRIPTION
`PUYA_SUPPORT` was not correctly enabled by default.

It was originally defined to 0 by default in `Esp.h` and later to 1 in `Arduino.h` (!).
Its definition is now only in `Esp.cpp`.

@TD-er should the definition of `PUYA_SUPPORT` be visible if it is not user-defined ?
