### PR TITLE
Add `ipv4_addr_t` for espconn/LwIP1.4 compat

### DIFF
--- a/cores/esp8266/IPAddress.h
+++ b/cores/esp8266/IPAddress.h
@@ -32,6 +32,7 @@
 #define LWIP_IPV6_NUM_ADDRESSES 0
 #define ip_2_ip4(x) (x)
 #define ipv4_addr ip_addr
+#define ipv4_addr_t ip_addr_t
 #define IP_IS_V4_VAL(x) (1)
 #define IP_SET_TYPE_VAL(x,y) do { (void)0; } while (0)
 #define IP_ANY_TYPE (&ip_addr_any)


### PR DESCRIPTION
`espconnn.h` references ipv4_addr_t, so it seems appropriate it be defined here also.

If `#include <IPAddress.h>` added to MCVE, closes #5753. 

The change to `espconn.h` suggested by the OP

```
#ifndef ipv4_addr_t
#define ipv4_addr_t ip_addr_t
#endif
```

sets off needing to define `ip_addr_t`, etc, so is not suitable. 
