### PR TITLE
[BREAKING] polledTimeout: new remaining() returns time units until (next) expiration

### DIFF
--- a/cores/esp8266/PolledTimeout.h
+++ b/cores/esp8266/PolledTimeout.h
@@ -271,7 +271,7 @@ protected:
   bool expiredOneShot()
   {
     // returns "always expired" or "has expired"
-    return !canWait();
+    if (!canWait()) return true;
     if (checkExpired(TimePolicyT::time()))
     {
       _timeout = alwaysExpired;

--- a/cores/esp8266/PolledTimeout.h
+++ b/cores/esp8266/PolledTimeout.h
@@ -158,7 +158,8 @@ public:
   bool expired()
   {
     bool hasExpired = PeriodicT ? expiredRetrigger() : expiredOneShot();
-    if (!hasExpired) YieldPolicyT::execute(); //in case of DoNothing: gets optimized away
+    if (!hasExpired) //in case of DoNothing: gets optimized away
+      YieldPolicyT::execute();
     return hasExpired;
   }
 

--- a/cores/esp8266/PolledTimeout.h
+++ b/cores/esp8266/PolledTimeout.h
@@ -246,8 +246,8 @@ private:
   bool checkExpired(const timeType internalUnit) const
   {
     // canWait() is not checked here
-    // returns "can expire" and "oneshot not expired" and "time expired"
-    return (_oneShotExpired) || ((!_neverExpires) && ((internalUnit - _start) >= _timeout));
+    // returns "oneshot has expired", otherwise returns "can expire" and "time has expired"
+    return _oneShotExpired || (!_neverExpires && ((internalUnit - _start) >= _timeout));
   }
 
 protected:

--- a/cores/esp8266/PolledTimeout.h
+++ b/cores/esp8266/PolledTimeout.h
@@ -145,7 +145,6 @@ public:
   using timeType = typename TimePolicyT::timeType;
   static_assert(std::is_unsigned<timeType>::value == true, "timeType must be unsigned");
 
-  static constexpr timeType alwaysExpired   = 0;
   static constexpr timeType neverExpires    = std::numeric_limits<timeType>::max();
   static constexpr timeType rangeCompensate = TimePolicyT::rangeCompensate; //debug
 
@@ -176,7 +175,7 @@ public:
 
   bool canWait () const
   {
-    return _timeout != alwaysExpired && !_oneShotExpired;
+    return _timeout != 0 && !_oneShotExpired;
   }
 
   // Resets, will trigger after this new timeout.
@@ -215,7 +214,7 @@ public:
 
   void resetToNeverExpires ()
   {
-    _timeout = alwaysExpired + 1; // because canWait() has precedence
+    _timeout = 1; // because canWait() has precedence
     _neverExpires = true;
   }
 

--- a/cores/esp8266/PolledTimeout.h
+++ b/cores/esp8266/PolledTimeout.h
@@ -260,7 +260,7 @@ protected:
     timeType current = TimePolicyT::time();
     if(checkExpired(current))
     {
-      unsigned long n = (current - _start) / _timeout; //how many _timeouts periods have elapsed, will usually be 1 (current - _start >= _timeout)
+      timeType n = (current - _start) / _timeout; //how many _timeouts periods have elapsed, will usually be 1 (current - _start >= _timeout)
       _start += n  * _timeout;
       return true;
     }

--- a/cores/esp8266/PolledTimeout.h
+++ b/cores/esp8266/PolledTimeout.h
@@ -176,7 +176,7 @@ public:
 
   bool canWait () const
   {
-    return _timeout != alwaysExpired;
+    return _timeout != alwaysExpired && !_oneShotExpired;
   }
 
   // Resets, will trigger after this new timeout.
@@ -193,6 +193,7 @@ public:
   void reset()
   {
     _start = TimePolicyT::time();
+    _oneShotExpired = false;
   }
 
   // Resets to just expired so that on next poll the check will immediately trigger for the user,
@@ -245,8 +246,8 @@ private:
   bool checkExpired(const timeType internalUnit) const
   {
     // canWait() is not checked here
-    // returns "can expire" and "time expired"
-    return (!_neverExpires) && ((internalUnit - _start) >= _timeout);
+    // returns "can expire" and "oneshot not expired" and "time expired"
+    return (_oneShotExpired) || ((!_neverExpires) && ((internalUnit - _start) >= _timeout));
   }
 
 protected:
@@ -274,7 +275,7 @@ protected:
     if (!canWait()) return true;
     if (checkExpired(TimePolicyT::time()))
     {
-      _timeout = alwaysExpired;
+      _oneShotExpired = true;
       return true;
     }
     return false;
@@ -283,6 +284,7 @@ protected:
   timeType _timeout;
   timeType _start;
   bool _neverExpires;
+  bool _oneShotExpired;
 };
 
 // legacy type names, deprecated (unit is milliseconds)

--- a/cores/esp8266/PolledTimeout.h
+++ b/cores/esp8266/PolledTimeout.h
@@ -269,7 +269,7 @@ protected:
   }
 
   IRAM_ATTR // fast
