### PR TITLE
Move eboot_command_clear to after firmware copy.

### DIFF
--- a/bootloaders/eboot/eboot.c
+++ b/bootloaders/eboot/eboot.c
@@ -128,13 +128,14 @@ int copy_raw(const uint32_t src_addr,
 void main()
 {
     int res = 9;
+    bool clear_cmd = false;
     struct eboot_command cmd;
     
     print_version(0);
 
     if (eboot_command_read(&cmd) == 0) {
         // valid command was passed via RTC_MEM
-        eboot_command_clear();
+        clear_cmd = true;
         ets_putc('@');
     } else {
         // no valid command found
@@ -153,6 +154,10 @@ void main()
             cmd.action = ACTION_LOAD_APP;
             cmd.args[0] = cmd.args[1];
         }
+    }
+
+    if (clear_cmd) {
+        eboot_command_clear();
     }
 
     if (cmd.action == ACTION_LOAD_APP) {


### PR DESCRIPTION
The eboot command was cleared from the rtc mem before the firmware copy
making it possible for a power failure during an OTA update to brick the
esp until the firmware was loaded via USB because of a partial firmware
copy that would never be restarted.

Moving the eboot_command_clear to after the copy ensures that any partial
copy is restarted at next power on.