### PR TITLE
add docs: how to get POST body in ESP8266WebSever

### DIFF
--- a/libraries/ESP8266WebServer/README.rst
+++ b/libraries/ESP8266WebServer/README.rst
@@ -96,7 +96,7 @@ Getting information about request arguments
   int args();
   bool hasArg();
 
-``arg`` - get request argument value
+``arg`` - get request argument value, use ``arg("plain")`` to get POST body
 	
 ``argName`` - get request argument name
 	


### PR DESCRIPTION
Getting the body of a POST request is a very common use-case in ESP8266WebServer. But it's now undocumented and very hard to find out how without reading whole `PostServer` example or source code. So I document it in README.

Also, I think there should be a `requestBody()` method. It's more reasonable than `arg("plain")`.