### PR TITLE
Puts to rest the confusion about the builtin leds for nodemcu boards

### DIFF
--- a/variants/nodemcu/pins_arduino.h
+++ b/variants/nodemcu/pins_arduino.h
@@ -32,7 +32,8 @@
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;
 
-#define LED_BUILTIN 16
+#define LED_BUILTIN 2
+#define LED_BUILTIN_AUX 16
 
 static const uint8_t D0   = 16;
 static const uint8_t D1   = 5;


### PR DESCRIPTION
Given that most nodemcu boards are based on the ESP12 boards, the definition of the builtin led is now changed to 2.
In addition, for those nodemcu boards that have an additional LED on the board connected to gpio16, an additional define is added called LED_BUILTIN_AUX.
Fixes #4715 