### PR TITLE
WIP -Make SPIFFS and LittleFS stay out of link when not needed

### DIFF
--- a/cores/esp8266/FS.h
+++ b/cores/esp8266/FS.h
@@ -245,6 +245,8 @@ protected:
 
 } // namespace fs
 
+extern void spiffs_weak_end();
+
 #ifndef FS_NO_GLOBALS
 using fs::FS;
 using fs::File;

--- a/cores/esp8266/spiffs_api.cpp
+++ b/cores/esp8266/spiffs_api.cpp
@@ -38,9 +38,8 @@ int32_t spiffs_hal_read(uint32_t addr, uint32_t size, uint8_t *dst) {
 }
 
 
-
-
 namespace spiffs_impl {
+
 
 FileImplPtr SPIFFSImpl::open(const char* path, OpenMode openMode, AccessMode accessMode)
 {

--- a/cores/esp8266/spiffs_api.h
+++ b/cores/esp8266/spiffs_api.h
@@ -58,6 +58,7 @@ extern int32_t spiffs_hal_read(uint32_t addr, uint32_t size, uint8_t *dst) __att
 
 
 
+extern void enable_real_spiffs_weak_end();
 
 namespace spiffs_impl {
 
@@ -171,6 +172,8 @@ public:
 
     bool begin() override
     {
+        enable_real_spiffs_weak_end(); // Ensure spiffs_weak_end actually calls SPIFFS.end();
+
         if (SPIFFS_mounted(&_fs) != 0) {
             return true;
         }

--- a/cores/esp8266/spiffs_weak.cpp
+++ b/cores/esp8266/spiffs_weak.cpp
@@ -1,0 +1,20 @@
+/*
+ *  Called from SPIFFS.begin() to avoid linking in httpUpdateServer FS when not needed
+ */
+
+#include <FS.h>
+
+void enable_real_spiffs_weak_end()
+{
+    /*
+     * does nothing
+     * allows overriding below
+     */
+}
+
+/* the following code is linked only if a call to the above function is made somewhere */
+
+extern void spiffs_weak_end_redefinable()
+{
+    SPIFFS.end();
+}

--- a/cores/esp8266/spiffs_weak_internal.cpp
+++ b/cores/esp8266/spiffs_weak_internal.cpp
@@ -1,0 +1,15 @@
+extern void spiffs_weak_end_redefinable() __attribute__((weak));
+extern void spiffs_weak_end_redefinable(void)
+{
+    /* noop unless oveerridden by SPIFFS.begin() */
+}
+
+static void spiffs_weak_end_custom (void) __attribute__((weakref("spiffs_weak_end_redefinable")));
+
+extern void spiffs_weak_end (void)
+{
+    spiffs_weak_end_custom();
+}
+
+
+

--- a/libraries/ESP8266HTTPUpdateServer/src/ESP8266HTTPUpdateServer-impl.h
+++ b/libraries/ESP8266HTTPUpdateServer/src/ESP8266HTTPUpdateServer-impl.h
@@ -94,8 +94,8 @@ void ESP8266HTTPUpdateServerTemplate<ServerType>::setup(ESP8266WebServerTemplate
           Serial.printf("Update: %s\n", upload.filename.c_str());
         if (upload.name == "filesystem") {
           size_t fsSize = ((size_t) &_FS_end - (size_t) &_FS_start);
-          SPIFFS.end();
-          LittleFS.end();
+          spiffs_weak_end();
+          littlefs_weak_end();
           if (!Update.begin(fsSize, U_FS)){//start with max available size
             if (_serial_output) Update.printError(Serial);
           }

--- a/libraries/LittleFS/src/LittleFS.h
+++ b/libraries/LittleFS/src/LittleFS.h
@@ -39,6 +39,9 @@
 
 using namespace fs;
 
+extern void enable_real_littlefs_weak_end();
+extern void littlefs_weak_end();
+
 namespace littlefs_impl {
 
 class LittleFSFileImpl;
@@ -181,6 +184,8 @@ public:
     }
 
     bool begin() override {
+        enable_real_littlefs_weak_end(); // Ensure littlefs_weak_end actually calls LittleFS.end();
+
         if (_size <= 0) {
             DEBUGV("LittleFS size is <= zero");
             return false;

--- a/libraries/LittleFS/src/littlefs_weak.cpp
+++ b/libraries/LittleFS/src/littlefs_weak.cpp
@@ -1,0 +1,20 @@
+/*
+ *  Called from LittleFS.begin() to avoid linking in httpUpdateServer FS when not needed
+ */
+
+#include <LittleFS.h>
+
+void enable_real_littlefs_weak_end()
+{
+    /*
+     * does nothing
+     * allows overriding below
+     */
+}
+
+/* the following code is linked only if a call to the above function is made somewhere */
+
+extern void littlefs_weak_end_redefinable()
+{
+    LittleFS.end();
+}

--- a/libraries/LittleFS/src/littlefs_weak_internal.cpp
+++ b/libraries/LittleFS/src/littlefs_weak_internal.cpp
@@ -1,0 +1,15 @@
+extern void littlefs_weak_end_redefinable() __attribute__((weak));
+extern void littlefs_weak_end_redefinable(void)
+{
+    /* noop unless oveerridden by SPIFFS.begin() */
+}
+
+static void littlefs_weak_end_custom (void) __attribute__((weakref("littlefs_weak_end_redefinable")));
+
+extern void littlefs_weak_end (void)
+{
+    littlefs_weak_end_custom();
+}
+
+
+


### PR DESCRIPTION
Fixes #6691

Idea is to use same principal of weak references to allow the call to
SPIFFS.end() only to ever be linked in (along with all of SPIFFS) if
there is a call somewhere in the app to SPIFFS.begin().

The biggest use case is httpUpdateServer which includes both LittleFS
and SPIFFS code because it has embedded SPIFFS/LittleFS.end() calls.

Standard apps need no changes and continue using standard calls.

Users of the HttpUpdateServer will automatically save an extra 10-40K
of code if they do not use one or both filesystems, or will be
unaffected if they use both.