### PR TITLE
Weak binding lessens version dependency between ESP8266 and MT library

### DIFF
--- a/cores/esp8266/core_esp8266_main.cpp
+++ b/cores/esp8266/core_esp8266_main.cpp
@@ -100,11 +100,13 @@ static void esp_yield_within_cont() {
         run_scheduled_recurrent_functions();
 }
 
-extern "C" void esp_yield() {
+extern "C" void __esp_yield() {
     if (can_yield()) {
         esp_yield_within_cont();
     }
 }
+
+extern "C" void esp_yield() __attribute__ ((weak, alias("__esp_yield")));
 
 extern "C" void esp_schedule() {
     // always on CONT stack here


### PR DESCRIPTION
This is a cosmetic change in master, that would kindly allow the use of CoopTask and similar pattern libraries to release adapted code that just-works while PR #6782 is in review.