### PR TITLE
Update ESP8266WifiGeneric.cpp to allow compile time selection of DNS …

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -644,6 +644,7 @@ int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResul
     return (err == ERR_OK) ? 1 : 0;
 }
 
+#if LWIP_VERSION_MAJOR > 1
 int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResult, uint32_t timeout_ms, uint8_t resolveType)
 {
     ip_addr_t addr;
@@ -656,11 +657,7 @@ int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResul
     }
 
     DEBUG_WIFI_GENERIC("[hostByName] request IP for: %s\n", aHostname);
-#if LWIP_VERSION_MAJOR > 1
     err_t err = dns_gethostbyname_addrtype(aHostname, &addr, &wifi_dns_found_callback, &aResult, resolveType);
-#else
-    err_t err = dns_gethostbyname(aHostname, &addr, &wifi_dns_found_callback, &aResult);
-#endif
     if(err == ERR_OK) {
         aResult = IPAddress(&addr);
     } else if(err == ERR_INPROGRESS) {
@@ -682,6 +679,7 @@ int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResul
 
     return (err == ERR_OK) ? 1 : 0;
 }
+#endif
 
 /**
  * DNS callback

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -618,8 +618,10 @@ int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResul
 
     DEBUG_WIFI_GENERIC("[hostByName] request IP for: %s\n", aHostname);
 #if LWIP_VERSION_MAJOR > 1
+#pragma message("cpp addrtype lwip 2.x")
     err_t err = dns_gethostbyname_addrtype(aHostname, &addr, &wifi_dns_found_callback, &aResult,LWIP_DNS_ADDRTYPE_DEFAULT);
 #else
+#pragma message("cpp lwip 1.x")
     err_t err = dns_gethostbyname(aHostname, &addr, &wifi_dns_found_callback, &aResult);
 #endif
     if(err == ERR_OK) {
@@ -645,6 +647,7 @@ int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResul
 }
 
 #if LWIP_VERSION_MAJOR > 1
+#pragma message("cpp addrtype resolveType lwip 2.x")
 int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResult, uint32_t timeout_ms, uint8_t resolveType)
 {
     ip_addr_t addr;

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -617,7 +617,7 @@ int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResul
     }
 
     DEBUG_WIFI_GENERIC("[hostByName] request IP for: %s\n", aHostname);
-    err_t err = dns_gethostbyname(aHostname, &addr, &wifi_dns_found_callback, &aResult);
+    err_t err = dns_gethostbyname_addrtype(aHostname, &addr, &wifi_dns_found_callback, &aResult, LWIP_DNS_ADDRTYPE_DEFAULT);
     if(err == ERR_OK) {
         aResult = IPAddress(&addr);
     } else if(err == ERR_INPROGRESS) {

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -666,6 +666,7 @@ int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResul
     } else if(err == ERR_INPROGRESS) {
         _dns_lookup_pending = true;
         delay(timeout_ms);
+	// will resume on timeout or when wifi_dns_found_callback fires
         _dns_lookup_pending = false;
         // will return here when dns_found_callback fires
         if(aResult.isSet()) {

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -617,11 +617,11 @@ int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResul
     }
 
     DEBUG_WIFI_GENERIC("[hostByName] request IP for: %s\n", aHostname);
-#if LWIP_VERSION_MAJOR > 1
-#pragma message("cpp addrtype lwip 2.x")
+#if LWIP_IPV4 && LWIP_IPV6
+#pragma message("Dualstack")
     err_t err = dns_gethostbyname_addrtype(aHostname, &addr, &wifi_dns_found_callback, &aResult,LWIP_DNS_ADDRTYPE_DEFAULT);
 #else
-#pragma message("cpp lwip 1.x")
+#pragma message("Singlestack")
     err_t err = dns_gethostbyname(aHostname, &addr, &wifi_dns_found_callback, &aResult);
 #endif
     if(err == ERR_OK) {
@@ -646,8 +646,8 @@ int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResul
     return (err == ERR_OK) ? 1 : 0;
 }
 
-#if LWIP_VERSION_MAJOR > 1
-#pragma message("cpp addrtype resolveType lwip 2.x")
+#if LWIP_IPV4 && LWIP_IPV6
+#pragma message("Dualstack API extension")
 int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResult, uint32_t timeout_ms, uint8_t resolveType)
 {
     ip_addr_t addr;

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -618,10 +618,8 @@ int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResul
 
     DEBUG_WIFI_GENERIC("[hostByName] request IP for: %s\n", aHostname);
 #if LWIP_IPV4 && LWIP_IPV6
-#pragma message("Dualstack")
     err_t err = dns_gethostbyname_addrtype(aHostname, &addr, &wifi_dns_found_callback, &aResult,LWIP_DNS_ADDRTYPE_DEFAULT);
 #else
-#pragma message("Singlestack")
     err_t err = dns_gethostbyname(aHostname, &addr, &wifi_dns_found_callback, &aResult);
 #endif
     if(err == ERR_OK) {
@@ -647,7 +645,6 @@ int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResul
 }
 
 #if LWIP_IPV4 && LWIP_IPV6
-#pragma message("Dualstack API extension")
 int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResult, uint32_t timeout_ms, uint8_t resolveType)
 {
     ip_addr_t addr;

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -627,7 +627,7 @@ int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResul
     } else if(err == ERR_INPROGRESS) {
         _dns_lookup_pending = true;
         delay(timeout_ms);
-	// will resume on timeout or when wifi_dns_found_callback fires
+        // will resume on timeout or when wifi_dns_found_callback fires
         _dns_lookup_pending = false;
         // will return here when dns_found_callback fires
         if(aResult.isSet()) {
@@ -666,7 +666,7 @@ int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResul
     } else if(err == ERR_INPROGRESS) {
         _dns_lookup_pending = true;
         delay(timeout_ms);
-	// will resume on timeout or when wifi_dns_found_callback fires
+        // will resume on timeout or when wifi_dns_found_callback fires
         _dns_lookup_pending = false;
         // will return here when dns_found_callback fires
         if(aResult.isSet()) {

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.h
@@ -114,7 +114,6 @@ class ESP8266WiFiGenericClass {
         int hostByName(const char* aHostname, IPAddress& aResult);
         int hostByName(const char* aHostname, IPAddress& aResult, uint32_t timeout_ms);
  #if LWIP_VERSION_MAJOR > 1
- #pragma message("header lwip 2.x")
         int hostByName(const char* aHostname, IPAddress& aResult, uint32_t timeout_ms, uint8_t resolveType);
  #endif
         bool getPersistent();

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.h
@@ -113,7 +113,10 @@ class ESP8266WiFiGenericClass {
     public:
         int hostByName(const char* aHostname, IPAddress& aResult);
         int hostByName(const char* aHostname, IPAddress& aResult, uint32_t timeout_ms);
+ #if LWIP_VERSION_MAJOR > 1
+ #pragma message("header lwip 2.x")
         int hostByName(const char* aHostname, IPAddress& aResult, uint32_t timeout_ms, uint8_t resolveType);
+ #endif
         bool getPersistent();
 
     protected:

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.h
@@ -113,6 +113,7 @@ class ESP8266WiFiGenericClass {
     public:
         int hostByName(const char* aHostname, IPAddress& aResult);
         int hostByName(const char* aHostname, IPAddress& aResult, uint32_t timeout_ms);
+        int hostByName(const char* aHostname, IPAddress& aResult, uint32_t timeout_ms, uint8_t resolveType);
         bool getPersistent();
 
     protected:

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.h
@@ -113,9 +113,9 @@ class ESP8266WiFiGenericClass {
     public:
         int hostByName(const char* aHostname, IPAddress& aResult);
         int hostByName(const char* aHostname, IPAddress& aResult, uint32_t timeout_ms);
- #if LWIP_VERSION_MAJOR > 1
+#if LWIP_IPV4 && LWIP_IPV6
         int hostByName(const char* aHostname, IPAddress& aResult, uint32_t timeout_ms, uint8_t resolveType);
- #endif
+#endif
         bool getPersistent();
 
     protected:


### PR DESCRIPTION
…resolution precedence IPv4/IPv6

eg. platformio uses prebuilt liblwip6-1460-feat.a which is built with DNS resolution order IPV4 before IPv6. This causes problems in IPv6 only environments if there is a DNS record with A and AAAA. lwip then tries to connect to the resolved v4 even if there is no global IPv4 address. Didn't find a way to get pio rebuild the complete library. That's why I patched ESP8266WifiGeneric.cpp to use dns_gethostbyname_addrtype instead of dns_gethostbyname (which is only a wrapper for gethostbyname_addrtype and the define to prefer v4). With this change it's possible to select resolution beaviour during compile time.