### PR TITLE
Remove user_interface.h from gdbstub includes

### DIFF
--- a/libraries/GDBStub/examples/gdbstub_example.ino
+++ b/libraries/GDBStub/examples/gdbstub_example.ino
@@ -1,0 +1,13 @@
+#include <GDBStub.h>
+
+void setup() {
+  Serial.begin(115200);
+  gdbstub_init();
+  Serial.printf("Starting...\n");
+}
+
+void loop() {
+  static uint32_t cnt = 0;
+  Serial.printf("%d\n", cnt++);
+  delay(100);
+}

--- a/libraries/GDBStub/src/internal/gdbstub.c
+++ b/libraries/GDBStub/src/internal/gdbstub.c
@@ -67,7 +67,6 @@ OS-less SDK defines. Defines some headers for things that aren't in the include 
 the xthal stack frame struct.
 */
 #include "osapi.h"
-#include "user_interface.h"
 
 void _xtos_set_exception_handler(int cause, void (exhandler)(struct XTensa_exception_frame_s *frame));
 


### PR DESCRIPTION
Avoid a warning by not including the unneeded "user_interface.h" from
gdbstub.c.  Leftover from original stub code from the SDK, this include
is unnecessary in the Arduino core.