-  bool expiredOneShot()
+  bool expiredOneShot() const
   {
     // returns "always expired" or "has expired"
     if (!canWait()) return true;
@@ -284,7 +284,7 @@ protected:
   timeType _timeout;
   timeType _start;
   bool _neverExpires;
-  bool _oneShotExpired;
+  mutable bool _oneShotExpired;
 };
 
 // legacy type names, deprecated (unit is milliseconds)

--- a/cores/esp8266/PolledTimeout.h
+++ b/cores/esp8266/PolledTimeout.h
@@ -157,10 +157,9 @@ public:
   IRAM_ATTR // fast
   bool expired()
   {
-    YieldPolicyT::execute(); //in case of DoNothing: gets optimized away
-    if(PeriodicT)           //in case of false: gets optimized away
-      return expiredRetrigger();
-    return expiredOneShot();
+    bool hasExpired = PeriodicT ? expiredRetrigger() : expiredOneShot();
+    if (!hasExpired) YieldPolicyT::execute(); //in case of DoNothing: gets optimized away
+    return hasExpired;
   }
 
   IRAM_ATTR // fast

--- a/cores/esp8266/PolledTimeout.h
+++ b/cores/esp8266/PolledTimeout.h
@@ -268,10 +268,16 @@ protected:
   }
 
   IRAM_ATTR // fast
-  bool expiredOneShot() const
+  bool expiredOneShot()
   {
     // returns "always expired" or "has expired"
-    return !canWait() || checkExpired(TimePolicyT::time());
+    return !canWait();
+    if (checkExpired(TimePolicyT::time()))
+    {
+      _timeout = alwaysExpired;
+      return true;
+    }
+    return false;
   }
 
   timeType _timeout;

--- a/cores/esp8266/PolledTimeout.h
+++ b/cores/esp8266/PolledTimeout.h
@@ -224,10 +224,12 @@ public:
   }
 
   IRAM_ATTR // fast
-  timeType expiresIn()
+  timeType remaining() const
   {
-    if (_neverExpires) return timeMax();
-    if (expired()) return TimePolicyT::toUserUnit(0);
+    if (_neverExpires)
+        return timeMax();
+    if (expired())
+        return TimePolicyT::toUserUnit(0);
     return TimePolicyT::toUserUnit(_timeout - (_current - _start));
   }
   

--- a/cores/esp8266/PolledTimeout.h
+++ b/cores/esp8266/PolledTimeout.h
@@ -227,10 +227,11 @@ public:
   timeType remaining() const
   {
     if (_neverExpires)
-        return timeMax();
-    if (expired())
-        return TimePolicyT::toUserUnit(0);
-    return TimePolicyT::toUserUnit(_timeout - (_current - _start));
+      return timeMax();
+    timeType current = TimePolicyT::time();
+    if (checkExpired(current))
+      return TimePolicyT::toUserUnit(0);
+    return TimePolicyT::toUserUnit(_timeout - (current - _start));
   }
   
   static constexpr timeType timeMax()
