### PR TITLE
host build: optimistic_yield() wrongly delays() instead of avoiding excessive yields

### DIFF
--- a/tests/host/common/Arduino.cpp
+++ b/tests/host/common/Arduino.cpp
@@ -44,6 +44,7 @@ extern "C" bool can_yield()
 
 extern "C" void optimistic_yield (uint32_t interval_us)
 {
+    (void)interval_us;
 }
 
 extern "C" void esp_yield()

--- a/tests/host/common/Arduino.cpp
+++ b/tests/host/common/Arduino.cpp
@@ -44,7 +44,6 @@ extern "C" bool can_yield()
 
 extern "C" void optimistic_yield (uint32_t interval_us)
 {
-    usleep(interval_us);
 }
 
 extern "C" void esp_yield()


### PR DESCRIPTION
On host, can work just like plain `yield()` there - do nothing at all.