### PR TITLE
Remove non-ASCII or non-UTF8 character

### DIFF
--- a/libraries/ESP8266HTTPUpdateServer/library.properties
+++ b/libraries/ESP8266HTTPUpdateServer/library.properties
@@ -1,6 +1,6 @@
 name=ESP8266HTTPUpdateServer
 version=1.0
-author=Ivan Grokhotkov, Miguel Ángel Ajo
+author=Ivan Grokhotkov, Miguel Angel Ajo
 maintainer=Ivan Grokhtkov <ivan@esp8266.com>
 sentence=Simple HTTP Update server based on the ESP8266WebServer
 paragraph=The library accepts HTTP post requests to the /update url, and updates the ESP8266 firmware.


### PR DESCRIPTION
Newer version of Platformio generates a warning