### PR TITLE
fix http client redirects (broken from const String& changes)

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -551,7 +551,6 @@ bool HTTPClient::setURL(const String& url)
     }
     // disconnect but preserve _client
     disconnect(true);
-    clear();
     return beginInternal(url, nullptr);
 }
 


### PR DESCRIPTION
remove `clear()` before `beginInternal()` so _location is not cleared before its passed to `beginInternal()`

Fixes #6778
