### PR TITLE
Terminate the chunked printDirectory in SDWebServer

### DIFF
--- a/libraries/ESP8266WebServer/examples/SDWebServer/SDWebServer.ino
+++ b/libraries/ESP8266WebServer/examples/SDWebServer/SDWebServer.ino
@@ -241,6 +241,7 @@ void printDirectory() {
     entry.close();
   }
   server.sendContent("]");
+  server.sendContent(""); // Terminate the HTTP chunked transmission with a 0-length chunk
   dir.close();
 }
 


### PR DESCRIPTION
Fixes #2481

Send a 0-len chunk when the directory is completed (in a chunked HTTP
transfer) to terminate the HTTP transfer properly.