### PR TITLE
CI: trusty (u14.04) -> bionic (u18.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: bash
 os: linux
-dist: trusty
+dist: bionic
 
 git:
   depth: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,17 +80,13 @@ jobs:
       stage: build
       script: $TRAVIS_BUILD_DIR/tests/ci/host_test.sh
       install:
-        - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-        - sudo apt-get update -q
-        - sudo apt-get install -y --allow-unauthenticated g++-7 gcc-7
         - sudo apt-get install valgrind lcov
-      env: CC=gcc-7 CXX=g++-7
 
     - name: "Docs"
       stage: build
       script: $TRAVIS_BUILD_DIR/tests/ci/build_docs.sh
       install:
-          - sudo apt-get install python3-pip
+          - sudo apt-get install python3-pip python3-setuptools
           - pip3 install --user -r doc/requirements.txt;
 
     - name: "Style check"
@@ -101,11 +97,6 @@ jobs:
     - name: "Mock trivial test"
       stage: build
       script: $TRAVIS_BUILD_DIR/tests/buildm.sh
-      install:
-        - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-        - sudo apt-get update -q
-        - sudo apt-get install -y --allow-unauthenticated g++-7 gcc-7
-      env: CC=gcc-7 CXX=g++-7
 
     - name: "Mac OSX can build sketches"
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: bash
 os: linux
-dist: trusty #
+dist: trusty
 
 git:
   depth: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: bash
 os: linux
-dist: trusty
+dist: trusty #
 
 git:
   depth: 1

--- a/tests/ci/build_docs.sh
+++ b/tests/ci/build_docs.sh
@@ -4,7 +4,7 @@
 
 set -ev
 
-sudo apt install python3-setuptools
+sudo apt -y install python3-setuptools
 
 cd $TRAVIS_BUILD_DIR/doc
 

--- a/tests/ci/build_docs.sh
+++ b/tests/ci/build_docs.sh
@@ -4,8 +4,6 @@
 
 set -ev
 
-sudo apt -y install python3-setuptools
-
 cd $TRAVIS_BUILD_DIR/doc
 
 SPHINXOPTS="-W" make html

--- a/tests/ci/build_docs.sh
+++ b/tests/ci/build_docs.sh
@@ -4,6 +4,8 @@
 
 set -ev
 
+sudo apt install python3-setuptools
+
 cd $TRAVIS_BUILD_DIR/doc
 
 SPHINXOPTS="-W" make html

--- a/tests/ci/style_check.sh
+++ b/tests/ci/style_check.sh
@@ -9,6 +9,7 @@ ${org}/../restyle.sh
 
 # Revert changes which astyle might have done to the submodules,
 # as we don't want to fail the build because of the 3rd party libraries
-git submodule foreach --recursive git reset --hard
+git --version || true
+git submodule foreach --recursive 'git reset --hard'
 
 git diff --exit-code -- $TRAVIS_BUILD_DIR/libraries


### PR DESCRIPTION
Ubuntu Trusty used in CI is EOL since may 2019, trying with Bionic(18.04)