### PR TITLE
Use F_CPU if (?) CPU frequency switch is compile-time only

### DIFF
--- a/cores/esp8266/Esp.cpp
+++ b/cores/esp8266/Esp.cpp
@@ -264,11 +264,6 @@ uint8_t EspClass::getBootMode(void)
     return system_get_boot_mode();
 }
 
-uint8_t EspClass::getCpuFreqMHz(void)
-{
-    return system_get_cpu_freq();
-}
-
 
 uint32_t EspClass::getFlashChipId(void)
 {

--- a/cores/esp8266/Esp.cpp
+++ b/cores/esp8266/Esp.cpp
@@ -264,6 +264,12 @@ uint8_t EspClass::getBootMode(void)
     return system_get_boot_mode();
 }
 
+#ifndef F_CPU
+uint8_t EspClass::getCpuFreqMHz(void)
+{
+    return system_get_cpu_freq();
+}
+#endif
 
 uint32_t EspClass::getFlashChipId(void)
 {

--- a/cores/esp8266/Esp.h
+++ b/cores/esp8266/Esp.h
@@ -157,7 +157,12 @@ class EspClass {
         uint8_t getBootVersion();
         uint8_t getBootMode();
 
+#ifndef CORE_MOCK
+        inline uint8_t getCpuFreqMHz() __attribute__((always_inline));
+#else
         uint8_t getCpuFreqMHz();
+#endif
+
 
         uint32_t getFlashChipId();
         uint8_t getFlashChipVendorId();
@@ -201,6 +206,12 @@ class EspClass {
 };
 
 #ifndef CORE_MOCK
+
+uint8_t EspClass::getCpuFreqMHz()
+{
+    return clockCyclesPerMicrosecond();
+}
+
 uint32_t EspClass::getCycleCount()
 {
     return esp_get_cycle_count();

--- a/cores/esp8266/Esp.h
+++ b/cores/esp8266/Esp.h
@@ -157,7 +157,7 @@ class EspClass {
         uint8_t getBootVersion();
         uint8_t getBootMode();
 
-#if !defined(CORE_MOCK) && defined(F_CPU)
+#if defined(F_CPU)
         constexpr uint8_t getCpuFreqMHz() const
         {
             return clockCyclesPerMicrosecond();
@@ -165,7 +165,6 @@ class EspClass {
 #else
         uint8_t getCpuFreqMHz();
 #endif
-
 
         uint32_t getFlashChipId();
         uint8_t getFlashChipVendorId();

--- a/cores/esp8266/Esp.h
+++ b/cores/esp8266/Esp.h
@@ -209,7 +209,11 @@ class EspClass {
 
 uint8_t EspClass::getCpuFreqMHz()
 {
+#if defined(F_CPU)
     return clockCyclesPerMicrosecond();
+#elif !defined(F_CPU)
+    return system_get_cpu_freq();
+#endif
 }
 
 uint32_t EspClass::getCycleCount()

--- a/cores/esp8266/Esp.h
+++ b/cores/esp8266/Esp.h
@@ -157,7 +157,7 @@ class EspClass {
         uint8_t getBootVersion();
         uint8_t getBootMode();
 
-#if defined(F_CPU)
+#if defined(F_CPU) || defined(CORE_MOCK)
         constexpr uint8_t getCpuFreqMHz() const
         {
             return clockCyclesPerMicrosecond();

--- a/cores/esp8266/Esp.h
+++ b/cores/esp8266/Esp.h
@@ -157,8 +157,11 @@ class EspClass {
         uint8_t getBootVersion();
         uint8_t getBootMode();
 
-#ifndef CORE_MOCK
-        inline uint8_t getCpuFreqMHz() __attribute__((always_inline));
+#if !defined(CORE_MOCK) && defined(F_CPU)
+        constexpr uint8_t getCpuFreqMHz() const
+        {
+            return clockCyclesPerMicrosecond();
+        }
 #else
         uint8_t getCpuFreqMHz();
 #endif
@@ -206,15 +209,6 @@ class EspClass {
 };
 
 #ifndef CORE_MOCK
-
-uint8_t EspClass::getCpuFreqMHz()
-{
-#if defined(F_CPU)
-    return clockCyclesPerMicrosecond();
-#elif !defined(F_CPU)
-    return system_get_cpu_freq();
-#endif
-}
 
 uint32_t EspClass::getCycleCount()
 {

--- a/cores/esp8266/PolledTimeout.h
+++ b/cores/esp8266/PolledTimeout.h
@@ -76,7 +76,7 @@ struct TimeSourceCycles
 
   using timeType = decltype(ESP.getCycleCount());
   static timeType time() {return ESP.getCycleCount();}
-  static constexpr timeType ticksPerSecond    = F_CPU;     // 80'000'000 or 160'000'000 Hz
+  static constexpr timeType ticksPerSecond    = ESP.getCpuFreqMHz() * 1000000UL;     // 80'000'000 or 160'000'000 Hz
   static constexpr timeType ticksPerSecondMax = 160000000; // 160MHz
 };
 

--- a/cores/esp8266/core_esp8266_main.cpp
+++ b/cores/esp8266/core_esp8266_main.cpp
@@ -81,13 +81,16 @@ void initVariant() __attribute__((weak));
 void initVariant() {
 }
 
-void preloop_update_frequency() __attribute__((weak));
-void preloop_update_frequency() {
+extern "C" void __preloop_update_frequency() {
 #if defined(F_CPU) && (F_CPU == 160000000L)
-    REG_SET_BIT(0x3ff00014, BIT(0));
     ets_update_cpu_frequency(160);
+    REG_SET_BIT(0x3ff00014, BIT(0));
+#elif !defined(F_CPU)
+    if (system_get_cpu_freq() == 160) REG_SET_BIT(0x3ff00014, BIT(0));
 #endif
 }
+
+extern "C" void preloop_update_frequency() __attribute__((weak, alias("__preloop_update_frequency")));
 
 extern "C" bool can_yield() {
   return cont_can_yield(g_pcont);

--- a/cores/esp8266/core_esp8266_main.cpp
+++ b/cores/esp8266/core_esp8266_main.cpp
@@ -84,10 +84,16 @@ void initVariant() {
 extern "C" void __preloop_update_frequency() {
 #if defined(F_CPU) && (F_CPU == 160000000L)
     ets_update_cpu_frequency(160);
-    CPU2X |= 1;
+    CPU2X |= 1UL;
+#elif defined(F_CPU)
+    ets_update_cpu_frequency(80);
+    CPU2X &= ~1UL;
 #elif !defined(F_CPU)
     if (system_get_cpu_freq() == 160) {
-        CPU2X |= 1;
+        CPU2X |= 1UL;
+    }
+    else {
+        CPU2X &= ~1UL;
     }
 #endif
 }

--- a/cores/esp8266/core_esp8266_main.cpp
+++ b/cores/esp8266/core_esp8266_main.cpp
@@ -84,9 +84,11 @@ void initVariant() {
 extern "C" void __preloop_update_frequency() {
 #if defined(F_CPU) && (F_CPU == 160000000L)
     ets_update_cpu_frequency(160);
-    REG_SET_BIT(0x3ff00014, BIT(0));
+    CPU2X |= 1;
 #elif !defined(F_CPU)
-    if (system_get_cpu_freq() == 160) REG_SET_BIT(0x3ff00014, BIT(0));
+    if (system_get_cpu_freq() == 160) {
+        CPU2X |= 1;
+    }
 #endif
 }
 

--- a/tests/host/common/MockEsp.cpp
+++ b/tests/host/common/MockEsp.cpp
@@ -118,11 +118,6 @@ uint32_t EspClass::getFreeSketchSpace()
   return 4 * 1024 * 1024;
 }
 
-uint8_t EspClass::getCpuFreqMHz()
-{
-  return F_CPU / 1000000;
-}
-
 const char *EspClass::getSdkVersion()
 {
   return "2.5.0";

--- a/tests/host/common/mock.h
+++ b/tests/host/common/mock.h
@@ -84,6 +84,10 @@ typedef uint32_t uint32;
 
 //
 
+#include <Arduino.h>
+
+//
+
 #include <stdlib.h>
 #define RANDOM_REG32 ((uint32_t)random())
 
@@ -161,10 +165,6 @@ void mock_start_spiffs (const String& fname, size_t size_kb, size_t block_kb = 8
 void mock_stop_spiffs ();
 void mock_start_littlefs (const String& fname, size_t size_kb, size_t block_kb = 8, size_t page_b = 512);
 void mock_stop_littlefs ();
-
-//
-
-#include <Arduino.h>
 
 //
 

--- a/tests/host/common/mock.h
+++ b/tests/host/common/mock.h
@@ -84,10 +84,6 @@ typedef uint32_t uint32;
 
 //
 
-#include <Arduino.h>
-
-//
-
 #include <stdlib.h>
 #define RANDOM_REG32 ((uint32_t)random())
 
@@ -165,6 +161,10 @@ void mock_start_spiffs (const String& fname, size_t size_kb, size_t block_kb = 8
 void mock_stop_spiffs ();
 void mock_start_littlefs (const String& fname, size_t size_kb, size_t block_kb = 8, size_t page_b = 512);
 void mock_stop_littlefs ();
+
+//
+
+#include <Arduino.h>
 
 //
 


### PR DESCRIPTION
Then ESP.getCpuFreqMHz() can be optimized to use F_CPU and be constexpr.
polledTimeout using F_CPU instead of the dynamic ``system_get_cpu_freq()`` anyway, I see no issue.

On review, please consider this, in `core_esp8266_main.cpp`:
```
void preloop_update_frequency() __attribute__((weak));
void preloop_update_frequency() {
#if defined(F_CPU) && (F_CPU == 160000000L)
    REG_SET_BIT(0x3ff00014, BIT(0));
    ets_update_cpu_frequency(160);
#endif
```

Could this be turned into dynamic frequency switching?