### PR TITLE
fake library directory: prevent building an archive

### DIFF
--- a/libraries/esp8266/library.properties
+++ b/libraries/esp8266/library.properties
@@ -7,4 +7,4 @@ paragraph=
 category=Other
 url=
 architectures=esp8266
-dot_a_linkage=true
+dot_a_linkage=false


### PR DESCRIPTION
In some cases, "esp8266" library archive is used by arduino builder but is non existent because there is no source file.
Disabling building this archive fixes #6663.
