### PR TITLE
WString explicit converters to reduce Flash size

### DIFF
--- a/cores/esp8266/WString.h
+++ b/cores/esp8266/WString.h
@@ -202,8 +202,20 @@ class String {
         unsigned char equalsIgnoreCase(const String &s) const;
         unsigned char equalsConstantTime(const String &s) const;
         unsigned char startsWith(const String &prefix) const;
+        unsigned char startsWith(const char * prefix) {
+            this->startsWith(String(prefix));
+        }
+        unsigned char startsWith(const __FlashStringHelper * prefix) {
+            this->startsWith(String(prefix));
+        }
         unsigned char startsWith(const String &prefix, unsigned int offset) const;
         unsigned char endsWith(const String &suffix) const;
+        unsigned char endsWith(const char * suffix) {
+            this->endsWith(String(suffix));
+        }
+        unsigned char endsWith(const __FlashStringHelper * suffix) {
+            this->endsWith(String(suffix));
+        }
 
         // character access
         char charAt(unsigned int index) const;
@@ -238,6 +250,21 @@ class String {
         // modification
         void replace(char find, char replace);
         void replace(const String& find, const String& replace);
+        void replace(const char * find, const String& replace) {
+            this->replace(String(find), replace);
+        }
+        void replace(const __FlashStringHelper * find, const String& replace) {
+            this->replace(String(find), replace);
+        }
+        void replace(const char * find, const char * replace) {
+            this->replace(String(find), String(replace));
+        }
+        void replace(const __FlashStringHelper * find, const char * replace) {
+            this->replace(String(find), String(replace));
+        }
+        void replace(const __FlashStringHelper * find, const __FlashStringHelper * replace) {
+            this->replace(String(find), String(replace));
+        }
         void remove(unsigned int index);
         void remove(unsigned int index, unsigned int count);
         void toLowerCase(void);

--- a/cores/esp8266/WString.h
+++ b/cores/esp8266/WString.h
@@ -202,18 +202,18 @@ class String {
         unsigned char equalsIgnoreCase(const String &s) const;
         unsigned char equalsConstantTime(const String &s) const;
         unsigned char startsWith(const String &prefix) const;
-        unsigned char startsWith(const char * prefix) {
+        unsigned char startsWith(const char * prefix) const {
             return this->startsWith(String(prefix));
         }
-        unsigned char startsWith(const __FlashStringHelper * prefix) {
+        unsigned char startsWith(const __FlashStringHelper * prefix) const {
             return this->startsWith(String(prefix));
         }
         unsigned char startsWith(const String &prefix, unsigned int offset) const;
         unsigned char endsWith(const String &suffix) const;
-        unsigned char endsWith(const char * suffix) {
+        unsigned char endsWith(const char * suffix) const {
             return this->endsWith(String(suffix));
         }
-        unsigned char endsWith(const __FlashStringHelper * suffix) {
+        unsigned char endsWith(const __FlashStringHelper * suffix) const {
             return this->endsWith(String(suffix));
         }
 

--- a/cores/esp8266/WString.h
+++ b/cores/esp8266/WString.h
@@ -203,18 +203,18 @@ class String {
         unsigned char equalsConstantTime(const String &s) const;
         unsigned char startsWith(const String &prefix) const;
         unsigned char startsWith(const char * prefix) {
-            this->startsWith(String(prefix));
+            return this->startsWith(String(prefix));
         }
         unsigned char startsWith(const __FlashStringHelper * prefix) {
-            this->startsWith(String(prefix));
+            return this->startsWith(String(prefix));
         }
         unsigned char startsWith(const String &prefix, unsigned int offset) const;
         unsigned char endsWith(const String &suffix) const;
         unsigned char endsWith(const char * suffix) {
-            this->endsWith(String(suffix));
+            return this->endsWith(String(suffix));
         }
         unsigned char endsWith(const __FlashStringHelper * suffix) {
-            this->endsWith(String(suffix));
+            return this->endsWith(String(suffix));
         }
 
         // character access


### PR DESCRIPTION
Tasmota uses a lot of `String` with constructs like below:

```
str->replace("aa", "bb);
str->replace(F("cc"), String(num));
str->startsWith(F("prefix"));
str->endsWith(F("suffix"));
```

Currently for any non `String` argument, the compiler silently instantiates a new `String`object and deletes it after the call. This generates more than 1k of not very useful code.

This PR adds explicit methods to deal with common arguments `const unsigned char *` and `const __FlashStringHelper *`. It does not change the fact that a `String` object is created then deleted, it just reduces redundant code.

With this change, we see a 1k code size reduction with Tasmota.