### PR TITLE
Add String::concat(char*, len) to allow non null-term strings

### DIFF
--- a/cores/esp8266/WString.cpp
+++ b/cores/esp8266/WString.cpp
@@ -331,6 +331,7 @@ unsigned char String::concat(const char *cstr, unsigned int length) {
         return 0;
     memmove_P(wbuffer() + len(), cstr, length + 1);
     setLen(newlen);
+    wbuffer()[newlen] = 0;
     return 1;
 }
 

--- a/cores/esp8266/WString.h
+++ b/cores/esp8266/WString.h
@@ -116,6 +116,7 @@ class String {
         unsigned char concat(float num);
         unsigned char concat(double num);
         unsigned char concat(const __FlashStringHelper * str);
+        unsigned char concat(const char *cstr, unsigned int length);
 
         // if there's not enough memory for the concatenated value, the string
         // will be left unchanged (but this isn't signalled in any way)
@@ -284,7 +285,6 @@ class String {
         void init(void);
         void invalidate(void);
         unsigned char changeBuffer(unsigned int maxStrLen);
-        unsigned char concat(const char *cstr, unsigned int length);
 
         // copy and move
         String & copy(const char *cstr, unsigned int length);

--- a/tests/host/core/test_string.cpp
+++ b/tests/host/core/test_string.cpp
@@ -135,13 +135,15 @@ TEST_CASE("String concantenation", "[core][String]")
     const char buff[] = "abcdefg";
     String n;
     n = "1234567890"; // Make it a SSO string, fill with non-0 data
-    n = "1"; // Overwrite [1] with 0, but leave old jump in SSO space still
+    n = "1"; // Overwrite [1] with 0, but leave old junk in SSO space still
     n.concat(buff, 3);
     REQUIRE(n == "1abc"); // Ensure the trailing 0 is always present even w/this funky concat
-    for (int i=0; i<20; i++) n.concat(buff, 1); // Add 20 'a's to go from SSO to normal string
+    for (int i=0; i<20; i++)
+        n.concat(buff, 1); // Add 20 'a's to go from SSO to normal string
     REQUIRE(n == "1abcaaaaaaaaaaaaaaaaaaaa");
     n = "";
-    for (int i=0; i<=5; i++) n.concat(buff, i);
+    for (int i=0; i<=5; i++)
+        n.concat(buff, i);
     REQUIRE(n == "aababcabcdabcde");
     n.concat(buff, 0); // And check no add'n
     REQUIRE(n == "aababcabcdabcde");

--- a/tests/host/core/test_string.cpp
+++ b/tests/host/core/test_string.cpp
@@ -131,6 +131,20 @@ TEST_CASE("String concantenation", "[core][String]")
     REQUIRE(str == "-100");
     str = String((long)-100, 10);
     REQUIRE(str == "-100");
+    // Non-zero-terminated array concatenation
+    const char buff[] = "abcdefg";
+    String n;
+    n = "1234567890"; // Make it a SSO string, fill with non-0 data
+    n = "1"; // Overwrite [1] with 0, but leave old jump in SSO space still
+    n.concat(buff, 3);
+    REQUIRE(n == "1abc"); // Ensure the trailing 0 is always present even w/this funky concat
+    for (int i=0; i<20; i++) n.concat(buff, 1); // Add 20 'a's to go from SSO to normal string
+    REQUIRE(n == "1abcaaaaaaaaaaaaaaaaaaaa");
+    n = "";
+    for (int i=0; i<=5; i++) n.concat(buff, i);
+    REQUIRE(n == "aababcabcdabcde");
+    n.concat(buff, 0); // And check no add'n
+    REQUIRE(n == "aababcabcdabcde");
 }
 
 TEST_CASE("String comparison", "[core][String]")


### PR DESCRIPTION
Fixes #5061

Adds a concat(const char *data, int len) method which allows arbitrary
sequences of data (including ones w/embedded \0s) to be appended to a
String.  May be useful for certain MQTT operations.

Adds sanity test for the feature to host suite