@@ -241,11 +242,11 @@ public:
 private:
 
   IRAM_ATTR // fast
-  bool checkExpired() const
+  bool checkExpired(const timeType internalUnit) const
   {
     // canWait() is not checked here
     // returns "can expire" and "time expired"
-    return (!_neverExpires) && ((_current - _start) >= _timeout);
+    return (!_neverExpires) && ((internalUnit - _start) >= _timeout);
   }
 
 protected:
@@ -256,10 +257,10 @@ protected:
     if (!canWait())
       return true;
 
-    _current = TimePolicyT::time();
-    if(checkExpired())
+    timeType current = TimePolicyT::time();
+    if(checkExpired(current))
     {
-      unsigned long n = (_current - _start) / _timeout; //how many _timeouts periods have elapsed, will usually be 1 (_current - _start >= _timeout)
+      unsigned long n = (current - _start) / _timeout; //how many _timeouts periods have elapsed, will usually be 1 (current - _start >= _timeout)
       _start += n  * _timeout;
       return true;
     }
@@ -267,16 +268,14 @@ protected:
   }
 
   IRAM_ATTR // fast
-  bool expiredOneShot()
+  bool expiredOneShot() const
   {
-    _current = TimePolicyT::time();
     // returns "always expired" or "has expired"
-    return !canWait() || checkExpired();
+    return !canWait() || checkExpired(TimePolicyT::time());
   }
 
   timeType _timeout;
   timeType _start;
-  timeType _current;
   bool _neverExpires;
 };
 

--- a/cores/esp8266/PolledTimeout.h
+++ b/cores/esp8266/PolledTimeout.h
@@ -175,7 +175,7 @@ public:
 
   bool canWait () const
   {
-    return _timeout != 0 && !_oneShotExpired;
+    return !(_timeout == 0 || _oneShotExpired);
   }
 
   // Resets, will trigger after this new timeout.

--- a/cores/esp8266/Stream.h
+++ b/cores/esp8266/Stream.h
@@ -168,7 +168,7 @@ class Stream: public Print {
 
         // transfers already buffered / immediately available data (no timeout)
         // returns number of transfered bytes
-        size_t sendAvailable (Print* to) { return sendGeneric(to, -1, -1, oneShotMs::alwaysExpired); }
+        size_t sendAvailable (Print* to) { return sendGeneric(to, -1, -1, 0); }
         size_t sendAvailable (Print& to) { return sendAvailable(&to); }
 
         // transfers data until timeout

--- a/libraries/ESP8266WiFiMesh/src/ExpiringTimeTracker.h
+++ b/libraries/ESP8266WiFiMesh/src/ExpiringTimeTracker.h
@@ -61,7 +61,7 @@ public:
    * Get the time since the ExpiringTimeTracker instance creation or the last reset(), whichever is more recent.
    */
   uint32_t elapsedTime() const;
-  bool expired();
+  bool expired() const;
   void reset();
   void reset(const uint32_t newDuration);
   void reset(const calculatorType newDurationCalculator);

--- a/libraries/ESP8266WiFiMesh/src/ExpiringTimeTracker.h
+++ b/libraries/ESP8266WiFiMesh/src/ExpiringTimeTracker.h
@@ -61,7 +61,7 @@ public:
    * Get the time since the ExpiringTimeTracker instance creation or the last reset(), whichever is more recent.
    */
   uint32_t elapsedTime() const;
-  bool expired() const;
+  bool expired();
   void reset();
   void reset(const uint32_t newDuration);
   void reset(const calculatorType newDurationCalculator);


### PR DESCRIPTION
There are cases where the remaining time until the next expiration is needed.
``remaining()`` returns that time value.
Also prevent the call to `YieldPolicyT::execute()` for expired timers, this looks like it generally just wastes time in needless delays.
It's a breaking change due to the removal of `alwaysExpired` id `0`.