### PR TITLE
Rollback setContentLength removal (#6715)

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
@@ -533,7 +533,7 @@ template <typename ServerType>
 void ESP8266WebServerTemplate<ServerType>::_streamFileCore(const size_t fileSize, const String &fileName, const String &contentType)
 {
   using namespace mime;
-  (void)fileSize;
+  setContentLength(fileSize);
   if (fileName.endsWith(String(FPSTR(mimeTable[gz].endsWith))) &&
       contentType != String(FPSTR(mimeTable[gz].mimeType)) &&
       contentType != String(FPSTR(mimeTable[none].mimeType))) {


### PR DESCRIPTION
Apparently I messed up testing #6715 and something broke. This rolls back that PR.
That means #2132 remains closed with no action.