### PR TITLE
Expand BSSL stack

### DIFF
--- a/cores/esp8266/StackThunk.cpp
+++ b/cores/esp8266/StackThunk.cpp
@@ -36,7 +36,8 @@ uint32_t *stack_thunk_top = NULL;
 uint32_t *stack_thunk_save = NULL;  /* Saved A1 while in BearSSL */
 uint32_t stack_thunk_refcnt = 0;
 
-#define _stackSize (5748/4)
+/* Largest stack usage seen in the wild at scripts.google.com at 5828 */
+#define _stackSize (5900/4)
 #define _stackPaint 0xdeadbeef
 
 /* Add a reference, and allocate the stack if necessary */

--- a/libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation.ino
+++ b/libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation.ino
@@ -6,6 +6,7 @@
 
 #include <ESP8266WiFi.h>
 #include <WiFiClientSecure.h>
+#include <StackThunk.h>
 #include <time.h>
 
 #ifndef STASSID
@@ -82,6 +83,7 @@ void fetchURL(BearSSL::WiFiClientSecure *client, const char *host, const uint16_
   client->stop();
   uint32_t freeStackEnd = ESP.getFreeContStack();
   Serial.printf("\nCONT stack used: %d\n-------\n\n", freeStackStart - freeStackEnd);
+  Serial.printf("\nBSSL stack used: %d\n-------\n\n", stack_thunk_get_max_usage());
 }
 
 void fetchNoConfig() {

--- a/libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation.ino
+++ b/libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation.ino
@@ -82,8 +82,8 @@ void fetchURL(BearSSL::WiFiClientSecure *client, const char *host, const uint16_
   }
   client->stop();
   uint32_t freeStackEnd = ESP.getFreeContStack();
-  Serial.printf("\nCONT stack used: %d\n-------\n\n", freeStackStart - freeStackEnd);
-  Serial.printf("\nBSSL stack used: %d\n-------\n\n", stack_thunk_get_max_usage());
+  Serial.printf("\nCONT stack used: %d\n", freeStackStart - freeStackEnd);
+  Serial.printf("BSSL stack used: %d\n-------\n\n", stack_thunk_get_max_usage());
 }
 
 void fetchNoConfig() {


### PR DESCRIPTION
Fixes #6811 which found an issue where connecting to scripts.google.com
would *occasionally* cause a crash.  On inspection, it was found that up
to 5828 bytes of stack were used once in a while, so expand the stack to
5900 bytes to cover this case plus a little extra.