### PR TITLE
Using clockCyclesPerMicrosecond() in host build fails

### DIFF
--- a/tests/host/common/mock.h
+++ b/tests/host/common/mock.h
@@ -61,6 +61,33 @@ typedef uint32_t uint32;
 
 //
 
+#define ARDUINO 267
+#define ESP8266 1
+#define A0 0
+#define LED_BUILTIN 0
+#define F_CPU 80000000
+#define LWIP_OPEN_SRC
+#define TCP_MSS 536
+#define LWIP_FEATURES 1
+
+//
+
+#define D0 0
+#define D1 1
+#define D2 3
+#define D3 3
+#define D4 4
+#define D5 5
+#define D6 6
+#define D7 7
+#define D8 8
+
+//
+
+#include <Arduino.h>
+
+//
+
 #include <stdlib.h>
 #define RANDOM_REG32 ((uint32_t)random())
 
@@ -136,33 +163,6 @@ void mock_start_spiffs (const String& fname, size_t size_kb, size_t block_kb = 8
 void mock_stop_spiffs ();
 void mock_start_littlefs (const String& fname, size_t size_kb, size_t block_kb = 8, size_t page_b = 512);
 void mock_stop_littlefs ();
-
-//
-
-#define ARDUINO 267
-#define ESP8266 1
-#define A0 0
-#define LED_BUILTIN 0
-#define F_CPU 80000000
-#define LWIP_OPEN_SRC
-#define TCP_MSS 536
-#define LWIP_FEATURES 1
-
-//
-
-#define D0 0
-#define D1 1
-#define D2 3
-#define D3 3
-#define D4 4
-#define D5 5
-#define D6 6
-#define D7 7
-#define D8 8
-
-//
-
-#include <Arduino.h>
 
 //
 

--- a/tests/host/common/mock.h
+++ b/tests/host/common/mock.h
@@ -61,10 +61,6 @@ typedef uint32_t uint32;
 
 //
 
-#include <Arduino.h>
-
-//
-
 #include <stdlib.h>
 #define RANDOM_REG32 ((uint32_t)random())
 
@@ -163,6 +159,10 @@ void mock_stop_littlefs ();
 #define D6 6
 #define D7 7
 #define D8 8
+
+//
+
+#include <Arduino.h>
 
 //
 


### PR DESCRIPTION
This PR fixes the include order of Arduino.h in mock.h.