### PR TITLE
Make upload.py compatible with existing FS upload

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -149,7 +149,7 @@ tools.esptool.upload.params.quiet=
 # First, potentially perform an erase or nothing
 # Next, do the binary upload
 # Combined in one rule because Arduino doesn't suport upload.1.pattern/upload.3.pattern
-tools.esptool.upload.pattern="{cmd}" "{runtime.platform.path}/tools/upload.py" --chip esp8266 --port "{serial.port}" --baud "{upload.speed}" "{upload.verbose}" {upload.erase_cmd} {upload.resetmethod} "{build.path}/{build.project_name}.bin"
+tools.esptool.upload.pattern="{cmd}" "{runtime.platform.path}/tools/upload.py" --chip esp8266 --port "{serial.port}" --baud "{upload.speed}" "{upload.verbose}" {upload.erase_cmd} {upload.resetmethod} write_flash 0x0 "{build.path}/{build.project_name}.bin"
 
 tools.esptool.upload.network_pattern="{network_cmd}" "{runtime.platform.path}/tools/espota.py" -i "{serial.port}" -p "{network.port}" "--auth={network.password}" -f "{build.path}/{build.project_name}.bin"
 

--- a/tools/upload.py
+++ b/tools/upload.py
@@ -22,6 +22,7 @@ except:
 
 cmdline = []
 write_option = ''
+write_addr = '0x0'
 erase_addr = ''
 erase_len = ''
 
@@ -45,6 +46,16 @@ while len(sys.argv):
         erase_len = sys.argv.pop(0)
         thisarg = ''
 
+    # Backwards compatibility with fs upload tools, eat --end
+    if thisarg == '--end':
+        thisarg = ''
+
+    # Backwards compatibility with fs upload tools, parse write_flash for later use
+    if thisarg == 'write_flash':
+        write_addr = sys.argv.pop(0)
+        binary = sys.argv.pop(0)
+        thisarg = ''
+
     if os.path.isfile(thisarg):
         binary = thisarg
         thisarg = ''
@@ -55,7 +66,7 @@ while len(sys.argv):
 cmdline = cmdline + ['write_flash']
 if len(write_option):
     cmdline = cmdline + [write_option]
-cmdline = cmdline + ['0x0', binary]
+cmdline = cmdline + [write_addr, binary]
 
 erase_file = ''
 if len(erase_addr):

--- a/tools/upload.py
+++ b/tools/upload.py
@@ -39,28 +39,16 @@ while len(sys.argv):
     # https://github.com/esp8266/Arduino/issues/6755#issuecomment-553208688
     if thisarg == "erase_flash":
         write_option = '--erase-all'
-        thisarg = ''
-
-    if thisarg == 'erase_region':
+    elif thisarg == 'erase_region':
         erase_addr = sys.argv.pop(0)
         erase_len = sys.argv.pop(0)
-        thisarg = ''
-
-    # Backwards compatibility with fs upload tools, eat --end
-    if thisarg == '--end':
-        thisarg = ''
-
-    # Backwards compatibility with fs upload tools, parse write_flash for later use
-    if thisarg == 'write_flash':
+    elif thisarg == '--end':
+        # Backwards compatibility with fs upload tools, eat --end
+        pass
+    elif thisarg == 'write_flash':
         write_addr = sys.argv.pop(0)
         binary = sys.argv.pop(0)
-        thisarg = ''
-
-    if os.path.isfile(thisarg):
-        binary = thisarg
-        thisarg = ''
-
-    if len(thisarg):
+    elif len(thisarg):
         cmdline = cmdline + [thisarg]
 
 cmdline = cmdline + ['write_flash']
@@ -70,7 +58,7 @@ cmdline = cmdline + [write_addr, binary]
 
 erase_file = ''
 if len(erase_addr):
-    # generate temporary empty (0xff) file
+    # Generate temporary empty (0xff) file
     eraser = tempfile.mkstemp()
     erase_file = eraser[1]
     os.write(eraser[0], bytearray([255] * int(erase_len, 0)))


### PR DESCRIPTION
PR #6765 introduced an incompatibility with the existing Java uploaders
for SPIFFS and LittleFS,  breaking them because of the upload.py
parameter format change to support single stage erase/upload.

Add in patch to silently eat the single --end and to parse the write
address and filename properly as generated by calls from the plugins,
while retaining compatibility with the current IDE changes.