### PR TITLE
WiFiClient.connected() and WiFiClient bool() operator should return true if data are available

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -331,7 +331,7 @@ bool WiFiClient::stop(unsigned int maxWaitMs)
 
 uint8_t WiFiClient::connected()
 {
-    if (!_client || _client->state() == CLOSED)
+    if (!_client)
         return 0;
 
     return _client->state() == ESTABLISHED || available();


### PR DESCRIPTION
fixes https://github.com/esp8266/Arduino/issues/6701