### PR TITLE
Fix typo in mode timeout loop

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -443,7 +443,7 @@ bool ESP8266WiFiGenericClass::mode(WiFiMode_t m, WiFiState* state) {
     //tasks to wait correctly.
     constexpr unsigned int timeoutValue = 1000; //1 second
     if(can_yield()) {
-        using oneShot = esp8266::polledTimeout::oneShotFastUs;
+        using oneShot = esp8266::polledTimeout::oneShotFastMs;
         oneShot timeout(timeoutValue);
         while(wifi_get_opmode() != (uint8) m && !timeout)
             delay(5);


### PR DESCRIPTION
Fix typo to make timeout 1s instead if 1ms, as originally intended.