### PR TITLE
Root page should be of type text/html

### DIFF
--- a/libraries/ESP8266WebServer/examples/PostServer/PostServer.ino
+++ b/libraries/ESP8266WebServer/examples/PostServer/PostServer.ino
@@ -38,7 +38,7 @@ const String postForms = "<html>\
 
 void handleRoot() {
   digitalWrite(led, 1);
-  server.send(200, "text/plain", postForms);
+  server.send(200, "text/html", postForms);
   digitalWrite(led, 0);
 }
 


### PR DESCRIPTION
In order to be displayed properly by a browser the HTML should be returned as text/html.