### PR TITLE
Updated EspSoftwareSerial brings backward compatibility

### DIFF
--- a/libraries/ESP8266WiFi/examples/WiFiTelnetToSerial/WiFiTelnetToSerial.ino
+++ b/libraries/ESP8266WiFi/examples/WiFiTelnetToSerial/WiFiTelnetToSerial.ino
@@ -85,8 +85,8 @@ void setup() {
   Serial.swap();
   // Hardware serial is now on RX:GPIO13 TX:GPIO15
   // use SoftwareSerial on regular RX(3)/TX(1) for logging
-  logger = new SoftwareSerial();
-  logger->begin(BAUD_LOGGER, 3, 1);
+  logger = new SoftwareSerial(3, 1);
+  logger->begin(BAUD_LOGGER);
   logger->enableIntTx(false);
   logger->println("\n\nUsing SoftwareSerial for logging");
 #else

--- a/libraries/esp8266/examples/SerialStress/SerialStress.ino
+++ b/libraries/esp8266/examples/SerialStress/SerialStress.ino
@@ -72,8 +72,8 @@ void setup() {
 
   // using HardwareSerial0 pins,
   // so we can still log to the regular usbserial chips
-  SoftwareSerial* ss = new SoftwareSerial;
-  ss->begin(SSBAUD, 3, 1);
+  SoftwareSerial* ss = new SoftwareSerial(3, 1);
+  ss->begin(SSBAUD);
   ss->enableIntTx(false);
   logger = ss;
   logger->println();


### PR DESCRIPTION
Due to user request, the ctor/begin() pair is now backward compatible with EspSoftwareSerial releases 5.0.4 and prior (only for the common cases with complete default argument use).