### PR TITLE
LEAmDNS2 (Host Version)

### DIFF
--- a/cores/esp8266/sntp-lwip2.cpp
+++ b/cores/esp8266/sntp-lwip2.cpp
@@ -38,6 +38,7 @@
  */
 
 #include <lwip/init.h>
+#include <time.h>
 #include <sys/time.h>
 #include <osapi.h>
 #include <os_type.h>
@@ -133,30 +134,8 @@ static const int year_lengths[2] = {
   365,
   366
 } ;
-struct tm
-{
-  int	tm_sec;
-  int	tm_min;
-  int	tm_hour;
-  int	tm_mday;
-  int	tm_mon;
-  int	tm_year;
-  int	tm_wday;
-  int	tm_yday;
-  int	tm_isdst;
-};
 
 struct tm res_buf;
-typedef struct __tzrule_struct
-{
-  char ch;
-  int m;
-  int n;
-  int d;
-  int s;
-  time_t change;
-  int offset;
-} __tzrule_type;
 
 __tzrule_type sntp__tzrule[2];
 struct tm *

--- a/libraries/ESP8266WebServer/src/detail/RequestHandler.h
+++ b/libraries/ESP8266WebServer/src/detail/RequestHandler.h
@@ -5,8 +5,9 @@
 
 template<typename ServerType>
 class RequestHandler {
-    using WebServerType = ESP8266WebServerTemplate<ServerType>;
 public:
+    using WebServerType = ESP8266WebServerTemplate<ServerType>;
+
     virtual ~RequestHandler() { }
     virtual bool canHandle(HTTPMethod method, String uri) { (void) method; (void) uri; return false; }
     virtual bool canUpload(String uri) { (void) uri; return false; }

--- a/libraries/ESP8266WiFi/src/include/UdpContext.h
+++ b/libraries/ESP8266WiFi/src/include/UdpContext.h
@@ -167,6 +167,22 @@ public:
 
 #endif // !LWIP_IPV6
 
+    /*
+     * Add a netif (by its index) as the multicast interface
+     */
+    void setMulticastInterface(netif* p_pNetIf)
+    {
+        udp_set_multicast_netif_index(_pcb, netif_get_index(p_pNetIf));
+    }
+
+    /*
+     * Allow access to pcb to change eg. options
+     */
+    udp_pcb* pcb(void)
+    {
+        return _pcb;
+    }
+
     void setMulticastTTL(int ttl)
     {
 #ifdef LWIP_MAYBE_XCC

--- a/libraries/ESP8266mDNS/src/ESP8266mDNS.h
+++ b/libraries/ESP8266mDNS/src/ESP8266mDNS.h
@@ -44,12 +44,14 @@
 
 #include "ESP8266mDNS_Legacy.h"
 #include "LEAmDNS.h"
+#include "LEAmDNS2.h"
 
 
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_MDNS)
 // Maps the implementation to use to the global namespace type
 //using MDNSResponder = Legacy_MDNSResponder::MDNSResponder; //legacy
 using MDNSResponder = esp8266::MDNSImplementation::MDNSResponder; //new
+//using MDNSResponder = esp8266::experimental::MDNSResponder; //new^2 not compatible
 
 extern MDNSResponder MDNS;
 #endif

--- a/libraries/ESP8266mDNS/src/LEAmDNS2.h
+++ b/libraries/ESP8266mDNS/src/LEAmDNS2.h
@@ -1,0 +1,1303 @@
+/*
+    LEAmDNS2.h
+    (c) 2018, LaborEtArs
+
+    Version 0.9 beta
+
+    Some notes (from LaborEtArs, 2018):
+    Essentially, this is an rewrite of the original EPS8266 Multicast DNS code (ESP8266mDNS).
+    The target of this rewrite was to keep the existing interface as stable as possible while
+    adding and extending the supported set of mDNS features.
+    A lot of the additions were basicly taken from Erik Ekman's lwIP mdns app code.
+
+    Supported mDNS features (in some cases somewhat limited):
+    - Presenting a DNS-SD service to interested observers, eg. a http server by presenting _http._tcp service
+    - Support for multi-level compressed names in input; in output only a very simple one-leven full-name compression is implemented
+    - Probing host and service domains for uniqueness in the local network
+    - Tiebreaking while probing is supportet in a very minimalistic way (the 'higher' IP address wins the tiebreak)
+    - Announcing available services after successful probing
+    - Using fixed service TXT items or
+    - Using dynamic service TXT items for presented services (via callback)
+    - Remove services (and un-announcing them to the observers by sending goodbye-messages)
+    - Static queries for DNS-SD services (creating a fixed answer set after a certain timeout period)
+    - Dynamic queries for DNS-SD services with cached and updated answers and user notifications
+
+
+    Usage:
+    In most cases, this implementation should work as a 'drop-in' replacement for the original
+    ESP8266 Multicast DNS code. Adjustments to the existing code would only be needed, if some
+    of the new features should be used.
+
+    For presenting services:
+    In 'setup()':
+      Install a callback for the probing of host (and service) domains via 'MDNS.setProbeResultCallback(probeResultCallback, &userData);'
+      Register DNS-SD services with 'MDNSResponder::hMDNSService hService = MDNS.addService("MyESP", "http", "tcp", 5000);'
+      (Install additional callbacks for the probing of these service domains via 'MDNS.setServiceProbeResultCallback(hService, probeResultCallback, &userData);')
+      Add service TXT items with 'MDNS.addServiceTxt(hService, "c#", "1");' or by installing a service TXT callback
+      using 'MDNS.setDynamicServiceTxtCallback(dynamicServiceTxtCallback, &userData);' or service specific
+      'MDNS.setDynamicServiceTxtCallback(hService, dynamicServiceTxtCallback, &userData);'
+      Call MDNS.begin("MyHostName");
+
+    In 'probeResultCallback(MDNSResponder* p_MDNSResponder, const char* p_pcDomain, MDNSResponder:hMDNSService p_hMDNSService, bool p_bProbeResult, void* p_pUserdata)':
+      Check the probe result and update the host or service domain name if the probe failed
+
+    In 'dynamicServiceTxtCallback(MDNSResponder* p_MDNSResponder, const hMDNSService p_hMDNSService, void* p_pUserdata)':
+      Add dynamic TXT items by calling 'MDNS.addDynamicServiceTxt(p_hMDNSService, "c#", "1");'
+
+    In loop():
+      Call 'MDNS.update();'
+
+
+    For querying services/hosts:
+    Static:
+      Call 'uint32_t u32AnswerCount = MDNS.queryService("http", "tcp");' or 'MDNS.queryHost("esp8266")';
+      Iterate answers by: 'for (uint32_t u=0; u<u32AnswerCount; ++u) { const char* pHostName = MDNS.answerHostName(u); }'
+      You should call MDNS.removeQuery() sometimes later (when the answers are not needed anymore)
+
+    Dynamic:
+      Install a dynamic service query by calling 'DNSResponder::hMDNSQuery hQuery = MDNS.installServiceQuery("http", "tcp", serviceQueryCallback, &userData);'
+      The callback 'serviceQueryCallback(MDNSResponder* p_MDNSResponder, const stcAnswerAccessor& p_MDNSAnswerAccessor, typeQueryAnswerType p_QueryAnswerTypeFlags, bool p_bSetContent)'
+      is called for any change in the answer set.
+      Call 'MDNS.removeQuery(hServiceQuery);' when the answers are not needed anymore
+
+
+    Reference:
+    Used mDNS messages:
+    A (0x01):               eg. esp8266.local A OP TTL 123.456.789.012
+    AAAA (0x1C):            eg. esp8266.local AAAA OP TTL 1234:5678::90
+    PTR (0x0C, srv name):   eg. _http._tcp.local PTR OP TTL MyESP._http._tcp.local
+    PTR (0x0C, srv type):   eg. _services._dns-sd._udp.local PTR OP TTL _http._tcp.local
+    PTR (0x0C, IPv4):        eg. 012.789.456.123.in-addr.arpa PTR OP TTL esp8266.local
+    PTR (0x0C, IPv6):        eg. 90.0.0.0.0.0.0.0.0.0.0.0.78.56.34.12.ip6.arpa PTR OP TTL esp8266.local
+    SRV (0x21):             eg. MyESP._http._tcp.local SRV OP TTL PRIORITY WEIGHT PORT esp8266.local
+    TXT (0x10):             eg. MyESP._http._tcp.local TXT OP TTL c#=1
+    NSEC (0x2F):            eg. esp8266.local ... (DNSSEC)
+
+    Some NOT used message types:
+    OPT (0x29):             eDNS
+
+
+    License (MIT license):
+      Permission is hereby granted, free of charge, to any person obtaining a copy
+      of this software and associated documentation files (the "Software"), to deal
+      in the Software without restriction, including without limitation the rights
+      to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+      copies of the Software, and to permit persons to whom the Software is
+      furnished to do so, subject to the following conditions:
+
+      The above copyright notice and this permission notice shall be included in
+      all copies or substantial portions of the Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+      THE SOFTWARE.
+
+*/
+
+#ifndef LEAMDNS2_H
+#define LEAMDNS2_H
+
+#include <functional>   // for UdpContext.h
+#include <list>
+#include <limits>
+#include <map>
+
+#include "lwip/netif.h"
+#include "WiFiUdp.h"
+#include "lwip/udp.h"
+#include "debug.h"
+#include "include/UdpContext.h"
+#include <PolledTimeout.h>
+
+#include "ESP8266WiFi.h"
+
+
+namespace esp8266
+{
+
+/**
+    LEAmDNS
+*/
+namespace experimental
+{
+
+//this should be user-defined at build time
+#ifndef ARDUINO_BOARD
+#define ARDUINO_BOARD "generic"
+#endif
+
+#define MDNS_IPV4_SUPPORT
+#if LWIP_IPV6
+#define MDNS_IPV6_SUPPORT	// If we've got IPv6 support, then we need IPv6 support :-)
+#endif
+
+
+#ifdef MDNS_IPV4_SUPPORT
+#define MDNS_IPV4_SIZE              	4
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+#define MDNS_IPV6_SIZE              	16
+#endif
+/*
+    Maximum length for all service txts for one service
+*/
+#define MDNS_SERVICE_TXT_MAXLENGTH      1300
+/*
+    Maximum length for a full domain name eg. MyESP._http._tcp.local
+*/
+#define MDNS_DOMAIN_MAXLENGTH           256
+/*
+    Maximum length of on label in a domain name (length info fits into 6 bits)
+*/
+#define MDNS_DOMAIN_LABEL_MAXLENGTH     63
+/*
+    Maximum length of a service name eg. http
+*/
+#define MDNS_SERVICE_NAME_LENGTH        15
+/*
+    Maximum length of a service protocol name eg. tcp
+*/
+#define MDNS_SERVICE_PROTOCOL_LENGTH    3
+/*
+    Default timeout for static service queries
+*/
+#define MDNS_QUERYSERVICES_WAIT_TIME    5000
+
+/*
+    DNS_RRTYPE_NSEC
+*/
+#ifndef DNS_RRTYPE_NSEC
+#define DNS_RRTYPE_NSEC             	0x2F
+#endif
+
+
+/**
+    MDNSResponder
+*/
+class MDNSResponder
+{
+protected:
+#include "LEAmDNS2_Host.hpp"
+
+public:
+    // MISC HELPERS
+    // Domain name helper
+    static bool indexDomain(char*& p_rpcDomain,
+                            const char* p_pcDivider = "-",
+                            const char* p_pcDefaultDomain = 0);
+    // Host name helper
+    static bool setNetIfHostName(netif* p_pNetIf,
+                                 const char* p_pcHostName);
+
+    // INTERFACE
+    MDNSResponder(void);
+    virtual ~MDNSResponder(void);
+
+    // HANDLEs for opaque access to responder objects
+    /**
+    	hMDNSHost
+    */
+    using hMDNSHost = const void*;
+    /**
+        hMDNSService
+    */
+    using hMDNSService = const void*;
+    /**
+        hMDNSTxt
+    */
+    using hMDNSTxt = const void*;
+    /**
+        hMDNSQuery
+    */
+    using hMDNSQuery = const void*;
+
+    // CALLBACKS
+    /**
+        MDNSHostProbeResultCallbackFn
+        Callback function for host domain probe results
+    */
+    using MDNSHostProbeResultCallbackFn = std::function<void(MDNSResponder& p_rMDNSResponder,
+                                                             const hMDNSHost p_hMDNSHost,
+                                                             const char* p_pcDomainName,
+                                                             bool p_bProbeResult)>;
+
+    // Create a MDNS netif responder netif by setting the default hostname
+    // Later call 'update()' in every 'loop' to run the process loop
+    // (probing, announcing, responding, ...)
+    // If no callback is given, the (maybe) already installed callback stays set
+    hMDNSHost begin(const char* p_pcHostName,
+                    netif* p_pNetIf,
+                    MDNSHostProbeResultCallbackFn p_fnCallback = 0);
+    bool begin(const char* p_pcHostName,
+               WiFiMode_t p_WiFiMode,
+               MDNSHostProbeResultCallbackFn p_fnCallback = 0);
+    bool begin(const char* p_pcHostName,
+               MDNSHostProbeResultCallbackFn p_fnCallback = 0);
+
+    // Finish MDNS processing
+    bool close(const hMDNSHost p_hMDNSHost);
+    bool close(void);
+
+    hMDNSHost getMDNSHost(netif* p_pNetIf) const;
+    hMDNSHost getMDNSHost(WiFiMode_t p_WiFiMode) const;
+
+    // Change hostname (probing is restarted)
+    // If no callback is given, the (maybe) already installed callback stays set
+    bool setHostName(const hMDNSHost p_hMDNSHost,
+                     const char* p_pcHostName,
+                     MDNSHostProbeResultCallbackFn p_fnCallback = 0);
+
+    const char* hostName(const hMDNSHost p_hMDNSHost) const;
+
+    // Set a callback function for host probe results
+    // The callback function is called, when the probeing for the host domain
+    // succeededs or fails.
+    // In case of failure, the failed domain name should be changed.
+    bool setHostProbeResultCallback(const hMDNSHost p_hMDNSHost,
+                                    MDNSHostProbeResultCallbackFn p_fnCallback);
+
+    // Returns 'true' is host domain probing is done
+    bool status(const hMDNSHost p_hMDNSHost) const;
+
+    // Add a 'global' default' instance name for new services
+    bool setInstanceName(const hMDNSHost p_hMDNSHost,
+                         const char* p_pcInstanceName);
+    const char* instanceName(const hMDNSHost p_hMDNSHost) const;
+
+    /**
+        MDNSServiceProbeResultCallbackFn
+        Callback function for service domain probe results
+    */
+    using MDNSServiceProbeResultCallbackFn = std::function<void(MDNSResponder& p_rMDNSResponder,
+                                                                const hMDNSHost p_hMDNSHost,
+                                                                const hMDNSService p_hMDNSService,
+                                                                const char* p_pcServiceName,
+                                                                bool p_bProbeResult)>;
+    // Add a new service to the MDNS responder. If no name (instance name) is given (p_pcName = 0)
+    // the current hostname is used. If the hostname is changed later, the instance names for
+    // these 'auto-named' services are changed to the new name also (and probing is restarted).
+    // The usual '_' before p_pcService (eg. http) and protocol (eg. tcp) may be given.#
+    // If no callback is given, the (maybe) already installed callback stays set
+    hMDNSService addService(const hMDNSHost p_hMDNSHost,
+                            const char* p_pcName,
+                            const char* p_pcServiceType,
+                            const char* p_pcProtocol,
+                            uint16_t p_u16Port,
+                            MDNSServiceProbeResultCallbackFn p_fnCallback = 0);
+    // Removes a service from the MDNS responder
+    bool removeService(const hMDNSHost p_hMDNSHost,
+                       const hMDNSService p_hMDNSService);
+    bool removeService(const hMDNSHost p_hMDNSHost,
+                       const char* p_pcInstanceName,
+                       const char* p_pcServiceType,
+                       const char* p_pcProtocol);
+    hMDNSService findService(const hMDNSHost p_hMDNSHost,
+                             const char* p_pcName,
+                             const char* p_pcService,
+                             const char* p_pcProtocol);
+
+    // Change the services instance name (and restart probing).
+    // If no callback is given, the (maybe) already installed callback stays set
+    bool setServiceName(const hMDNSHost p_hMDNSHost,
+                        const hMDNSService p_hMDNSService,
+                        const char* p_pcInstanceName,
+                        MDNSServiceProbeResultCallbackFn p_fnCallback = 0);
+    const char* serviceName(const hMDNSHost p_hMDNSHost,
+                            const hMDNSService p_hMDNSService) const;
+    const char* serviceType(const hMDNSHost p_hMDNSHost,
+                            const hMDNSService p_hMDNSService) const;
+    const char* serviceProtocol(const hMDNSHost p_hMDNSHost,
+                                const hMDNSService p_hMDNSService) const;
+    uint16_t servicePort(const hMDNSHost p_hMDNSHost,
+                         const hMDNSService p_hMDNSService) const;
+
+    // Set a service specific probe result callcack
+    bool setServiceProbeResultCallback(const hMDNSHost p_hMDNSHost,
+                                       const hMDNSService p_hMDNSService,
+                                       MDNSServiceProbeResultCallbackFn p_fnCallback);
+
+    bool serviceStatus(const hMDNSHost p_hMDNSHost,
+                       const hMDNSService p_hMDNSService) const;
+
+    // Add a (static) MDNS TXT item ('key' = 'value') to the service
+    hMDNSTxt addServiceTxt(const hMDNSHost p_hMDNSHost,
+                           const hMDNSService p_hMDNSService,
+                           const char* p_pcKey,
+                           const char* p_pcValue);
+    hMDNSTxt addServiceTxt(const hMDNSHost p_hMDNSHost,
+                           const hMDNSService p_hMDNSService,
+                           const char* p_pcKey,
+                           uint32_t p_u32Value);
+    hMDNSTxt addServiceTxt(const hMDNSHost p_hMDNSHost,
+                           const hMDNSService p_hMDNSService,
+                           const char* p_pcKey,
+                           uint16_t p_u16Value);
+    hMDNSTxt addServiceTxt(const hMDNSHost p_hMDNSHost,
+                           const hMDNSService p_hMDNSService,
+                           const char* p_pcKey,
+                           uint8_t p_u8Value);
+    hMDNSTxt addServiceTxt(const hMDNSHost p_hMDNSHost,
+                           const hMDNSService p_hMDNSService,
+                           const char* p_pcKey,
+                           int32_t p_i32Value);
+    hMDNSTxt addServiceTxt(const hMDNSHost p_hMDNSHost,
+                           const hMDNSService p_hMDNSService,
+                           const char* p_pcKey,
+                           int16_t p_i16Value);
+    hMDNSTxt addServiceTxt(const hMDNSHost p_hMDNSHost,
+                           const hMDNSService p_hMDNSService,
+                           const char* p_pcKey,
+                           int8_t p_i8Value);
+
+    // Remove an existing (static) MDNS TXT item from the service
+    bool removeServiceTxt(const hMDNSHost p_hMDNSHost,
+                          const hMDNSService p_hMDNSService,
+                          const hMDNSTxt p_hTxt);
+    bool removeServiceTxt(const hMDNSHost p_hMDNSHost,
+                          const hMDNSService p_hMDNSService,
+                          const char* p_pcKey);
+
+    /**
+         MDNSDynamicServiceTxtCallbackFn
+         Callback function for dynamic MDNS TXT items
+    */
+    using MDNSDynamicServiceTxtCallbackFn = std::function<void(MDNSResponder& p_rMDNSResponder,
+                                                               const hMDNSHost p_hMDNSHost,
+                                                               const hMDNSService p_hMDNSService)>;
+    bool setDynamicServiceTxtCallback(const hMDNSHost p_hMDNSHost,
+                                      MDNSDynamicServiceTxtCallbackFn p_fnCallback);
+    bool setDynamicServiceTxtCallback(const hMDNSHost p_hMDNSHost,
+                                      const hMDNSService p_hMDNSService,
+                                      MDNSDynamicServiceTxtCallbackFn p_fnCallback);
+
+    // Add a (dynamic) MDNS TXT item ('key' = 'value') to the service
+    // Dynamic TXT items are removed right after one-time use. So they need to be added
+    // every time the value s needed (via callback).
+    hMDNSTxt addDynamicServiceTxt(const hMDNSHost p_hMDNSHost,
+                                  const hMDNSService p_hMDNSService,
+                                  const char* p_pcKey,
+                                  const char* p_pcValue);
+    hMDNSTxt addDynamicServiceTxt(const hMDNSHost p_hMDNSHost,
+                                  const hMDNSService p_hMDNSService,
+                                  const char* p_pcKey,
+                                  uint32_t p_u32Value);
+    hMDNSTxt addDynamicServiceTxt(const hMDNSHost p_hMDNSHost,
+                                  const hMDNSService p_hMDNSService,
+                                  const char* p_pcKey,
+                                  uint16_t p_u16Value);
+    hMDNSTxt addDynamicServiceTxt(const hMDNSHost p_hMDNSHost,
+                                  const hMDNSService p_hMDNSService,
+                                  const char* p_pcKey,
+                                  uint8_t p_u8Value);
+    hMDNSTxt addDynamicServiceTxt(const hMDNSHost p_hMDNSHost,
+                                  const hMDNSService p_hMDNSService,
+                                  const char* p_pcKey,
+                                  int32_t p_i32Value);
+    hMDNSTxt addDynamicServiceTxt(const hMDNSHost p_hMDNSHost,
+                                  const hMDNSService p_hMDNSService,
+                                  const char* p_pcKey,
+                                  int16_t p_i16Value);
+    hMDNSTxt addDynamicServiceTxt(const hMDNSHost p_hMDNSHost,
+                                  const hMDNSService p_hMDNSService,
+                                  const char* p_pcKey,
+                                  int8_t p_i8Value);
+
+    // QUERIES & ANSWERS
+    /**
+        clsMDNSAnswerAccessor & clsAnswerAccessorVector
+    */
+    struct clsMDNSAnswerAccessor
+    {
+    protected:
+        /**
+            stcCompareTxtKey
+        */
+        struct stcCompareTxtKey
+        {
+            bool operator()(char const* p_pA, char const* p_pB) const;
+        };
+    public:
+        clsMDNSAnswerAccessor(const clsHost::stcQuery::stcAnswer* p_pAnswer);
+        ~clsMDNSAnswerAccessor(void);
+
+        /**
+            clsTxtKeyValueMap
+        */
+        using clsTxtKeyValueMap = std::map<const char*, const char*, stcCompareTxtKey>;
+
+        bool serviceDomainAvailable(void) const;
+        const char* serviceDomain(void) const;
+        bool hostDomainAvailable(void) const;
+        const char* hostDomain(void) const;
+        bool hostPortAvailable(void) const;
+        uint16_t hostPort(void) const;
+#ifdef MDNS_IPV4_SUPPORT
+        bool IPv4AddressAvailable(void) const;
+        std::vector<IPAddress> IPv4Addresses(void) const;
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+        bool IPv6AddressAvailable(void) const;
+        std::vector<IPAddress> IPv6Addresses(void) const;
+#endif
+        bool txtsAvailable(void) const;
+        const char* txts(void) const;
+        const clsTxtKeyValueMap& txtKeyValues(void) const;
+        const char* txtValue(const char* p_pcKey) const;
+
+        size_t printTo(Print& p_Print) const;
+
+    protected:
+        const clsHost::stcQuery::stcAnswer*   m_pAnswer;
+        clsTxtKeyValueMap                                   m_TxtKeyValueMap;
+    };
+    using clsMDNSAnswerAccessorVector   = std::vector<clsMDNSAnswerAccessor>;
+    using typeQueryAnswerType           = clsHost::typeQueryAnswerType;
+    using enuQueryAnswerType            = clsHost::enuQueryAnswerType;
+
+    // STATIC QUERY
+    // Perform a (static) service/host query. The function returns after p_u16Timeout milliseconds
+    // The answers (the number of received answers is returned) can be retrieved by calling
+    // - answerHostName (or hostname)
+    // - answerIP (or IP)
+    // - answerPort (or port)
+    uint32_t queryService(const hMDNSHost p_hMDNSHost,
+                          const char* p_pcService,
+                          const char* p_pcProtocol,
+                          const uint16_t p_u16Timeout = MDNS_QUERYSERVICES_WAIT_TIME);
+    uint32_t queryHost(const hMDNSHost p_hMDNSHost,
+                       const char* p_pcHostName,
+                       const uint16_t p_u16Timeout = MDNS_QUERYSERVICES_WAIT_TIME);
+    bool removeQuery(const hMDNSHost p_hMDNSHost);
+    bool hasQuery(const hMDNSHost p_hMDNSHost);
+    hMDNSQuery getQuery(const hMDNSHost p_hMDNSHost);
+
+    clsMDNSAnswerAccessorVector answerAccessors(const hMDNSHost p_hMDNSHost);
+    uint32_t answerCount(const hMDNSHost p_hMDNSHost);
+    clsMDNSAnswerAccessor answerAccessor(const hMDNSHost p_hMDNSHost,
+                                         uint32_t p_u32AnswerIndex);
+
+    // DYNAMIC QUERIES
+    /**
+        MDNSQueryCallbackFn
+
+        Callback function for received answers for dynamic queries
+    */
+    using MDNSQueryCallbackFn = std::function<void(MDNSResponder& p_pMDNSResponder,
+                                                   hMDNSHost p_hMDNSHost,
+                                                   const hMDNSQuery p_hMDNSQuery,
+                                                   const clsMDNSAnswerAccessor& p_MDNSAnswerAccessor,
+                                                   typeQueryAnswerType p_QueryAnswerTypeFlags,          // flags for the updated answer item
+                                                   bool p_bSetContent)>;                                // true: Answer component set, false: component deleted
+
+    // Install a dynamic service/host query. For every received answer (part) the given callback
+    // function is called. The query will be updated every time, the TTL for an answer
+    // has timed-out.
+    // The answers can also be retrieved by calling
+    // - answerCount                                service/host (for host queries, this should never be >1)
+    // - answerServiceDomain                        service
+    // - hasAnswerHostDomain/answerHostDomain       service/host
+    // - hasAnswerIPv4Address/answerIPv4Address     service/host
+    // - hasAnswerIPv6Address/answerIPv6Address     service/host
+    // - hasAnswerPort/answerPort                   service
+    // - hasAnswerTxts/answerTxts                   service
+    hMDNSQuery installServiceQuery(const hMDNSHost p_hMDNSHost,
+                                   const char* p_pcServiceType,
+                                   const char* p_pcProtocol,
+                                   MDNSQueryCallbackFn p_fnCallback);
+    hMDNSQuery installHostQuery(const hMDNSHost p_hMDNSHost,
+                                const char* p_pcHostName,
+                                MDNSQueryCallbackFn p_fnCallback);
+    // Remove a dynamic service query
+    bool removeQuery(const hMDNSHost p_hMDNSHost,
+                     const hMDNSQuery p_hMDNSQuery);
+
+
+    uint32_t answerCount(const hMDNSHost p_hMDNSHost,
+                         const hMDNSQuery p_hMDNSQuery);
+    clsMDNSAnswerAccessorVector answerAccessors(const hMDNSHost p_hMDNSHost,
+                                                const hMDNSQuery p_hMDNSQuery);
+    clsMDNSAnswerAccessor answerAccessor(const hMDNSHost p_hMDNSHost,
+                                         const hMDNSQuery p_hMDNSQuery,
+                                         uint32 p_u32AnswerIndex);
+
+    /*  bool hasAnswerServiceDomain(const hMDNSHost p_hMDNSHost,
+                                const hMDNSQuery p_hQuery,
+                                const uint32_t p_u32AnswerIndex);
+        const char* answerServiceDomain(const hMDNSHost p_hMDNSHost,
+                                    const hMDNSQuery p_hQuery,
+                                    const uint32_t p_u32AnswerIndex);
+        bool hasAnswerHostDomain(const hMDNSHost p_hMDNSHost,
+                             const hMDNSQuery p_hQuery,
+                             const uint32_t p_u32AnswerIndex);
+        const char* answerHostDomain(const hMDNSHost p_hMDNSHost,
+                                 const hMDNSQuery p_hQuery,
+                                 const uint32_t p_u32AnswerIndex);
+        #ifdef MDNS_IPV4_SUPPORT
+        bool hasAnswerIPv4Address(const hMDNSHost p_hMDNSHost,
+                              const hMDNSQuery p_hQuery,
+                              const uint32_t p_u32AnswerIndex);
+        uint32_t answerIPv4AddressCount(const hMDNSHost p_hMDNSHost,
+                                    const hMDNSQuery p_hQuery,
+                                    const uint32_t p_u32AnswerIndex);
+        IPAddress answerIPv4Address(const hMDNSHost p_hMDNSHost,
+                                const hMDNSQuery p_hQuery,
+                                const uint32_t p_u32AnswerIndex,
+                                const uint32_t p_u32AddressIndex);
+        #endif
+        #ifdef MDNS_IPV6_SUPPORT
+        bool hasAnswerIPv6Address(const hMDNSHost p_hMDNSHost,
+                              const hMDNSQuery p_hQuery,
+                              const uint32_t p_u32AnswerIndex);
+        uint32_t answerIPv6AddressCount(const hMDNSHost p_hMDNSHost,
+                                    const hMDNSQuery p_hQuery,
+                                    const uint32_t p_u32AnswerIndex);
+        IPAddress answerIPv6Address(const hMDNSHost p_hMDNSHost,
+                                const hMDNSQuery p_hQuery,
+                                const uint32_t p_u32AnswerIndex,
+                                const uint32_t p_u32AddressIndex);
+        #endif
+        bool hasAnswerPort(const hMDNSHost p_hMDNSHost,
+                       const hMDNSQuery p_hQuery,
+                       const uint32_t p_u32AnswerIndex);
+        uint16_t answerPort(const hMDNSHost p_hMDNSHost,
+                        const hMDNSQuery p_hQuery,
+                        const uint32_t p_u32AnswerIndex);
+        bool hasAnswerTxts(const hMDNSHost p_hMDNSHost,
+                       const hMDNSQuery p_hQuery,
+                       const uint32_t p_u32AnswerIndex);
+        // Get the TXT items as a ';'-separated string
+        const char* answerTxts(const hMDNSHost p_hMDNSHost,
+                           const hMDNSQuery p_hQuery,
+                           const uint32_t p_u32AnswerIndex);*/
+
+    // GENERAL MANAGEMENT
+    // Application should call this whenever AP is configured/disabled
+    bool notifyNetIfChange(netif* p_pNetIf);
+
+    // 'update' should be called in every 'loop' to run the MDNS processing
+    bool update(const hMDNSHost p_hMDNSHost);
+    bool update(void);    // Convenience
+
+    // 'announce' can be called every time, the configuration of some service
+    // changes. Mainly, this would be changed content of TXT items.
+    bool announce(const hMDNSHost p_hMDNSHost);
+    bool announce(void);    // Convenience
+
+    // MISC
+    // Enable OTA update
+    hMDNSService enableArduino(const hMDNSHost p_hMDNSHost,
+                               uint16_t p_u16Port,
+                               bool p_bAuthUpload = false);
+
+protected:
+    /** Internal CLASSES & STRUCTS **/
+
+    // InstanceData
+    UdpContext*		m_pUDPContext;
+    clsHostList		m_HostList;
+
+    // UDP CONTEXT
+    bool _allocUDPContext(void);
+    bool _releaseUDPContext(void);
+    bool _processUDPInput(void);
+
+    // NETIF
+    clsHost* _createHost(netif* p_pNetIf);
+    bool _releaseHost(clsHost* p_pHost);
+
+    const clsHost* _findHost(netif* p_pNetIf) const;
+    clsHost* _findHost(netif* p_pNetIf);
+    const clsHost* _findHost(const hMDNSHost p_hMDNSHost) const;
+    clsHost* _findHost(const hMDNSHost p_hMDNSHost);
+
+
+    // HANDLE HELPERS
+    bool _validateMDNSHostHandle(const hMDNSHost p_hMDNSHost) const;
+    bool _validateMDNSHostHandle(const hMDNSHost p_hMDNSHost,
+                                 const hMDNSService p_hMDNSService) const;
+
+    clsHost* _NRH2Ptr(const hMDNSHost p_hMDNSHost);
+    const clsHost* _NRH2Ptr(const hMDNSHost p_hMDNSHost) const;
+    clsHost::stcService* _SH2Ptr(const hMDNSService p_hMDNSService);
+    const clsHost::stcService* _SH2Ptr(const hMDNSService p_hMDNSService) const;
+
+    // INIT
+    clsHost* _begin(const char* p_pcHostName,
+                    netif* p_pNetIf,
+                    MDNSHostProbeResultCallbackFn p_fnCallback);
+    bool _close(clsHost& p_rHost);
+
+
+#if not defined ESP_8266_MDNS_INCLUDE || defined DEBUG_ESP_MDNS_RESPONDER
+
+    const char* _DH(hMDNSHost p_hMDNSResponder = 0) const;
+
+#endif  // not defined ESP_8266_MDNS_INCLUDE || defined DEBUG_ESP_MDNS_RESPONDER
+
+};
+
+#ifdef __MDNS_USE_LEGACY
+/**
+    MDNSResponder_Legacy
+*/
+class MDNSResponder_Legacy //: public MDNSResponder
+{
+public:
+    /* INTERFACE */
+    MDNSResponder_Legacy(void);
+    virtual ~MDNSResponder_Legacy(void);
+
+    /**
+        hMDNSHost (opaque handle to access a netif binding)
+    */
+    using hMDNSHost = const void*;
+    /**
+        hMDNSService (opaque handle to access the service)
+    */
+    using hMDNSService = const void*;
+    /**
+        MDNSHostProbeResultCallbackFn
+        Callback function for host domain probe results
+    */
+    using MDNSHostProbeResultCallbackFn = std::function<void(MDNSResponder* p_pMDNSResponder,
+                                                             const hMDNSHost p_hMDNSHost,
+                                                             const char* p_pcDomainName,
+                                                             bool p_bProbeResult)>;
+    /* LEGACY 2 */
+    using MDNSServiceProbeResultCallbackFn1 = std::function<void(MDNSResponder* p_pMDNSResponder,
+                                                                 const hMDNSService p_hMDNSService,
+                                                                 const char* p_pcServiceName,
+                                                                 bool p_bProbeResult)>;
+    using MDNSServiceProbeResultCallbackFn2 = std::function<void(const hMDNSService p_hMDNSService,
+                                                                 const char* p_pcServiceName,
+                                                                 bool p_bProbeResult)>;
+    /**
+        hMDNSTxt (opaque handle to access the TXT items)
+    */
+    using hMDNSTxt = const void*;
+    /**
+        MDNSDynamicServiceTxtCallbackFn
+        Callback function for dynamic MDNS TXT items
+    */
+    using MDNSDynamicServiceTxtCallbackFn = std::function<void(MDNSResponder* p_pMDNSResponder,
+                                                               const hMDNSHost p_hMDNSHost,
+                                                               const hMDNSService p_hMDNSService)>;
+    // LEGACY
+    using MDNSDynamicServiceTxtCallbackFn1 = std::function<void(MDNSResponder* p_pMDNSResponder,
+                                                                const hMDNSService p_hMDNSService)>;
+    using MDNSDynamicServiceTxtCallbackFn2 = std::function<void(const hMDNSService p_hMDNSService)>;
+
+
+    hMDNSHost getNetIfBinding(netif* p_pNetIf) const;
+    hMDNSHost getNetIfBinding(WiFiMode_t p_WiFiMode) const;
+
+    // Create a MDNS responder netif binding by setting the default hostname
+    // Later call 'update()' in every 'loop' to run the process loop
+    // (probing, announcing, responding, ...)
+
+    hMDNSHost begin(const char* p_pcHostName,
+                    netif* p_pNetIf,
+                    MDNSHostProbeResultCallbackFn p_fnCallback = 0);
+    bool begin(const char* p_pcHostName,
+               WiFiMode_t p_WiFiMode,
+               MDNSHostProbeResultCallbackFn p_fnCallback = 0);
+    bool begin(const char* p_pcHostName,
+               MDNSHostProbeResultCallbackFn p_fnCallback = 0);
+
+    /*  bool begin(const String& p_strHostName) {return begin(p_strHostName.c_str());}
+        // for compatibility
+        bool begin(const char* p_pcHostName,
+                   IPAddress p_IPAddress,       // ignored
+                   uint32_t p_u32TTL = 120);    // ignored
+        bool begin(const String& p_strHostName,
+                   IPAddress p_IPAddress,       // ignored
+                   uint32_t p_u32TTL = 120) {   // ignored
+            return begin(p_strHostName.c_str(), p_IPAddress, p_u32TTL);
+        }*/
+    // Finish MDNS processing
+    bool close(const hMDNSHost p_hMDNSHost);
+    bool close(void);
+    // for ESP32 compatibility
+    bool end(void);
+
+    // Change hostname (probing is restarted)
+    bool setHostName(const hMDNSHost p_hMDNSHost,
+                     const char* p_pcHostName);
+    // for compatibility...
+    bool setHostname(const char* p_pcHostName);
+    bool setHostname(String p_strHostName);
+
+    const char* hostName(const hMDNSHost p_hMDNSHost) const;
+    const char* hostname(void) const;
+
+    // Returns 'true' is host domain probing is done
+    bool status(const hMDNSHost p_hMDNSHost) const;
+    bool status(void) const;
+
+    bool setInstanceName(const hMDNSHost p_hMDNSHost,
+                         const char* p_pcInstanceName);
+    bool setInstanceName(const char* p_pcInstanceName);
+    // for ESP32 compatibility
+    bool setInstanceName(const String& p_strHostName);
+
+    // Add a new service to the MDNS responder. If no name (instance name) is given (p_pcName = 0)
+    // the current hostname is used. If the hostname is changed later, the instance names for
+    // these 'auto-named' services are changed to the new name also (and probing is restarted).
+    // The usual '_' before p_pcService (eg. http) and protocol (eg. tcp) may be given.
+    hMDNSService addService(const hMDNSHost p_hMDNSHost,
+                            const char* p_pcName,
+                            const char* p_pcService,
+                            const char* p_pcProtocol,
+                            uint16_t p_u16Port);
+    hMDNSService addService(const char* p_pcName,
+                            const char* p_pcService,
+                            const char* p_pcProtocol,
+                            uint16_t p_u16Port);
+    // Removes a service from the MDNS responder
+    bool removeService(const hMDNSHost p_hMDNSHost,
+                       const hMDNSService p_hMDNSService);
+    bool removeService(const hMDNSHost p_hMDNSHost,
+                       const char* p_pcInstanceName,
+                       const char* p_pcServiceName,
+                       const char* p_pcProtocol);
+    bool removeService(const hMDNSService p_hMDNSService);
+    bool removeService(const char* p_pcInstanceName,
+                       const char* p_pcServiceName,
+                       const char* p_pcProtocol);
+    // for compatibility...
+    bool addService(String p_strServiceName,
+                    String p_strProtocol,
+                    uint16_t p_u16Port);
+    hMDNSService findService(const hMDNSHost p_hMDNSHost,
+                             const char* p_pcName,
+                             const char* p_pcService,
+                             const char* p_pcProtocol);
+    hMDNSService findService(const char* p_pcName,
+                             const char* p_pcService,
+                             const char* p_pcProtocol);
+
+    // Change the services instance name (and restart probing).
+    bool setServiceName(const hMDNSHost p_hMDNSHost,
+                        const hMDNSService p_hMDNSService,
+                        const char* p_pcInstanceName);
+    bool setServiceName(const hMDNSService p_hMDNSService,
+                        const char* p_pcInstanceName);
+
+    const char* serviceName(const hMDNSHost p_hMDNSHost,
+                            const hMDNSService p_hMDNSService) const;
+    const char* service(const hMDNSHost p_hMDNSHost,
+                        const hMDNSService p_hMDNSService) const;
+    const char* serviceProtocol(const hMDNSHost p_hMDNSHost,
+                                const hMDNSService p_hMDNSService) const;
+    /* LEGACY */
+    const char* serviceName(const hMDNSService p_hMDNSService) const;
+    const char* service(const hMDNSService p_hMDNSService) const;
+    const char* serviceProtocol(const hMDNSService p_hMDNSService) const;
+
+    bool serviceStatus(const hMDNSHost p_hMDNSHost,
+                       const hMDNSService p_hMDNSService) const;
+    bool serviceStatus(const hMDNSService p_hMDNSService) const;
+
+    // Add a (static) MDNS TXT item ('key' = 'value') to the service
+    hMDNSTxt addServiceTxt(const hMDNSHost p_hMDNSHost,
+                           const hMDNSService p_hMDNSService,
+                           const char* p_pcKey,
+                           const char* p_pcValue);
+    hMDNSTxt addServiceTxt(const hMDNSHost p_hMDNSHost,
+                           const hMDNSService p_hMDNSService,
+                           const char* p_pcKey,
+                           uint32_t p_u32Value);
+    hMDNSTxt addServiceTxt(const hMDNSHost p_hMDNSHost,
+                           const hMDNSService p_hMDNSService,
+                           const char* p_pcKey,
+                           uint16_t p_u16Value);
+    hMDNSTxt addServiceTxt(const hMDNSHost p_hMDNSHost,
+                           const hMDNSService p_hMDNSService,
+                           const char* p_pcKey,
+                           uint8_t p_u8Value);
+    hMDNSTxt addServiceTxt(const hMDNSHost p_hMDNSHost,
+                           const hMDNSService p_hMDNSService,
+                           const char* p_pcKey,
+                           int32_t p_i32Value);
+    hMDNSTxt addServiceTxt(const hMDNSHost p_hMDNSHost,
+                           const hMDNSService p_hMDNSService,
+                           const char* p_pcKey,
+                           int16_t p_i16Value);
+    hMDNSTxt addServiceTxt(const hMDNSHost p_hMDNSHost,
+                           const hMDNSService p_hMDNSService,
+                           const char* p_pcKey,
+                           int8_t p_i8Value);
+    // LEGACY
+    hMDNSTxt addServiceTxt(const hMDNSService p_hMDNSService,
+                           const char* p_pcKey,
+                           const char* p_pcValue);
+    hMDNSTxt addServiceTxt(const hMDNSService p_hMDNSService,
+                           const char* p_pcKey,
+                           uint32_t p_u32Value);
+    hMDNSTxt addServiceTxt(const hMDNSService p_hMDNSService,
+                           const char* p_pcKey,
+                           uint16_t p_u16Value);
+    hMDNSTxt addServiceTxt(const hMDNSService p_hMDNSService,
+                           const char* p_pcKey,
+                           uint8_t p_u8Value);
+    hMDNSTxt addServiceTxt(const hMDNSService p_hMDNSService,
+                           const char* p_pcKey,
+                           int32_t p_i32Value);
+    hMDNSTxt addServiceTxt(const hMDNSService p_hMDNSService,
+                           const char* p_pcKey,
+                           int16_t p_i16Value);
+    hMDNSTxt addServiceTxt(const hMDNSService p_hMDNSService,
+                           const char* p_pcKey,
+                           int8_t p_i8Value);
+
+    // Remove an existing (static) MDNS TXT item from the service
+    bool removeServiceTxt(const hMDNSHost p_hMDNSHost,
+                          const hMDNSService p_hMDNSService,
+                          const hMDNSTxt p_hTxt);
+    bool removeServiceTxt(const hMDNSHost p_hMDNSHost,
+                          const hMDNSService p_hMDNSService,
+                          const char* p_pcKey);
+    bool removeServiceTxt(const hMDNSHost p_hMDNSHost,
+                          const char* p_pcinstanceName,
+                          const char* p_pcServiceName,
+                          const char* p_pcProtocol,
+                          const char* p_pcKey);
+    bool removeServiceTxt(const hMDNSService p_hMDNSService,
+                          const hMDNSTxt p_hTxt);
+    bool removeServiceTxt(const hMDNSService p_hMDNSService,
+                          const char* p_pcKey);
+    bool removeServiceTxt(const char* p_pcinstanceName,
+                          const char* p_pcServiceName,
+                          const char* p_pcProtocol,
+                          const char* p_pcKey);
+    // for compatibility...
+    bool addServiceTxt(const char* p_pcService,
+                       const char* p_pcProtocol,
+                       const char* p_pcKey,
+                       const char* p_pcValue);
+    bool addServiceTxt(String p_strService,
+                       String p_strProtocol,
+                       String p_strKey,
+                       String p_strValue);
+
+    bool setDynamicServiceTxtCallback(const hMDNSHost p_hMDNSHost,
+                                      MDNSDynamicServiceTxtCallbackFn p_fnCallback);
+    bool setDynamicServiceTxtCallback(const hMDNSHost p_hMDNSHost,
+                                      const hMDNSService p_hMDNSService,
+                                      MDNSDynamicServiceTxtCallbackFn p_fnCallback);
+
+    // Set a global callback for dynamic MDNS TXT items. The callback function is called
+    // every time, a TXT item is needed for one of the installed services.
+    bool setDynamicServiceTxtCallback(MDNSDynamicServiceTxtCallbackFn1 p_fnCallback);
+    bool setDynamicServiceTxtCallback(MDNSDynamicServiceTxtCallbackFn2 p_fnCallback);
+
+    // Set a service specific callback for dynamic MDNS TXT items. The callback function
+    // is called every time, a TXT item is needed for the given service.
+    bool setDynamicServiceTxtCallback(const hMDNSService p_hMDNSService,
+                                      MDNSDynamicServiceTxtCallbackFn1 p_fnCallback);
+    bool setDynamicServiceTxtCallback(const hMDNSService p_hMDNSService,
+                                      MDNSDynamicServiceTxtCallbackFn2 p_fnCallback);
+
+    // Add a (dynamic) MDNS TXT item ('key' = 'value') to the service
+    // Dynamic TXT items are removed right after one-time use. So they need to be added
+    // every time the value s needed (via callback).
+    hMDNSTxt addDynamicServiceTxt(const hMDNSHost p_hMDNSHost,
+                                  const hMDNSService p_hMDNSService,
+                                  const char* p_pcKey,
+                                  const char* p_pcValue);
+    hMDNSTxt addDynamicServiceTxt(const hMDNSHost p_hMDNSHost,
+                                  const hMDNSService p_hMDNSService,
+                                  const char* p_pcKey,
+                                  uint32_t p_u32Value);
+    hMDNSTxt addDynamicServiceTxt(const hMDNSHost p_hMDNSHost,
+                                  const hMDNSService p_hMDNSService,
+                                  const char* p_pcKey,
+                                  uint16_t p_u16Value);
+    hMDNSTxt addDynamicServiceTxt(const hMDNSHost p_hMDNSHost,
+                                  const hMDNSService p_hMDNSService,
+                                  const char* p_pcKey,
+                                  uint8_t p_u8Value);
+    hMDNSTxt addDynamicServiceTxt(const hMDNSHost p_hMDNSHost,
+                                  const hMDNSService p_hMDNSService,
+                                  const char* p_pcKey,
+                                  int32_t p_i32Value);
+    hMDNSTxt addDynamicServiceTxt(const hMDNSHost p_hMDNSHost,
+                                  const hMDNSService p_hMDNSService,
+                                  const char* p_pcKey,
+                                  int16_t p_i16Value);
+    hMDNSTxt addDynamicServiceTxt(const hMDNSHost p_hMDNSHost,
+                                  const hMDNSService p_hMDNSService,
+                                  const char* p_pcKey,
+                                  int8_t p_i8Value);
+    /* LEGACY */
+    hMDNSTxt addDynamicServiceTxt(const hMDNSService p_hMDNSService,
+                                  const char* p_pcKey,
+                                  const char* p_pcValue);
+    hMDNSTxt addDynamicServiceTxt(const hMDNSService p_hMDNSService,
+                                  const char* p_pcKey,
+                                  uint32_t p_u32Value);
+    hMDNSTxt addDynamicServiceTxt(const hMDNSService p_hMDNSService,
+                                  const char* p_pcKey,
+                                  uint16_t p_u16Value);
+    hMDNSTxt addDynamicServiceTxt(const hMDNSService p_hMDNSService,
+                                  const char* p_pcKey,
+                                  uint8_t p_u8Value);
+    hMDNSTxt addDynamicServiceTxt(const hMDNSService p_hMDNSService,
+                                  const char* p_pcKey,
+                                  int32_t p_i32Value);
+    hMDNSTxt addDynamicServiceTxt(const hMDNSService p_hMDNSService,
+                                  const char* p_pcKey,
+                                  int16_t p_i16Value);
+    hMDNSTxt addDynamicServiceTxt(const hMDNSService p_hMDNSService,
+                                  const char* p_pcKey,
+                                  int8_t p_i8Value);
+
+    /**
+        hMDNSQuery (opaque handle to access dynamic service queries)
+    */
+    using hMDNSQuery = const void*;
+    //using hMDNSServiceQuery = hMDNSQuery;   // for compatibility with V1
+
+    // Perform a (static) service/host query. The function returns after p_u16Timeout milliseconds
+    // The answers (the number of received answers is returned) can be retrieved by calling
+    // - answerHostName (or hostname)
+    // - answerIP (or IP)
+    // - answerPort (or port)
+    uint32_t queryService(const hMDNSHost p_hMDNSHost,
+                          const char* p_pcService,
+                          const char* p_pcProtocol,
+                          const uint16_t p_u16Timeout = MDNS_QUERYSERVICES_WAIT_TIME);
+    uint32_t queryService(const char* p_pcService,
+                          const char* p_pcProtocol,
+                          const uint16_t p_u16Timeout = MDNS_QUERYSERVICES_WAIT_TIME);
+    // for compatibility...
+    uint32_t queryService(const String& p_strService,
+                          const String& p_strProtocol);
+    uint32_t queryHost(const hMDNSHost p_hMDNSHost,
+                       const char* p_pcHostName,
+                       const uint16_t p_u16Timeout = MDNS_QUERYSERVICES_WAIT_TIME);
+    uint32_t queryHost(const char* p_pcHostName,
+                       const uint16_t p_u16Timeout = MDNS_QUERYSERVICES_WAIT_TIME);
+    bool removeQuery(const hMDNSHost p_hMDNSHost);
+    bool removeQuery(void);
+    bool hasQuery(const hMDNSHost p_hMDNSHost);
+    bool hasQuery(void);
+    hMDNSQuery getQuery(const hMDNSHost p_hMDNSHost);
+    hMDNSQuery getQuery(void);
+
+    const char* answerHostName(const hMDNSHost p_hMDNSHost,
+                               const uint32_t p_u32AnswerIndex);
+    const char* answerHostName(const uint32_t p_u32AnswerIndex);
+    // for compatibility...
+    String hostname(const uint32_t p_u32AnswerIndex);
+#ifdef MDNS_IPV4_SUPPORT
+    IPAddress answerIPv4(const hMDNSHost p_hMDNSHost,
+                         const uint32_t p_u32AnswerIndex);
+    IPAddress answerIPv4(const uint32_t p_u32AnswerIndex);
+    // for compatibility
+    IPAddress answerIP(const uint32_t p_u32AnswerIndex);
+    IPAddress IP(const uint32_t p_u32AnswerIndex);
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+    IPAddress answerIPv6(const hMDNSHost p_hMDNSHost,
+                         const uint32_t p_u32AnswerIndex);
+    IPAddress answerIPv6(const uint32_t p_u32AnswerIndex);
+#endif
+    uint16_t answerPort(const hMDNSHost p_hMDNSHost,
+                        const uint32_t p_u32AnswerIndex);
+    uint16_t answerPort(const uint32_t p_u32AnswerIndex);
+    // for compatibility
+    uint16_t port(const uint32_t p_u32AnswerIndex);
+
+    /**
+        typeQueryAnswerType & enuQueryAnswerType
+    */
+    using typeQueryAnswerType = uint8_t;
+    enum class enuQueryAnswerType : typeQueryAnswerType
+    {
+        Unknown             = 0x00,
+        ServiceDomain       = 0x01,     // Service domain
+        HostDomain          = 0x02,     // Host domain
+        Port                = 0x04,     // Port
+        Txts                = 0x08,     // TXT items
+#ifdef MDNS_IPV4_SUPPORT
+        IPv4Address         = 0x10,     // IPv4 address
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+        IPv6Address         = 0x20,     // IPv6 address
+#endif
+    };
+    //using AnswerType = enuQueryAnswerType;   // for compatibility with V1
+
+    /**
+        stcAnswerAccessor
+    */
+    struct stcAnswerAccessor
+    {
+    protected:
+        /**
+            stcCompareTxtKey
+        */
+        struct stcCompareTxtKey
+        {
+            bool operator()(char const* p_pA, char const* p_pB) const;
+        };
+    public:
+        stcAnswerAccessor(MDNSResponder& p_rMDNSResponder,
+                          hMDNSQuery p_hQuery,
+                          uint32_t p_u32AnswerIndex);
+        /**
+            clsTxtKeyValueMap
+        */
+        using clsTxtKeyValueMap = std::map<const char*, const char*, stcCompareTxtKey>;
+
+        bool serviceDomainAvailable(void) const;
+        const char* serviceDomain(void) const;
+        bool hostDomainAvailable(void) const;
+        const char* hostDomain(void) const;
+        bool hostPortAvailable(void) const;
+        uint16_t hostPort(void) const;
+#ifdef MDNS_IPV4_SUPPORT
+        bool IPv4AddressAvailable(void) const;
+        std::vector<IPAddress> IPv4Addresses(void) const;
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+        bool IPv6AddressAvailable(void) const;
+        std::vector<IPAddress> IPv6Addresses(void) const;
+#endif
+        bool txtsAvailable(void) const;
+        const char* txts(void) const;
+        const clsTxtKeyValueMap& txtKeyValues(void) const;
+        const char* txtValue(const char* p_pcKey) const;
+
+        size_t printTo(Print& p_Print) const;
+
+    protected:
+        MDNSResponder&      m_rMDNSResponder;
+        hMDNSQuery          m_hQuery;
+        uint32_t            m_u32AnswerIndex;
+        clsTxtKeyValueMap   m_TxtKeyValueMap;
+    };
+
+    /**
+        MDNSQueryCallbackFn
+
+        Callback function for received answers for dynamic queries
+    */
+    using MDNSQueryCallbackFn = std::function<void(MDNSResponder* p_pMDNSResponder,
+                                                   hMDNSHost p_hMDNSHost,
+                                                   const stcAnswerAccessor& p_MDNSAnswerAccessor,
+                                                   typeQueryAnswerType p_QueryAnswerTypeFlags,          // flags for the updated answer item
+                                                   bool p_bSetContent)>;                                // true: Answer component set, false: component deleted
+    // LEGACY
+    using MDNSQueryCallbackFn1 = std::function<void(MDNSResponder* p_pMDNSResponder,
+                                                    const stcAnswerAccessor& p_MDNSAnswerAccessor,
+                                                    typeQueryAnswerType p_QueryAnswerTypeFlags,          // flags for the updated answer item
+                                                    bool p_bSetContent)>;                                // true: Answer component set, false: component deleted
+    using MDNSQueryCallbackFn2 = std::function<void(const stcAnswerAccessor& p_MDNSAnswerAccessor,
+                                                    typeQueryAnswerType p_QueryAnswerTypeFlags,         // flags for the updated answer item
+                                                    bool p_bSetContent)>;                               // true: Answer component set, false: component deleted
+    //using MDNSServiceInfo = stcAnswerAccessor;  // for compatibility with V1
+
+    // Install a dynamic service/host query. For every received answer (part) the given callback
+    // function is called. The query will be updated every time, the TTL for an answer
+    // has timed-out.
+    // The answers can also be retrieved by calling
+    // - answerCount                                service/host (for host queries, this should never be >1)
+    // - answerServiceDomain                        service
+    // - hasAnswerHostDomain/answerHostDomain       service/host
+    // - hasAnswerIPv4Address/answerIPv4Address     service/host
+    // - hasAnswerIPv6Address/answerIPv6Address     service/host
+    // - hasAnswerPort/answerPort                   service
+    // - hasAnswerTxts/answerTxts                   service
+    hMDNSQuery installServiceQuery(const hMDNSHost p_hMDNSHost,
+                                   const char* p_pcService,
+                                   const char* p_pcProtocol,
+                                   MDNSQueryCallbackFn p_fnCallback);
+    hMDNSQuery installHostQuery(const hMDNSHost p_hMDNSHost,
+                                const char* p_pcHostName,
+                                MDNSQueryCallbackFn p_fnCallback);
+
+    hMDNSQuery installServiceQuery(const char* p_pcService,
+                                   const char* p_pcProtocol,
+                                   MDNSQueryCallbackFn1 p_fnCallback);
+    hMDNSQuery installServiceQuery(const char* p_pcService,
+                                   const char* p_pcProtocol,
+                                   MDNSQueryCallbackFn2 p_fnCallback);
+
+    hMDNSQuery installHostQuery(const char* p_pcHostName,
+                                MDNSQueryCallbackFn1 p_fnCallback);
+    hMDNSQuery installHostQuery(const char* p_pcHostName,
+                                MDNSQueryCallbackFn2 p_fnCallback);
+    // Remove a dynamic service query
+    bool removeDynamicQuery(const hMDNSHost p_hMDNSHost,
+                            const hMDNSQuery p_hMDNSQuery);
+    bool removeDynamicQuery(const hMDNSQuery p_hQuery);
+
+    /**
+        clsMDNSAnswerAccessorVector
+    */
+    using clsMDNSAnswerAccessorVector = std::vector<stcAnswerAccessor>;
+
+    clsMDNSAnswerAccessorVector answerAccessors(const hMDNSHost p_hMDNSHost,
+                                                const hMDNSQuery p_hMDNSQuery);
+    clsMDNSAnswerAccessorVector answerAccessors(const hMDNSQuery p_hQuery);
+
+    uint32_t answerCount(const hMDNSHost p_hMDNSHost,
+                         const hMDNSQuery p_hMDNSQuery);
+    uint32_t answerCount(const hMDNSQuery p_hQuery);
+
+    bool hasAnswerServiceDomain(const hMDNSHost p_hMDNSHost,
+                                const hMDNSQuery p_hQuery,
+                                const uint32_t p_u32AnswerIndex);
+    bool hasAnswerServiceDomain(const hMDNSQuery p_hQuery,
+                                const uint32_t p_u32AnswerIndex);
+    const char* answerServiceDomain(const hMDNSHost p_hMDNSHost,
+                                    const hMDNSQuery p_hQuery,
+                                    const uint32_t p_u32AnswerIndex);
+    const char* answerServiceDomain(const hMDNSQuery p_hQuery,
+                                    const uint32_t p_u32AnswerIndex);
+    bool hasAnswerHostDomain(const hMDNSHost p_hMDNSHost,
+                             const hMDNSQuery p_hQuery,
+                             const uint32_t p_u32AnswerIndex);
+    bool hasAnswerHostDomain(const hMDNSQuery p_hQuery,
+                             const uint32_t p_u32AnswerIndex);
+    const char* answerHostDomain(const hMDNSHost p_hMDNSHost,
+                                 const hMDNSQuery p_hQuery,
+                                 const uint32_t p_u32AnswerIndex);
+    const char* answerHostDomain(const hMDNSQuery p_hQuery,
+                                 const uint32_t p_u32AnswerIndex);
+#ifdef MDNS_IPV4_SUPPORT
+    bool hasAnswerIPv4Address(const hMDNSHost p_hMDNSHost,
+                              const hMDNSQuery p_hQuery,
+                              const uint32_t p_u32AnswerIndex);
+    uint32_t answerIPv4AddressCount(const hMDNSHost p_hMDNSHost,
+                                    const hMDNSQuery p_hQuery,
+                                    const uint32_t p_u32AnswerIndex);
+    IPAddress answerIPv4Address(const hMDNSHost p_hMDNSHost,
+                                const hMDNSQuery p_hQuery,
+                                const uint32_t p_u32AnswerIndex,
+                                const uint32_t p_u32AddressIndex);
+    bool hasAnswerIPv4Address(const hMDNSQuery p_hQuery,
+                              const uint32_t p_u32AnswerIndex);
+    uint32_t answerIPv4AddressCount(const hMDNSQuery p_hQuery,
+                                    const uint32_t p_u32AnswerIndex);
+    IPAddress answerIPv4Address(const hMDNSQuery p_hQuery,
+                                const uint32_t p_u32AnswerIndex,
+                                const uint32_t p_u32AddressIndex);
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+    bool hasAnswerIPv6Address(const hMDNSHost p_hMDNSHost,
+                              const hMDNSQuery p_hQuery,
+                              const uint32_t p_u32AnswerIndex);
+    uint32_t answerIPv6AddressCount(const hMDNSHost p_hMDNSHost,
+                                    const hMDNSQuery p_hQuery,
+                                    const uint32_t p_u32AnswerIndex);
+    IPAddress answerIPv6Address(const hMDNSHost p_hMDNSHost,
+                                const hMDNSQuery p_hQuery,
+                                const uint32_t p_u32AnswerIndex,
+                                const uint32_t p_u32AddressIndex);
+    bool hasAnswerIPv6Address(const hMDNSQuery p_hQuery,
+                              const uint32_t p_u32AnswerIndex);
+    uint32_t answerIPv6AddressCount(const hMDNSQuery p_hQuery,
+                                    const uint32_t p_u32AnswerIndex);
+    IPAddress answerIPv6Address(const hMDNSQuery p_hQuery,
+                                const uint32_t p_u32AnswerIndex,
+                                const uint32_t p_u32AddressIndex);
+#endif
+    bool hasAnswerPort(const hMDNSHost p_hMDNSHost,
+                       const hMDNSQuery p_hQuery,
+                       const uint32_t p_u32AnswerIndex);
+    bool hasAnswerPort(const hMDNSQuery p_hQuery,
+                       const uint32_t p_u32AnswerIndex);
+    uint16_t answerPort(const hMDNSHost p_hMDNSHost,
+                        const hMDNSQuery p_hQuery,
+                        const uint32_t p_u32AnswerIndex);
+    /*  uint16_t answerPort(const hMDNSQuery p_hQuery,
+                        const uint32_t p_u32AnswerIndex);*/
+    bool hasAnswerTxts(const hMDNSHost p_hMDNSHost,
+                       const hMDNSQuery p_hQuery,
+                       const uint32_t p_u32AnswerIndex);
+    bool hasAnswerTxts(const hMDNSQuery p_hQuery,
+                       const uint32_t p_u32AnswerIndex);
+    // Get the TXT items as a ';'-separated string
+    const char* answerTxts(const hMDNSHost p_hMDNSHost,
+                           const hMDNSQuery p_hQuery,
+                           const uint32_t p_u32AnswerIndex);
+    const char* answerTxts(const hMDNSQuery p_hQuery,
+                           const uint32_t p_u32AnswerIndex);
+
+    // Set a callback function for host probe results
+    // The callback function is called, when the probeing for the host domain
+    // succeededs or fails.
+    // In case of failure, the failed domain name should be changed.
+    bool setHostProbeResultCallback(MDNSHostProbeResultCallbackFn p_fnCallback);
+    /* LEGACY 2 */
+    using MDNSHostProbeResultCallbackFn1 = std::function<void(MDNSResponder* p_pMDNSResponder,
+                                                              const char* p_pcDomainName,
+                                                              bool p_bProbeResult)>;
+    using MDNSHostProbeResultCallbackFn2 = std::function<void(const char* p_pcDomainName,
+                                                              bool p_bProbeResult)>;
+
+    bool setHostProbeResultCallback(MDNSHostProbeResultCallbackFn1 p_fnCallback);
+    bool setHostProbeResultCallback(MDNSHostProbeResultCallbackFn2 p_fnCallback);
+
+    /**
+        MDNSServiceProbeResultCallbackFn
+        Callback function for service domain probe results
+    */
+    using MDNSServiceProbeResultCallbackFn = std::function<void(MDNSResponder* p_pMDNSResponder,
+                                                                const hMDNSHost p_hMDNSHost,
+                                                                const hMDNSService p_hMDNSService,
+                                                                const char* p_pcServiceName,
+                                                                bool p_bProbeResult)>;
+    // Set a service specific probe result callcack
+    bool setServiceProbeResultCallback(const hMDNSService p_hMDNSService,
+                                       MDNSServiceProbeResultCallbackFn p_fnCallback);
+
+    bool setServiceProbeResultCallback(const hMDNSService p_hMDNSService,
+                                       MDNSServiceProbeResultCallbackFn1 p_fnCallback);
+    bool setServiceProbeResultCallback(const hMDNSService p_hMDNSService,
+                                       MDNSServiceProbeResultCallbackFn2 p_fnCallback);
+
+    // Application should call this whenever AP is configured/disabled
+    bool notifyNetIfChange(netif* p_pNetIf);
+
+    // 'update' should be called in every 'loop' to run the MDNS processing
+    bool update(const hMDNSHost p_hMDNSHost);
+    bool update(void);
+
+    // 'announce' can be called every time, the configuration of some service
+    // changes. Mainly, this would be changed content of TXT items.
+    bool announce(const hMDNSHost p_hMDNSHost);
+    bool announce(void);
+
+    // Enable OTA update
+    hMDNSService enableArduino(const hMDNSHost p_hMDNSHost,
+                               uint16_t p_u16Port,
+                               bool p_bAuthUpload = false);
+    hMDNSService enableArduino(uint16_t p_u16Port,
+                               bool p_bAuthUpload = false);
+
+    // Domain name helper
+    static bool indexDomain(char*& p_rpcDomain,
+                            const char* p_pcDivider = "-",
+                            const char* p_pcDefaultDomain = 0);
+    // Host name helper
+    static bool setNetIfHostName(netif* p_pNetIf,
+                                 const char* p_pcHostName);
+};
+#endif
+
+}	// namespace MDNSImplementation
+
+}	// namespace esp8266
+
+#endif // LEAMDNS2_H
+
+
+

--- a/libraries/ESP8266mDNS/src/LEAmDNS2_API.cpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS2_API.cpp
@@ -1,0 +1,4164 @@
+/*
+    LEAmDNS2_API.cpp
+
+    License (MIT license):
+      Permission is hereby granted, free of charge, to any person obtaining a copy
+      of this software and associated documentation files (the "Software"), to deal
+      in the Software without restriction, including without limitation the rights
+      to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+      copies of the Software, and to permit persons to whom the Software is
+      furnished to do so, subject to the following conditions:
+
+      The above copyright notice and this permission notice shall be included in
+      all copies or substantial portions of the Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+      THE SOFTWARE.
+
+*/
+
+
+#include <Schedule.h>
+#include <lwip/netif.h>
+
+#include "LEAmDNS2_Priv.h"
+
+
+namespace
+{
+
+/*
+    strrstr (static)
+
+    Backwards search for p_pcPattern in p_pcString
+    Based on: https://stackoverflow.com/a/1634398/2778898
+
+*/
+const char* strrstr(const char*__restrict p_pcString, const char*__restrict p_pcPattern)
+{
+    const char* pcResult = 0;
+
+    size_t      stStringLength = (p_pcString ? strlen(p_pcString) : 0);
+    size_t      stPatternLength = (p_pcPattern ? strlen(p_pcPattern) : 0);
+
+    if ((stStringLength) &&
+        (stPatternLength) &&
+        (stPatternLength <= stStringLength))
+    {
+        // Pattern is shorter or has the same length tham the string
+
+        for (const char* s = (p_pcString + stStringLength - stPatternLength); s >= p_pcString; --s)
+        {
+            if (0 == strncmp(s, p_pcPattern, stPatternLength))
+            {
+                pcResult = s;
+                break;
+            }
+        }
+    }
+    return pcResult;
+}
+
+} // anonymous
+
+
+namespace esp8266
+{
+
+/*
+    LEAmDNS
+*/
+namespace experimental
+{
+
+/**
+    STRINGIZE
+*/
+#ifndef STRINGIZE
+#define STRINGIZE(x) #x
+#endif
+#ifndef STRINGIZE_VALUE_OF
+#define STRINGIZE_VALUE_OF(x) STRINGIZE(x)
+#endif
+
+/**
+    HELPERS
+*/
+
+/*
+    MDNSResponder::indexDomain (static)
+
+    Updates the given domain 'p_rpcHostName' by appending a delimiter and an index number.
+
+    If the given domain already hasa numeric index (after the given delimiter), this index
+    incremented. If not, the delimiter and index '2' is added.
+
+    If 'p_rpcHostName' is empty (==0), the given default name 'p_pcDefaultHostName' is used,
+    if no default is given, 'esp8266' is used.
+
+*/
+/*static*/ bool MDNSResponder::indexDomain(char*& p_rpcDomain,
+                                           const char* p_pcDivider /*= "-"*/,
+                                           const char* p_pcDefaultDomain /*= 0*/)
+{
+    bool    bResult = false;
+
+    // Ensure a divider exists; use '-' as default
+    const char*   pcDivider = (p_pcDivider ? : "-");
+
+    if (p_rpcDomain)
+    {
+        const char* pFoundDivider = strrstr(p_rpcDomain, pcDivider);
+        if (pFoundDivider)          // maybe already extended
+        {
+            char*         pEnd = 0;
+            unsigned long ulIndex = strtoul((pFoundDivider + strlen(pcDivider)), &pEnd, 10);
+            if ((ulIndex) &&
+                ((pEnd - p_rpcDomain) == (ptrdiff_t)strlen(p_rpcDomain)) &&
+                (!*pEnd))           // Valid (old) index found
+            {
+
+                char    acIndexBuffer[16];
+                sprintf(acIndexBuffer, "%lu", (++ulIndex));
+                size_t  stLength = ((pFoundDivider - p_rpcDomain + strlen(pcDivider)) + strlen(acIndexBuffer) + 1);
+                char*   pNewHostName = new char[stLength];
+                if (pNewHostName)
+                {
+                    memcpy(pNewHostName, p_rpcDomain, (pFoundDivider - p_rpcDomain + strlen(pcDivider)));
+                    pNewHostName[pFoundDivider - p_rpcDomain + strlen(pcDivider)] = 0;
+                    strcat(pNewHostName, acIndexBuffer);
+
+                    delete[] p_rpcDomain;
+                    p_rpcDomain = pNewHostName;
+
+                    bResult = true;
+                }
+                else
+                {
+                    DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] indexDomain: FAILED to alloc new hostname!\n")););
+                }
+            }
+            else
+            {
+                pFoundDivider = 0;  // Flag the need to (base) extend the hostname
+            }
+        }
+
+        if (!pFoundDivider)         // not yet extended (or failed to increment extension) -> start indexing
+        {
+            size_t    stLength = strlen(p_rpcDomain) + (strlen(pcDivider) + 1 + 1);   // Name + Divider + '2' + '\0'
+            char*     pNewHostName = new char[stLength];
+            if (pNewHostName)
+            {
+                sprintf(pNewHostName, "%s%s2", p_rpcDomain, pcDivider);
+
+                delete[] p_rpcDomain;
+                p_rpcDomain = pNewHostName;
+
+                bResult = true;
+            }
+            else
+            {
+                DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] indexDomain: FAILED to alloc new hostname!\n")););
+            }
+        }
+    }
+    else
+    {
+        // No given host domain, use base or default
+        const char* cpcDefaultName = (p_pcDefaultDomain ? : "esp8266");
+
+        size_t      stLength = strlen(cpcDefaultName) + 1;   // '\0'
+        p_rpcDomain = new char[stLength];
+        if (p_rpcDomain)
+        {
+            strncpy(p_rpcDomain, cpcDefaultName, stLength);
+            bResult = true;
+        }
+        else
+        {
+            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] indexDomain: FAILED to alloc new hostname!\n")););
+        }
+    }
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] indexDomain: %s\n"), p_rpcDomain););
+    return bResult;
+}
+
+
+/*
+    MDNSResponder::setStationHostName (static)
+
+    Sets the staion hostname
+
+*/
+/*static*/ bool MDNSResponder::setNetIfHostName(netif* p_pNetIf,
+                                                const char* p_pcHostName)
+{
+    if ((p_pNetIf) &&
+        (p_pcHostName))
+    {
+        netif_set_hostname(p_pNetIf, p_pcHostName);
+        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] setNetIfHostName host name: %s!\n"), p_pcHostName););
+    }
+    return true;
+}
+
+
+/**
+    INTERFACE
+*/
+
+/**
+    MDNSResponder::MDNSResponder
+*/
+MDNSResponder::MDNSResponder(void)
+    :   m_pUDPContext(0)
+{
+    _allocUDPContext();
+}
+
+/*
+    MDNSResponder::~MDNSResponder
+*/
+MDNSResponder::~MDNSResponder(void)
+{
+    close();
+}
+
+/*
+    MDNSResponder::begin (hostname, netif, probe_callback)
+*/
+MDNSResponder::hMDNSHost MDNSResponder::begin(const char* p_pcHostName,
+                                              netif* p_pNetIf,
+                                              MDNSHostProbeResultCallbackFn p_fnCallback /*= 0*/)
+{
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s begin(%s, netif: %u)\n"), _DH(), (p_pcHostName ? : "-"), (p_pNetIf ? netif_get_index(p_pNetIf) : 0)););
+
+    return (hMDNSHost)_begin(p_pcHostName, p_pNetIf, p_fnCallback);
+}
+
+/*
+    MDNSResponder::begin (hostname, probe_callback)
+*/
+bool MDNSResponder::begin(const char* p_pcHostName,
+                          MDNSHostProbeResultCallbackFn p_fnCallback /*= 0*/)
+{
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s begin(%s)\n"), _DH(), (p_pcHostName ? : "_")););
+
+    return begin(p_pcHostName, (WiFiMode_t)wifi_get_opmode(), p_fnCallback);
+}
+
+/*
+    MDNSResponder::begin (hostname, WiFiMode, probe_callback)
+*/
+bool MDNSResponder::begin(const char* p_pcHostName,
+                          WiFiMode_t p_WiFiMode,
+                          MDNSHostProbeResultCallbackFn p_fnCallback /*= 0*/)
+{
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s begin(%s, opmode: %u)\n"), _DH(), (p_pcHostName ? : "_"), (uint32_t)p_WiFiMode););
+
+    bool bResult = true;
+
+    if ((bResult) &&
+        (p_WiFiMode & WIFI_STA))
+    {
+        bResult = (0 != _begin(p_pcHostName, netif_get_by_index(WIFI_STA), p_fnCallback));
+    }
+    if ((bResult) &&
+        (p_WiFiMode & WIFI_AP))
+    {
+        bResult = (0 != _begin(p_pcHostName, netif_get_by_index(WIFI_AP), p_fnCallback));
+    }
+    return bResult;
+}
+
+/*
+	MDNSResponder::close
+*/
+bool MDNSResponder::close(const MDNSResponder::hMDNSHost p_hMDNSHost)
+{
+    return ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+            (_close(*(clsHost*)p_hMDNSHost)));
+}
+
+/*
+    MDNSResponder::close (convenience)
+*/
+bool MDNSResponder::close(void)
+{
+    clsHostList::iterator	it(m_HostList.begin());
+    while (m_HostList.end() != it)
+    {
+        _close(**it++);
+    }
+
+    return _releaseUDPContext();
+}
+
+
+/*
+    MDNSResponder::getMDNSHost (netif)
+*/
+MDNSResponder::hMDNSHost MDNSResponder::getMDNSHost(netif* p_pNetIf) const
+{
+    return (hMDNSHost)(p_pNetIf ? _findHost(p_pNetIf) : 0);
+}
+
+/*
+    MDNSResponder::getMDNSHost (WiFiMode)
+*/
+MDNSResponder::hMDNSHost MDNSResponder::getMDNSHost(WiFiMode_t p_WiFiMode) const
+{
+    hMDNSHost hResult = 0;
+
+    if (WIFI_STA == p_WiFiMode)
+    {
+        hResult = getMDNSHost(netif_get_by_index(WIFI_STA));
+    }
+    else if (WIFI_AP == p_WiFiMode)
+    {
+        hResult = getMDNSHost(netif_get_by_index(WIFI_AP));
+    }
+    return hResult;
+}
+
+/*
+	MDNSResponder::setHostName
+*/
+bool MDNSResponder::setHostName(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                const char* p_pcHostName,
+                                MDNSHostProbeResultCallbackFn p_fnCallback /*= 0*/)
+{
+    bool	bResult = ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+                       (_NRH2Ptr(p_hMDNSHost)->setHostName(p_pcHostName)) &&
+                       (p_fnCallback ? setHostProbeResultCallback(p_hMDNSHost, p_fnCallback) : true));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s setHostName: FAILED for '%s'!\n"), _DH(p_hMDNSHost), (p_pcHostName ? : "-")););
+    return bResult;
+}
+
+/*
+    MDNSResponder::hostName
+*/
+const char* MDNSResponder::hostName(const MDNSResponder::hMDNSHost p_hMDNSHost) const
+{
+    return (_validateMDNSHostHandle(p_hMDNSHost)
+            ? (_NRH2Ptr(p_hMDNSHost)->hostName())
+            : 0);
+}
+
+/*
+	MDNSResponder::setHostProbeResultCallback
+*/
+bool MDNSResponder::setHostProbeResultCallback(const hMDNSHost p_hMDNSHost,
+                                               MDNSHostProbeResultCallbackFn p_fnCallback)
+{
+    bool    bResult = false;
+    if ((bResult = _validateMDNSHostHandle(p_hMDNSHost)))
+    {
+        if (p_fnCallback)
+        {
+            _NRH2Ptr(p_hMDNSHost)->m_HostProbeInformation.m_fnProbeResultCallback = [this, p_fnCallback](clsHost & p_rHost,
+                                                                                                         const char* p_pcDomainName,
+                                                                                                         bool p_bProbeResult)->void
+            {
+                p_fnCallback(*this, (hMDNSHost)&p_rHost, p_pcDomainName, p_bProbeResult);
+            };
+        }
+        else
+        {
+            _NRH2Ptr(p_hMDNSHost)->m_HostProbeInformation.m_fnProbeResultCallback = 0;
+        }
+    }
+    return bResult;
+}
+
+/*
+	MDNSResponder::status
+*/
+bool MDNSResponder::status(const MDNSResponder::hMDNSHost p_hMDNSHost) const
+{
+    return ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+            (_NRH2Ptr(p_hMDNSHost)->probeStatus()));
+}
+
+
+/*
+    SERVICES
+*/
+
+/*
+	MDNSResponder::setInstanceName
+*/
+bool MDNSResponder::setInstanceName(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                    const char* p_pcInstanceName)
+{
+    bool	bResult = ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+                       (_NRH2Ptr(p_hMDNSHost)->setInstanceName(p_pcInstanceName)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s setInstanceName: FAILED for '%s'!\n"), _DH(p_hMDNSHost), (p_pcInstanceName ? : "-")););
+    return bResult;
+}
+
+/*
+    MDNSResponder::instanceName
+*/
+const char* MDNSResponder::instanceName(const MDNSResponder::hMDNSHost p_hMDNSHost) const
+{
+    return (_validateMDNSHostHandle(p_hMDNSHost)
+            ? (_NRH2Ptr(p_hMDNSHost)->instanceName())
+            : 0);
+}
+
+/*
+    MDNSResponder::addService
+
+    Add service; using hostname if no name is explicitly provided for the service
+    The usual '_' underline, which is prepended to service and protocol, eg. _http,
+    may be given. If not, it is added automatically.
+
+*/
+MDNSResponder::hMDNSService MDNSResponder::addService(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                      const char* p_pcName,
+                                                      const char* p_pcServiceType,
+                                                      const char* p_pcProtocol,
+                                                      uint16_t p_u16Port,
+                                                      MDNSServiceProbeResultCallbackFn p_fnCallback /*= 0*/)
+{
+    hMDNSService	hService = (_validateMDNSHostHandle(p_hMDNSHost)
+                                ? (hMDNSService)_NRH2Ptr(p_hMDNSHost)->addService(p_pcName, p_pcServiceType, p_pcProtocol, p_u16Port)
+                                : 0);
+    if ((p_fnCallback) &&
+        (hService))
+    {
+        setServiceProbeResultCallback(p_hMDNSHost, hService, p_fnCallback);
+    }
+    DEBUG_EX_ERR(if (!hService) DEBUG_OUTPUT.printf_P(PSTR("%s addService: FAILED for '%s._%s._%s.local'!\n"), _DH(p_hMDNSHost), (p_pcName ? : "-"), (p_pcServiceType ? : "-"), (p_pcProtocol ? : "-")););
+    return hService;
+}
+
+/*
+    MDNSResponder::removeService
+
+    Unanounce a service (by sending a goodbye message) and remove it
+    from the MDNS responder
+
+*/
+bool MDNSResponder::removeService(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                  const MDNSResponder::hMDNSService p_hMDNSService)
+{
+    bool	bResult = ((_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)) &&
+                       (_NRH2Ptr(p_hMDNSHost)->removeService(_SH2Ptr(p_hMDNSService))));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s removeService: FAILED!\n"), _DH(p_hMDNSHost)););
+    return bResult;
+}
+
+/*
+	MDNSResponder::removeService
+*/
+bool MDNSResponder::removeService(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                  const char* p_pcInstanceName,
+                                  const char* p_pcServiceType,
+                                  const char* p_pcProtocol)
+{
+    clsHost*                  pMDNSHost;
+    clsHost::stcService*  pMDNSService;
+    bool	bResult = ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+                       (pMDNSHost = (clsHost*)p_hMDNSHost) &&
+                       ((pMDNSService = _NRH2Ptr(p_hMDNSHost)->findService(p_pcInstanceName, p_pcServiceType, p_pcProtocol))) &&
+                       (_NRH2Ptr(p_hMDNSHost)->removeService(pMDNSService)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s removeService: FAILED for '%s._%s._%s.local'!\n"), _DH(p_hMDNSHost), (p_pcInstanceName ? : "-"), (p_pcServiceType ? : "-"), (p_pcProtocol ? : "-")););
+    return bResult;
+}
+
+/*
+    MDNSResponder::findService
+
+    Find an existing service.
+
+*/
+MDNSResponder::hMDNSService MDNSResponder::findService(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                       const char* p_pcInstanceName,
+                                                       const char* p_pcServiceType,
+                                                       const char* p_pcProtocol)
+{
+    clsHost*    pMDNSHost;
+    return (((_validateMDNSHostHandle(p_hMDNSHost)) &&
+             (pMDNSHost = (clsHost*)p_hMDNSHost))
+            ? _NRH2Ptr(p_hMDNSHost)->findService(p_pcInstanceName, p_pcServiceType, p_pcProtocol)
+            : 0);
+}
+
+/*
+    MDNSResponder::setServiceName
+*/
+bool MDNSResponder::setServiceName(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                   const MDNSResponder::hMDNSService p_hMDNSService,
+                                   const char* p_pcInstanceName,
+                                   MDNSServiceProbeResultCallbackFn p_fnCallback /*= 0*/)
+{
+    bool	bResult = ((_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)) &&
+                       (_NRH2Ptr(p_hMDNSHost)->setServiceName(_SH2Ptr(p_hMDNSService), p_pcInstanceName)) &&
+                       (p_fnCallback ? setServiceProbeResultCallback(p_hMDNSHost, p_hMDNSService, p_fnCallback) : true));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s setServiceName: FAILED for '%s'!\n"), _DH(p_hMDNSHost), (p_pcInstanceName ? : "-")););
+    return bResult;
+}
+
+/*
+    MDNSResponder::serviceName
+*/
+const char* MDNSResponder::serviceName(const hMDNSHost p_hMDNSHost,
+                                       const hMDNSService p_hMDNSService) const
+{
+    return (_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)
+            ? (_SH2Ptr(p_hMDNSService)->m_pcName)
+            : 0);
+}
+
+/*
+    MDNSResponder::serviceType
+*/
+const char* MDNSResponder::serviceType(const hMDNSHost p_hMDNSHost,
+                                       const hMDNSService p_hMDNSService) const
+{
+    return (_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)
+            ? (_SH2Ptr(p_hMDNSService)->m_pcServiceType)
+            : 0);
+}
+
+/*
+    MDNSResponder::serviceProtocol
+*/
+const char* MDNSResponder::serviceProtocol(const hMDNSHost p_hMDNSHost,
+                                           const hMDNSService p_hMDNSService) const
+{
+    return (_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)
+            ? (_SH2Ptr(p_hMDNSService)->m_pcProtocol)
+            : 0);
+}
+
+/*
+    MDNSResponder::serviceProtocol
+*/
+uint16_t MDNSResponder::servicePort(const hMDNSHost p_hMDNSHost,
+                                    const hMDNSService p_hMDNSService) const
+{
+    return (_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)
+            ? (_SH2Ptr(p_hMDNSService)->m_u16Port)
+            : 0);
+}
+
+/*
+    MDNSResponder::setServiceProbeResultCallback
+
+    Set a service specific callback for probe results. The callback is called, when probing
+    for the service domain failes or succeedes.
+    In the case of failure, the service name should be changed via 'setServiceName'.
+    When succeeded, the service domain will be announced by the MDNS responder.
+
+*/
+bool MDNSResponder::setServiceProbeResultCallback(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                  const MDNSResponder::hMDNSService p_hMDNSService,
+                                                  MDNSResponder::MDNSServiceProbeResultCallbackFn p_fnCallback)
+{
+    bool    bResult = false;
+    if ((bResult = _validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)))
+    {
+        if (p_fnCallback)
+        {
+            _SH2Ptr(p_hMDNSService)->m_ProbeInformation.m_fnProbeResultCallback = [this, p_fnCallback](clsHost & p_rHost,
+                                                                                                       clsHost::stcService & p_rMDNSService,
+                                                                                                       const char* p_pcDomainName,
+                                                                                                       bool p_bProbeResult)->void
+            {
+                p_fnCallback(*this, (hMDNSHost)&p_rHost, (hMDNSService)&p_rMDNSService, p_pcDomainName, p_bProbeResult);
+            };
+        }
+        else
+        {
+            _SH2Ptr(p_hMDNSService)->m_ProbeInformation.m_fnProbeResultCallback = 0;
+        }
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::serviceStatus
+*/
+bool MDNSResponder::serviceStatus(const hMDNSHost p_hMDNSHost,
+                                  const hMDNSService p_hMDNSService) const
+{
+    return ((_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)) &&
+            (_SH2Ptr(p_hMDNSService)->probeStatus()));
+}
+
+
+/*
+    SERVICE TXT
+*/
+
+/*
+    MDNSResponder::addServiceTxt
+
+    Add a static service TXT item ('Key'='Value') to a service.
+
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                     const MDNSResponder::hMDNSService p_hMDNSService,
+                                                     const char* p_pcKey,
+                                                     const char* p_pcValue)
+{
+    hMDNSTxt	hTxt = (_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)
+                        ? (hMDNSTxt)_NRH2Ptr(p_hMDNSHost)->addServiceTxt(_SH2Ptr(p_hMDNSService), p_pcKey, p_pcValue)
+                        : 0);
+    DEBUG_EX_ERR(if (!hTxt) DEBUG_OUTPUT.printf_P(PSTR("%s addServiceTxt: FAILED for '%s=%s'!\n"), _DH(p_hMDNSHost), (p_pcKey ? : "-"), (p_pcValue ? : "-")););
+    return hTxt;
+}
+
+/*
+	MDNSRESPONDER_xxx_TO_CHAR
+	Formats: http://www.cplusplus.com/reference/cstdio/printf/
+*/
+#define MDNSRESPONDER_U32_TO_CHAR(BUFFERNAME, U32VALUE)	\
+	char    BUFFERNAME[16];	/* 32-bit max 10 digits */	\
+	*BUFFERNAME = 0;									\
+    sprintf(BUFFERNAME, "%u", U32VALUE);
+#define MDNSRESPONDER_U16_TO_CHAR(BUFFERNAME, U16VALUE)	\
+	char    BUFFERNAME[8];	/* 16-bit max 5 digits */	\
+	*BUFFERNAME = 0;									\
+    sprintf(BUFFERNAME, "%hu", U16VALUE);
+#define MDNSRESPONDER_U8_TO_CHAR(BUFFERNAME, U8VALUE)	\
+	char    BUFFERNAME[8];	/* 8-bit max 3 digits */	\
+	*BUFFERNAME = 0;									\
+    sprintf(BUFFERNAME, "%hhu", U8VALUE);
+#define MDNSRESPONDER_I32_TO_CHAR(BUFFERNAME, I32VALUE)	\
+	char    BUFFERNAME[16];	/* 32-bit max 10 digits */	\
+	*BUFFERNAME = 0;									\
+    sprintf(BUFFERNAME, "%i", I32VALUE);
+#define MDNSRESPONDER_I16_TO_CHAR(BUFFERNAME, I16VALUE)	\
+	char    BUFFERNAME[8];	/* 16-bit max 5 digits */	\
+	*BUFFERNAME = 0;									\
+    sprintf(BUFFERNAME, "%hi", I16VALUE);
+#define MDNSRESPONDER_I8_TO_CHAR(BUFFERNAME, I8VALUE)	\
+	char    BUFFERNAME[8];	/* 8-bit max 3 digits */	\
+	*BUFFERNAME = 0;									\
+    sprintf(BUFFERNAME, "%hhi", I8VALUE);
+
+/*
+    MDNSResponder::addServiceTxt (uint32_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                     const MDNSResponder::hMDNSService p_hMDNSService,
+                                                     const char* p_pcKey,
+                                                     uint32_t p_u32Value)
+{
+    MDNSRESPONDER_U32_TO_CHAR(acBuffer, p_u32Value);
+    return addServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer);
+}
+
+/*
+    MDNSResponder::addServiceTxt (uint16_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                     const MDNSResponder::hMDNSService p_hMDNSService,
+                                                     const char* p_pcKey,
+                                                     uint16_t p_u16Value)
+{
+    MDNSRESPONDER_U16_TO_CHAR(acBuffer, p_u16Value);
+    return addServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer);
+}
+
+/*
+    MDNSResponder::addServiceTxt (uint8_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                     const MDNSResponder::hMDNSService p_hMDNSService,
+                                                     const char* p_pcKey,
+                                                     uint8_t p_u8Value)
+{
+    MDNSRESPONDER_U8_TO_CHAR(acBuffer, p_u8Value);
+    return addServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer);
+}
+
+/*
+    MDNSResponder::addServiceTxt (int32_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                     const MDNSResponder::hMDNSService p_hMDNSService,
+                                                     const char* p_pcKey,
+                                                     int32_t p_i32Value)
+{
+    MDNSRESPONDER_I32_TO_CHAR(acBuffer, p_i32Value);
+    return addServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer);
+}
+
+/*
+    MDNSResponder::addServiceTxt (int16_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                     const MDNSResponder::hMDNSService p_hMDNSService,
+                                                     const char* p_pcKey,
+                                                     int16_t p_i16Value)
+{
+    MDNSRESPONDER_I16_TO_CHAR(acBuffer, p_i16Value);
+    return addServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer);
+}
+
+/*
+    MDNSResponder::addServiceTxt (int8_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                     const MDNSResponder::hMDNSService p_hMDNSService,
+                                                     const char* p_pcKey,
+                                                     int8_t p_i8Value)
+{
+    MDNSRESPONDER_I8_TO_CHAR(acBuffer, p_i8Value);
+    return addServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer);
+}
+
+/*
+    MDNSResponder::removeServiceTxt
+
+    Remove a static service TXT item from a service.
+*/
+bool MDNSResponder::removeServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                     const MDNSResponder::hMDNSService p_hMDNSService,
+                                     const MDNSResponder::hMDNSTxt p_hTxt)
+{
+    bool	bResult = ((_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)) &&
+                       (p_hTxt) &&
+                       (_NRH2Ptr(p_hMDNSHost)->removeServiceTxt(_SH2Ptr(p_hMDNSService), (clsHost::stcServiceTxt*)p_hTxt)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s removeServiceTxt: FAILED!\n"), _DH(p_hMDNSHost)););
+    return bResult;
+}
+
+/*
+    MDNSResponder::removeServiceTxt
+*/
+bool MDNSResponder::removeServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                     const MDNSResponder::hMDNSService p_hMDNSService,
+                                     const char* p_pcKey)
+{
+    bool	bResult = ((_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)) &&
+                       (p_pcKey) &&
+                       (_NRH2Ptr(p_hMDNSHost)->removeServiceTxt(_SH2Ptr(p_hMDNSService), _NRH2Ptr(p_hMDNSHost)->findServiceTxt(_SH2Ptr(p_hMDNSService), p_pcKey))));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s removeServiceTxt: FAILED!\n"), _DH(p_hMDNSHost)););
+    return bResult;
+}
+
+/*
+	MDNSResponder::setDynamicServiceTxtCallback (binding)
+
+    Set a netif binding specific callback for dynamic service TXT items. The callback is called, whenever
+    service TXT items are needed for any service on the netif binding.
+
+*/
+bool MDNSResponder::setDynamicServiceTxtCallback(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                 MDNSResponder::MDNSDynamicServiceTxtCallbackFn p_fnCallback)
+{
+    bool	bResult = ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+                       ((!p_fnCallback) ||
+                        (_NRH2Ptr(p_hMDNSHost)->setDynamicServiceTxtCallback([this, p_fnCallback](clsHost & p_rHost,
+                                                                                                  clsHost::stcService & p_rMDNSService)->void
+    {
+        if (p_fnCallback)
+        {
+            p_fnCallback(*this, (hMDNSHost)&p_rHost, (hMDNSService)&p_rMDNSService);
+        }
+    }))));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s setDynamicServiceTxtCallback: FAILED!\n"), _DH(p_hMDNSHost)););
+    return bResult;
+}
+
+/*
+	MDNSResponder::setDynamicServiceTxtCallback (service)
+
+    Set a service specific callback for dynamic service TXT items. The callback is called, whenever
+    service TXT items are needed for the given service.
+*/
+bool MDNSResponder::setDynamicServiceTxtCallback(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                 const MDNSResponder::hMDNSService p_hMDNSService,
+                                                 MDNSResponder::MDNSDynamicServiceTxtCallbackFn p_fnCallback)
+{
+    bool	bResult = ((_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)) &&
+                       ((!p_fnCallback) ||
+                        (_NRH2Ptr(p_hMDNSHost)->setDynamicServiceTxtCallback(_SH2Ptr(p_hMDNSService), [this, p_fnCallback](clsHost & p_rHost,
+                                                                                                                           clsHost::stcService & p_rMDNSService)->void
+    {
+        if (p_fnCallback)
+        {
+            p_fnCallback(*this, (hMDNSHost)&p_rHost, (hMDNSService)&p_rMDNSService);
+        }
+    }))));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s setDynamicServiceTxtCallback: FAILED!\n"), _DH(p_hMDNSHost)););
+    return bResult;
+}
+
+/*
+    MDNSResponder::addDynamicServiceTxt
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                            const MDNSResponder::hMDNSService p_hMDNSService,
+                                                            const char* p_pcKey,
+                                                            const char* p_pcValue)
+{
+    hMDNSTxt    hTxt = (_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)
+                        ? (hMDNSTxt)_NRH2Ptr(p_hMDNSHost)->addDynamicServiceTxt(_SH2Ptr(p_hMDNSService), p_pcKey, p_pcValue)
+                        : 0);
+    DEBUG_EX_ERR(if (!hTxt) DEBUG_OUTPUT.printf_P(PSTR("%s addServiceTxt: FAILED for '%s=%s'!\n"), _DH(p_hMDNSHost), (p_pcKey ? : "-"), (p_pcValue ? : "-")););
+    return hTxt;
+}
+
+/*
+    MDNSResponder::addDynamicServiceTxt (uint32_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                            MDNSResponder::hMDNSService p_hMDNSService,
+                                                            const char* p_pcKey,
+                                                            uint32_t p_u32Value)
+{
+    MDNSRESPONDER_U32_TO_CHAR(acBuffer, p_u32Value);
+    return addDynamicServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer);
+}
+
+/*
+    MDNSResponder::addDynamicServiceTxt (uint16_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                            const MDNSResponder::hMDNSService p_hMDNSService,
+                                                            const char* p_pcKey,
+                                                            uint16_t p_u16Value)
+{
+    MDNSRESPONDER_U16_TO_CHAR(acBuffer, p_u16Value);
+    return addDynamicServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer);
+}
+
+/*
+    MDNSResponder::addDynamicServiceTxt (uint8_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                            const MDNSResponder::hMDNSService p_hMDNSService,
+                                                            const char* p_pcKey,
+                                                            uint8_t p_u8Value)
+{
+    MDNSRESPONDER_U8_TO_CHAR(acBuffer, p_u8Value);
+    return addDynamicServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer);
+}
+
+/*
+    MDNSResponder::addDynamicServiceTxt (int32_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                            const MDNSResponder::hMDNSService p_hMDNSService,
+                                                            const char* p_pcKey,
+                                                            int32_t p_i32Value)
+{
+    MDNSRESPONDER_I32_TO_CHAR(acBuffer, p_i32Value);
+    return addDynamicServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer);
+}
+
+/*
+    MDNSResponder::addDynamicServiceTxt (int16_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                            const MDNSResponder::hMDNSService p_hMDNSService,
+                                                            const char* p_pcKey,
+                                                            int16_t p_i16Value)
+{
+    MDNSRESPONDER_I16_TO_CHAR(acBuffer, p_i16Value);
+    return addDynamicServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer);
+}
+
+/*
+    MDNSResponder::addDynamicServiceTxt (int8_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                            const MDNSResponder::hMDNSService p_hMDNSService,
+                                                            const char* p_pcKey,
+                                                            int8_t p_i8Value)
+{
+    MDNSRESPONDER_I8_TO_CHAR(acBuffer, p_i8Value);
+    return addDynamicServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer);
+}
+
+
+/**
+    QUERIES
+*/
+
+
+/**
+    MDNSResponder::clsMDNSAnswerAccessor
+
+*/
+
+/*
+    MDNSResponder::clsMDNSAnswerAccessor::clsMDNSAnswerAccessor constructor
+*/
+MDNSResponder::clsMDNSAnswerAccessor::clsMDNSAnswerAccessor(const MDNSResponder::clsHost::stcQuery::stcAnswer* p_pAnswer)
+    :   m_pAnswer(p_pAnswer)
+{
+    if ((m_pAnswer) &&
+        (txtsAvailable()))
+    {
+        // Prepare m_TxtKeyValueMap
+        for (const clsHost::stcServiceTxt* pTxt = m_pAnswer->m_Txts.m_pTxts; pTxt; pTxt = pTxt->m_pNext)
+        {
+            m_TxtKeyValueMap.emplace(std::pair<const char*, const char*>(pTxt->m_pcKey, pTxt->m_pcValue));
+        }
+    }
+}
+
+/*
+    MDNSResponder::clsMDNSAnswerAccessor::~clsMDNSAnswerAccessor destructor
+*/
+MDNSResponder::clsMDNSAnswerAccessor::~clsMDNSAnswerAccessor(void)
+{
+}
+
+/**
+    MDNSResponder::clsMDNSAnswerAccessor::stcCompareTxtKey
+*/
+
+/*
+    MDNSResponder::clsMDNSAnswerAccessor::stcCompareTxtKey::operator()
+*/
+bool MDNSResponder::clsMDNSAnswerAccessor::stcCompareTxtKey::operator()(char const* p_pA,
+                                                                        char const* p_pB) const
+{
+    return (0 > strcasecmp(p_pA, p_pB));
+}
+
+/*
+    MDNSResponder::clsMDNSAnswerAccessor::serviceDomainAvailable
+*/
+bool MDNSResponder::clsMDNSAnswerAccessor::serviceDomainAvailable(void) const
+{
+    return ((m_pAnswer) &&
+            (m_pAnswer->m_QueryAnswerFlags & static_cast<typeQueryAnswerType>(enuQueryAnswerType::ServiceDomain)));
+}
+
+/*
+    MDNSResponder::clsMDNSAnswerAccessor::serviceDomain
+*/
+const char* MDNSResponder::clsMDNSAnswerAccessor::serviceDomain(void) const
+{
+    return ((m_pAnswer)
+            ?   m_pAnswer->m_ServiceDomain.c_str()
+            : 0);
+}
+
+/*
+    MDNSResponder::clsMDNSAnswerAccessor::hostDomainAvailable
+*/
+bool MDNSResponder::clsMDNSAnswerAccessor::hostDomainAvailable(void) const
+{
+    return ((m_pAnswer) &&
+            (m_pAnswer->m_QueryAnswerFlags & static_cast<typeQueryAnswerType>(enuQueryAnswerType::HostDomain)));
+}
+
+/*
+    MDNSResponder::clsMDNSAnswerAccessor::hostDomain
+*/
+const char* MDNSResponder::clsMDNSAnswerAccessor::hostDomain(void) const
+{
+    return ((m_pAnswer)
+            ?   m_pAnswer->m_HostDomain.c_str()
+            : 0);
+}
+
+/*
+    MDNSResponder::clsMDNSAnswerAccessor::hostPortAvailable
+*/
+bool MDNSResponder::clsMDNSAnswerAccessor::hostPortAvailable(void) const
+{
+    return ((m_pAnswer) &&
+            (m_pAnswer->m_QueryAnswerFlags & static_cast<typeQueryAnswerType>(enuQueryAnswerType::Port)));
+}
+
+/*
+    MDNSResponder::clsMDNSAnswerAccessor::hostPort
+*/
+uint16_t MDNSResponder::clsMDNSAnswerAccessor::hostPort(void) const
+{
+    return ((m_pAnswer)
+            ? (m_pAnswer->m_u16Port)
+            : 0);
+}
+
+#ifdef MDNS_IPV4_SUPPORT
+/*
+    MDNSResponder::clsMDNSAnswerAccessor::IPv4AddressAvailable
+*/
+bool MDNSResponder::clsMDNSAnswerAccessor::IPv4AddressAvailable(void) const
+{
+    return ((m_pAnswer) &&
+            (m_pAnswer->m_QueryAnswerFlags & static_cast<typeQueryAnswerType>(enuQueryAnswerType::IPv4Address)));
+}
+
+/*
+    MDNSResponder::clsMDNSAnswerAccessor::IPv4Addresses
+*/
+std::vector<IPAddress> MDNSResponder::clsMDNSAnswerAccessor::IPv4Addresses(void) const
+{
+    std::vector<IPAddress>  internalIP;
+    if ((m_pAnswer) &&
+        (IPv4AddressAvailable()))
+    {
+        for (uint32_t u = 0; u < m_pAnswer->IPv4AddressCount(); ++u)
+        {
+            const clsHost::stcQuery::stcAnswer::stcIPAddress*    pIPAddr = m_pAnswer->IPv4AddressAtIndex(u);
+            if (pIPAddr)
+            {
+                internalIP.emplace_back(pIPAddr->m_IPAddress);
+            }
+        }
+    }
+    return internalIP;
+}
+#endif
+
+#ifdef MDNS_IPV6_SUPPORT
+/*
+    MDNSResponder::clsMDNSAnswerAccessor::IPv6AddressAvailable
+*/
+bool MDNSResponder::clsMDNSAnswerAccessor::IPv6AddressAvailable(void) const
+{
+    return ((m_pAnswer) &&
+            (m_pAnswer->m_QueryAnswerFlags & static_cast<typeQueryAnswerType>(enuQueryAnswerType::IPv6Address)));
+}
+
+/*
+    MDNSResponder::clsMDNSAnswerAccessor::IPv6Addresses
+*/
+std::vector<IPAddress> MDNSResponder::clsMDNSAnswerAccessor::IPv6Addresses(void) const
+{
+    std::vector<IPAddress>  internalIP;
+    if ((m_pAnswer) &&
+        (IPv6AddressAvailable()))
+    {
+        for (uint32_t u = 0; u < m_pAnswer->IPv6AddressCount(); ++u)
+        {
+            const clsHost::stcQuery::stcAnswer::stcIPAddress*    pIPAddr = m_pAnswer->IPv6AddressAtIndex(u);
+            if (pIPAddr)
+            {
+                internalIP.emplace_back(pIPAddr->m_IPAddress);
+            }
+        }
+    }
+    return internalIP;
+}
+#endif
+
+/*
+    MDNSResponder::clsMDNSAnswerAccessor::txtsAvailable
+*/
+bool MDNSResponder::clsMDNSAnswerAccessor::txtsAvailable(void) const
+{
+    return ((m_pAnswer) &&
+            (m_pAnswer->m_QueryAnswerFlags & static_cast<typeQueryAnswerType>(enuQueryAnswerType::Txts)));
+}
+
+/*
+    MDNSResponder::clsMDNSAnswerAccessor::txts
+
+    Returns all TXT items for the given service as a ';'-separated string.
+    If not already existing; the string is alloced, filled and attached to the answer.
+*/
+const char* MDNSResponder::clsMDNSAnswerAccessor::txts(void) const
+{
+    return ((m_pAnswer)
+            ?   m_pAnswer->m_Txts.c_str()
+            : 0);
+}
+
+/*
+    MDNSResponder::clsMDNSAnswerAccessor::txtKeyValues
+*/
+const MDNSResponder::clsMDNSAnswerAccessor::clsTxtKeyValueMap& MDNSResponder::clsMDNSAnswerAccessor::txtKeyValues(void) const
+{
+    return m_TxtKeyValueMap;
+}
+
+/*
+    MDNSResponder::clsMDNSAnswerAccessor::txtValue
+*/
+const char* MDNSResponder::clsMDNSAnswerAccessor::txtValue(const char* p_pcKey) const
+{
+    char*   pcResult = 0;
+
+    if (m_pAnswer)
+    {
+        for (const clsHost::stcServiceTxt* pTxt = m_pAnswer->m_Txts.m_pTxts; pTxt; pTxt = pTxt->m_pNext)
+        {
+            if ((p_pcKey) &&
+                (0 == strcasecmp(pTxt->m_pcKey, p_pcKey)))
+            {
+                pcResult = pTxt->m_pcValue;
+                break;
+            }
+        }
+    }
+    return pcResult;
+}
+
+/*
+    MDNSResponder::clsMDNSAnswerAccessor::printTo
+ **/
+size_t MDNSResponder::clsMDNSAnswerAccessor::printTo(Print& p_Print) const
+{
+    size_t      stLen = 0;
+    const char* cpcI = " * ";
+    const char* cpcS = "  ";
+
+    stLen += p_Print.println(" * * * * *");
+    if (hostDomainAvailable())
+    {
+        stLen += p_Print.print(cpcI);
+        stLen += p_Print.print("Host domain: ");
+        stLen += p_Print.println(hostDomain());
+    }
+#ifdef MDNS_IPV4_SUPPORT
+    if (IPv4AddressAvailable())
+    {
+        stLen += p_Print.print(cpcI);
+        stLen += p_Print.println("IPv4 address(es):");
+        for (const IPAddress& addr : IPv4Addresses())
+        {
+            stLen += p_Print.print(cpcI);
+            stLen += p_Print.print(cpcS);
+            stLen += p_Print.println(addr);
+        }
+    }
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+    if (IPv6AddressAvailable())
+    {
+        stLen += p_Print.print(cpcI);
+        stLen += p_Print.println("IPv6 address(es):");
+        for (const IPAddress& addr : IPv6Addresses())
+        {
+            stLen += p_Print.print(cpcI);
+            stLen += p_Print.print(cpcS);
+            stLen += p_Print.println(addr);
+        }
+    }
+#endif
+    if (serviceDomainAvailable())
+    {
+        stLen += p_Print.print(cpcI);
+        stLen += p_Print.print("Service domain: ");
+        stLen += p_Print.println(serviceDomain());
+    }
+    if (hostPortAvailable())
+    {
+        stLen += p_Print.print(cpcI);
+        stLen += p_Print.print("Host port: ");
+        stLen += p_Print.println(hostPort());
+    }
+    if (txtsAvailable())
+    {
+        stLen += p_Print.print(cpcI);
+        stLen += p_Print.print("TXTs:");
+        for (auto const& x : txtKeyValues())
+        {
+            stLen += p_Print.print(cpcI);
+            stLen += p_Print.print(cpcS);
+            stLen += p_Print.print(x.first);
+            stLen += p_Print.print("=");
+            stLen += p_Print.println(x.second);
+        }
+    }
+    stLen += p_Print.println(" * * * * *");
+
+    return stLen;
+}
+
+/**
+    STATIC QUERIES
+*/
+
+/*
+    MDNSResponder::queryService
+
+    Perform a (blocking) static service query.
+    The arrived answers can be queried by calling:
+    - answerHostName (or 'hostname')
+    - answerIP (or 'IP')
+    - answerPort (or 'port')
+
+*/
+uint32_t MDNSResponder::queryService(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                     const char* p_pcService,
+                                     const char* p_pcProtocol,
+                                     const uint16_t p_u16Timeout /*= MDNS_QUERYSERVICES_WAIT_TIME*/)
+{
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s queryService '_%s._%s.local'\n"), _DH(p_hMDNSHost), p_pcService, p_pcProtocol););
+
+    uint32_t    u32Result = ((_validateMDNSHostHandle(p_hMDNSHost))
+                             ? (_NRH2Ptr(p_hMDNSHost)->queryService(p_pcService, p_pcProtocol, p_u16Timeout))
+                             : 0);
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s queryService '_%s._%s.local' returned %u hits!\n"), _DH(p_hMDNSHost), p_pcService, p_pcProtocol, u32Result););
+    return u32Result;
+}
+
+/*
+    MDNSResponder::queryHost
+
+    Perform a (blocking) static host query.
+    The arrived answers can be queried by calling:
+    - answerHostName (or 'hostname')
+    - answerIP (or 'IP')
+    - answerPort (or 'port')
+
+*/
+uint32_t MDNSResponder::queryHost(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                  const char* p_pcHostName,
+                                  const uint16_t p_u16Timeout /*= MDNS_QUERYSERVICES_WAIT_TIME*/)
+{
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s queryHost '%s.local'\n"), _DH(p_hMDNSHost), p_pcHostName););
+
+    uint32_t    u32Result = ((_validateMDNSHostHandle(p_hMDNSHost))
+                             ? (_NRH2Ptr(p_hMDNSHost)->queryHost(p_pcHostName, p_u16Timeout))
+                             : 0);
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s queryHost '%s.local' returned %u hits!\n"), _DH(p_hMDNSHost), p_pcHostName, u32Result););
+    return u32Result;
+}
+
+/*
+    MDNSResponder::removeQuery
+
+    Remove the last static query (and all answers).
+
+*/
+bool MDNSResponder::removeQuery(const MDNSResponder::hMDNSHost p_hMDNSHost)
+{
+    return ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+            (_NRH2Ptr(p_hMDNSHost)->removeQuery()));
+}
+
+/*
+    MDNSResponder::hasQuery
+
+    Return 'true', if a static query is currently installed
+
+*/
+bool MDNSResponder::hasQuery(const MDNSResponder::hMDNSHost p_hMDNSHost)
+{
+    return ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+            (0 != _NRH2Ptr(p_hMDNSHost)->hasQuery()));
+}
+
+/*
+    MDNSResponder::getQuery
+
+    Return handle to the last static query
+
+*/
+MDNSResponder::hMDNSQuery MDNSResponder::getQuery(const MDNSResponder::hMDNSHost p_hMDNSHost)
+{
+    return (_validateMDNSHostHandle(p_hMDNSHost)
+            ? (hMDNSQuery)_NRH2Ptr(p_hMDNSHost)->getQuery()
+            : 0);
+}
+
+
+/*
+    MDNSResponder::answerAccessors
+*/
+MDNSResponder::clsMDNSAnswerAccessorVector MDNSResponder::answerAccessors(const MDNSResponder::hMDNSHost p_hMDNSHost)
+{
+    hMDNSQuery  hLegacyQuery = getQuery(p_hMDNSHost);
+    return ((hLegacyQuery)
+            ? answerAccessors(p_hMDNSHost, hLegacyQuery)
+            : clsMDNSAnswerAccessorVector());
+}
+
+/*
+    MDNSResponder::answerCount
+*/
+uint32_t MDNSResponder::answerCount(const MDNSResponder::hMDNSHost p_hMDNSHost)
+{
+    hMDNSQuery  hLegacyQuery = getQuery(p_hMDNSHost);
+    return ((hLegacyQuery)
+            ? answerCount(p_hMDNSHost, hLegacyQuery)
+            : 0);
+}
+
+/*
+    MDNSResponder::answerAccessor
+*/
+MDNSResponder::clsMDNSAnswerAccessor MDNSResponder::answerAccessor(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                                   uint32_t p_u32AnswerIndex)
+{
+    hMDNSQuery  hLegacyQuery = getQuery(p_hMDNSHost);
+    return ((hLegacyQuery)
+            ? answerAccessor(p_hMDNSHost, hLegacyQuery, p_u32AnswerIndex)
+            : clsMDNSAnswerAccessor(0));
+}
+
+
+
+#ifdef NOTUSED
+
+/*
+    MDNSResponder::answerHostName
+*/
+const char* MDNSResponder::answerHostName(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                          const uint32_t p_u32AnswerIndex)
+{
+    const stcQuery*            pQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findLegacyQuery(*(clsHost*)p_hMDNSHost) : 0);
+    stcQuery::stcAnswer* pSQAnswer = (pQuery ? pQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+
+    if ((pSQAnswer) &&
+        (pSQAnswer->m_HostDomain.m_u16NameLength) &&
+        (!pSQAnswer->m_pcHostDomain))
+    {
+        char*   pcHostDomain = pSQAnswer->allocHostDomain(pSQAnswer->m_HostDomain.c_strLength());
+        if (pcHostDomain)
+        {
+            pSQAnswer->m_HostDomain.c_str(pcHostDomain);
+        }
+    }
+    return (pSQAnswer ? pSQAnswer->m_pcHostDomain : 0);
+}
+
+#ifdef MDNS_IPV4_SUPPORT
+/*
+    MDNSResponder::answerIPv4
+*/
+IPAddress MDNSResponder::answerIPv4(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                    const uint32_t p_u32AnswerIndex)
+{
+    const stcQuery*            					pQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findLegacyQuery(*(clsHost*)p_hMDNSHost) : 0);
+    const stcQuery::stcAnswer*                  pSQAnswer = (pQuery ? pQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+    const stcQuery::stcAnswer::stcIPv4Address*	pIPv4Address = (((pSQAnswer) && (pSQAnswer->m_pIPv4Addresses)) ? pSQAnswer->IPv4AddressAtIndex(0) : 0);
+    return (pIPv4Address ? pIPv4Address->m_IPAddress : IPAddress());
+}
+#endif
+
+#ifdef MDNS_IPV6_SUPPORT
+/*
+    MDNSResponder::answerIPv6
+*/
+IPAddress MDNSResponder::answerIPv6(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                    const uint32_t p_u32AnswerIndex)
+{
+    const stcQuery*            					pQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findLegacyQuery(*(clsHost*)p_hMDNSHost) : 0);
+    const stcQuery::stcAnswer*                  pSQAnswer = (pQuery ? pQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+    const stcQuery::stcAnswer::stcIPv6Address*	pIPv6Address = (((pSQAnswer) && (pSQAnswer->m_pIPv6Addresses)) ? pSQAnswer->IPv6AddressAtIndex(0) : 0);
+    return (pIPv6Address ? pIPv6Address->m_IPAddress : IPAddress());
+}
+#endif
+
+/*
+    MDNSResponder::answerPort
+*/
+uint16_t MDNSResponder::answerPort(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                   const uint32_t p_u32AnswerIndex)
+{
+    const stcQuery*            	pQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findLegacyQuery(*(clsHost*)p_hMDNSHost) : 0);
+    const stcQuery::stcAnswer*  pSQAnswer = (pQuery ? pQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+    return (pSQAnswer ? pSQAnswer->m_u16Port : 0);
+}
+
+#endif
+
+
+/**
+    DYNAMIC SERVICE QUERY
+*/
+
+/*
+    MDNSResponder::installServiceQuery
+
+    Add a dynamic service query and a corresponding callback to the MDNS responder.
+    The callback will be called for every answer update.
+    The answers can also be queried by calling:
+    - answerServiceDomain
+    - answerHostDomain
+    - answerIPv4Address/answerIPv6Address
+    - answerPort
+    - answerTxts
+
+*/
+MDNSResponder::hMDNSQuery MDNSResponder::installServiceQuery(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                             const char* p_pcService,
+                                                             const char* p_pcProtocol,
+                                                             MDNSResponder::MDNSQueryCallbackFn p_fnCallback)
+{
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s queryService '_%s._%s.local'\n"), _DH(p_hMDNSHost), p_pcService, p_pcProtocol););
+
+    hMDNSQuery  hResult = ((_validateMDNSHostHandle(p_hMDNSHost))
+                           ? (_NRH2Ptr(p_hMDNSHost)->installServiceQuery(p_pcService, p_pcProtocol, [this, p_fnCallback](clsHost & p_rHost,
+                                                                                                                         const clsHost::stcQuery & p_Query,
+                                                                                                                         const clsHost::stcQuery::stcAnswer & p_Answer,
+                                                                                                                         clsHost::typeQueryAnswerType p_QueryAnswerTypeFlags,          // flags for the updated answer item
+                                                                                                                         bool p_bSetContent)->void
+    {
+        if (p_fnCallback)
+        {
+            p_fnCallback(*this, (hMDNSHost)&p_rHost, (hMDNSQuery)&p_Query, clsMDNSAnswerAccessor(&p_Answer), p_QueryAnswerTypeFlags, p_bSetContent);
+        }
+    }))
+    : 0);
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s installServiceQuery: %s for '_%s._%s.local'!\n\n"), _DH(p_hMDNSHost), (hResult ? "Succeeded" : "FAILED"), (p_pcService ? : "-"), (p_pcProtocol ? : "-")););
+    DEBUG_EX_ERR(if (!hResult) DEBUG_OUTPUT.printf_P(PSTR("%s installServiceQuery: FAILED for '_%s._%s.local'!\n\n"), _DH(p_hMDNSHost), (p_pcService ? : "-"), (p_pcProtocol ? : "-")););
+    return hResult;
+}
+
+/*
+    MDNSResponder::installHostQuery
+*/
+MDNSResponder::hMDNSQuery MDNSResponder::installHostQuery(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                          const char* p_pcHostName,
+                                                          MDNSResponder::MDNSQueryCallbackFn p_fnCallback)
+{
+    hMDNSQuery  hResult = ((_validateMDNSHostHandle(p_hMDNSHost))
+                           ? (_NRH2Ptr(p_hMDNSHost)->installHostQuery(p_pcHostName, [this, p_fnCallback](clsHost & p_rHost,
+                                                                                                         const clsHost::stcQuery & p_Query,
+                                                                                                         const clsHost::stcQuery::stcAnswer & p_Answer,
+                                                                                                         clsHost::typeQueryAnswerType p_QueryAnswerTypeFlags,          // flags for the updated answer item
+                                                                                                         bool p_bSetContent)->void
+    {
+        if (p_fnCallback)
+        {
+            p_fnCallback(*this, (hMDNSHost)&p_rHost, (hMDNSQuery)&p_Query, clsMDNSAnswerAccessor(&p_Answer), p_QueryAnswerTypeFlags, p_bSetContent);
+        }
+    }))
+    : 0);
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s installHostQuery: %s for '%s.local'!\n\n"), _DH(p_hMDNSHost), (hResult ? "Succeeded" : "FAILED"), (p_pcHostName ? : "-")););
+    DEBUG_EX_ERR(if (!hResult) DEBUG_OUTPUT.printf_P(PSTR("%s installHostQuery: FAILED for '%s.local'!\n\n"), _DH(p_hMDNSHost), (p_pcHostName ? : "-")););
+    return hResult;
+}
+
+/*
+    MDNSResponder::removeQuery
+
+    Remove a dynamic query (and all collected answers) from the MDNS responder
+
+*/
+bool MDNSResponder::removeQuery(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                const MDNSResponder::hMDNSQuery p_hMDNSQuery)
+{
+    bool    bResult = ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+                       (p_hMDNSQuery) &&
+                       (_NRH2Ptr(p_hMDNSHost)->removeQuery((clsHost::stcQuery*)p_hMDNSQuery)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s removeQuery: FAILED!\n"), _DH(p_hMDNSHost)););
+    return bResult;
+}
+
+/*
+    MDNSResponder::answerAccessors
+*/
+MDNSResponder::clsMDNSAnswerAccessorVector MDNSResponder::answerAccessors(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                                          const MDNSResponder::hMDNSQuery p_hMDNSQuery)
+{
+    clsMDNSAnswerAccessorVector tempVector;
+    for (uint32_t u = 0; u < answerCount(p_hMDNSHost, p_hMDNSQuery); ++u)
+    {
+        clsHost::stcQuery::stcAnswer* pAnswer = 0;
+        if ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+            (p_hMDNSQuery) &&
+            ((pAnswer = ((clsHost::stcQuery*)p_hMDNSQuery)->answerAtIndex(u))))
+        {
+            tempVector.emplace_back(clsMDNSAnswerAccessor(pAnswer));
+            //tempVector.emplace_back(*pAnswer);
+        }
+    }
+    return tempVector;
+}
+
+/*
+    MDNSResponder::answerCount
+*/
+uint32_t MDNSResponder::answerCount(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                    const MDNSResponder::hMDNSQuery p_hMDNSQuery)
+{
+    _validateMDNSHostHandle(p_hMDNSHost);
+    return ((clsHost::stcQuery*)p_hMDNSQuery)->answerCount();
+}
+
+/*
+    MDNSResponder::answerAccessor
+*/
+MDNSResponder::clsMDNSAnswerAccessor MDNSResponder::answerAccessor(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                                   const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                   uint32_t p_u32AnswerIndex)
+{
+    clsHost::stcQuery::stcAnswer* pAnswer = (((_validateMDNSHostHandle(p_hMDNSHost)) &&
+                                              (p_hMDNSQuery))
+                                             ? ((clsHost::stcQuery*)p_hMDNSQuery)->answerAtIndex(p_u32AnswerIndex)
+                                             : 0);
+    return MDNSResponder::clsMDNSAnswerAccessor(pAnswer);
+}
+
+#ifdef LATER
+/*
+    MDNSResponder::hasAnswerServiceDomain
+*/
+bool MDNSResponder::hasAnswerServiceDomain(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                           const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                           const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*         		pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer*	pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          return ((pSQAnswer) &&
+                                                  (pSQAnswer->m_QueryAnswerFlags & static_cast<typeQueryAnswerType>(enuQueryAnswerType::ServiceDomain)));
+}
+
+                                     /*
+                                         MDNSResponder::answerServiceDomain
+
+                                         Returns the domain for the given service.
+                                         If not already existing, the string is allocated, filled and attached to the answer.
+
+                                     */
+                                     const char* MDNSResponder::answerServiceDomain(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                                                    const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                                    const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*        		pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer*	pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          // Fill m_pcServiceDomain (if not already done)
+                                          if ((pSQAnswer) &&
+                                              (pSQAnswer->m_ServiceDomain.m_u16NameLength) &&
+                                              (!pSQAnswer->m_pcServiceDomain))
+{
+
+    pSQAnswer->m_pcServiceDomain = pSQAnswer->allocServiceDomain(pSQAnswer->m_ServiceDomain.c_strLength());
+        if (pSQAnswer->m_pcServiceDomain)
+        {
+            pSQAnswer->m_ServiceDomain.c_str(pSQAnswer->m_pcServiceDomain);
+        }
+    }
+    return (pSQAnswer ? pSQAnswer->m_pcServiceDomain : 0);
+}
+
+/*
+    MDNSResponder::hasAnswerHostDomain
+*/
+bool MDNSResponder::hasAnswerHostDomain(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                        const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                        const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*        		pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer*	pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          return ((pSQAnswer) &&
+                                                  (pSQAnswer->m_QueryAnswerFlags & static_cast<typeQueryAnswerType>(enuQueryAnswerType::HostDomain)));
+}
+
+                                     /*
+                                         MDNSResponder::answerHostDomain
+
+                                         Returns the host domain for the given service.
+                                         If not already existing, the string is allocated, filled and attached to the answer.
+
+                                     */
+                                     const char* MDNSResponder::answerHostDomain(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                                                 const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                                 const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*        		pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer* 	pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          // Fill m_pcHostDomain (if not already done)
+                                          if ((pSQAnswer) &&
+                                              (pSQAnswer->m_HostDomain.m_u16NameLength) &&
+                                              (!pSQAnswer->m_pcHostDomain))
+{
+
+    pSQAnswer->m_pcHostDomain = pSQAnswer->allocHostDomain(pSQAnswer->m_HostDomain.c_strLength());
+        if (pSQAnswer->m_pcHostDomain)
+        {
+            pSQAnswer->m_HostDomain.c_str(pSQAnswer->m_pcHostDomain);
+        }
+    }
+    return (pSQAnswer ? pSQAnswer->m_pcHostDomain : 0);
+}
+
+#ifdef MDNS_IPV4_SUPPORT
+/*
+    MDNSResponder::hasAnswerIPv4Address
+*/
+bool MDNSResponder::hasAnswerIPv4Address(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                         const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                         const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*        		pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer* 	pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          return ((pSQAnswer) &&
+                                                  (pSQAnswer->m_QueryAnswerFlags & static_cast<typeQueryAnswerType>(enuQueryAnswerType::IPv4Address)));
+}
+
+                                     /*
+                                         MDNSResponder::answerIPv4AddressCount
+                                     */
+                                     uint32_t MDNSResponder::answerIPv4AddressCount(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                                                    const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                                    const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*        		pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer* 	pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          return (pSQAnswer ? pSQAnswer->IPv4AddressCount() : 0);
+}
+
+                                     /*
+                                         MDNSResponder::answerIPv4Address
+                                     */
+                                     IPAddress MDNSResponder::answerIPv4Address(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                                                const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                                const uint32_t p_u32AnswerIndex,
+                                                                                const uint32_t p_u32AddressIndex)
+{
+    stcQuery*        						pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                                          stcQuery::stcAnswer*                 	pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                                          stcQuery::stcAnswer::stcIPv4Address* 	pIPv4Address = (pSQAnswer ? pSQAnswer->IPv4AddressAtIndex(p_u32AddressIndex) : 0);
+                                                          return (pIPv4Address ? pIPv4Address->m_IPAddress : IPAddress());
+}
+#endif
+
+#ifdef MDNS_IPV6_SUPPORT
+                                                     /*
+                                                         MDNSResponder::hasAnswerIPv6Address
+                                                     */
+                                                     bool MDNSResponder::hasAnswerIPv6Address(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                                                              const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                                              const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*        		pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer*	pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          return ((pSQAnswer) &&
+                                                  (pSQAnswer->m_QueryAnswerFlags & static_cast<typeQueryAnswerType>(enuQueryAnswerType::IPv6Address)));
+}
+
+                                     /*
+                                         MDNSResponder::answerIPv6AddressCount
+                                     */
+                                     uint32_t MDNSResponder::answerIPv6AddressCount(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                                                    const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                                    const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*        		pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer* 	pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          return (pSQAnswer ? pSQAnswer->IPv6AddressCount() : 0);
+}
+
+                                     /*
+                                         MDNSResponder::answerIPv6Address
+                                     */
+                                     IPAddress MDNSResponder::answerIPv6Address(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                                                const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                                const uint32_t p_u32AnswerIndex,
+                                                                                const uint32_t p_u32AddressIndex)
+{
+    stcQuery*        						pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                                          stcQuery::stcAnswer*                 	pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                                          stcQuery::stcAnswer::stcIPv6Address*  	pIPv6Address = (pSQAnswer ? pSQAnswer->IPv6AddressAtIndex(p_u32AddressIndex) : 0);
+                                                          return (pIPv6Address ? pIPv6Address->m_IPAddress : IPAddress());
+}
+#endif
+
+                                                     /*
+                                                         MDNSResponder::hasAnswerPort
+                                                     */
+                                                     bool MDNSResponder::hasAnswerPort(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                                                       const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                                       const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*        		pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer* 	pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          return ((pSQAnswer) &&
+                                                  (pSQAnswer->m_QueryAnswerFlags & static_cast<typeQueryAnswerType>(enuQueryAnswerType::Port)));
+}
+
+                                     /*
+                                         MDNSResponder::answerPort
+                                     */
+                                     uint16_t MDNSResponder::answerPort(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                                        const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                        const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*        		pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer* 	pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          return (pSQAnswer ? pSQAnswer->m_u16Port : 0);
+}
+
+                                     /*
+                                         MDNSResponder::hasAnswerTxts
+                                     */
+                                     bool MDNSResponder::hasAnswerTxts(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                                       const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                       const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*        		pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer* 	pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          return ((pSQAnswer) &&
+                                                  (pSQAnswer->m_QueryAnswerFlags & static_cast<typeQueryAnswerType>(enuQueryAnswerType::Txts)));
+}
+
+                                     /*
+                                         MDNSResponder::answerTxts
+
+                                         Returns all TXT items for the given service as a ';'-separated string.
+                                         If not already existing; the string is alloced, filled and attached to the answer.
+
+                                     */
+                                     const char* MDNSResponder::answerTxts(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                                           const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                           const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*        		pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer* 	pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          // Fill m_pcTxts (if not already done)
+                                          if ((pSQAnswer) &&
+                                              (pSQAnswer->m_Txts.m_pTxts) &&
+                                              (!pSQAnswer->m_pcTxts))
+{
+
+    pSQAnswer->m_pcTxts = pSQAnswer->allocTxts(pSQAnswer->m_Txts.c_strLength());
+        if (pSQAnswer->m_pcTxts)
+        {
+            pSQAnswer->m_Txts.c_str(pSQAnswer->m_pcTxts);
+        }
+    }
+    return (pSQAnswer ? pSQAnswer->m_pcTxts : 0);
+}
+
+
+/*
+    PROBING
+*/
+
+/*
+    MDNSResponder::setHostProbeResultCallback
+
+    Set a callback for probe results. The callback is called, when probing
+    for the host domain failes or succeedes.
+    In the case of failure, the domain name should be changed via 'setHostName'
+    When succeeded, the host domain will be announced by the MDNS responder.
+
+*/
+bool MDNSResponder::setHostProbeResultCallback(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                               MDNSResponder::MDNSHostProbeResultCallbackFn p_fnCallback)
+{
+    return ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+            (((clsHost*)p_hMDNSHost)->m_HostProbeInformation.m_fnProbeResultCallback = p_fnCallback, true));
+}
+
+
+/*
+    MISC
+*/
+
+/*
+    MDNSResponder::notifyNetIfChange
+
+    Should be called, whenever the AP for the MDNS responder changes.
+    A bit of this is caught by the event callbacks installed in the constructor.
+
+*/
+bool MDNSResponder::notifyNetIfChange(netif* p_pNetIf)
+{
+    clsHost*	pMDNSHost;
+    return (((pMDNSHost = _findHost(p_pNetIf))) &&
+            (_restart(*pMDNSHost)));
+}
+
+/*
+    MDNSResponder::update
+
+    Should be called in every 'loop'.
+
+*/
+bool MDNSResponder::update(const MDNSResponder::hMDNSHost p_hMDNSHost)
+{
+    return ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+            (_process(*(clsHost*)p_hMDNSHost, true)));
+}
+
+/*
+	MDNSResponder::update (convenience)
+*/
+bool MDNSResponder::update(void)
+{
+    bool	bResult = true;
+    for (clsHost*& pMDNSHost : m_HostList)
+    {
+        if (!_process(*it, true))
+        {
+            bResult = false;
+        }
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::announce (convenience)
+
+    Should be called, if the 'configuration' changes. Mainly this will be changes in the TXT items...
+*/
+bool MDNSResponder::announce(const MDNSResponder::hMDNSHost p_hMDNSHost)
+{
+    return ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+            (_announce(*(clsHost*)p_hMDNSHost, true, true)));
+}
+
+/*
+    MDNSResponder::announce (convenience)
+*/
+bool MDNSResponder::announce(void)
+{
+    bool	bResult = true;
+    for (clsHost*& pMDNSHost : m_HostList)
+    {
+        if (!_announce(*it, true, true))
+        {
+            bResult = false;
+        }
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::enableArduino
+
+    Enable the OTA update service.
+
+*/
+MDNSResponder::hMDNSService MDNSResponder::enableArduino(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                         uint16_t p_u16Port,
+                                                         bool p_bAuthUpload /*= false*/)
+{
+    hMDNSService    hService = addService(p_hMDNSHost, 0, "arduino", "tcp", p_u16Port);
+    if (hService)
+    {
+        if ((!addServiceTxt(p_hMDNSHost, hService, "tcp_check", "no")) ||
+            (!addServiceTxt(p_hMDNSHost, hService, "ssh_upload", "no")) ||
+            (!addServiceTxt(p_hMDNSHost, hService, "board", STRINGIZE_VALUE_OF(ARDUINO_BOARD))) ||
+            (!addServiceTxt(p_hMDNSHost, hService, "auth_upload", (p_bAuthUpload) ? "yes" : "no")))
+        {
+
+            removeService(p_hMDNSHost, hService);
+            hService = 0;
+        }
+    }
+    return hService;
+}
+#endif  // LATER
+
+#ifdef __MDNS_USE_LEGACY
+
+/**
+    INTERFACE
+*/
+
+/**
+    MDNSResponder::MDNSResponder
+*/
+MDNSResponder::MDNSResponder(void)
+    :   m_pUDPContext(0)
+{
+}
+
+/*
+    MDNSResponder::~MDNSResponder
+*/
+MDNSResponder::~MDNSResponder(void)
+{
+    close();
+}
+
+
+/*
+    MDNSResponder::getHost (netif)
+*/
+MDNSResponder::hMDNSHost MDNSResponder::getHost(netif* p_pNetIf) const
+{
+    return (hMDNSHost)(p_pNetIf ? _findHost(p_pNetIf) : 0);
+}
+
+/*
+    MDNSResponder::getHost (WiFiMode)
+*/
+MDNSResponder::hMDNSHost MDNSResponder::getHost(WiFiMode_t p_WiFiMode) const
+{
+    hMDNSHost   hResult = 0;
+
+    if (WIFI_STA == p_WiFiMode)
+    {
+        hResult = getHost(netif_get_by_index(WIFI_STA));
+    }
+    else if (WIFI_AP == p_WiFiMode)
+    {
+        hResult = getHost(netif_get_by_index(WIFI_AP));
+    }
+    return hResult;
+}
+
+/*
+    MDNSResponder::begin (hostname, netif, probe_callback)
+*/
+MDNSResponder::hMDNSHost MDNSResponder::begin(const char* p_pcHostName,
+                                              netif* p_pNetIf,
+                                              MDNSHostProbeResultCallbackFn p_fnCallback /*= 0*/)
+{
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s begin(%s, netif: %u)\n"), _DH(), (p_pcHostName ? : "_"), (p_pNetIf ? netif_get_index(p_pNetIf) : 0)););
+
+    return (hMDNSHost)_begin(p_pcHostName, p_pNetIf, p_fnCallback);
+}
+
+/*
+    MDNSResponder::begin (hostname, probe_callback)
+*/
+bool MDNSResponder::begin(const char* p_pcHostName,
+                          MDNSHostProbeResultCallbackFn p_fnCallback /*= 0*/)
+{
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s begin(%s)\n"), _DH(), (p_pcHostName ? : "_")););
+
+    return begin(p_pcHostName, (WiFiMode_t)wifi_get_opmode(), p_fnCallback);
+}
+
+/*
+    MDNSResponder::begin (hostname, WiFiMode, probe_callback)
+*/
+bool MDNSResponder::begin(const char* p_pcHostName,
+                          WiFiMode_t p_WiFiMode,
+                          MDNSHostProbeResultCallbackFn p_fnCallback /*= 0*/)
+{
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s begin(%s, opmode: %u)\n"), _DH(), (p_pcHostName ? : "_"), (uint32_t)p_WiFiMode););
+
+    bool bResult = true;
+
+    if ((bResult) &&
+        (p_WiFiMode & WIFI_STA))
+    {
+        bResult = (0 != _begin(p_pcHostName, netif_get_by_index(WIFI_STA), p_fnCallback));
+    }
+    if ((bResult) &&
+        (p_WiFiMode & WIFI_AP))
+    {
+        bResult = (0 != _begin(p_pcHostName, netif_get_by_index(WIFI_AP), p_fnCallback));
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::close
+*/
+bool MDNSResponder::close(const MDNSResponder::hMDNSHost p_hMDNSHost)
+{
+    return ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+            (_close(*(clsHost*)p_hMDNSHost)));
+}
+
+/*
+    MDNSResponder::close (convenience)
+*/
+bool MDNSResponder::close(void)
+{
+    clsHostList::iterator   it(m_HostList.begin());
+    while (m_HostList.end() != it)
+    {
+        _close(**it++);
+    }
+
+    _releaseUDPContext();
+
+    return true;
+}
+
+/*
+    MDNSResponder::end (ESP32)
+*/
+bool MDNSResponder::end(void)
+{
+    return close();
+}
+
+/*
+    MDNSResponder::setHostName
+*/
+bool MDNSResponder::setHostName(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                const char* p_pcHostName)
+{
+    bool    bResult = ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+                       (_setHostName(*(clsHost*)p_hMDNSHost, p_pcHostName)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s setHostName: FAILED for '%s'!\n"), _DH(), (p_pcHostName ? : "-")););
+    return bResult;
+}
+
+/*
+    MDNSResponder::setHostname (LEGACY 2)
+
+    Set the host name in all netif bindings
+
+*/
+bool MDNSResponder::setHostname(const char* p_pcHostName)
+{
+    bool    bResult = true;
+    for (clsHost*& pMDNSHost : m_HostList)
+    {
+        if (!setHostName((hMDNSHost)pMDNSHost, p_pcHostName))
+        {
+            bResult = false;
+        }
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::setHostname (LEGACY)
+*/
+bool MDNSResponder::setHostname(String p_strHostName)
+{
+    return setHostname(p_strHostName.c_str());
+}
+
+/*
+    MDNSResponder::hostName
+*/
+const char* MDNSResponder::hostName(const MDNSResponder::hMDNSHost p_hMDNSHost) const
+{
+    return (_validateMDNSHostHandle(p_hMDNSHost)
+            ? (((clsHost*)p_hMDNSHost)->m_pcHostName)
+            : 0);
+}
+
+/*
+    MDNSResponder::hostname (LEGACY 2)
+*/
+const char* MDNSResponder::hostname(void) const
+{
+    return ((!m_HostList.empty())
+            ? hostName((hMDNSHost)m_HostList.front())
+            : 0);
+}
+
+/*
+    MDNSResponder::status
+*/
+bool MDNSResponder::status(const MDNSResponder::hMDNSHost p_hMDNSHost) const
+{
+    return ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+            (enuProbingStatus::Done == ((clsHost*)p_hMDNSHost)->m_HostProbeInformation.m_ProbingStatus));
+}
+
+/*
+    MDNSResponder::status (LEGACY 2)
+*/
+bool MDNSResponder::status(void) const
+{
+    bool    bResult = true;
+    for (clsHost * const& pMDNSHost : m_HostList)
+    {
+        if (!((bResult = status((hMDNSHost)pMDNSHost))))
+        {
+            break;
+        }
+    }
+    return bResult;
+}
+
+
+/*
+    SERVICES
+*/
+
+/*
+    MDNSResponder::setInstanceName
+*/
+bool MDNSResponder::setInstanceName(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                    const char* p_pcInstanceName)
+{
+    bool    bResult = ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+                       (_setInstanceName(*(clsHost*)p_hMDNSHost, p_pcInstanceName)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s setInstanceName: FAILED for '%s'!\n"), _DH(), (p_pcInstanceName ? : "-")););
+    return bResult;
+}
+
+/*
+    MDNSResponder::setInstanceName (LEGACY 2)
+
+    Set the instance name in all netif bindings
+
+*/
+bool MDNSResponder::setInstanceName(const char* p_pcInstanceName)
+{
+    bool    bResult = true;
+    for (clsHost*& pMDNSHost : m_HostList)
+    {
+        if (!setInstanceName((hMDNSHost)pMDNSHost, p_pcInstanceName))
+        {
+            bResult = false;
+        }
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::setInstanceName (LEGACY 2)
+*/
+bool MDNSResponder::setInstanceName(const String& p_strInstanceName)
+{
+    return setInstanceName(p_strInstanceName.c_str());
+}
+
+/*
+    MDNSResponder::addService
+
+    Add service; using hostname if no name is explicitly provided for the service
+    The usual '_' underline, which is prepended to service and protocol, eg. _http,
+    may be given. If not, it is added automatically.
+
+*/
+MDNSResponder::hMDNSService MDNSResponder::addService(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                      const char* p_pcName,
+                                                      const char* p_pcService,
+                                                      const char* p_pcProtocol,
+                                                      uint16_t p_u16Port)
+{
+    hMDNSService    hService = (_validateMDNSHostHandle(p_hMDNSHost)
+                                ? (hMDNSService)_addService(*(clsHost*)p_hMDNSHost, p_pcName, p_pcService, p_pcProtocol, p_u16Port)
+                                : 0);
+    DEBUG_EX_ERR(if (!hService) DEBUG_OUTPUT.printf_P(PSTR("%s addService: FAILED for '%s._%s._%s.local'!\n"), _DH((clsHost*)p_hMDNSHost), (p_pcName ? : "-"), (p_pcService ? : "-"), (p_pcProtocol ? : "-")););
+    return hService;
+}
+
+/*
+    MDNSResponder::addService (LEGACY 2)
+
+    Add a service to all netif bindings.
+    (Only) the first service (handle) is returned.
+
+*/
+MDNSResponder::hMDNSService MDNSResponder::addService(const char* p_pcName,
+                                                      const char* p_pcService,
+                                                      const char* p_pcProtocol,
+                                                      uint16_t p_u16Port)
+{
+    hMDNSService    hResult = 0;
+    for (clsHost*& pMDNSHost : m_HostList)
+    {
+        hMDNSService    hNewService = addService((hMDNSHost)pMDNSHost, p_pcName, p_pcService, p_pcProtocol, p_u16Port);
+        if (!hResult)
+        {
+            hResult = hNewService;
+        }
+    }
+    return hResult;
+}
+
+/*
+    MDNSResponder::removeService
+
+    Unanounce a service (by sending a goodbye message) and remove it
+    from the MDNS responder
+
+*/
+bool MDNSResponder::removeService(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                  const MDNSResponder::hMDNSService p_hMDNSService)
+{
+    bool    bResult = ((_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)) &&
+                       (_removeService(*(clsHost*)p_hMDNSHost, *(stcService*)p_hMDNSService)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s removeService: FAILED!\n"), _DH((clsHost*)p_hMDNSHost)););
+    return bResult;
+}
+
+/*
+    MDNSResponder::removeService (LEGACY 2)
+
+    Find and remove the service from one netif binding
+*/
+bool MDNSResponder::removeService(const MDNSResponder::hMDNSService p_hMDNSService)
+{
+    clsHost*    pHost = 0;
+    return ((_validateMDNSHostHandle(p_hMDNSService, &pHost)) &&
+            (removeService((hMDNSHost)pHost, p_hMDNSService)));
+}
+
+/*
+    MDNSResponder::removeService
+*/
+bool MDNSResponder::removeService(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                  const char* p_pcName,
+                                  const char* p_pcService,
+                                  const char* p_pcProtocol)
+{
+    clsHost*    pMDNSHost;
+    stcService*         pMDNSService;
+    bool    bResult = ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+                       (pMDNSHost = (clsHost*)p_hMDNSHost) &&
+                       ((pMDNSService = _findService(*pMDNSHost, (p_pcName ? : (pMDNSHost->m_pcInstanceName ? : pMDNSHost->m_pcHostName)), p_pcService, p_pcProtocol))) &&
+                       (_removeService(*(clsHost*)p_hMDNSHost, *pMDNSService)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s removeService: FAILED for '%s._%s._%s.local'!\n"), _DH((clsHost*)p_hMDNSHost), (p_pcName ? : "-"), (p_pcService ? : "-"), (p_pcProtocol ? : "-")););
+    return bResult;
+}
+
+/*
+    MDNSResponder::removeService (LEGACY 2)
+*/
+bool MDNSResponder::removeService(const char* p_pcName,
+                                  const char* p_pcService,
+                                  const char* p_pcProtocol)
+{
+    bool    bResult = true;
+
+    for (clsHost*& pMDNSHost : m_HostList)
+    {
+        if (!removeService((hMDNSHost)pMDNSHost, p_pcName, p_pcService, p_pcProtocol))
+        {
+            bResult = false;
+        }
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::addService (LEGACY)
+*/
+bool MDNSResponder::addService(String p_strService,
+                               String p_strProtocol,
+                               uint16_t p_u16Port)
+{
+    return (0 != addService(0, p_strService.c_str(), p_strProtocol.c_str(), p_u16Port));
+}
+
+/*
+    MDNSResponder::findService
+
+    Find an existing service.
+
+*/
+MDNSResponder::hMDNSService MDNSResponder::findService(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                       const char* p_pcName,
+                                                       const char* p_pcService,
+                                                       const char* p_pcProtocol)
+{
+    clsHost*    pMDNSHost;
+    return (((_validateMDNSHostHandle(p_hMDNSHost)) &&
+             (pMDNSHost = (clsHost*)p_hMDNSHost))
+            ? _findService(*pMDNSHost, (p_pcName ? : (pMDNSHost->m_pcInstanceName ? : pMDNSHost->m_pcHostName)), p_pcService, p_pcProtocol)
+            : 0);
+}
+
+/*
+    MDNSResponder::findService (LEGACY 2)
+
+    (Only) the first service handle is returned.
+
+*/
+MDNSResponder::hMDNSService MDNSResponder::findService(const char* p_pcName,
+                                                       const char* p_pcService,
+                                                       const char* p_pcProtocol)
+{
+    hMDNSService    hResult = 0;
+    for (clsHost*& pMDNSHost : m_HostList)
+    {
+        if ((hResult = findService((hMDNSHost)pMDNSHost, p_pcName, p_pcService, p_pcProtocol)))
+        {
+            break;
+        }
+    }
+    return hResult;
+}
+
+/*
+    MDNSResponder::setServiceName
+*/
+bool MDNSResponder::setServiceName(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                   const MDNSResponder::hMDNSService p_hMDNSService,
+                                   const char* p_pcInstanceName)
+{
+    bool    bResult = ((_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)) &&
+                       (_setServiceName(*(clsHost*)p_hMDNSHost, *(stcService*)p_hMDNSService, p_pcInstanceName)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s setServiceName: FAILED for '%s'!\n"), _DH((clsHost*)p_hMDNSHost), (p_pcInstanceName ? : "-")););
+    return bResult;
+}
+
+/*
+    MDNSResponder::setServiceName (LEGACY 2)
+*/
+bool MDNSResponder::setServiceName(const MDNSResponder::hMDNSService p_hMDNSService,
+                                   const char* p_pcInstanceName)
+{
+    clsHost*    pHost = 0;
+    return ((_validateMDNSServiceHandle(p_hMDNSService, &pHost)) &&
+            (setServiceName((hMDNSHost)pHost, p_hMDNSService, p_pcInstanceName)));
+}
+
+/*
+    MDNSResponder::serviceName
+*/
+const char* MDNSResponder::serviceName(const hMDNSHost p_hMDNSHost,
+                                       const hMDNSService p_hMDNSService) const
+{
+    return (_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)
+            ? ((stcService*)p_hMDNSService)->m_pcName
+            : 0);
+}
+
+/*
+    MDNSResponder::serviceName (LEGACY 2)
+*/
+const char* MDNSResponder::serviceName(const hMDNSService p_hMDNSService) const
+{
+    clsHost*    pHost = 0;
+    return (_validateMDNSServiceHandle(p_hMDNSService, &pHost)
+            ? serviceName((hMDNSHost)pHost, p_hMDNSService)
+            : 0);
+}
+
+/*
+    MDNSResponder::service
+*/
+const char* MDNSResponder::service(const hMDNSHost p_hMDNSHost,
+                                   const hMDNSService p_hMDNSService) const
+{
+    return (_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)
+            ? ((stcService*)p_hMDNSService)->m_pcService
+            : 0);
+}
+
+/*
+    MDNSResponder::service (LEGACY 2)
+*/
+const char* MDNSResponder::service(const hMDNSService p_hMDNSService) const
+{
+    clsHost*    pHost = 0;
+    return (_validateMDNSServiceHandle(p_hMDNSService, &pHost)
+            ? service((hMDNSHost)pHost, p_hMDNSService)
+            : 0);
+}
+
+/*
+    MDNSResponder::serviceProtocol
+*/
+const char* MDNSResponder::serviceProtocol(const hMDNSHost p_hMDNSHost,
+                                           const hMDNSService p_hMDNSService) const
+{
+    return (_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)
+            ? ((stcService*)p_hMDNSService)->m_pcProtocol
+            : 0);
+}
+
+/*
+    MDNSResponder::serviceProtocol (LEGACY)
+*/
+const char* MDNSResponder::serviceProtocol(const hMDNSService p_hMDNSService) const
+{
+    clsHost*    pHost = 0;
+    return (_validateMDNSServiceHandle(p_hMDNSService, &pHost)
+            ? serviceProtocol((hMDNSHost)pHost, p_hMDNSService)
+            : 0);
+}
+
+/*
+    MDNSResponder::serviceStatus
+*/
+bool MDNSResponder::serviceStatus(const hMDNSHost p_hMDNSHost,
+                                  const hMDNSService p_hMDNSService) const
+{
+    return ((_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)) &&
+            (enuProbingStatus::Done == ((stcService*)p_hMDNSService)->m_ProbeInformation.m_ProbingStatus));
+}
+
+/*
+    MDNSResponder::serviceStatus (LEGACY 2)
+
+    Returns 'true' if probing for the service 'hMDNSService' is done
+
+*/
+bool MDNSResponder::serviceStatus(const hMDNSService p_hMDNSService) const
+{
+    clsHost*    pHost = 0;
+    return (_validateMDNSServiceHandle(p_hMDNSService, &pHost)
+            ? serviceStatus((hMDNSHost)pHost, p_hMDNSService)
+            : false);
+}
+
+
+/*
+    SERVICE TXT
+*/
+
+/*
+    MDNSResponder::addServiceTxt
+
+    Add a static service TXT item ('Key'='Value') to a service.
+
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                     const MDNSResponder::hMDNSService p_hMDNSService,
+                                                     const char* p_pcKey,
+                                                     const char* p_pcValue)
+{
+    hMDNSTxt    hTxt = (_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)
+                        ? (hMDNSTxt)_addServiceTxt((clsHost*)p_hMDNSHost, (stcService*)p_hMDNSService, p_pcKey, p_pcValue, false)
+                        : 0);
+    DEBUG_EX_ERR(if (!hTxt) DEBUG_OUTPUT.printf_P(PSTR("%s addServiceTxt: FAILED for '%s=%s'!\n"), _DH(), (p_pcKey ? : "-"), (p_pcValue ? : "-")););
+    return hTxt;
+}
+
+/*
+    MDNSResponder::addServiceTxt (LEGACY 2)
+
+    Add a static service TXT item ('Key'='Value') to a service.
+
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSService p_hMDNSService,
+                                                     const char* p_pcKey,
+                                                     const char* p_pcValue)
+{
+    clsHost*    pHost = 0;
+    return (_validateMDNSHostHandle(p_hMDNSService, &pHost)
+            ? addServiceTxt((hMDNSHost)pHost, p_hMDNSService, p_pcKey, p_pcValue)
+            : 0);
+}
+
+/*
+    MDNSRESPONDER_xxx_TO_CHAR
+    Formats: http://www.cplusplus.com/reference/cstdio/printf/
+*/
+#define MDNSRESPONDER_U32_TO_CHAR(BUFFERNAME, U32VALUE) \
+    char    BUFFERNAME[16]; /* 32-bit max 10 digits */  \
+    *BUFFERNAME = 0;                                    \
+    sprintf(BUFFERNAME, "%u", U32VALUE);
+#define MDNSRESPONDER_U16_TO_CHAR(BUFFERNAME, U16VALUE) \
+    char    BUFFERNAME[8];  /* 16-bit max 5 digits */   \
+    *BUFFERNAME = 0;                                    \
+    sprintf(BUFFERNAME, "%hu", U16VALUE);
+#define MDNSRESPONDER_U8_TO_CHAR(BUFFERNAME, U8VALUE)   \
+    char    BUFFERNAME[8];  /* 8-bit max 3 digits */    \
+    *BUFFERNAME = 0;                                    \
+    sprintf(BUFFERNAME, "%hhu", U8VALUE);
+#define MDNSRESPONDER_I32_TO_CHAR(BUFFERNAME, I32VALUE) \
+    char    BUFFERNAME[16]; /* 32-bit max 10 digits */  \
+    *BUFFERNAME = 0;                                    \
+    sprintf(BUFFERNAME, "%i", I32VALUE);
+#define MDNSRESPONDER_I16_TO_CHAR(BUFFERNAME, I16VALUE) \
+    char    BUFFERNAME[8];  /* 16-bit max 5 digits */   \
+    *BUFFERNAME = 0;                                    \
+    sprintf(BUFFERNAME, "%hi", I16VALUE);
+#define MDNSRESPONDER_I8_TO_CHAR(BUFFERNAME, I8VALUE)   \
+    char    BUFFERNAME[8];  /* 8-bit max 3 digits */    \
+    *BUFFERNAME = 0;                                    \
+    sprintf(BUFFERNAME, "%hhi", I8VALUE);
+
+
+/*
+    MDNSResponder::addServiceTxt (uint32_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                     const MDNSResponder::hMDNSService p_hMDNSService,
+                                                     const char* p_pcKey,
+                                                     uint32_t p_u32Value)
+{
+    MDNSRESPONDER_U32_TO_CHAR(acBuffer, p_u32Value);
+    return addServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer):
+    }
+
+    /*
+        MDNSResponder::addServiceTxt (uint32_t) (LEGACY 2)
+    */
+    MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSService p_hMDNSService,
+                                                         const char* p_pcKey,
+                                                         uint32_t p_u32Value)
+{
+    clsHost*    pHost = 0;
+    return (_validateMDNSHostHandle(p_hMDNSService, &pHost)
+            ? addServiceTxt((hMDNSHost)pHost, p_hMDNSService, p_pcKey, p_u32Value)
+            : 0);
+}
+
+/*
+    MDNSResponder::addServiceTxt (uint16_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                     const MDNSResponder::hMDNSService p_hMDNSService,
+                                                     const char* p_pcKey,
+                                                     uint16_t p_u16Value)
+{
+    MDNSRESPONDER_U16_TO_CHAR(acBuffer, p_u16Value);
+    return addServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer):
+    }
+
+    /*
+        MDNSResponder::addServiceTxt (uint16_t) (LEGACY 2)
+    */
+    MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSService p_hMDNSService,
+                                                         const char* p_pcKey,
+                                                         uint16_t p_u16Value)
+{
+    clsHost*    pHost = 0;
+    return (_validateMDNSHostHandle(p_hMDNSService, &pHost)
+            ? addServiceTxt((hMDNSHost)pHost, p_hMDNSService, p_pcKey, p_u16Value)
+            : 0);
+}
+
+/*
+    MDNSResponder::addServiceTxt (uint8_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                     const MDNSResponder::hMDNSService p_hMDNSService,
+                                                     const char* p_pcKey,
+                                                     uint8_t p_u8Value)
+{
+    MDNSRESPONDER_U8_TO_CHAR(acBuffer, p_u8Value);
+    return addServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer):
+    }
+
+    /*
+        MDNSResponder::addServiceTxt (uint8_t) (LEGACY 2)
+    */
+    MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSService p_hMDNSService,
+                                                         const char* p_pcKey,
+                                                         uint8_t p_u8Value)
+{
+    clsHost*    pHost = 0;
+    return (_validateMDNSHostHandle(p_hMDNSService, &pHost)
+            ? addServiceTxt((hMDNSHost)pHost, p_hMDNSService, p_pcKey, p_u8Value)
+            : 0);
+}
+
+/*
+    MDNSResponder::addServiceTxt (int32_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                     const MDNSResponder::hMDNSService p_hMDNSService,
+                                                     const char* p_pcKey,
+                                                     int32_t p_i32Value)
+{
+    MDNSRESPONDER_I32_TO_CHAR(acBuffer, p_i32Value);
+    return addServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer):
+    }
+
+    /*
+        MDNSResponder::addServiceTxt (int32_t) (LEGACY 2)
+    */
+    MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSService p_hMDNSService,
+                                                         const char* p_pcKey,
+                                                         int32_t p_i32Value)
+{
+    clsHost*    pHost = 0;
+    return (_validateMDNSHostHandle(p_hMDNSService, &pHost)
+            ? addServiceTxt((hMDNSHost)pHost, p_hMDNSService, p_pcKey, p_i32Value)
+            : 0);
+}
+
+/*
+    MDNSResponder::addServiceTxt (int16_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                     const MDNSResponder::hMDNSService p_hMDNSService,
+                                                     const char* p_pcKey,
+                                                     int16_t p_i16Value)
+{
+    MDNSRESPONDER_I16_TO_CHAR(acBuffer, p_i16Value);
+    return addServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer):
+    }
+
+    /*
+        MDNSResponder::addServiceTxt (int16_t) (LEGACY 2)
+    */
+    MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSService p_hMDNSService,
+                                                         const char* p_pcKey,
+                                                         int16_t p_i16Value)
+{
+    clsHost*    pHost = 0;
+    return (_validateMDNSHostHandle(p_hMDNSService, &pHost)
+            ? addServiceTxt((hMDNSHost)pHost, p_hMDNSService, p_pcKey, p_i16Value)
+            : 0);
+}
+
+/*
+    MDNSResponder::addServiceTxt (int8_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                     const MDNSResponder::hMDNSService p_hMDNSService,
+                                                     const char* p_pcKey,
+                                                     int8_t p_i8Value)
+{
+    MDNSRESPONDER_I8_TO_CHAR(acBuffer, p_i8Value);
+    return addServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer):
+    }
+
+    /*
+        MDNSResponder::addServiceTxt (int8_t) (LEGACY 2)
+    */
+    MDNSResponder::hMDNSTxt MDNSResponder::addServiceTxt(const MDNSResponder::hMDNSService p_hMDNSService,
+                                                         const char* p_pcKey,
+                                                         int8_t p_i8Value)
+{
+    clsHost*    pHost = 0;
+    return (_validateMDNSHostHandle(p_hMDNSService, &pHost)
+            ? addServiceTxt((hMDNSHost)pHost, p_hMDNSService, p_pcKey, p_i8Value)
+            : 0);
+}
+
+/*
+    MDNSResponder::removeServiceTxt
+
+    Remove a static service TXT item from a service.
+*/
+bool MDNSResponder::removeServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                     const MDNSResponder::hMDNSService p_hMDNSService,
+                                     const MDNSResponder::hMDNSTxt p_hTxt)
+{
+    bool    bResult = ((_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)) &&
+                       (p_hTxt) &&
+                       (_findServiceTxt(*(clsHost*)p_hMDNSHost, *(stcService*)p_hMDNSService, p_hTxt)) &&
+                       (_releaseServiceTxt(*(clsHost*)p_hMDNSHost, *(stcService*)p_hMDNSService, (stcServiceTxt*)p_hTxt)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s removeServiceTxt: FAILED!\n"), _DH((clsHost*)p_hMDNSHost)););
+    return bResult;
+}
+
+/*
+    MDNSResponder::removeServiceTxt (LEGACY 2)
+*/
+bool MDNSResponder::removeServiceTxt(const MDNSResponder::hMDNSService p_hMDNSService,
+                                     const MDNSResponder::hMDNSTxt p_hTxt)
+{
+    clsHost*    pHost = 0;
+    return (_validateMDNSHostHandle(p_hMDNSService, &pHost)
+            ? removeServiceTxt((hMDNSHost)pHost, p_hMDNSService, p_hTxt)
+            : false);
+}
+
+/*
+    MDNSResponder::removeServiceTxt
+*/
+bool MDNSResponder::removeServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                     const MDNSResponder::hMDNSService p_hMDNSService,
+                                     const char* p_pcKey)
+{
+    stcServiceTxt*  pTxt;
+    bool    bResult = ((_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)) &&
+                       (p_pcKey) &&
+                       ((pTxt = _findServiceTxt(*(clsHost*)p_hMDNSHost, *(stcService*)p_hMDNSService, p_pcKey))) &&
+                       (_releaseServiceTxt(*(clsHost*)p_hMDNSHost, *(stcService*)p_hMDNSService, pTxt)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s removeServiceTxt: FAILED!\n"), _DH((clsHost*)p_hMDNSHost)););
+    return bResult;
+}
+
+/*
+    MDNSResponder::removeServiceTxt (LEGACY 2)
+*/
+bool MDNSResponder::removeServiceTxt(const MDNSResponder::hMDNSService p_hMDNSService,
+                                     const char* p_pcKey)
+{
+    clsHost*    pHost = 0;
+    return (_validateMDNSHostHandle(p_hMDNSService, &pHost)
+            ? removeServiceTxt((hMDNSHost)pHost, p_hMDNSService, p_pcKey)
+            : false);
+}
+
+/*
+    MDNSResponder::removeServiceTxt (LEGACY)
+*/
+bool MDNSResponder::removeServiceTxt(const char* p_pcName,
+                                     const char* p_pcService,
+                                     const char* p_pcProtocol,
+                                     const char* p_pcKey)
+{
+    hMDNSService    hService;
+    return (((hService = findService(p_pcName, p_pcService, p_pcProtocol)))
+            ? removeServiceTxt(hService, p_pcKey)
+            : false);
+}
+
+/*
+    MDNSResponder::addServiceTxt (LEGACY)
+*/
+bool MDNSResponder::addServiceTxt(const char* p_pcService,
+                                  const char* p_pcProtocol,
+                                  const char* p_pcKey,
+                                  const char* p_pcValue)
+{
+    hMDNSService    hService;
+    return (((hService = findService(p_pcName, p_pcService, p_pcProtocol)))
+            ? addServiceTxt(hService, p_pcKey, p_pcValue)
+            : false);
+}
+
+/*
+    MDNSResponder::addServiceTxt (LEGACY)
+*/
+bool MDNSResponder::addServiceTxt(String p_strService,
+                                  String p_strProtocol,
+                                  String p_strKey,
+                                  String p_strValue)
+{
+    return addServiceTxt(p_strService.c_str(), p_strProtocol.c_str(), p_strKey.c_str(), p_strValue.c_str());
+}
+
+/*
+    MDNSResponder::setDynamicServiceTxtCallback (binding)
+
+    Set a netif binding specific callback for dynamic service TXT items. The callback is called, whenever
+    service TXT items are needed for any service on the netif binding.
+
+*/
+bool MDNSResponder::setDynamicServiceTxtCallback(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                 MDNSResponder::MDNSDynamicServiceTxtCallbackFn p_fnCallback)
+{
+    bool    bResult = ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+                       ((!p_fnCallback) ||
+                        ((((clsHost*)p_hMDNSHost)->m_fnServiceTxtCallback = p_fnCallback))));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s setDynamicServiceTxtCallback: FAILED!\n"), _DH((clsHost*)p_hMDNSHost)););
+    return bResult;
+}
+
+/*
+    MDNSResponder::setDynamicServiceTxtCallback (service)
+
+    Set a service specific callback for dynamic service TXT items. The callback is called, whenever
+    service TXT items are needed for the given service.
+*/
+bool MDNSResponder::setDynamicServiceTxtCallback(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                 const MDNSResponder::hMDNSService p_hMDNSService,
+                                                 MDNSResponder::MDNSDynamicServiceTxtCallbackFn p_fnCallback)
+{
+    bool    bResult = ((_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)) &&
+                       ((!p_fnCallback) ||
+                        ((((stcService*)p_hMDNSService)->m_fnServiceTxtCallback = p_fnCallback))));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s setDynamicServiceTxtCallback: FAILED!\n"), _DH((clsHost*)p_hMDNSHost)););
+    return bResult;
+}
+
+/*
+    MDNSResponder::setDynamicServiceTxtCallback (global) (LEGACY 2)
+
+    Set a global callback for dynamic service TXT items. The callback is called, whenever
+    service TXT items are needed.
+
+*/
+bool MDNSResponder::setDynamicServiceTxtCallback(MDNSResponder::MDNSDynamicServiceTxtCallbackFn1 p_fnCallback)
+{
+    for (clsHostList : .iterator it : m_HostList)
+    {
+        setDynamicServiceTxtCallback((hMDNSHost)it, p_fnCallback);
+    }
+    return true;
+}
+
+/*
+    MDNSResponder::setDynamicServiceTxtCallback (global) (LEGACY 2 (Fn2))
+*/
+bool MDNSResponder::setDynamicServiceTxtCallback(MDNSResponder::MDNSDynamicServiceTxtCallbackFn2 p_fnCallback)
+{
+    return setDynamicServiceTxtCallback([p_fnCallback](MDNSResponder*, const hMDNSService p_hMDNSService)
+    {
+        if (p_fnCallback)
+        {
+            p_fnCallback(p_hMDNSService);
+        }
+    });
+}
+
+/*
+    MDNSResponder::setDynamicServiceTxtCallback (service) (LEGACY 2)
+*/
+bool MDNSResponder::setDynamicServiceTxtCallback(MDNSResponder::hMDNSService p_hMDNSService,
+                                                 MDNSResponder::MDNSDynamicServiceTxtCallbackFn1 p_fnCallback)
+{
+    clsHost*    pHost;
+    return ((_validateMDNSHostHandle(p_hMDNSService, &pHost)) &&
+            (setDynamicServiceTxtCallback((hMDNSHost)pHost, hMDNSService, p_fnCallback)));
+}
+
+/*
+    MDNSResponder::setDynamicServiceTxtCallback (service) (LEGACY 2 (Fn2))
+*/
+bool MDNSResponder::setDynamicServiceTxtCallback(MDNSResponder::hMDNSService p_hMDNSService,
+                                                 MDNSResponder::MDNSDynamicServiceTxtCallbackFn2 p_fnCallback)
+{
+    return setDynamicServiceTxtCallback(p_hMDNSService, [p_fnCallback](MDNSResponder*, const hMDNSService p_hMDNSService)
+    {
+        if (p_fnCallback)
+        {
+            p_fnCallback(p_hMDNSService);
+        }
+    });
+}
+
+/*
+    MDNSResponder::addDynamicServiceTxt
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                            const MDNSResponder::hMDNSService p_hMDNSService,
+                                                            const char* p_pcKey,
+                                                            const char* p_pcValue)
+{
+    hMDNSTxt    hTxt = (_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)
+                        ? _addServiceTxt(*(clsHost*)p_hMDNSHost, *(stcService*)p_hMDNSService, p_pcKey, p_pcValue, true)
+                        : 0);
+    DEBUG_EX_ERR(if (!hTxt) DEBUG_OUTPUT.printf_P(PSTR("%s addDynamicServiceTxt: FAILED for '%s=%s'!\n"), _DH(), (p_pcKey ? : "-"), (p_pcValue ? : "-")););
+    return hTxt;
+}
+
+/*
+    MDNSResponder::addDynamicServiceTxt (LEGACY 2)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(const MDNSResponder::hMDNSService p_hMDNSService,
+                                                            const char* p_pcKey,
+                                                            const char* p_pcValue)
+{
+    clsHost*    pHost = 0;
+    return (_validateMDNSHostHandle(p_hMDNSService, &pHost)
+            ? addDynamicServiceTxt((hMDNSHost)pHost, p_hMDNSService, p_pcKey, p_pcValue)
+            : 0);
+}
+
+/*
+    MDNSResponder::addDynamicServiceTxt (uint32_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                            MDNSResponder::hMDNSService p_hMDNSService,
+                                                            const char* p_pcKey,
+                                                            uint32_t p_u32Value)
+{
+    MDNSRESPONDER_U32_TO_CHAR(acBuffer, p_u32Value);
+    return addDynamicServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer):
+    }
+
+    /*
+        MDNSResponder::addDynamicServiceTxt (uint32_t) (LEGACY 2)
+    */
+    MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(const MDNSResponder::hMDNSService p_hMDNSService,
+                                                                const char* p_pcKey,
+                                                                uint32_t p_u32Value)
+{
+    clsHost*    pHost = 0;
+    return (_validateMDNSHostHandle(p_hMDNSService, &pHost)
+            ? addDynamicServiceTxt((hMDNSHost)pHost, p_hMDNSService, p_pcKey, p_u32Value)
+            : 0);
+}
+
+/*
+    MDNSResponder::addDynamicServiceTxt (uint16_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                            const MDNSResponder::hMDNSService p_hMDNSService,
+                                                            const char* p_pcKey,
+                                                            uint16_t p_u16Value)
+{
+    MDNSRESPONDER_U16_TO_CHAR(acBuffer, p_u16Value);
+    return addDynamicServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer):
+    }
+
+    /*
+        MDNSResponder::addDynamicServiceTxt (uint16_t) (LEGACY 2)
+    */
+    MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(const MDNSResponder::hMDNSService p_hMDNSService,
+                                                                const char* p_pcKey,
+                                                                uint16_t p_u16Value)
+{
+    clsHost*    pHost = 0;
+    return (_validateMDNSHostHandle(p_hMDNSService, &pHost)
+            ? addDynamicServiceTxt((hMDNSHost)pHost, p_hMDNSService, p_pcKey, p_u16Value)
+            : 0);
+}
+
+/*
+    MDNSResponder::addDynamicServiceTxt (uint8_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                            const MDNSResponder::hMDNSService p_hMDNSService,
+                                                            const char* p_pcKey,
+                                                            uint8_t p_u8Value)
+{
+    MDNSRESPONDER_U8_TO_CHAR(acBuffer, p_u8Value);
+    return addDynamicServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer):
+    }
+
+    /*
+        MDNSResponder::addDynamicServiceTxt (uint8_t) (LEGACY 2)
+    */
+    MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(const MDNSResponder::hMDNSService p_hMDNSService,
+                                                                const char* p_pcKey,
+                                                                uint8_t p_u8Value)
+{
+    clsHost*    pHost = 0;
+    return (_validateMDNSHostHandle(p_hMDNSService, &pHost)
+            ? addDynamicServiceTxt((hMDNSHost)pHost, p_hMDNSService, p_pcKey, p_u8Value)
+            : 0);
+}
+
+/*
+    MDNSResponder::addDynamicServiceTxt (int32_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                            const MDNSResponder::hMDNSService p_hMDNSService,
+                                                            const char* p_pcKey,
+                                                            int32_t p_i32Value)
+{
+    MDNSRESPONDER_I32_TO_CHAR(acBuffer, p_i32Value);
+    return addDynamicServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer):
+    }
+
+    /*
+        MDNSResponder::addDynamicServiceTxt (int32_t) (LEGACY 2)
+    */
+    MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(const MDNSResponder::hMDNSService p_hMDNSService,
+                                                                const char* p_pcKey,
+                                                                uint32_t p_i32Value)
+{
+    clsHost*    pHost = 0;
+    return (_validateMDNSHostHandle(p_hMDNSService, &pHost)
+            ? addDynamicServiceTxt((hMDNSHost)pHost, p_hMDNSService, p_pcKey, p_i32Value)
+            : 0);
+}
+
+/*
+    MDNSResponder::addDynamicServiceTxt (int16_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                            const MDNSResponder::hMDNSService p_hMDNSService,
+                                                            const char* p_pcKey,
+                                                            int16_t p_i16Value)
+{
+    MDNSRESPONDER_I16_TO_CHAR(acBuffer, p_i16Value);
+    return addDynamicServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer):
+    }
+
+    /*
+        MDNSResponder::addDynamicServiceTxt (int16_t) (LEGACY 2)
+    */
+    MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(const MDNSResponder::hMDNSService p_hMDNSService,
+                                                                const char* p_pcKey,
+                                                                uint16_t p_i16Value)
+{
+    clsHost*    pHost = 0;
+    return (_validateMDNSHostHandle(p_hMDNSService, &pHost)
+            ? addDynamicServiceTxt((hMDNSHost)pHost, p_hMDNSService, p_pcKey, p_i16Value)
+            : 0);
+}
+
+/*
+    MDNSResponder::addDynamicServiceTxt (int8_t)
+*/
+MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                            const MDNSResponder::hMDNSService p_hMDNSService,
+                                                            const char* p_pcKey,
+                                                            int8_t p_i8Value)
+{
+    MDNSRESPONDER_I8_TO_CHAR(acBuffer, p_i8Value);
+    return addDynamicServiceTxt(p_hMDNSHost, p_hMDNSService, p_pcKey, acBuffer):
+    }
+
+    /*
+        MDNSResponder::addDynamicServiceTxt (int8_t) (LEGACY 2)
+    */
+    MDNSResponder::hMDNSTxt MDNSResponder::addDynamicServiceTxt(const MDNSResponder::hMDNSService p_hMDNSService,
+                                                                const char* p_pcKey,
+                                                                uint8_t p_i8Value)
+{
+    clsHost*    pHost = 0;
+    return (_validateMDNSHostHandle(p_hMDNSService, &pHost)
+            ? addDynamicServiceTxt((hMDNSHost)pHost, p_hMDNSService, p_pcKey, p_i8Value)
+            : 0);
+}
+
+
+/**
+    STATIC QUERIES
+*/
+
+/*
+    MDNSResponder::queryService
+
+    Perform a (blocking) static service query.
+    The arrived answers can be queried by calling:
+    - answerHostName (or 'hostname')
+    - answerIP (or 'IP')
+    - answerPort (or 'port')
+
+*/
+uint32_t MDNSResponder::queryService(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                     const char* p_pcService,
+                                     const char* p_pcProtocol,
+                                     const uint16_t p_u16Timeout /*= MDNS_QUERYSERVICES_WAIT_TIME*/)
+{
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s queryService '%s.%s'\n"), _DH(), p_pcService, p_pcProtocol););
+
+    uint32_t    u32Result = 0;
+
+    stcQuery*    pMDNSQuery = 0;
+    if ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+        (p_pcService) &&
+        (os_strlen(p_pcService)) &&
+        (p_pcProtocol) &&
+        (os_strlen(p_pcProtocol)) &&
+        (p_u16Timeout) &&
+        (_removeLegacyQuery()) &&
+        ((pMDNSQuery = _allocQuery(*(clsHost*)p_hMDNSHost, stcQuery::enuQueryType::Service))) &&
+        (_buildDomainForService(p_pcService, p_pcProtocol, pMDNSQuery->m_Domain)))
+    {
+        pMDNSQuery->m_bLegacyQuery = true;
+
+        if (_sendMDNSQuery(*(clsHost*)p_hMDNSHost, *pMDNSQuery))
+        {
+            // Wait for answers to arrive
+            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s queryService: Waiting %u ms for answers...\n"), _DH(), p_u16Timeout););
+            delay(p_u16Timeout);
+
+            // All answers should have arrived by now -> stop adding new answers
+            pMDNSQuery->m_bAwaitingAnswers = false;
+            u32Result = pMDNSQuery->answerCount();
+        }
+        else    // FAILED to send query
+        {
+            _removeQuery(*(clsHost*)p_hMDNSHost, pMDNSQuery);
+        }
+    }
+    else
+    {
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s queryService: INVALID input data!\n"), _DH()););
+    }
+    return u32Result;
+}
+
+/*
+    MDNSResponder::queryService (LEGACY 2)
+*/
+uint32_t MDNSResponder::queryService(const char* p_pcService,
+                                     const char* p_pcProtocol,
+                                     const uint16_t p_u16Timeout /*= MDNS_QUERYSERVICES_WAIT_TIME*/)
+{
+    return ((!m_HostList.empty())
+            ? queryService((hMDNSHost)m_HostList.front(), p_pcService, p_pcProtocol, p_u16Timeout)
+            : 0);
+}
+
+/*
+    MDNSResponder::queryService (LEGACY)
+*/
+uint32_t MDNSResponder::queryService(const String& p_strService,
+                                     const String& p_strProtocol)
+{
+    return queryService(p_strService.c_str(), p_strProtocol.c_str());
+}
+
+/*
+    MDNSResponder::queryHost
+
+    Perform a (blocking) static host query.
+    The arrived answers can be queried by calling:
+    - answerHostName (or 'hostname')
+    - answerIP (or 'IP')
+    - answerPort (or 'port')
+
+*/
+uint32_t MDNSResponder::queryHost(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                  const char* p_pcHostName,
+                                  const uint16_t p_u16Timeout /*= MDNS_QUERYSERVICES_WAIT_TIME*/)
+{
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s queryHost '%s.local'\n"), _DH(), p_pcHostName););
+
+    uint32_t    u32Result = 0;
+
+    stcQuery*    pHostQuery = 0;
+    if ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+        (p_pcHostName) &&
+        (os_strlen(p_pcHostName)) &&
+        (p_u16Timeout) &&
+        (_removeLegacyQuery()) &&
+        ((pHostQuery = _allocQuery(*(clsHost*)p_hMDNSHost, stcQuery::enuQueryType::Host))) &&
+        (_buildDomainForHost(p_pcHostName, pHostQuery->m_Domain)))
+    {
+
+        pHostQuery->m_bLegacyQuery = true;
+
+        if (_sendMDNSQuery(*(clsHost*)p_hMDNSHost, *pHostQuery))
+        {
+            // Wait for answers to arrive
+            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s queryHost: Waiting %u ms for answers...\n"), _DH(), p_u16Timeout););
+            delay(p_u16Timeout);
+
+            // All answers should have arrived by now -> stop adding new answers
+            pHostQuery->m_bAwaitingAnswers = false;
+            u32Result = pHostQuery->answerCount();
+        }
+        else    // FAILED to send query
+        {
+            _removeQuery(*(clsHost*)p_hMDNSHost, pHostQuery);
+        }
+    }
+    else
+    {
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s queryHost: INVALID input data!\n"), _DH()););
+    }
+    return u32Result;
+}
+
+/*
+    queryHost (LEGACY 2)
+*/
+uint32_t MDNSResponder::queryHost(const char* p_pcHostName,
+                                  const uint16_t p_u16Timeout /*= MDNS_QUERYSERVICES_WAIT_TIME*/)
+{
+    return ((!m_HostList.empty())
+            ? queryHost((hMDNSHost)m_HostList.front(), p_pcService, p_pcProtocol, p_u16Timeout)
+            : 0);
+}
+
+/*
+    MDNSResponder::removeQuery
+
+    Remove the last static query (and all answers).
+
+*/
+bool MDNSResponder::removeQuery(const MDNSResponder::hMDNSHost p_hMDNSHost)
+{
+    return ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+            (_removeLegacyQuery(*(clsHost*)p_hMDNSHost)));
+}
+
+/*
+    MDNSResponder::removeQuery (LEGACY 2)
+*/
+bool MDNSResponder::removeQuery(void)
+{
+    return ((!m_HostList.empty())
+            ? removeQuery((hMDNSHost)m_HostList.front())
+            : false);
+}
+
+/*
+    MDNSResponder::hasQuery
+
+    Return 'true', if a static query is currently installed
+
+*/
+bool MDNSResponder::hasQuery(const MDNSResponder::hMDNSHost p_hMDNSHost)
+{
+    return ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+            (0 != _findLegacyQuery(*(clsHost*)p_hMDNSHost)));
+}
+
+/*
+    MDNSResponder::hasQuery (LEGACY 2)
+*/
+bool MDNSResponder::hasQuery(void)
+{
+    return ((!m_HostList.empty())
+            ? hasQuery((hMDNSHost)m_HostList.front())
+            : false);
+}
+
+/*
+    MDNSResponder::getQuery
+
+    Return handle to the last static query
+
+*/
+MDNSResponder::hMDNSQuery MDNSResponder::getQuery(const MDNSResponder::hMDNSHost p_hMDNSHost)
+{
+    return (_validateMDNSHostHandle(p_hMDNSHost)
+            ? (hMDNSQuery)_findLegacyQuery()
+            : 0);
+}
+
+/*
+    MDNSResponder::getQuery (LEGACY 2)
+*/
+MDNSResponder::hMDNSQuery MDNSResponder::getQuery(void)
+{
+    return ((!m_HostList.empty())
+            ? getQuery((hMDNSHost)m_HostList.front())
+            : false);
+}
+
+/*
+    MDNSResponder::answerHostName
+*/
+const char* MDNSResponder::answerHostName(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                          const uint32_t p_u32AnswerIndex)
+{
+    const stcQuery*            pQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findLegacyQuery(*(clsHost*)p_hMDNSHost) : 0);
+    stcQuery::stcAnswer* pSQAnswer = (pQuery ? pQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+
+    if ((pSQAnswer) &&
+        (pSQAnswer->m_HostDomain.m_u16NameLength) &&
+        (!pSQAnswer->m_pcHostDomain))
+    {
+        char*   pcHostDomain = pSQAnswer->allocHostDomain(pSQAnswer->m_HostDomain.c_strLength());
+        if (pcHostDomain)
+        {
+            pSQAnswer->m_HostDomain.c_str(pcHostDomain);
+        }
+    }
+    return (pSQAnswer ? pSQAnswer->m_pcHostDomain : 0);
+}
+
+/*
+    MDNSResponder::answerHostName (LEGACY 2)
+*/
+const char* MDNSResponder::answerHostName(const uint32_t p_u32AnswerIndex)
+{
+    return ((!m_HostList.empty())
+            ? answerHostName((hMDNSHost)m_HostList.front(), p_u32AnswerIndex)
+            : 0);
+}
+
+/*
+    MDNSResponder::hostname (LEGACY)
+*/
+String MDNSResponder::hostname(const uint32_t p_u32AnswerIndex)
+{
+    return String(answerHostName(p_u32AnswerIndex));
+}
+
+#ifdef MDNS_IPV4_SUPPORT
+/*
+    MDNSResponder::answerIPv4
+*/
+IPAddress MDNSResponder::answerIPv4(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                    const uint32_t p_u32AnswerIndex)
+{
+    const stcQuery*                             pQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findLegacyQuery(*(clsHost*)p_hMDNSHost) : 0);
+    const stcQuery::stcAnswer*                  pSQAnswer = (pQuery ? pQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+    const stcQuery::stcAnswer::stcIPv4Address*  pIPv4Address = (((pSQAnswer) && (pSQAnswer->m_pIPv4Addresses)) ? pSQAnswer->IPv4AddressAtIndex(0) : 0);
+    return (pIPv4Address ? pIPv4Address->m_IPAddress : IPAddress());
+}
+
+/*
+    MDNSResponder::answerIPv4 (LEGACY 2)
+*/
+IPAddress MDNSResponder::answerIPv4(const uint32_t p_u32AnswerIndex)
+{
+    return ((!m_HostList.empty())
+            ? answerIPv4((hMDNSHost)m_HostList.front(), p_u32AnswerIndex)
+            : IPAddress());
+}
+
+/*
+    MDNSResponder::answerIP (LEGACY 2)
+*/
+IPAddress MDNSResponder::answerIP(const uint32_t p_u32AnswerIndex)
+{
+    return answerIPv4(p_u32AnswerIndex);
+}
+
+/*
+    MDNSResponder::IP (LEGACY)
+*/
+IPAddress MDNSResponder::IP(const uint32_t p_u32AnswerIndex)
+{
+    return answerIPv4(p_u32AnswerIndex);
+}
+#endif
+
+#ifdef MDNS_IPV6_SUPPORT
+/*
+    MDNSResponder::answerIPv6
+*/
+IPAddress MDNSResponder::answerIPv6(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                    const uint32_t p_u32AnswerIndex)
+{
+    const stcQuery*                             pQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findLegacyQuery(*(clsHost*)p_hMDNSHost) : 0);
+    const stcQuery::stcAnswer*                  pSQAnswer = (pQuery ? pQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+    const stcQuery::stcAnswer::stcIPv6Address*  pIPv6Address = (((pSQAnswer) && (pSQAnswer->m_pIPv6Addresses)) ? pSQAnswer->IPv6AddressAtIndex(0) : 0);
+    return (pIPv6Address ? pIPv6Address->m_IPAddress : IPAddress());
+}
+
+/*
+    MDNSResponder::answerIPv6 (LEGACY 2)
+*/
+IPAddress MDNSResponder::answerIPv6(const uint32_t p_u32AnswerIndex)
+{
+    return ((!m_HostList.empty())
+            ? answerIPv6((hMDNSHost)m_HostList.front(), p_u32AnswerIndex)
+            : IPAddress());
+}
+#endif
+
+/*
+    MDNSResponder::answerPort
+*/
+uint16_t MDNSResponder::answerPort(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                   const uint32_t p_u32AnswerIndex)
+{
+    const stcQuery*             pQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findLegacyQuery(*(clsHost*)p_hMDNSHost) : 0);
+    const stcQuery::stcAnswer*  pSQAnswer = (pQuery ? pQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+    return (pSQAnswer ? pSQAnswer->m_u16Port : 0);
+}
+
+/*
+    MDNSResponder::answerPort (LEGACY 2)
+*/
+uint16_t MDNSResponder::answerPort(const uint32_t p_u32AnswerIndex)
+{
+    return ((!m_HostList.empty())
+            ? answerPort((hMDNSHost)m_HostList.front(), p_u32AnswerIndex)
+            : 0);
+}
+
+/*
+    MDNSResponder::port (LEGACY)
+*/
+uint16_t MDNSResponder::port(const uint32_t p_u32AnswerIndex)
+{
+    return answerPort(p_u32AnswerIndex);
+}
+
+
+/**
+    DYNAMIC SERVICE QUERY
+*/
+
+/*
+    MDNSResponder::installServiceQuery
+
+    Add a dynamic service query and a corresponding callback to the MDNS responder.
+    The callback will be called for every answer update.
+    The answers can also be queried by calling:
+    - answerServiceDomain
+    - answerHostDomain
+    - answerIPv4Address/answerIPv6Address
+    - answerPort
+    - answerTxts
+
+*/
+MDNSResponder::hMDNSQuery MDNSResponder::installServiceQuery(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                             const char* p_pcService,
+                                                             const char* p_pcProtocol,
+                                                             MDNSResponder::MDNSQueryCallbackFn p_fnCallback)
+{
+    hMDNSQuery      hResult = 0;
+
+    stcQuery*   pMDNSQuery = 0;
+    if ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+        (p_pcService) &&
+        (os_strlen(p_pcService)) &&
+        (p_pcProtocol) &&
+        (os_strlen(p_pcProtocol)) &&
+        (p_fnCallback) &&
+        ((pMDNSQuery = _allocQuery(*(clsHost*)p_hMDNSHost, stcQuery::enuQueryType::Service))) &&
+        (_buildDomainForService(p_pcService, p_pcProtocol, pMDNSQuery->m_Domain)))
+    {
+
+        pMDNSQuery->m_fnCallback = p_fnCallback;
+        pMDNSQuery->m_bLegacyQuery = false;
+
+        if (_sendMDNSQuery(*(clsHost*)p_hMDNSHost, *pMDNSQuery))
+        {
+            pMDNSQuery->m_u8SentCount = 1;
+            pMDNSQuery->m_ResendTimeout.reset(MDNS_DYNAMIC_QUERY_RESEND_DELAY);
+
+            hResult = (hMDNSQuery)pMDNSQuery;
+        }
+        else
+        {
+            _removeQuery(*(clsHost*)p_hMDNSHost, pMDNSQuery);
+        }
+    }
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s installServiceQuery: %s for '%s.%s'!\n\n"), _DH(), (hResult ? "Succeeded" : "FAILED"), (p_pcService ? : "-"), (p_pcProtocol ? : "-")););
+    DEBUG_EX_ERR(if (!hResult) DEBUG_OUTPUT.printf_P(PSTR("%s installServiceQuery: FAILED for '%s.%s'!\n\n"), _DH(), (p_pcService ? : "-"), (p_pcProtocol ? : "-")););
+    return hResult;
+}
+
+/*
+    MDNSResponder::installServiceQuery (LEGACY 2)
+*/
+MDNSResponder::hMDNSQuery MDNSResponder::installServiceQuery(const char* p_pcService,
+                                                             const char* p_pcProtocol,
+                                                             MDNSResponder::MDNSQueryCallbackFn1 p_fnCallback)
+{
+    return ((!m_HostList.empty())
+            ? installServiceQuery((hMDNSHost)m_HostList.front(), p_pcService, p_pcProtocol, [p_fnCallback])(MDNSResponder * p_pMDNSResponder,
+                                                                                                            MDNSResponder::hMDNSHost,
+                                                                                                            const stcAnswerAccessor & p_MDNSAnswerAccessor,
+                                                                                                            typeQueryAnswerType p_QueryAnswerTypeFlags,
+                                                                                                            bool p_bSetContent)
+    {
+        if (p_fnCallback)
+        {
+            p_fnCallback(p_pMDNSResponder, p_MDNSAnswerAccessor, p_QueryAnswerTypeFlags, p_bSetContent);
+        }
+    })
+        : 0);
+    }
+
+    /*
+        MDNSResponder::installServiceQuery (LEGACY 2)
+    */
+    MDNSResponder::hMDNSQuery MDNSResponder::installServiceQuery(const char* p_pcService,
+                                                                 const char* p_pcProtocol,
+                                                                 MDNSResponder::MDNSQueryCallbackFn2 p_fnCallback)
+{
+    return ((!m_HostList.empty())
+            ? installServiceQuery((hMDNSHost)m_HostList.front(), p_pcService, p_pcProtocol, [p_fnCallback])(MDNSResponder*,
+                                                                                                            MDNSResponder::hMDNSHost,
+                                                                                                            const stcAnswerAccessor & p_MDNSAnswerAccessor,
+                                                                                                            typeQueryAnswerType p_QueryAnswerTypeFlags,
+                                                                                                            bool p_bSetContent)
+    {
+        if (p_fnCallback)
+        {
+            p_fnCallback(p_MDNSAnswerAccessor, p_QueryAnswerTypeFlags, p_bSetContent);
+        }
+    })
+        : 0);
+    }
+
+    /*
+        MDNSResponder::installHostQuery
+    */
+    MDNSResponder::hMDNSQuery MDNSResponder::installHostQuery(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                              const char* p_pcHostName,
+                                                              MDNSResponder::MDNSQueryCallbackFn p_fnCallback)
+{
+    hMDNSQuery       hResult = 0;
+
+    if ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+        (p_pcHostName) &&
+        (os_strlen(p_pcHostName)))
+    {
+        stcRRDomain    domain;
+        hResult = ((_buildDomainForHost(p_pcHostName, domain))
+                   ? _installDomainQuery(*(clsHost*)p_hMDNSHost, domain, stcQuery::enuQueryType::Host, p_fnCallback)
+                   : 0);
+    }
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s installHostQuery: %s for '%s.local'!\n\n"), _DH(), (hResult ? "Succeeded" : "FAILED"), (p_pcHostName ? : "-")););
+    DEBUG_EX_ERR(if (!hResult) DEBUG_OUTPUT.printf_P(PSTR("%s installHostQuery: FAILED for '%s.local'!\n\n"), _DH(), (p_pcHostName ? : "-")););
+    return hResult;
+}
+
+/*
+    MDNSResponder::installHostQuery (LEGACY 2)
+*/
+MDNSResponder::hMDNSQuery MDNSResponder::installHostQuery(const char* p_pcHostName,
+                                                          MDNSResponder::MDNSQueryCallbackFn1 p_fnCallback)
+{
+    return installHostQuery(p_pcHostName, [p_fnCallback](MDNSResponder * p_pMDNSResponder,
+                                                         hMDNSHost,
+                                                         const stcAnswerAccessor & p_MDNSAnswerAccessor,
+                                                         typeQueryAnswerType p_QueryAnswerTypeFlags,
+                                                         bool p_bSetContent)
+    {
+        if (p_fnCallback)
+        {
+            p_fnCallback(p_pMDNSResponder, p_MDNSAnswerAccessor, p_QueryAnswerTypeFlags, p_bSetContent);
+        }
+    });
+}
+
+/*
+    MDNSResponder::installHostQuery (LEGACY 2)
+*/
+MDNSResponder::hMDNSQuery MDNSResponder::installHostQuery(const char* p_pcHostName,
+                                                          MDNSResponder::MDNSQueryCallbackFn2 p_fnCallback)
+{
+    return installHostQuery(p_pcHostName, [p_fnCallback](MDNSResponder*,
+                                                         hMDNSHost,
+                                                         const stcAnswerAccessor & p_MDNSAnswerAccessor,
+                                                         typeQueryAnswerType p_QueryAnswerTypeFlags,
+                                                         bool p_bSetContent)
+    {
+        if (p_fnCallback)
+        {
+            p_fnCallback(p_MDNSAnswerAccessor, p_QueryAnswerTypeFlags, p_bSetContent);
+        }
+    });
+}
+
+/*
+    MDNSResponder::removeQuery
+
+    Remove a dynamic query (and all collected answers) from the MDNS responder
+
+*/
+bool MDNSResponder::removeQuery(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                const MDNSResponder::hMDNSQuery p_hMDNSQuery)
+{
+    stcQuery*    pMDNSQuery = 0;
+    bool    bResult = ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+                       ((pMDNSQuery = _findQuery(*(clsHost*)p_hMDNSHost, p_hQuery))) &&
+                       (_removeQuery(*(clsHost*)p_hMDNSHost, pMDNSQuery)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s removeQuery: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::removeQuery (LEGACY 2)
+*/
+bool MDNSResponder::removeQuery(const MDNSResponder::hMDNSQuery p_hMDNSQuery)
+{
+    return ((!m_HostList.empty())
+            ? removeQuery((hMDNSHost)m_HostList.front(), p_hMDNSQuery)
+            : false);
+}
+
+/*
+    MDNSResponder::answerAccessors
+*/
+MDNSResponder::clsMDNSAnswerAccessorVector MDNSResponder::answerAccessors(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                                          const MDNSResponder::hMDNSQuery p_hMDNSQuery)
+{
+    MDNSResponder::clsMDNSAnswerAccessorVector  tempVector;
+    for (uint32_t u = 0; u < answerCount(p_hMDNSHost, p_hMDNSQuery); ++u)
+    {
+        tempVector.emplace_back(*this, p_hMDNSQuery, u);
+    }
+    return tempVector;
+}
+
+/*
+    MDNSResponder::answerAccessors (LEGACY 2)
+*/
+MDNSResponder::clsMDNSAnswerAccessorVector MDNSResponder::answerAccessors(const MDNSResponder::hMDNSQuery p_hMDNSQuery)
+{
+    return ((!m_HostList.empty())
+            ? answerAccessors((hMDNSHost)m_HostList.front(), p_hMDNSQuery)
+            : MDNSResponder::clsMDNSAnswerAccessorVector());
+}
+
+/*
+    MDNSResponder::answerCount
+*/
+uint32_t MDNSResponder::answerCount(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                    const MDNSResponder::hMDNSQuery p_hMDNSQuery)
+{
+    stcQuery*    pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery) : 0);
+    return (pMDNSQuery ? pMDNSQuery->answerCount() : 0);
+}
+
+/*
+    MDNSResponder::answerCount (LEGACY 2)
+*/
+uint32_t MDNSResponder::answerCount(const MDNSResponder::hMDNSQuery p_hMDNSQuery)
+{
+    return ((!m_HostList.empty())
+            ? answerCount((hMDNSHost)m_HostList.front(), p_hMDNSQuery)
+            : 0);
+}
+
+/*
+    MDNSResponder::hasAnswerServiceDomain
+*/
+bool MDNSResponder::hasAnswerServiceDomain(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                           const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                           const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*               pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer*    pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          return ((pSQAnswer) &&
+                                                  (pSQAnswer->m_QueryAnswerFlags & static_cast<typeQueryAnswerType>(enuQueryAnswerType::ServiceDomain)));
+}
+
+                                     /*
+                                         MDNSResponder::hasAnswerServiceDomain (LEGACY 2)
+                                     */
+                                     bool MDNSResponder::hasAnswerServiceDomain(const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                                const uint32_t p_u32AnswerIndex)
+{
+    return ((!m_HostList.empty())
+            ? hasAnswerServiceDomain((hMDNSHost)m_HostList.front(), p_hMDNSQuery, p_u32AnswerIndex)
+            : false);
+}
+
+/*
+    MDNSResponder::answerServiceDomain
+
+    Returns the domain for the given service.
+    If not already existing, the string is allocated, filled and attached to the answer.
+
+*/
+const char* MDNSResponder::answerServiceDomain(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                               const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                               const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*               pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer*    pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          // Fill m_pcServiceDomain (if not already done)
+                                          if ((pSQAnswer) &&
+                                              (pSQAnswer->m_ServiceDomain.m_u16NameLength) &&
+                                              (!pSQAnswer->m_pcServiceDomain))
+{
+
+    pSQAnswer->m_pcServiceDomain = pSQAnswer->allocServiceDomain(pSQAnswer->m_ServiceDomain.c_strLength());
+        if (pSQAnswer->m_pcServiceDomain)
+        {
+            pSQAnswer->m_ServiceDomain.c_str(pSQAnswer->m_pcServiceDomain);
+        }
+    }
+    return (pSQAnswer ? pSQAnswer->m_pcServiceDomain : 0);
+}
+
+/*
+    MDNSResponder::answerServiceDomain (LEGACY 2)
+*/
+const char* MDNSResponder::answerServiceDomain(const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                               const uint32_t p_u32AnswerIndex)
+{
+    return ((!m_HostList.empty())
+            ? answerServiceDomain((hMDNSHost)m_HostList.front(), p_hMDNSQuery, p_u32AnswerIndex)
+            : 0);
+}
+
+/*
+    MDNSResponder::hasAnswerHostDomain
+*/
+bool MDNSResponder::hasAnswerHostDomain(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                        const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                        const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*               pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer*    pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          return ((pSQAnswer) &&
+                                                  (pSQAnswer->m_QueryAnswerFlags & static_cast<typeQueryAnswerType>(enuQueryAnswerType::HostDomain)));
+}
+
+                                     /*
+                                         MDNSResponder::hasAnswerHostDomain (LEGACY 2)
+                                     */
+                                     bool MDNSResponder::hasAnswerHostDomain(const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                             const uint32_t p_u32AnswerIndex)
+{
+    return ((!m_HostList.empty())
+            ? hasAnswerHostDomain((hMDNSHost)m_HostList.front(), p_hMDNSQuery, p_u32AnswerIndex)
+            : false);
+}
+
+/*
+    MDNSResponder::answerHostDomain
+
+    Returns the host domain for the given service.
+    If not already existing, the string is allocated, filled and attached to the answer.
+
+*/
+const char* MDNSResponder::answerHostDomain(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                            const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                            const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*               pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer*    pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          // Fill m_pcHostDomain (if not already done)
+                                          if ((pSQAnswer) &&
+                                              (pSQAnswer->m_HostDomain.m_u16NameLength) &&
+                                              (!pSQAnswer->m_pcHostDomain))
+{
+
+    pSQAnswer->m_pcHostDomain = pSQAnswer->allocHostDomain(pSQAnswer->m_HostDomain.c_strLength());
+        if (pSQAnswer->m_pcHostDomain)
+        {
+            pSQAnswer->m_HostDomain.c_str(pSQAnswer->m_pcHostDomain);
+        }
+    }
+    return (pSQAnswer ? pSQAnswer->m_pcHostDomain : 0);
+}
+
+/*
+    MDNSResponder::answerHostDomain (LEGACY 2)
+*/
+const char* MDNSResponder::answerHostDomain(const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                            const uint32_t p_u32AnswerIndex)
+{
+    return ((!m_HostList.empty())
+            ? answerHostDomain((hMDNSHost)m_HostList.front(), p_hMDNSQuery, p_u32AnswerIndex)
+            : 0);
+}
+
+#ifdef MDNS_IPV4_SUPPORT
+/*
+    MDNSResponder::hasAnswerIPv4Address
+*/
+bool MDNSResponder::hasAnswerIPv4Address(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                         const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                         const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*               pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer*    pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          return ((pSQAnswer) &&
+                                                  (pSQAnswer->m_QueryAnswerFlags & static_cast<typeQueryAnswerType>(enuQueryAnswerType::IPv4Address)));
+}
+
+                                     /*
+                                         MDNSResponder::hasAnswerIPv4Address (LEGACY 2)
+                                     */
+                                     bool MDNSResponder::hasAnswerIPv4Address(const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                              const uint32_t p_u32AnswerIndex)
+{
+    return ((!m_HostList.empty())
+            ? hasAnswerIPv4Address((hMDNSHost)m_HostList.front(), p_hMDNSQuery, p_u32AnswerIndex)
+            : false);
+}
+
+/*
+    MDNSResponder::answerIPv4AddressCount
+*/
+uint32_t MDNSResponder::answerIPv4AddressCount(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                               const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                               const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*               pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer*    pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          return (pSQAnswer ? pSQAnswer->IPv4AddressCount() : 0);
+}
+
+                                     /*
+                                         MDNSResponder::answerIPv4AddressCount (LEGACY 2)
+                                     */
+                                     uint32_t MDNSResponder::answerIPv4AddressCount(const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                                    const uint32_t p_u32AnswerIndex)
+{
+    return ((!m_HostList.empty())
+            ? answerIPv4AddressCount((hMDNSHost)m_HostList.front(), p_hMDNSQuery, p_u32AnswerIndex)
+            : 0);
+}
+
+/*
+    MDNSResponder::answerIPv4Address
+*/
+IPAddress MDNSResponder::answerIPv4Address(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                           const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                           const uint32_t p_u32AnswerIndex,
+                                           const uint32_t p_u32AddressIndex)
+{
+    stcQuery*                               pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                                          stcQuery::stcAnswer*                    pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                                          stcQuery::stcAnswer::stcIPv4Address*    pIPv4Address = (pSQAnswer ? pSQAnswer->IPv4AddressAtIndex(p_u32AddressIndex) : 0);
+                                                          return (pIPv4Address ? pIPv4Address->m_IPAddress : IPAddress());
+}
+
+                                                     /*
+                                                         MDNSResponder::answerIPv4Address (LEGACY 2)
+                                                     */
+                                                     IPAddress MDNSResponder::answerIPv4Address(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                                                                const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                                                const uint32_t p_u32AnswerIndex,
+                                                                                                const uint32_t p_u32AddressIndex)
+{
+    return ((!m_HostList.empty())
+            ? answerIPv4Address((hMDNSHost)m_HostList.front(), p_hMDNSQuery, p_u32AnswerIndex, p_u32AddressIndex)
+            : IPAddress());
+}
+#endif
+
+#ifdef MDNS_IPV6_SUPPORT
+/*
+    MDNSResponder::hasAnswerIPv6Address
+*/
+bool MDNSResponder::hasAnswerIPv6Address(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                         const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                         const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*               pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer*    pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          return ((pSQAnswer) &&
+                                                  (pSQAnswer->m_QueryAnswerFlags & static_cast<typeQueryAnswerType>(enuQueryAnswerType::IPv6Address)));
+}
+
+                                     /*
+                                         MDNSResponder::hasAnswerIPv6Address (LEGACY 2)
+                                     */
+                                     bool MDNSResponder::hasAnswerIPv6Address(const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                              const uint32_t p_u32AnswerIndex)
+{
+    return ((!m_HostList.empty())
+            ? hasAnswerIPv6Address((hMDNSHost)m_HostList.front(), p_hMDNSQuery, p_u32AnswerIndex)
+            : false);
+}
+
+/*
+    MDNSResponder::answerIPv6AddressCount
+*/
+uint32_t MDNSResponder::answerIPv6AddressCount(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                               const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                               const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*               pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer*    pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          return (pSQAnswer ? pSQAnswer->IPv6AddressCount() : 0);
+}
+
+                                     /*
+                                         MDNSResponder::answerIPv6AddressCount (LEGACY 2)
+                                     */
+                                     uint32_t MDNSResponder::answerIPv6AddressCount(const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                                    const uint32_t p_u32AnswerIndex)
+{
+    return ((!m_HostList.empty())
+            ? answerIPv6AddressCount((hMDNSHost)m_HostList.front(), p_hMDNSQuery, p_u32AnswerIndex)
+            : 0);
+}
+
+/*
+    MDNSResponder::answerIPv6Address
+*/
+IPAddress MDNSResponder::answerIPv6Address(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                           const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                           const uint32_t p_u32AnswerIndex,
+                                           const uint32_t p_u32AddressIndex)
+{
+    stcQuery*                               pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                                          stcQuery::stcAnswer*                    pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                                          stcQuery::stcAnswer::stcIPv6Address*    pIPv6Address = (pSQAnswer ? pSQAnswer->IPv6AddressAtIndex(p_u32AddressIndex) : 0);
+                                                          return (pIPv6Address ? pIPv6Address->m_IPAddress : IPAddress());
+}
+
+                                                     /*
+                                                         MDNSResponder::answerIPv6Address (LEGACY 2)
+                                                     */
+                                                     IPAddress MDNSResponder::answerIPv6Address(const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                                                const uint32_t p_u32AnswerIndex,
+                                                                                                const uint32_t p_u32AddressIndex)
+{
+    return ((!m_HostList.empty())
+            ? answerIPv6Address((hMDNSHost)m_HostList.front(), p_hMDNSQuery, p_u32AnswerIndex)
+            : IPAddress());
+}
+#endif
+
+/*
+    MDNSResponder::hasAnswerPort
+*/
+bool MDNSResponder::hasAnswerPort(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                  const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                  const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*               pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer*    pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          return ((pSQAnswer) &&
+                                                  (pSQAnswer->m_QueryAnswerFlags & static_cast<typeQueryAnswerType>(enuQueryAnswerType::Port)));
+}
+
+                                     /*
+                                         MDNSResponder::hasAnswerPort (LEGACY 2)
+                                     */
+                                     bool MDNSResponder::hasAnswerPort(const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                       const uint32_t p_u32AnswerIndex)
+{
+    return ((!m_HostList.empty())
+            ? hasAnswerPort((hMDNSHost)m_HostList.front(), p_hMDNSQuery, p_u32AnswerIndex)
+            : false);
+}
+
+/*
+    MDNSResponder::answerPort
+*/
+uint16_t MDNSResponder::answerPort(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                   const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                   const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*               pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer*    pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          return (pSQAnswer ? pSQAnswer->m_u16Port : 0);
+}
+
+                                     /*
+                                         MDNSResponder::answerPort (LEGACY 2)
+                                     */
+                                     uint16_t MDNSResponder::answerPort(const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                        const uint32_t p_u32AnswerIndex)
+{
+    return ((!m_HostList.empty())
+            ? answerPort((hMDNSHost)m_HostList.front(), p_hMDNSQuery, p_u32AnswerIndex)
+            : 0);
+}
+
+/*
+    MDNSResponder::hasAnswerTxts
+*/
+bool MDNSResponder::hasAnswerTxts(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                  const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                  const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*               pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer*    pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          return ((pSQAnswer) &&
+                                                  (pSQAnswer->m_QueryAnswerFlags & static_cast<typeQueryAnswerType>(enuQueryAnswerType::Txts)));
+}
+
+                                     /*
+                                         MDNSResponder::hasAnswerTxts (LEGACY 2)
+                                     */
+                                     bool MDNSResponder::hasAnswerTxts(const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                                                       const uint32_t p_u32AnswerIndex)
+{
+    return ((!m_HostList.empty())
+            ? hasAnswerTxts((hMDNSHost)m_HostList.front(), p_hMDNSQuery, p_u32AnswerIndex)
+            : false);
+}
+
+/*
+    MDNSResponder::answerTxts
+
+    Returns all TXT items for the given service as a ';'-separated string.
+    If not already existing; the string is alloced, filled and attached to the answer.
+
+*/
+const char* MDNSResponder::answerTxts(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                      const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                      const uint32_t p_u32AnswerIndex)
+{
+    stcQuery*               pMDNSQuery = (_validateMDNSHostHandle(p_hMDNSHost) ? _findQuery(*(clsHost*)p_hMDNSHost, p_hMDNSQuery);
+                                          stcQuery::stcAnswer*    pSQAnswer = (pMDNSQuery ? pMDNSQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+                                          // Fill m_pcTxts (if not already done)
+                                          if ((pSQAnswer) &&
+                                              (pSQAnswer->m_Txts.m_pTxts) &&
+                                              (!pSQAnswer->m_pcTxts))
+{
+
+    pSQAnswer->m_pcTxts = pSQAnswer->allocTxts(pSQAnswer->m_Txts.c_strLength());
+        if (pSQAnswer->m_pcTxts)
+        {
+            pSQAnswer->m_Txts.c_str(pSQAnswer->m_pcTxts);
+        }
+    }
+    return (pSQAnswer ? pSQAnswer->m_pcTxts : 0);
+}
+
+/*
+    MDNSResponder::answerTxts (LEGACY 2)
+*/
+const char* MDNSResponder::answerTxts(const MDNSResponder::hMDNSQuery p_hMDNSQuery,
+                                      const uint32_t p_u32AnswerIndex)
+{
+    return ((!m_HostList.empty())
+            ? answerTxts((hMDNSHost)m_HostList.front(), p_hMDNSQuery, p_u32AnswerIndex)
+            : 0);
+}
+
+
+/*
+    PROBING
+*/
+
+/*
+    MDNSResponder::setHostProbeResultCallback
+
+    Set a callback for probe results. The callback is called, when probing
+    for the host domain failes or succeedes.
+    In the case of failure, the domain name should be changed via 'setHostName'
+    When succeeded, the host domain will be announced by the MDNS responder.
+
+*/
+bool MDNSResponder::setHostProbeResultCallback(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                               MDNSResponder::MDNSHostProbeResultCallbackFn p_fnCallback)
+{
+    return ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+            (((clsHost*)p_hMDNSHost)->m_HostProbeInformation.m_fnProbeResultCallback = p_fnCallback, true));
+}
+
+/*
+    MDNSResponder::setHostProbeResultCallback (LEGACY 2)
+*/
+bool MDNSResponder::setHostProbeResultCallback(MDNSResponder::MDNSHostProbeResultCallbackFn1 p_fnCallback)
+{
+    return setHostProbeResultCallback([p_fnCallback](MDNSResponder * p_pMDNSResponder,
+                                                     hMDNSHost,
+                                                     const char* p_pcDomainName,
+                                                     bool p_bProbeResult)
+    {
+        if (p_fnCallback)
+        {
+            p_fnCallback(p_pMDNSResponder, p_pcDomainName, p_bProbeResult);
+        }
+    });
+}
+
+/*
+    MDNSResponder::setHostProbeResultCallback (LEGACY 2)
+*/
+bool MDNSResponder::setHostProbeResultCallback(MDNSResponder::MDNSHostProbeResultCallbackFn2 p_fnCallback)
+{
+    return setHostProbeResultCallback([p_fnCallback](MDNSResponder*,
+                                                     hMDNSHost,
+                                                     const char* p_pcDomainName,
+                                                     bool p_bProbeResult)
+    {
+        if (p_fnCallback)
+        {
+            p_fnCallback(p_pcDomainName, p_bProbeResult);
+        }
+    });
+}
+
+/*
+    MDNSResponder::setServiceProbeResultCallback
+
+    Set a service specific callback for probe results. The callback is called, when probing
+    for the service domain failes or succeedes.
+    In the case of failure, the service name should be changed via 'setServiceName'.
+    When succeeded, the service domain will be announced by the MDNS responder.
+
+*/
+bool MDNSResponder::setServiceProbeResultCallback(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                  const MDNSResponder::hMDNSService p_hMDNSService,
+                                                  MDNSResponder::MDNSServiceProbeResultCallbackFn p_fnCallback)
+{
+    return ((_validateMDNSHostHandle(p_hMDNSHost, p_hMDNSService)) &&
+            (((stcService*)p_hMDNSService)->m_ProbeInformation.m_fnProbeResultCallback = p_fnCallback, true));
+}
+
+/*
+    MDNSResponder::setServiceProbeResultCallback (LEGACY 2)
+*/
+bool MDNSResponder::setServiceProbeResultCallback(const MDNSResponder::hMDNSService p_hMDNSService,
+                                                  MDNSResponder::MDNSServiceProbeResultCallbackFn1 p_fnCallback)
+{
+    return setServiceProbeResultCallback(p_hMDNSService, [p_fnCallback](MDNSResponder * p_pMDNSResponder,
+                                                                        hMDNSHost,
+                                                                        const hMDNSService p_hMDNSService,
+                                                                        const char* p_pcServiceName,
+                                                                        bool p_bProbeResult)
+    {
+        if (p_fnCallback)
+        {
+            p_fnCallback(p_pMDNSResponder, p_hMDNSService, p_pcServiceName, p_bProbeResult);
+        }
+    });
+}
+
+/*
+    MDNSResponder::setServiceProbeResultCallback (LEGACY 2)
+*/
+bool MDNSResponder::setServiceProbeResultCallback(const MDNSResponder::hMDNSService p_hMDNSService,
+                                                  MDNSResponder::MDNSServiceProbeResultCallbackFn2 p_fnCallback)
+{
+    return setServiceProbeResultCallback(p_hMDNSService, [p_fnCallback](MDNSResponder*,
+                                                                        hMDNSHost,
+                                                                        const hMDNSService p_hMDNSService,
+                                                                        const char* p_pcServiceName,
+                                                                        bool p_bProbeResult)
+    {
+        if (p_fnCallback)
+        {
+            p_fnCallback(p_hMDNSService, p_pcServiceName, p_bProbeResult);
+        }
+    });
+}
+#endif
+
+/*
+    MISC
+*/
+
+/*
+    MDNSResponder::notifyNetIfChange
+
+    Should be called, whenever the AP for the MDNS responder changes.
+    A bit of this is caught by the event callbacks installed in the constructor.
+
+*/
+bool MDNSResponder::notifyNetIfChange(netif* p_pNetIf)
+{
+    clsHost*    pMDNSHost;
+    return (((pMDNSHost = _findHost(p_pNetIf))) &&
+            (pMDNSHost->restart()));
+}
+
+/*
+    MDNSResponder::update
+
+    Should be called in every 'loop'.
+
+*/
+bool MDNSResponder::update(const MDNSResponder::hMDNSHost p_hMDNSHost)
+{
+    return ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+            (_NRH2Ptr(p_hMDNSHost)->update()));
+}
+
+/*
+    MDNSResponder::update (convenience)
+*/
+bool MDNSResponder::update(void)
+{
+    bool    bResult = true;
+    for (clsHost* pMDNSHost : m_HostList)
+    {
+        if (!pMDNSHost->update())
+        {
+            bResult = false;
+        }
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::announce
+
+    Should be called, if the 'configuration' changes. Mainly this will be changes in the TXT items...
+*/
+bool MDNSResponder::announce(const MDNSResponder::hMDNSHost p_hMDNSHost)
+{
+    return ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+            (_NRH2Ptr(p_hMDNSHost)->announce(true, true)));
+}
+
+/*
+    MDNSResponder::announce (convenience)
+*/
+bool MDNSResponder::announce(void)
+{
+    bool    bResult = true;
+    for (clsHost* pMDNSHost : m_HostList)
+    {
+        if (!pMDNSHost->announce(true, true))
+        {
+            bResult = false;
+        }
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::enableArduino
+
+    Enable the OTA update service.
+
+*/
+MDNSResponder::hMDNSService MDNSResponder::enableArduino(const MDNSResponder::hMDNSHost p_hMDNSHost,
+                                                         uint16_t p_u16Port,
+                                                         bool p_bAuthUpload /*= false*/)
+{
+    hMDNSService    hService = addService(p_hMDNSHost, 0, "arduino", "tcp", p_u16Port);
+    if (hService)
+    {
+        if ((!addServiceTxt(p_hMDNSHost, hService, "tcp_check", "no")) ||
+            (!addServiceTxt(p_hMDNSHost, hService, "ssh_upload", "no")) ||
+            (!addServiceTxt(p_hMDNSHost, hService, "board", STRINGIZE_VALUE_OF(ARDUINO_BOARD))) ||
+            (!addServiceTxt(p_hMDNSHost, hService, "auth_upload", (p_bAuthUpload) ? "yes" : "no")))
+        {
+
+            removeService(p_hMDNSHost, hService);
+            hService = 0;
+        }
+    }
+    return hService;
+}
+
+#ifdef LATER
+
+/*
+    MDNSResponder::enableArduino (LEGACY 2)
+*/
+MDNSResponder::hMDNSService MDNSResponder::enableArduino(uint16_t p_u16Port,
+                                                         bool p_bAuthUpload /*= false*/)
+{
+    hMDNSService    hMDNSService = 0;
+    for (clsHost*& pMDNSHost : m_HostList)
+    {
+        hMDNSService    hLastMDNSService = enableArduino((hMDNSHost)it, p_u16Port, p_bAuthUpload);
+        if ((hLastMDNSService) &&
+            (!hMDNSService))
+        {
+            hMDNSService = hLastMDNSService;
+        }
+    }
+    return hMDNSService;
+}
+
+#endif
+
+} //namespace MDNSImplementation
+
+} //namespace esp8266
+
+

--- a/libraries/ESP8266mDNS/src/LEAmDNS2_APIHelpers.cpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS2_APIHelpers.cpp
@@ -1,0 +1,354 @@
+/*
+    LEAmDNS2_APIHelpers.cpp
+
+    License (MIT license):
+      Permission is hereby granted, free of charge, to any person obtaining a copy
+      of this software and associated documentation files (the "Software"), to deal
+      in the Software without restriction, including without limitation the rights
+      to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+      copies of the Software, and to permit persons to whom the Software is
+      furnished to do so, subject to the following conditions:
+
+      The above copyright notice and this permission notice shall be included in
+      all copies or substantial portions of the Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+      THE SOFTWARE.
+
+*/
+
+#include <arch/cc.h>
+#include <sys/time.h>
+#include <HardwareSerial.h>
+#include <IPAddress.h>
+#include <lwip/ip_addr.h>
+#include <WString.h>
+#include <cstdint>
+
+/*
+    ESP8266mDNS Control.cpp
+*/
+
+extern "C" {
+#include "user_interface.h"
+}
+
+#include "LEAmDNS2_lwIPdefs.h"
+#include "LEAmDNS2_Priv.h"
+
+namespace esp8266
+{
+/*
+    LEAmDNS
+*/
+namespace experimental
+{
+
+/*
+    MDNSResponder::_allocUDPContext
+*/
+bool MDNSResponder::_allocUDPContext(void)
+{
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _allocUDPContext\n"), _DH()););
+    if (_releaseUDPContext())
+    {
+        m_pUDPContext = new UdpContext;
+        if (m_pUDPContext)
+        {
+            m_pUDPContext->ref();
+
+            ip_set_option(m_pUDPContext->pcb(), SOF_REUSEADDR);
+            //udp_bind_netif(m_pUDPContext->pcb(), m_pNetIf);
+
+            if (m_pUDPContext->listen(IP_ANY_TYPE, DNS_MQUERY_PORT))
+            {
+                //m_pUDPContext->setMulticastInterface(m_pNetIf);
+                m_pUDPContext->setMulticastTTL(MDNS_MULTICAST_TTL);
+                m_pUDPContext->onRx(std::bind(&MDNSResponder::_processUDPInput, this));
+                m_pUDPContext->connect(IP_ANY_TYPE, DNS_MQUERY_PORT);
+                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _allocUDPContext: Succeeded to alloc UDPContext!\n"), _DH()););
+            }
+            else
+            {
+                DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _allocUDPContext: FAILED to make UDPContext listening!\n"), _DH()););
+                _releaseUDPContext();
+            }
+        }
+        else
+        {
+            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _allocUDPContext: FAILED to alloc UDPContext!\n"), _DH()););
+        }
+    }
+    DEBUG_EX_ERR(if (!m_pUDPContext) DEBUG_OUTPUT.printf_P(PSTR("%s _allocUDPContext: FAILED!\n"), _DH()););
+    return (0 != m_pUDPContext);
+}
+
+/*
+    MDNSResponder::_releaseUDPContext
+*/
+bool MDNSResponder::_releaseUDPContext(void)
+{
+    if (m_pUDPContext)
+    {
+        m_pUDPContext->unref();
+        m_pUDPContext = 0;
+    }
+    return true;
+}
+
+/*
+    MDNSResponder::_processUDPInput
+
+    Called in SYS context!
+
+*/
+bool MDNSResponder::_processUDPInput(void)
+{
+    //DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _processUDPInput\n"), _DH()););
+
+    if (m_pUDPContext->next())
+    {
+        netif*                                      pNetIf = ip_current_input_netif();
+        MDNSResponder::clsHost*    pHost = 0;
+        if ((pNetIf) &&
+            ((pHost = _findHost(pNetIf))))
+        {
+            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _processUDPInput: netif:%u,src:%s,dest:%s\n"), _DH(), netif_get_index(pNetIf), IPAddress(ip_current_src_addr()).toString().c_str(), IPAddress(ip_current_dest_addr()).toString().c_str()););
+            pHost->processUDPInput(/*IPAddress(ip_current_src_addr()), IPAddress(ip_current_dest_addr())*/);
+        }
+        else
+        {
+            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _processUDPInput: Received UDP datagramm for unused netif at index: %u\n"), _DH(), (pNetIf ? netif_get_index(pNetIf) : (-1))););
+        }
+        m_pUDPContext->flush();
+    }
+    return true;
+}
+
+/*
+    MDNSResponder::_createHost
+*/
+MDNSResponder::clsHost* MDNSResponder::_createHost(netif* p_pNetIf)
+{
+    clsHost*    pHost = 0;
+
+    if ((p_pNetIf) &&
+        (!((pHost = _findHost(p_pNetIf)))) &&
+        (m_pUDPContext) &&
+        ((pHost = new clsHost(*p_pNetIf, *m_pUDPContext))))
+    {
+        if (pHost->init())
+        {
+            //pHost->setHostProbeResultCallback(_defaultHostProbeResultCallback);
+            m_HostList.push_back(pHost);
+        }
+        else
+        {
+            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _createHost: FAILED!\n"), _DH()););
+            _releaseHost(pHost);
+            pHost = 0;
+        }
+    }
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _createHost: Attaching to netif %s!\n"), _DH(), (pHost ? "succeeded" : "FAILED")););
+    return pHost;
+}
+
+/*
+    MDNSResponder::_releaseHost
+*/
+bool MDNSResponder::_releaseHost(MDNSResponder::clsHost* p_pHost)
+{
+    bool    bResult = false;
+
+    if ((p_pHost) &&
+        (m_HostList.end() != std::find(m_HostList.begin(), m_HostList.end(), p_pHost)))
+    {
+        // Delete and remove Responder object
+        delete p_pHost;
+        m_HostList.remove(p_pHost);
+        bResult = true;
+    }
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _releaseHost: %s to release netif Responder!\n"), _DH(), (bResult ? "Succeeded" : "FAILED")););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_findHost
+*/
+const MDNSResponder::clsHost* MDNSResponder::_findHost(netif* p_pNetIf) const
+{
+    const clsHost*    pResult = 0;
+    for (const clsHost* pHost : m_HostList)
+    {
+        if ((p_pNetIf) &&
+            (&(pHost->m_rNetIf) == p_pNetIf))
+        {
+            pResult = pHost;
+            break;
+        }
+    }
+    return pResult;
+}
+
+/*
+    MDNSResponder::_findHost
+*/
+MDNSResponder::clsHost* MDNSResponder::_findHost(netif* p_pNetIf)
+{
+    return (clsHost*)(((const MDNSResponder*)this)->_findHost(p_pNetIf));
+}
+
+/*
+    MDNSResponder::_findHost
+*/
+const MDNSResponder::clsHost* MDNSResponder::_findHost(const MDNSResponder::hMDNSHost p_hMDNSHost) const
+{
+    clsHostList::const_iterator it(std::find(m_HostList.begin(), m_HostList.end(), _NRH2Ptr(p_hMDNSHost)));
+    return ((m_HostList.end() != it) ? *it : 0);
+}
+
+/*
+    MDNSResponder::_findHost
+*/
+MDNSResponder::clsHost* MDNSResponder::_findHost(const MDNSResponder::hMDNSHost p_hMDNSHost)
+{
+    return (clsHost*)(((const MDNSResponder*)this)->_findHost(p_hMDNSHost));
+}
+
+
+/*
+    HANDLE HELPERS
+*/
+
+/*
+    MDNSResponder::_validateMDNSHostHandle
+*/
+bool MDNSResponder::_validateMDNSHostHandle(const hMDNSHost p_hMDNSHost) const
+{
+    return (0 != _findHost(_NRH2Ptr(p_hMDNSHost)));
+}
+
+/*
+    MDNSResponder::_validateMDNSHostHandle
+*/
+bool MDNSResponder::_validateMDNSHostHandle(const hMDNSHost p_hMDNSHost,
+                                            const hMDNSService p_hMDNSService) const
+{
+    return ((_validateMDNSHostHandle(p_hMDNSHost)) &&
+            (_NRH2Ptr(p_hMDNSHost)->validateService(_SH2Ptr(p_hMDNSService))));
+}
+
+/*
+    MDNSResponder::_NRH2Ptr
+*/
+MDNSResponder::clsHost* MDNSResponder::_NRH2Ptr(const hMDNSHost p_hMDNSHost)
+{
+    return (clsHost*)p_hMDNSHost;
+}
+
+/*
+    MDNSResponder::_NRH2Ptr
+*/
+const MDNSResponder::clsHost* MDNSResponder::_NRH2Ptr(const hMDNSHost p_hMDNSHost) const
+{
+    return (const clsHost*)p_hMDNSHost;
+}
+
+/*
+    MDNSResponder::_SH2Ptr
+*/
+MDNSResponder::clsHost::stcService* MDNSResponder::_SH2Ptr(const hMDNSService p_hMDNSService)
+{
+    return (clsHost::stcService*)p_hMDNSService;
+}
+
+/*
+    MDNSResponder::_SH2Ptr
+*/
+const MDNSResponder::clsHost::stcService* MDNSResponder::_SH2Ptr(const hMDNSService p_hMDNSService) const
+{
+    return (const clsHost::stcService*)p_hMDNSService;
+}
+
+/*
+    MDNSResponder::_begin
+
+    Creates a new netif responder (adding the netif to the multicast groups),
+    sets up the instance data (hostname, ...) and starts the probing process
+
+*/
+MDNSResponder::clsHost* MDNSResponder::_begin(const char* p_pcHostName,
+                                              netif* p_pNetIf,
+                                              MDNSHostProbeResultCallbackFn p_fnCallback)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _begin(%s, netif: %u)\n"), _DH(), (p_pcHostName ?: "_"), (p_pNetIf ? netif_get_index(p_pNetIf) : 0)););
+
+    clsHost*  pHost = 0;
+    if ((!m_pUDPContext) ||
+        (!p_pNetIf) ||
+        (!((pHost = _createHost(p_pNetIf)))) ||
+        (p_fnCallback ? !setHostProbeResultCallback((hMDNSHost)pHost, p_fnCallback) : false) ||
+        (!pHost->setHostName(p_pcHostName)) ||
+        (!pHost->restart()))
+    {
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _begin: FAILED for '%s'!\n"), _DH(), (p_pcHostName ? : "-")););
+    }
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _begin: %s to init netif with hostname %s!\n"), _DH(), (pHost ? "Succeeded" : "FAILED"), (p_pcHostName ? : "-")););
+    return pHost;
+}
+
+/*
+    MDNSResponder::_close
+
+    The announced host and services are unannounced (by multicasting a goodbye message)
+    All connected objects and finally the netif Responder is removed.
+
+*/
+bool MDNSResponder::_close(MDNSResponder::clsHost& p_rHost)
+{
+    _releaseHost(&p_rHost); // Will call 'delete' on the pHost object!
+
+    return true;
+}
+
+
+/*
+    MISC
+*/
+
+#if not defined ESP_8266_MDNS_INCLUDE || defined DEBUG_ESP_MDNS_RESPONDER
+
+/*
+	MDNSResponder::_DH
+*/
+const char* MDNSResponder::_DH(const hMDNSHost p_hMDNSHost /*= 0*/) const
+{
+    static char acBuffer[64];
+
+    *acBuffer = 0;
+    if (p_hMDNSHost)
+    {
+        sprintf_P(acBuffer, PSTR("[MDNSResponder %s]"), ((WIFI_STA == netif_get_index(&((clsHost*)p_hMDNSHost)->m_rNetIf))
+                                                         ? "STA"
+                                                         : ((WIFI_AP == netif_get_index(&((clsHost*)p_hMDNSHost)->m_rNetIf))
+                                                            ? "AP"
+                                                            : "??")));
+    }
+    else
+    {
+        sprintf_P(acBuffer, PSTR("[MDNSResponder]"));
+    }
+    return acBuffer;
+}
+
+#endif
+
+
+} // namespace MDNSImplementation
+
+} // namespace esp8266

--- a/libraries/ESP8266mDNS/src/LEAmDNS2_Host.cpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS2_Host.cpp
@@ -1,0 +1,1336 @@
+/*
+    LEAmDNS2_Host.cpp
+
+    License (MIT license):
+      Permission is hereby granted, free of charge, to any person obtaining a copy
+      of this software and associated documentation files (the "Software"), to deal
+      in the Software without restriction, including without limitation the rights
+      to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+      copies of the Software, and to permit persons to whom the Software is
+      furnished to do so, subject to the following conditions:
+
+      The above copyright notice and this permission notice shall be included in
+      all copies or substantial portions of the Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+      THE SOFTWARE.
+
+*/
+
+#include <arch/cc.h>
+#include <sys/time.h>
+#include <HardwareSerial.h>
+#include <IPAddress.h>
+#include <lwip/ip_addr.h>
+#include <lwip/netif.h>
+#include <WString.h>
+#include <cstdint>
+
+/*
+    ESP8266mDNS Control.cpp
+*/
+
+extern "C" {
+#include "user_interface.h"
+}
+
+#include "LEAmDNS2_lwIPdefs.h"
+#include "LEAmDNS2_Priv.h"
+
+#ifdef MDNS_IPV4_SUPPORT
+#include <lwip/igmp.h>
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+#include <lwip/mld6.h>
+#endif
+
+
+namespace esp8266
+{
+
+/*
+    LEAmDNS
+*/
+namespace experimental
+{
+
+/*
+    MDNSResponder::clsHost::clsHost constructor
+*/
+MDNSResponder::clsHost::clsHost(netif& p_rNetIf,
+                                UdpContext& p_rUDPContext)
+    :   m_rNetIf(p_rNetIf),
+        m_NetIfState(static_cast<typeNetIfState>(enuNetIfState::None)),
+        m_rUDPContext(p_rUDPContext),
+        m_pcHostName(0),
+        m_pcInstanceName(0),
+        m_pServices(0),
+        m_pQueries(0),
+        m_fnServiceTxtCallback(0),
+        m_HostProbeInformation()
+{
+}
+
+/*
+    MDNSResponder::clsHost::~clsHost destructor
+*/
+MDNSResponder::clsHost::~clsHost(void)
+{
+    _close();
+}
+
+/*
+    MDNSResponder::clsHost::init
+*/
+bool MDNSResponder::clsHost::init(void)
+{
+    bool    bResult = true;
+
+    // Join multicast group(s)
+#ifdef MDNS_IPV4_SUPPORT
+    ip_addr_t   multicast_addr_V4 = DNS_MQUERY_IPV4_GROUP_INIT;
+    if (!(m_rNetIf.flags & NETIF_FLAG_IGMP))
+    {
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _createHost: Setting flag: flags & NETIF_FLAG_IGMP\n"), _DH()););
+        m_rNetIf.flags |= NETIF_FLAG_IGMP;
+
+        if (ERR_OK != igmp_start(&m_rNetIf))
+        {
+            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _createHost: igmp_start FAILED!\n"), _DH()););
+        }
+    }
+
+    bResult = ((bResult) &&
+               (ERR_OK == igmp_joingroup_netif(&m_rNetIf, ip_2_ip4(&multicast_addr_V4))));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _createHost: igmp_joingroup_netif(%s) FAILED!\n"), _DH(), IPAddress(multicast_addr_V4).toString().c_str()););
+#endif
+
+#ifdef MDNS_IPV6_SUPPORT
+    ip_addr_t   multicast_addr_V6 = DNS_MQUERY_IPV6_GROUP_INIT;
+    bResult = ((bResult) &&
+               (ERR_OK == mld6_joingroup_netif(&m_rNetIf, ip_2_ip6(&multicast_addr_V6))));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _createHost: mld6_joingroup_netif FAILED!\n"), _DH()););
+#endif
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::setHostName
+*/
+bool MDNSResponder::clsHost::setHostName(const char* p_pcHostName)
+{
+    bool    bResult;
+    if ((bResult = _allocHostName(p_pcHostName)))
+    {
+        m_HostProbeInformation.m_ProbingStatus = enuProbingStatus::ReadyToStart;
+
+        // Replace 'auto-set' service names
+        for (stcService* pService = m_pServices; ((bResult) && (pService)); pService = pService->m_pNext)
+        {
+            if ((pService->m_bAutoName) &&
+                (!m_pcInstanceName))
+            {
+                bResult = pService->setName(p_pcHostName);
+                pService->m_ProbeInformation.m_ProbingStatus = enuProbingStatus::ReadyToStart;
+            }
+        }
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::setHostName
+*/
+const char* MDNSResponder::clsHost::hostName(void) const
+{
+    return m_pcHostName;
+}
+
+/*
+    MDNSResponder::clsHost::setHostProbeResultCallback
+*/
+bool MDNSResponder::clsHost::setHostProbeResultCallback(HostProbeResultCallbackFn p_fnCallback)
+{
+    m_HostProbeInformation.m_fnProbeResultCallback = p_fnCallback;
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::probeStatus
+*/
+bool MDNSResponder::clsHost::probeStatus(void) const
+{
+    return (enuProbingStatus::Done == m_HostProbeInformation.m_ProbingStatus);
+}
+
+
+/*
+    SERVICE
+*/
+
+/*
+    MDNSResponder::clsHost::setInstanceName
+*/
+bool MDNSResponder::clsHost::setInstanceName(const char* p_pcInstanceName)
+{
+    bool    bResult;
+    if ((bResult = _allocInstanceName(p_pcInstanceName)))
+    {
+        // Replace 'auto-set' service names
+        for (stcService* pService = m_pServices; ((bResult) && (pService)); pService = pService->m_pNext)
+        {
+            if (pService->m_bAutoName)
+            {
+                bResult = pService->setName(p_pcInstanceName);
+                pService->m_ProbeInformation.m_ProbingStatus = enuProbingStatus::ReadyToStart;
+            }
+        }
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::instanceName
+*/
+const char* MDNSResponder::clsHost::instanceName(void) const
+{
+    return m_pcInstanceName;
+}
+
+/*
+    MDNSResponder::clsHost::addService
+*/
+MDNSResponder::clsHost::stcService* MDNSResponder::clsHost::addService(const char* p_pcInstanceName,
+                                                                       const char* p_pcServiceType,
+                                                                       const char* p_pcProtocol,
+                                                                       uint16_t p_u16Port)
+{
+    stcService* pService = 0;
+
+    if (((!p_pcInstanceName) ||                                                     // NO name OR
+         (MDNS_DOMAIN_LABEL_MAXLENGTH >= os_strlen(p_pcInstanceName))) &&           // Fitting name
+        (p_pcServiceType) &&
+        (MDNS_SERVICE_NAME_LENGTH >= os_strlen(p_pcServiceType)) &&
+        (p_pcProtocol) &&
+        ((MDNS_SERVICE_PROTOCOL_LENGTH - 1) != os_strlen(p_pcProtocol)) &&
+        (p_u16Port))
+    {
+        if (!((pService = findService((p_pcInstanceName ? : (m_pcInstanceName ? : m_pcHostName)), p_pcServiceType, p_pcProtocol, p_u16Port)))) // Not already used
+        {
+            if (0 != (pService = _allocService(p_pcInstanceName, p_pcServiceType, p_pcProtocol, p_u16Port)))
+            {
+                // Init probing
+                pService->m_ProbeInformation.m_ProbingStatus = enuProbingStatus::ReadyToStart;
+            }
+        }
+    }   // else: bad arguments
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s addService: %s to add service '%s.%s.%s.local'!\n"), _DH(pService), (pService ? "Succeeded" : "FAILED"), (p_pcInstanceName ? : (m_pcInstanceName ? : (m_pcHostName ? :  "-"))), (p_pcServiceType ? : ""), (p_pcProtocol ? : "")););
+    DEBUG_EX_ERR(if (!pService) DEBUG_OUTPUT.printf_P(PSTR("%s addService: FAILED to add service '%s.%s.%s.local'!\n"), _DH(pService), (p_pcInstanceName ? : (m_pcInstanceName ? : (m_pcHostName ? :  "-"))), (p_pcServiceType ? : ""), (p_pcProtocol ? : "")););
+    return pService;
+}
+
+/*
+    MDNSResponder::clsHost::removeService
+*/
+bool MDNSResponder::clsHost::removeService(MDNSResponder::clsHost::stcService* p_pMDNSService)
+{
+    bool    bResult = ((p_pMDNSService) &&
+                       (_announceService(*p_pMDNSService, false)) &&
+                       (_releaseService(p_pMDNSService)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _removeService: FAILED!\n"), _DH(p_pMDNSService)););
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::findService (const)
+*/
+const MDNSResponder::clsHost::stcService* MDNSResponder::clsHost::findService(const char* p_pcInstanceName,
+                                                                              const char* p_pcServiceType,
+                                                                              const char* p_pcProtocol,
+                                                                              uint16_t p_u16Port /*= 0*/) const
+{
+    stcService* pService = m_pServices;
+    while (pService)
+    {
+        if ((0 == strcmp(pService->m_pcName, p_pcInstanceName)) &&
+            (0 == strcmp(pService->m_pcServiceType, p_pcServiceType)) &&
+            (0 == strcmp(pService->m_pcProtocol, p_pcProtocol)) &&
+            ((!p_u16Port) ||
+             (p_u16Port == pService->m_u16Port)))
+        {
+
+            break;
+        }
+        pService = pService->m_pNext;
+    }
+    return pService;
+}
+
+/*
+    MDNSResponder::clsHost::findService
+*/
+MDNSResponder::clsHost::stcService* MDNSResponder::clsHost::findService(const char* p_pcInstanceName,
+                                                                        const char* p_pcServiceType,
+                                                                        const char* p_pcProtocol,
+                                                                        uint16_t p_u16Port /*= 0*/)
+{
+    return (stcService*)((const clsHost*)this)->findService(p_pcInstanceName, p_pcServiceType, p_pcProtocol, p_u16Port);
+}
+
+/*
+    MDNSResponder::clsHost::validateService
+*/
+bool MDNSResponder::clsHost::validateService(const MDNSResponder::clsHost::stcService* p_pService) const
+{
+    const stcService*   pService = m_pServices;
+    while (pService)
+    {
+        if (pService == p_pService)
+        {
+            break;
+        }
+        pService = pService->m_pNext;
+    }
+    return (0 != pService);
+}
+
+/*
+    MDNSResponder::clsHost::setServiceName
+*/
+bool MDNSResponder::clsHost::setServiceName(MDNSResponder::clsHost::stcService* p_pMDNSService,
+                                            const char* p_pcInstanceName)
+{
+    p_pcInstanceName = p_pcInstanceName ? : m_pcInstanceName;
+
+    bool    bResult = ((p_pMDNSService) &&
+                       ((!p_pcInstanceName) ||
+                        (MDNS_DOMAIN_LABEL_MAXLENGTH >= os_strlen(p_pcInstanceName))) &&
+                       (p_pMDNSService->setName(p_pcInstanceName)) &&
+                       ((p_pMDNSService->m_ProbeInformation.m_ProbingStatus = enuProbingStatus::ReadyToStart), true));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _setServiceName: FAILED for '%s'!\n"), _DH(p_pMDNSService), (p_pcInstanceName ? : "-")););
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::setServiceName
+*/
+const char* MDNSResponder::clsHost::serviceName(const stcService* p_pMDNSService) const
+{
+    return ((p_pMDNSService)
+            ? (p_pMDNSService->m_pcName)
+            : 0);
+}
+
+/*
+    MDNSResponder::clsHost::serviceType
+*/
+const char* MDNSResponder::clsHost::serviceType(const stcService* p_pMDNSService) const
+{
+    return ((p_pMDNSService)
+            ? (p_pMDNSService->m_pcServiceType)
+            : 0);
+}
+
+/*
+    MDNSResponder::clsHost::serviceProtocol
+*/
+const char* MDNSResponder::clsHost::serviceProtocol(const stcService* p_pMDNSService) const
+{
+    return ((p_pMDNSService)
+            ? (p_pMDNSService->m_pcProtocol)
+            : 0);
+}
+
+/*
+    MDNSResponder::clsHost::servicePort
+*/
+uint16_t MDNSResponder::clsHost::servicePort(const stcService* p_pMDNSService) const
+{
+    return ((p_pMDNSService)
+            ? (p_pMDNSService->m_u16Port)
+            : 0);
+}
+
+
+/*
+    MDNSResponder::clsHost::setServiceProbeResultCallback
+*/
+bool MDNSResponder::clsHost::setServiceProbeResultCallback(stcService* p_pMDNSService,
+                                                           ServiceProbeResultCallbackFn p_fnCallback)
+{
+    return ((p_pMDNSService)
+            ? ((p_pMDNSService->m_ProbeInformation.m_fnProbeResultCallback = p_fnCallback), true)
+            : false);
+}
+
+/*
+    MDNSResponder::clsHost::setServiceName
+*/
+bool MDNSResponder::clsHost::serviceProbeStatus(const stcService* p_pMDNSService) const
+{
+    return ((p_pMDNSService) &&
+            (enuProbingStatus::Done == p_pMDNSService->m_ProbeInformation.m_ProbingStatus));
+}
+
+
+/*
+    SERVICE TXT
+*/
+
+/*
+    MDNSResponder::clsHost::addServiceTxt
+*/
+MDNSResponder::clsHost::stcServiceTxt* MDNSResponder::clsHost::addServiceTxt(stcService* p_pMDNSService,
+                                                                             const char* p_pcKey,
+                                                                             const char* p_pcValue)
+{
+    return _addServiceTxt(p_pMDNSService, p_pcKey, p_pcValue, false);
+}
+
+/*
+    MDNSResponder::clsHost::removeServiceTxt
+*/
+bool MDNSResponder::clsHost::removeServiceTxt(stcService* p_pMDNSService,
+                                              stcServiceTxt* p_pTxt)
+{
+    bool    bResult = ((p_pMDNSService) &&
+                       (p_pTxt) &&
+                       (_releaseServiceTxt(p_pMDNSService, p_pTxt)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s removeServiceTxt: FAILED!\n"), _DH(p_pMDNSService)););
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::findServiceTxt (const)
+*/
+const MDNSResponder::clsHost::stcServiceTxt* MDNSResponder::clsHost::findServiceTxt(MDNSResponder::clsHost::stcService* p_pMDNSService,
+                                                                                    const char* p_pcKey) const
+{
+    return (const stcServiceTxt*)((const clsHost*)this)->findServiceTxt(p_pMDNSService, p_pcKey);
+}
+
+/*
+    MDNSResponder::clsHost::findServiceTxt
+*/
+MDNSResponder::clsHost::stcServiceTxt* MDNSResponder::clsHost::findServiceTxt(MDNSResponder::clsHost::stcService* p_pMDNSService,
+                                                                              const char* p_pcKey)
+{
+    return _findServiceTxt(p_pMDNSService, p_pcKey);
+}
+
+/*
+    MDNSResponder::clsHost::setDynamicServiceTxtCallback
+*/
+bool MDNSResponder::clsHost::setDynamicServiceTxtCallback(DynamicServiceTxtCallbackFn p_fnCallback)
+{
+    m_fnServiceTxtCallback = p_fnCallback;
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::setDynamicServiceTxtCallback
+*/
+bool MDNSResponder::clsHost::setDynamicServiceTxtCallback(stcService* p_pMDNSService,
+                                                          DynamicServiceTxtCallbackFn p_fnCallback)
+{
+    return ((p_pMDNSService)
+            ? ((p_pMDNSService->m_fnTxtCallback = p_fnCallback), true)
+            : false);
+}
+
+/*
+    MDNSResponder::clsHost::addDynamicServiceTxt
+
+    Add a (dynamic) MDNS TXT item ('key' = 'value') to the service
+    Dynamic TXT items are removed right after one-time use. So they need to be added
+    every time the value s needed (via callback).
+*/
+MDNSResponder::clsHost::stcServiceTxt* MDNSResponder::clsHost::addDynamicServiceTxt(stcService* p_pMDNSService,
+                                                                                    const char* p_pcKey,
+                                                                                    const char* p_pcValue)
+{
+    return _addServiceTxt(p_pMDNSService, p_pcKey, p_pcValue, true);
+}
+
+
+/*
+    QUERIES
+*/
+/*
+    MDNSResponder::clsHost::queryService
+*/
+uint32_t MDNSResponder::clsHost::queryService(const char* p_pcService,
+                                              const char* p_pcProtocol,
+                                              const uint16_t p_u16Timeout /*= MDNS_QUERYSERVICES_WAIT_TIME*/)
+{
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s queryService '_%s._%s.local'\n"), _DH(), p_pcService, p_pcProtocol););
+
+    stcQuery*    pMDNSQuery = 0;
+    if ((p_pcService) && (*p_pcService) &&
+        (p_pcProtocol) && (*p_pcProtocol) &&
+        (p_u16Timeout) &&
+        ((pMDNSQuery = _allocQuery(stcQuery::enuQueryType::Service))) &&
+        (_buildDomainForService(p_pcService, p_pcProtocol, pMDNSQuery->m_Domain)))
+    {
+        if ((_removeLegacyQuery()) &&
+            ((pMDNSQuery->m_bLegacyQuery = true)) &&
+            (_sendMDNSQuery(*pMDNSQuery)))
+        {
+            // Wait for answers to arrive
+            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s queryService: Waiting %u ms for answers...\n"), _DH(), p_u16Timeout););
+            delay(p_u16Timeout);
+
+            // All answers should have arrived by now -> stop adding new answers
+            pMDNSQuery->m_bAwaitingAnswers = false;
+        }
+        else    // FAILED to send query
+        {
+            _removeQuery(pMDNSQuery);
+        }
+    }
+    else
+    {
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s queryService: INVALID input data!\n"), _DH()););
+    }
+    return ((pMDNSQuery)
+            ?   pMDNSQuery->answerCount()
+            : 0);
+}
+
+/*
+    MDNSResponder::clsHost::queryHost
+*/
+uint32_t MDNSResponder::clsHost::queryHost(const char* p_pcHostName,
+                                           const uint16_t p_u16Timeout /*= MDNS_QUERYSERVICES_WAIT_TIME*/)
+{
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s queryHost '%s.local'\n"), _DH(), p_pcHostName););
+
+    stcQuery*    pMDNSQuery = 0;
+    if ((p_pcHostName) && (*p_pcHostName) &&
+        (p_u16Timeout) &&
+        ((pMDNSQuery = _allocQuery(stcQuery::enuQueryType::Host))) &&
+        (_buildDomainForHost(p_pcHostName, pMDNSQuery->m_Domain)))
+    {
+        if ((_removeLegacyQuery()) &&
+            ((pMDNSQuery->m_bLegacyQuery = true)) &&
+            (_sendMDNSQuery(*pMDNSQuery)))
+        {
+            // Wait for answers to arrive
+            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s queryHost: Waiting %u ms for answers...\n"), _DH(), p_u16Timeout););
+            delay(p_u16Timeout);
+
+            // All answers should have arrived by now -> stop adding new answers
+            pMDNSQuery->m_bAwaitingAnswers = false;
+        }
+        else    // FAILED to send query
+        {
+            _removeQuery(pMDNSQuery);
+        }
+    }
+    else
+    {
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s queryHost: INVALID input data!\n"), _DH()););
+    }
+    return ((pMDNSQuery)
+            ?   pMDNSQuery->answerCount()
+            : 0);
+}
+
+/*
+    MDNSResponder::clsHost::removeQuery
+*/
+bool MDNSResponder::clsHost::removeQuery(void)
+{
+    return _removeLegacyQuery();
+}
+
+/*
+    MDNSResponder::clsHost::hasQuery
+*/
+bool MDNSResponder::clsHost::hasQuery(void)
+{
+    return (0 != _findLegacyQuery());
+}
+
+/*
+    MDNSResponder::clsHost::getQuery
+*/
+MDNSResponder::clsHost::stcQuery* MDNSResponder::clsHost::getQuery(void)
+{
+    return _findLegacyQuery();
+}
+
+/*
+    MDNSResponder::clsHost::installServiceQuery
+*/
+MDNSResponder::clsHost::stcQuery* MDNSResponder::clsHost::installServiceQuery(const char* p_pcService,
+                                                                              const char* p_pcProtocol,
+                                                                              MDNSResponder::clsHost::QueryCallbackFn p_fnCallback)
+{
+    stcQuery*   pMDNSQuery = 0;
+    if ((p_pcService) && (*p_pcService) &&
+        (p_pcProtocol) && (*p_pcProtocol) &&
+        (p_fnCallback) &&
+        ((pMDNSQuery = _allocQuery(stcQuery::enuQueryType::Service))) &&
+        (_buildDomainForService(p_pcService, p_pcProtocol, pMDNSQuery->m_Domain)))
+    {
+
+        pMDNSQuery->m_fnCallback = p_fnCallback;
+        pMDNSQuery->m_bLegacyQuery = false;
+
+        if (_sendMDNSQuery(*pMDNSQuery))
+        {
+            pMDNSQuery->m_u8SentCount = 1;
+            pMDNSQuery->m_ResendTimeout.reset(MDNS_DYNAMIC_QUERY_RESEND_DELAY);
+        }
+        else
+        {
+            _removeQuery(pMDNSQuery);
+        }
+    }
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s installServiceQuery: %s for '_%s._%s.local'!\n\n"), _DH(), (pMDNSQuery ? "Succeeded" : "FAILED"), (p_pcService ? : "-"), (p_pcProtocol ? : "-")););
+    DEBUG_EX_ERR(if (!pMDNSQuery) DEBUG_OUTPUT.printf_P(PSTR("%s installServiceQuery: FAILED for '_%s._%s.local'!\n\n"), _DH(), (p_pcService ? : "-"), (p_pcProtocol ? : "-")););
+    return pMDNSQuery;
+}
+
+/*
+    MDNSResponder::clsHost::installHostQuery
+*/
+MDNSResponder::clsHost::stcQuery* MDNSResponder::clsHost::installHostQuery(const char* p_pcHostName,
+                                                                           MDNSResponder::clsHost::QueryCallbackFn p_fnCallback)
+{
+    stcQuery*   pMDNSQuery = 0;
+    if ((p_pcHostName) && (*p_pcHostName))
+    {
+        stcRRDomain    domain;
+        pMDNSQuery = ((_buildDomainForHost(p_pcHostName, domain))
+                      ? _installDomainQuery(domain, stcQuery::enuQueryType::Host, p_fnCallback)
+                      : 0);
+    }
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s installHostQuery: %s for '%s.local'!\n\n"), _DH(), (pMDNSQuery ? "Succeeded" : "FAILED"), (p_pcHostName ? : "-")););
+    DEBUG_EX_ERR(if (!pMDNSQuery) DEBUG_OUTPUT.printf_P(PSTR("%s installHostQuery: FAILED for '%s.local'!\n\n"), _DH(), (p_pcHostName ? : "-")););
+    return pMDNSQuery;
+}
+
+/*
+    MDNSResponder::clsHost::removeQuery
+*/
+bool MDNSResponder::clsHost::removeQuery(MDNSResponder::clsHost::stcQuery* p_pMDNSQuery)
+{
+    bool    bResult = ((p_pMDNSQuery) &&
+                       (_removeQuery(p_pMDNSQuery)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s removeQuery: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+
+/*
+    PROCESSING
+*/
+
+/*
+    MDNSResponder::clsHost::processUDPInput
+*/
+bool MDNSResponder::clsHost::processUDPInput()
+{
+    bool    bResult = false;
+
+    bResult = ((_checkNetIfState()) &&      // Any changes in the netif state?
+               (_parseMessage()));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("")););
+
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::update
+*/
+bool MDNSResponder::clsHost::update(void)
+{
+    return ((_checkNetIfState()) &&      // Any changes in the netif state?
+            (_updateProbeStatus()) &&    // Probing
+            (_checkQueryCache()));
+}
+
+/*
+    MDNSResponder::clsHost::restart
+*/
+bool MDNSResponder::clsHost::restart(void)
+{
+    return (_resetProbeStatus(true));   // Stop and restart probing
+}
+
+
+
+
+
+/*
+    P R O T E C T E D
+*/
+
+/*
+    MDNSResponder::clsHost::_close
+*/
+bool MDNSResponder::clsHost::_close(void)
+{
+    /*  _resetProbeStatus(false);   // Stop probing
+
+        _releaseQueries();
+        _releaseServices();
+        _releaseHostName();*/
+
+    // Leave multicast group(s)
+#ifdef MDNS_IPV4_SUPPORT
+    ip_addr_t   multicast_addr_V4 = DNS_MQUERY_IPV4_GROUP_INIT;
+    if (ERR_OK != igmp_leavegroup_netif(&m_rNetIf, ip_2_ip4(&multicast_addr_V4)/*(const struct ip4_addr *)&multicast_addr_V4.u_addr.ip4*/))
+    {
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("\n")););
+    }
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+    ip_addr_t   multicast_addr_V6 = DNS_MQUERY_IPV6_GROUP_INIT;
+    if (ERR_OK != mld6_leavegroup_netif(&m_rNetIf, ip_2_ip6(&multicast_addr_V6)/*&(multicast_addr_V6.u_addr.ip6)*/))
+    {
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("\n")););
+    }
+#endif
+    return true;
+}
+
+
+/*
+    NETIF
+*/
+
+/*
+    MDNSResponder::clsHost::_getNetIfState
+
+    Returns the current netif state.
+
+*/
+MDNSResponder::clsHost::typeNetIfState MDNSResponder::clsHost::_getNetIfState(void) const
+{
+    typeNetIfState  curNetIfState = static_cast<typeNetIfState>(enuNetIfState::None);
+
+    if (netif_is_up(&m_rNetIf))
+    {
+        curNetIfState |= static_cast<typeNetIfState>(enuNetIfState::IsUp);
+
+        // Check if netif link is up
+        if ((netif_is_link_up(&m_rNetIf)) &&
+            ((&m_rNetIf != netif_get_by_index(WIFI_STA)) ||
+             (STATION_GOT_IP == wifi_station_get_connect_status())))
+        {
+            curNetIfState |= static_cast<typeNetIfState>(enuNetIfState::LinkIsUp);
+        }
+
+        // Check for IPv4 address
+        if (_getResponderIPAddress(enuIPProtocolType::V4).isSet())
+        {
+            curNetIfState |= static_cast<typeNetIfState>(enuNetIfState::IPv4);
+        }
+        // Check for IPv6 address
+        if (_getResponderIPAddress(enuIPProtocolType::V6).isSet())
+        {
+            curNetIfState |= static_cast<typeNetIfState>(enuNetIfState::IPv6);
+        }
+    }
+    return curNetIfState;
+}
+
+/*
+    MDNSResponder::clsHost::_checkNetIfState
+
+    Checks the netif state.
+    If eg. a new address appears, the announcing is restarted.
+
+*/
+bool MDNSResponder::clsHost::_checkNetIfState(void)
+{
+    typeNetIfState  curNetIfState;
+    if (m_NetIfState != ((curNetIfState = _getNetIfState())))
+    {
+        // Some state change happened
+        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _checkNetIfState: DID CHANGE NETIF STATE\n\n"), _DH()););
+        DEBUG_EX_INFO(
+            if ((curNetIfState & static_cast<typeNetIfState>(enuNetIfState::IsUp)) != (m_NetIfState & static_cast<typeNetIfState>(enuNetIfState::IsUp)))
+    {
+        DEBUG_OUTPUT.printf_P(PSTR("%s _checkNetIfState: Netif is up: %s\n"), _DH(), ((curNetIfState & static_cast<typeNetIfState>(enuNetIfState::IsUp)) ? "YES" : "NO"));
+        }
+        if ((curNetIfState & static_cast<typeNetIfState>(enuNetIfState::LinkIsUp)) != (m_NetIfState & static_cast<typeNetIfState>(enuNetIfState::LinkIsUp)))
+    {
+        DEBUG_OUTPUT.printf_P(PSTR("%s _checkNetIfState: Netif link is up: %s\n"), _DH(), ((curNetIfState & static_cast<typeNetIfState>(enuNetIfState::LinkIsUp)) ? "YES" : "NO"));
+        }
+        if ((curNetIfState & static_cast<typeNetIfState>(enuNetIfState::IPv4)) != (m_NetIfState & static_cast<typeNetIfState>(enuNetIfState::IPv4)))
+    {
+        DEBUG_OUTPUT.printf_P(PSTR("%s _checkNetIfState: IPv4 address is set: %s\n"), _DH(), ((curNetIfState & static_cast<typeNetIfState>(enuNetIfState::IPv4)) ? "YES" : "NO"));
+            if (curNetIfState & static_cast<typeNetIfState>(enuNetIfState::IPv4))
+            {
+                DEBUG_OUTPUT.printf_P(PSTR("%s _checkNetIfState: IPv4 address: %s\n"), _DH(), _getResponderIPAddress(enuIPProtocolType::V4).toString().c_str());
+            }
+        }
+        if ((curNetIfState & static_cast<typeNetIfState>(enuNetIfState::IPv6)) != (m_NetIfState & static_cast<typeNetIfState>(enuNetIfState::IPv6)))
+    {
+        DEBUG_OUTPUT.printf_P(PSTR("%s _checkNetIfState: IPv6 address is set: %s\n"), _DH(), ((curNetIfState & static_cast<typeNetIfState>(enuNetIfState::IPv6)) ? "YES" : "NO"));
+            if (curNetIfState & static_cast<typeNetIfState>(enuNetIfState::IPv6))
+            {
+                DEBUG_OUTPUT.printf_P(PSTR("%s _checkNetIfState: IPv6 address: %s\n"), _DH(), _getResponderIPAddress(enuIPProtocolType::V6).toString().c_str());
+            }
+        }
+        );
+
+        if ((curNetIfState & static_cast<typeNetIfState>(enuNetIfState::LinkMask)) != (m_NetIfState & static_cast<typeNetIfState>(enuNetIfState::LinkMask)))
+        {
+            // Link came up (restart() will alloc a m_pUDPContext, ...) or down (_restart() will remove an existing m_pUDPContext, ...)
+            restart();
+        }
+        else if (curNetIfState & static_cast<typeNetIfState>(enuNetIfState::LinkIsUp))
+        {
+            // Link is up (unchanged)
+            if ((curNetIfState & static_cast<typeNetIfState>(enuNetIfState::IPMask)) != (m_NetIfState & static_cast<typeNetIfState>(enuNetIfState::IPMask)))
+            {
+                // IP state changed
+                // TODO: If just a new IP address was added, a simple re-announcement should be enough
+                restart();
+            }
+        }
+        /*  if (enuProbingStatus::Done == m_HostProbeInformation.m_ProbingStatus) {
+            // Probing is done, prepare to (re)announce host
+            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _checkNetIfState: Preparing to (re)announce host.\n")););
+            //m_HostProbeInformation.m_ProbingStatus = enuProbingStatus::Done;
+            m_HostProbeInformation.m_u8SentCount = 0;
+            m_HostProbeInformation.m_Timeout.reset(MDNS_ANNOUNCE_DELAY);
+            }*/
+        m_NetIfState = curNetIfState;
+    }
+
+    bool    bResult = ((curNetIfState & static_cast<typeNetIfState>(enuNetIfState::LinkMask)) &&    // Continue if Link is UP
+                       (curNetIfState & static_cast<typeNetIfState>(enuNetIfState::IPMask)));       // AND has any IP
+    //DEBUG_EX_INFO(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _checkNetIfState: Link is DOWN or NO IP address!\n"), _DH()););
+    return bResult;
+}
+
+
+/*
+    DOMAIN NAMES
+*/
+
+/*
+    MDNSResponder::clsHost::_allocDomainName
+*/
+bool MDNSResponder::clsHost::_allocDomainName(const char* p_pcNewDomainName,
+                                              char*& p_rpcDomainName)
+{
+    bool    bResult = false;
+
+    _releaseDomainName(p_rpcDomainName);
+
+    size_t  stLength = 0;
+    if ((p_pcNewDomainName) &&
+        (MDNS_DOMAIN_LABEL_MAXLENGTH >= (stLength = strlen(p_pcNewDomainName))))   // char max size for a single label
+    {
+        // Copy in hostname characters as lowercase
+        if ((bResult = (0 != (p_rpcDomainName = new char[stLength + 1]))))
+        {
+#ifdef MDNS_FORCE_LOWERCASE_HOSTNAME
+            size_t i = 0;
+            for (; i < stLength; ++i)
+            {
+                p_rpcDomainName[i] = (isupper(p_pcNewDomainName[i]) ? tolower(p_pcNewDomainName[i]) : p_pcNewDomainName[i]);
+            }
+            p_rpcDomainName[i] = 0;
+#else
+            strncpy(p_rpcDomainName, p_pcNewDomainName, (stLength + 1));
+#endif
+        }
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::_releaseDomainName
+*/
+bool MDNSResponder::clsHost::_releaseDomainName(char*& p_rpcDomainName)
+{
+    bool    bResult;
+    if ((bResult = (0 != p_rpcDomainName)))
+    {
+        delete[] p_rpcDomainName;
+        p_rpcDomainName = 0;
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::_allocHostName
+*/
+bool MDNSResponder::clsHost::_allocHostName(const char* p_pcHostName)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _allocHostName (%s)\n"), _DH(), p_pcHostName););
+    return _allocDomainName(p_pcHostName, m_pcHostName);
+}
+
+/*
+    MDNSResponder::clsHost::_releaseHostName
+*/
+bool MDNSResponder::clsHost::_releaseHostName(void)
+{
+    return _releaseDomainName(m_pcHostName);
+}
+
+/*
+    MDNSResponder::clsHost::_allocInstanceName
+*/
+bool MDNSResponder::clsHost::_allocInstanceName(const char* p_pcInstanceName)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _allocInstanceName (%s)\n"), _DH(), p_pcHostName););
+    return _allocDomainName(p_pcInstanceName, m_pcInstanceName);
+}
+
+/*
+    MDNSResponder::clsHost::_releaseInstanceName
+*/
+bool MDNSResponder::clsHost::_releaseInstanceName(void)
+{
+    return _releaseDomainName(m_pcInstanceName);
+}
+
+
+/*
+    SERVICE
+*/
+
+/*
+    MDNSResponder::clsHost::_allocService
+*/
+MDNSResponder::clsHost::stcService* MDNSResponder::clsHost::_allocService(const char* p_pcName,
+                                                                          const char* p_pcServiceType,
+                                                                          const char* p_pcProtocol,
+                                                                          uint16_t p_u16Port)
+{
+    stcService* pService = 0;
+    if (((!p_pcName) ||
+         (MDNS_DOMAIN_LABEL_MAXLENGTH >= strlen(p_pcName))) &&
+        (p_pcServiceType) &&
+        (MDNS_SERVICE_NAME_LENGTH >= strlen(p_pcServiceType)) &&
+        (p_pcProtocol) &&
+        (MDNS_SERVICE_PROTOCOL_LENGTH >= strlen(p_pcProtocol)) &&
+        (p_u16Port) &&
+        (0 != ((pService = new stcService))) &&
+        (pService->setName(p_pcName ? : (m_pcInstanceName ? : m_pcHostName))) &&
+        (pService->setServiceType(p_pcServiceType)) &&
+        (pService->setProtocol(p_pcProtocol)))
+    {
+        pService->m_bAutoName = (0 == p_pcName);
+        pService->m_u16Port = p_u16Port;
+
+        // Add to list (or start list)
+        pService->m_pNext = m_pServices;
+        m_pServices = pService;
+    }
+    return pService;
+}
+
+/*
+    MDNSResponder::clsHost::_releaseService
+*/
+bool MDNSResponder::clsHost::_releaseService(MDNSResponder::clsHost::stcService* p_pService)
+{
+    bool    bResult = false;
+
+    if (p_pService)
+    {
+        stcService* pPred = m_pServices;
+        while ((pPred) &&
+               (pPred->m_pNext != p_pService))
+        {
+            pPred = pPred->m_pNext;
+        }
+        if (pPred)
+        {
+            pPred->m_pNext = p_pService->m_pNext;
+            delete p_pService;
+            bResult = true;
+        }
+        else    // No predecesor
+        {
+            if (m_pServices == p_pService)
+            {
+                m_pServices = p_pService->m_pNext;
+                delete p_pService;
+                bResult = true;
+            }
+            else
+            {
+                DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _releaseService: INVALID service!"), _DH(p_pService)););
+            }
+        }
+    }
+    return bResult;
+}
+
+
+/*
+    SERVICE TXT
+*/
+
+/*
+    MDNSResponder::clsHost::_allocServiceTxt
+*/
+MDNSResponder::clsHost::stcServiceTxt* MDNSResponder::clsHost::_allocServiceTxt(MDNSResponder::clsHost::stcService* p_pService,
+                                                                                const char* p_pcKey,
+                                                                                const char* p_pcValue,
+                                                                                bool p_bTemp)
+{
+    stcServiceTxt*  pTxt = 0;
+
+    if ((p_pService) &&
+        (p_pcKey) &&
+        (MDNS_SERVICE_TXT_MAXLENGTH > (p_pService->m_Txts.length() +
+                                       1 +                                 // Length byte
+                                       (p_pcKey ? strlen(p_pcKey) : 0) +
+                                       1 +                                 // '='
+                                       (p_pcValue ? strlen(p_pcValue) : 0))))
+    {
+
+        pTxt = new stcServiceTxt;
+        if (pTxt)
+        {
+            size_t  stLength = (p_pcKey ? strlen(p_pcKey) : 0);
+            pTxt->m_pcKey = new char[stLength + 1];
+            if (pTxt->m_pcKey)
+            {
+                strncpy(pTxt->m_pcKey, p_pcKey, stLength); pTxt->m_pcKey[stLength] = 0;
+            }
+
+            if (p_pcValue)
+            {
+                stLength = (p_pcValue ? strlen(p_pcValue) : 0);
+                pTxt->m_pcValue = new char[stLength + 1];
+                if (pTxt->m_pcValue)
+                {
+                    strncpy(pTxt->m_pcValue, p_pcValue, stLength); pTxt->m_pcValue[stLength] = 0;
+                }
+            }
+            pTxt->m_bTemp = p_bTemp;
+
+            // Add to list (or start list)
+            p_pService->m_Txts.add(pTxt);
+        }
+    }
+    return pTxt;
+}
+
+/*
+    MDNSResponder::clsHost::_releaseServiceTxt
+*/
+bool MDNSResponder::clsHost::_releaseServiceTxt(MDNSResponder::clsHost::stcService* p_pService,
+                                                MDNSResponder::clsHost::stcServiceTxt* p_pTxt)
+{
+    return ((p_pService) &&
+            (p_pTxt) &&
+            (p_pService->m_Txts.remove(p_pTxt)));
+}
+
+/*
+    MDNSResponder::clsHost::_updateServiceTxt
+*/
+MDNSResponder::clsHost::stcServiceTxt* MDNSResponder::clsHost::_updateServiceTxt(MDNSResponder::clsHost::stcService* p_pService,
+                                                                                 MDNSResponder::clsHost::stcServiceTxt* p_pTxt,
+                                                                                 const char* p_pcValue,
+                                                                                 bool p_bTemp)
+{
+    if ((p_pService) &&
+        (p_pTxt) &&
+        (MDNS_SERVICE_TXT_MAXLENGTH > (p_pService->m_Txts.length() -
+                                       (p_pTxt->m_pcValue ? strlen(p_pTxt->m_pcValue) : 0) +
+                                       (p_pcValue ? strlen(p_pcValue) : 0))))
+    {
+        p_pTxt->update(p_pcValue);
+        p_pTxt->m_bTemp = p_bTemp;
+    }
+    return p_pTxt;
+}
+
+/*
+    MDNSResponder::clsHost::_findServiceTxt
+*/
+MDNSResponder::clsHost::stcServiceTxt* MDNSResponder::clsHost::_findServiceTxt(MDNSResponder::clsHost::stcService* p_pService,
+                                                                               const char* p_pcKey)
+{
+    return (p_pService ? p_pService->m_Txts.find(p_pcKey) : 0);
+}
+
+/*
+    MDNSResponder::clsHost::_addServiceTxt
+*/
+MDNSResponder::clsHost::stcServiceTxt* MDNSResponder::clsHost::_addServiceTxt(MDNSResponder::clsHost::stcService* p_pService,
+                                                                              const char* p_pcKey,
+                                                                              const char* p_pcValue,
+                                                                              bool p_bTemp)
+{
+    stcServiceTxt*  pResult = 0;
+
+    if ((p_pService) &&
+        (p_pcKey) &&
+        (strlen(p_pcKey)))
+    {
+
+        stcServiceTxt*  pTxt = p_pService->m_Txts.find(p_pcKey);
+        if (pTxt)
+        {
+            pResult = _updateServiceTxt(p_pService, pTxt, p_pcValue, p_bTemp);
+        }
+        else
+        {
+            pResult = _allocServiceTxt(p_pService, p_pcKey, p_pcValue, p_bTemp);
+        }
+    }
+    return pResult;
+}
+
+/*
+    MDNSResponder::clsHost::_answerKeyValue
+    /
+    MDNSResponder::clsHost::stcServiceTxt* MDNSResponder::clsHost::_answerKeyValue(const MDNSResponder::clsHost::stcQuery p_pQuery,
+                                                                 const uint32_t p_u32AnswerIndex)
+    {
+    stcQuery::stcAnswer* pSQAnswer = (p_pQuery ? p_pQuery->answerAtIndex(p_u32AnswerIndex) : 0);
+    // Fill m_pcTxts (if not already done)
+    return (pSQAnswer) ?  pSQAnswer->m_Txts.m_pTxts : 0;
+    }*/
+
+/*
+    MDNSResponder::clsHost::_collectServiceTxts
+*/
+bool MDNSResponder::clsHost::_collectServiceTxts(MDNSResponder::clsHost::stcService& p_rService)
+{
+    if (m_fnServiceTxtCallback)
+    {
+        //m_fnServiceTxtCallback(*this, p_pService);
+    }
+    if (p_rService.m_fnTxtCallback)
+    {
+        //p_pService->m_fnTxtCallback(*this, p_pService);
+    }
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::_releaseTempServiceTxts
+*/
+bool MDNSResponder::clsHost::_releaseTempServiceTxts(MDNSResponder::clsHost::stcService& p_rService)
+{
+    return (p_rService.m_Txts.removeTempTxts());
+}
+
+
+/*
+    QUERIES
+*/
+
+/*
+    MDNSResponder::_allocQuery
+*/
+MDNSResponder::clsHost::stcQuery* MDNSResponder::clsHost::_allocQuery(MDNSResponder::clsHost::stcQuery::enuQueryType p_QueryType)
+{
+    stcQuery*    pQuery = new stcQuery(p_QueryType);
+    if (pQuery)
+    {
+        // Link to query list
+        pQuery->m_pNext = m_pQueries;
+        m_pQueries = pQuery;
+    }
+    return m_pQueries;
+}
+
+/*
+    MDNSResponder:clsHost:::_removeQuery
+*/
+bool MDNSResponder::clsHost::_removeQuery(MDNSResponder::clsHost::stcQuery* p_pQuery)
+{
+    bool    bResult = false;
+
+    if (p_pQuery)
+    {
+        stcQuery*    pPred = m_pQueries;
+        while ((pPred) &&
+               (pPred->m_pNext != p_pQuery))
+        {
+            pPred = pPred->m_pNext;
+        }
+        if (pPred)
+        {
+            pPred->m_pNext = p_pQuery->m_pNext;
+            delete p_pQuery;
+            bResult = true;
+        }
+        else    // No predecesor
+        {
+            if (m_pQueries == p_pQuery)
+            {
+                m_pQueries = p_pQuery->m_pNext;
+                delete p_pQuery;
+                bResult = true;
+            }
+            else
+            {
+                DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _releaseQuery: INVALID query!"), _DH()););
+            }
+        }
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::_removeLegacyQuery
+*/
+bool MDNSResponder::clsHost::_removeLegacyQuery(void)
+{
+    stcQuery*    pLegacyQuery = 0;
+    return (((pLegacyQuery = _findLegacyQuery()))
+            ? _removeQuery(pLegacyQuery)
+            : false);
+}
+
+/*
+    MDNSResponder::clsHost::_findLegacyQuery
+*/
+MDNSResponder::clsHost::stcQuery* MDNSResponder::clsHost::_findLegacyQuery(void)
+{
+    stcQuery*    pLegacyQuery = m_pQueries;
+    while (pLegacyQuery)
+    {
+        if (pLegacyQuery->m_bLegacyQuery)
+        {
+            break;
+        }
+        pLegacyQuery = pLegacyQuery->m_pNext;
+    }
+    return pLegacyQuery;
+}
+
+/*
+    MDNSResponder::clsHost::_releaseQueries
+*/
+bool MDNSResponder::clsHost::_releaseQueries(void)
+{
+    while (m_pQueries)
+    {
+        stcQuery*    pNext = m_pQueries->m_pNext;
+        delete m_pQueries;
+        m_pQueries = pNext;
+    }
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::_findNextQueryByDomain
+*/
+MDNSResponder::clsHost::stcQuery* MDNSResponder::clsHost::_findNextQueryByDomain(const MDNSResponder::clsHost::stcRRDomain& p_Domain,
+                                                                                 const MDNSResponder::clsHost::stcQuery::enuQueryType p_QueryType,
+                                                                                 const stcQuery* p_pPrevQuery)
+{
+    stcQuery*    pMatchingQuery = 0;
+
+    stcQuery*    pQuery = (p_pPrevQuery ? p_pPrevQuery->m_pNext : m_pQueries);
+    while (pQuery)
+    {
+        if (((stcQuery::enuQueryType::None == p_QueryType) ||
+             (pQuery->m_QueryType == p_QueryType)) &&
+            (p_Domain == pQuery->m_Domain))
+        {
+
+            pMatchingQuery = pQuery;
+            break;
+        }
+        pQuery = pQuery->m_pNext;
+    }
+    return pMatchingQuery;
+}
+
+/*
+    MDNSResponder::clsHost::_installDomainQuery
+*/
+MDNSResponder::clsHost::stcQuery* MDNSResponder::clsHost::_installDomainQuery(MDNSResponder::clsHost::stcRRDomain& p_Domain,
+                                                                              MDNSResponder::clsHost::stcQuery::enuQueryType p_QueryType,
+                                                                              MDNSResponder::clsHost::QueryCallbackFn p_fnCallback)
+{
+    stcQuery*    pQuery = 0;
+
+    if ((p_fnCallback) &&
+        ((pQuery = _allocQuery(p_QueryType))))
+    {
+        pQuery->m_Domain = p_Domain;
+        pQuery->m_fnCallback = p_fnCallback;
+        pQuery->m_bLegacyQuery = false;
+
+        if (_sendMDNSQuery(*pQuery))
+        {
+            pQuery->m_u8SentCount = 1;
+            pQuery->m_ResendTimeout.reset(MDNS_DYNAMIC_QUERY_RESEND_DELAY);
+        }
+        else
+        {
+            _removeQuery(pQuery);
+        }
+    }
+    DEBUG_EX_INFO(
+        DEBUG_OUTPUT.printf_P(PSTR("%s _installDomainQuery: %s for "), (pQuery ? "Succeeded" : "FAILED"), _DH());
+        _printRRDomain(p_Domain);
+        DEBUG_OUTPUT.println();
+    );
+    DEBUG_EX_ERR(
+        if (!pQuery)
+{
+    DEBUG_OUTPUT.printf_P(PSTR("%s _installDomainQuery: FAILED for "), _DH());
+        _printRRDomain(p_Domain);
+        DEBUG_OUTPUT.println();
+    }
+    );
+    return pQuery;
+}
+
+/*
+    MDNSResponder::clsHost::_hasQueriesWaitingForAnswers
+*/
+bool MDNSResponder::clsHost::_hasQueriesWaitingForAnswers(void) const
+{
+    bool    bOpenQueries = false;
+
+    for (stcQuery* pQuery = m_pQueries; pQuery; pQuery = pQuery->m_pNext)
+    {
+        if (pQuery->m_bAwaitingAnswers)
+        {
+            bOpenQueries = true;
+            break;
+        }
+    }
+    return bOpenQueries;
+}
+
+/*
+    MDNSResponder::clsHost::_executeQueryCallback
+*/
+bool MDNSResponder::clsHost::_executeQueryCallback(const stcQuery& p_Query,
+                                                   const stcQuery::stcAnswer& p_Answer,
+                                                   typeQueryAnswerType p_QueryAnswerTypeFlags,
+                                                   bool p_bSetContent)
+{
+    if (p_Query.m_fnCallback)
+    {
+        p_Query.m_fnCallback(*this, p_Query, p_Answer, p_QueryAnswerTypeFlags, p_bSetContent);
+    }
+    return true;
+}
+
+
+
+}   // namespace MDNSImplementation
+
+}   // namespace esp8266

--- a/libraries/ESP8266mDNS/src/LEAmDNS2_Host.hpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS2_Host.hpp
@@ -1,0 +1,1177 @@
+/*
+    LEAmDNS2_Host.hpp
+
+    License (MIT license):
+      Permission is hereby granted, free of charge, to any person obtaining a copy
+      of this software and associated documentation files (the "Software"), to deal
+      in the Software without restriction, including without limitation the rights
+      to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+      copies of the Software, and to permit persons to whom the Software is
+      furnished to do so, subject to the following conditions:
+
+      The above copyright notice and this permission notice shall be included in
+      all copies or substantial portions of the Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+      THE SOFTWARE.
+
+*/
+
+/**
+    clsHost & clsHostList
+*/
+class clsHost
+{
+public:
+
+    // File: ..._Host_Structs
+    /**
+        typeIPProtocolType & enuIPProtocolType
+    */
+    using typeIPProtocolType = uint8_t;
+    enum class enuIPProtocolType : typeIPProtocolType
+    {
+#ifdef MDNS_IPV4_SUPPORT
+        V4  =   0x01,
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+        V6  =   0x02,
+#endif
+    };
+
+    /**
+        typeNetIfState & enuNetIfState
+    */
+    using   typeNetIfState = uint8_t;
+    enum class enuNetIfState : typeNetIfState
+    {
+        None        = 0x00,
+
+        IsUp        = 0x01,
+        UpMask      = (IsUp),
+
+        LinkIsUp    = 0x02,
+        LinkMask    = (LinkIsUp),
+
+        IPv4        = 0x04,
+        IPv6        = 0x08,
+        IPMask      = (IPv4 | IPv6),
+    };
+
+    /**
+        stcServiceTxt
+    */
+    struct stcServiceTxt
+    {
+        stcServiceTxt*	m_pNext;
+        char*           m_pcKey;
+        char*           m_pcValue;
+        bool            m_bTemp;
+
+        stcServiceTxt(const char* p_pcKey = 0,
+                      const char* p_pcValue = 0,
+					  bool p_bTemp = false);
+        stcServiceTxt(const stcServiceTxt& p_Other);
+        ~stcServiceTxt(void);
+
+        stcServiceTxt& operator=(const stcServiceTxt& p_Other);
+        bool clear(void);
+
+        char* allocKey(size_t p_stLength);
+        bool setKey(const char* p_pcKey,
+                    size_t p_stLength);
+        bool setKey(const char* p_pcKey);
+        bool releaseKey(void);
+
+        char* allocValue(size_t p_stLength);
+        bool setValue(const char* p_pcValue,
+                      size_t p_stLength);
+        bool setValue(const char* p_pcValue);
+        bool releaseValue(void);
+
+        bool set(const char* p_pcKey,
+                 const char* p_pcValue,
+                 bool p_bTemp = false);
+
+        bool update(const char* p_pcValue);
+
+        size_t length(void) const;
+    };
+
+    /**
+        stcServiceTxts
+    */
+    struct stcServiceTxts
+    {
+        stcServiceTxt*	m_pTxts;
+        char*           m_pcCache;
+
+        stcServiceTxts(void);
+        stcServiceTxts(const stcServiceTxts& p_Other);
+        ~stcServiceTxts(void);
+
+        stcServiceTxts& operator=(const stcServiceTxts& p_Other);
+
+        bool clear(void);
+        bool clearCache(void);
+
+        bool add(stcServiceTxt* p_pTxt);
+        bool remove(stcServiceTxt* p_pTxt);
+
+        bool removeTempTxts(void);
+
+        stcServiceTxt* find(const char* p_pcKey);
+        const stcServiceTxt* find(const char* p_pcKey) const;
+        stcServiceTxt* find(const stcServiceTxt* p_pTxt);
+
+        uint16_t length(void) const;
+
+        size_t c_strLength(void) const;
+        bool c_str(char* p_pcBuffer);
+        const char* c_str(void) const;
+
+        size_t bufferLength(void) const;
+        bool buffer(char* p_pcBuffer);
+
+        bool compare(const stcServiceTxts& p_Other) const;
+        bool operator==(const stcServiceTxts& p_Other) const;
+        bool operator!=(const stcServiceTxts& p_Other) const;
+    };
+
+    /**
+        typeProbingStatus & enuProbingStatus
+    */
+    using typeProbingStatus = uint8_t;
+    enum class enuProbingStatus : typeProbingStatus
+    {
+        WaitingForData,
+        ReadyToStart,
+        InProgress,
+        Done
+    };
+
+    /**
+        stcProbeInformation_Base
+    */
+    struct stcProbeInformation_Base
+    {
+        enuProbingStatus                m_ProbingStatus;
+        uint8_t                         m_u8SentCount;  // Used for probes and announcements
+        esp8266::polledTimeout::oneShot m_Timeout;      // Used for probes and announcements
+        bool                            m_bConflict;
+        bool                            m_bTiebreakNeeded;
+
+        stcProbeInformation_Base(void);
+
+        bool clear(void);  // No 'virtual' needed, no polymorphic use (save 4 bytes)
+    };
+
+    /**
+        HostProbeResultCallbackFn
+        Callback function for host domain probe results
+    */
+    using HostProbeResultCallbackFn = std::function<void(clsHost& p_rHost,
+                                                         const char* p_pcDomainName,
+                                                         bool p_bProbeResult)>;
+    /**
+        MDNSServiceProbeResultCallbackFn
+        Callback function for service domain probe results
+    */
+    struct stcService;
+    using ServiceProbeResultCallbackFn = std::function<void(clsHost& p_rHost,
+                                                            stcService& p_rMDNSService,
+                                                            const char* p_pcDomainName,
+                                                            bool p_bProbeResult)>;
+
+    /**
+        stcProbeInformation_Host
+    */
+    struct stcProbeInformation_Host : public stcProbeInformation_Base
+    {
+        HostProbeResultCallbackFn		m_fnProbeResultCallback;
+
+        stcProbeInformation_Host(void);
+
+        bool clear(bool p_bClearUserdata = false);
+    };
+
+    /**
+        stcProbeInformation_Service
+    */
+    struct stcProbeInformation_Service : public stcProbeInformation_Base
+    {
+        ServiceProbeResultCallbackFn    m_fnProbeResultCallback;
+
+        stcProbeInformation_Service(void);
+
+        bool clear(bool p_bClearUserdata = false);
+    };
+
+    /**
+        DynamicServiceTxtCallbackFn
+        Callback function for dynamic MDNS TXT items
+    */
+    struct stcService;
+    using DynamicServiceTxtCallbackFn = std::function<void(clsHost& p_rHost,
+                                                           stcService& p_rMDNSService)>;
+
+    /**
+        stcService
+    */
+    struct stcService
+    {
+        stcService*                	m_pNext;
+        char*                       m_pcName;
+        bool                        m_bAutoName;		// Name was set automatically to hostname (if no name was supplied)
+        char*                       m_pcServiceType;
+        char*                       m_pcProtocol;
+        uint16_t                    m_u16Port;
+        uint32_t                    m_u32ReplyMask;
+        stcServiceTxts              m_Txts;
+        DynamicServiceTxtCallbackFn m_fnTxtCallback;
+        stcProbeInformation_Service m_ProbeInformation;
+
+        stcService(const char* p_pcName = 0,
+                   const char* p_pcServiceType = 0,
+                   const char* p_pcProtocol = 0);
+        ~stcService(void);
+
+        bool setName(const char* p_pcName);
+        bool releaseName(void);
+
+        bool setServiceType(const char* p_pcService);
+        bool releaseServiceType(void);
+
+        bool setProtocol(const char* p_pcProtocol);
+        bool releaseProtocol(void);
+
+        bool probeStatus(void) const;
+    };
+
+    /**
+        typeContentFlag & enuContentFlag
+    */
+    using typeContentFlag = uint16_t;
+    enum class enuContentFlag : typeContentFlag
+    {
+        // Host
+        A           = 0x0001,
+        PTR_IPv4    = 0x0002,
+        PTR_IPv6    = 0x0004,
+        AAAA        = 0x0008,
+        // Service
+        PTR_TYPE    = 0x0010,
+        PTR_NAME    = 0x0020,
+        TXT         = 0x0040,
+        SRV         = 0x0080,
+        // DNSSEC
+        NSEC        = 0x0100,
+
+        PTR         = (PTR_IPv4 | PTR_IPv6 | PTR_TYPE | PTR_NAME)
+    };
+
+    /**
+        stcMsgHeader
+    */
+    struct stcMsgHeader
+    {
+        uint16_t        m_u16ID;            // Identifier
+        bool            m_1bQR      : 1;    // Query/Response flag
+        uint8_t         m_4bOpcode  : 4;    // Operation code
+        bool            m_1bAA      : 1;    // Authoritative Answer flag
+        bool            m_1bTC      : 1;    // Truncation flag
+        bool            m_1bRD      : 1;    // Recursion desired
+        bool            m_1bRA      : 1;    // Recursion available
+        uint8_t         m_3bZ       : 3;    // Zero
+        uint8_t         m_4bRCode   : 4;    // Response code
+        uint16_t        m_u16QDCount;       // Question count
+        uint16_t        m_u16ANCount;       // Answer count
+        uint16_t        m_u16NSCount;       // Authority Record count
+        uint16_t        m_u16ARCount;       // Additional Record count
+
+        stcMsgHeader(uint16_t p_u16ID = 0,
+                     bool p_bQR = false,
+					 uint8_t p_u8Opcode = 0,
+					 bool p_bAA = false,
+					 bool p_bTC = false,
+					 bool p_bRD = false,
+					 bool p_bRA = false,
+					 uint8_t p_u8RCode = 0,
+					 uint16_t p_u16QDCount = 0,
+					 uint16_t p_u16ANCount = 0,
+					 uint16_t p_u16NSCount = 0,
+					 uint16_t p_u16ARCount = 0);
+    };
+
+    /**
+        stcRRDomain
+    */
+    struct stcRRDomain
+    {
+        char            m_acName[MDNS_DOMAIN_MAXLENGTH];    // Encoded domain name
+        uint16_t        m_u16NameLength;                    // Length (incl. '\0')
+        char*           m_pcDecodedName;
+
+        stcRRDomain(void);
+        stcRRDomain(const stcRRDomain& p_Other);
+        ~stcRRDomain(void);
+
+        stcRRDomain& operator=(const stcRRDomain& p_Other);
+
+        bool clear(void);
+        bool clearNameCache(void);
+
+        bool addLabel(const char* p_pcLabel,
+                      bool p_bPrependUnderline = false);
+
+        bool compare(const stcRRDomain& p_Other) const;
+        bool operator==(const stcRRDomain& p_Other) const;
+        bool operator!=(const stcRRDomain& p_Other) const;
+        bool operator>(const stcRRDomain& p_Other) const;
+
+        size_t c_strLength(void) const;
+        bool c_str(char* p_pcBuffer) const;
+        const char* c_str(void) const;
+    };
+
+    /**
+        stcRRAttributes
+    */
+    struct stcRRAttributes
+    {
+        uint16_t            m_u16Type;      // Type
+        uint16_t            m_u16Class;     // Class, nearly always 'IN'
+
+        stcRRAttributes(uint16_t p_u16Type = 0,
+                        uint16_t p_u16Class = 1 /*DNS_RRCLASS_IN Internet*/);
+        stcRRAttributes(const stcRRAttributes& p_Other);
+
+        stcRRAttributes& operator=(const stcRRAttributes& p_Other);
+    };
+
+    /**
+        stcRRHeader
+    */
+    struct stcRRHeader
+    {
+        stcRRDomain			m_Domain;
+        stcRRAttributes    	m_Attributes;
+
+        stcRRHeader(void);
+        stcRRHeader(const stcRRHeader& p_Other);
+
+        stcRRHeader& operator=(const stcRRHeader& p_Other);
+
+        bool clear(void);
+    };
+
+    /**
+        stcRRQuestion
+    */
+    struct stcRRQuestion
+    {
+        stcRRQuestion*     	m_pNext;
+        stcRRHeader        	m_Header;
+        bool                m_bUnicast;		// Unicast reply requested
+
+        stcRRQuestion(void);
+    };
+
+    /**
+        stcNSECBitmap
+    */
+    struct stcNSECBitmap
+    {
+        uint8_t m_au8BitmapData[6]; // 6 bytes data
+
+        stcNSECBitmap(void);
+
+        bool clear(void);
+        uint16_t length(void) const;
+        bool setBit(uint16_t p_u16Bit);
+        bool getBit(uint16_t p_u16Bit) const;
+    };
+
+    /**
+        typeAnswerType & enuAnswerType
+    */
+    using typeAnswerType = uint8_t;
+    enum class enuAnswerType : typeAnswerType
+    {
+        A,
+        PTR,
+        TXT,
+        AAAA,
+        SRV,
+        //NSEC,
+        Generic
+    };
+
+    /**
+        stcRRAnswer
+    */
+    struct stcRRAnswer
+    {
+        stcRRAnswer*   		m_pNext;
+        const enuAnswerType	m_AnswerType;
+        stcRRHeader    		m_Header;
+        bool                m_bCacheFlush;	// Cache flush command bit
+        uint32_t            m_u32TTL;       // Validity time in seconds
+
+        virtual ~stcRRAnswer(void);
+
+        enuAnswerType answerType(void) const;
+
+        bool clear(void);
+
+    protected:
+        stcRRAnswer(enuAnswerType p_AnswerType,
+                    const stcRRHeader& p_Header,
+					uint32_t p_u32TTL);
+    };
+
+#ifdef MDNS_IPV4_SUPPORT
+    /**
+        stcRRAnswerA
+    */
+    struct stcRRAnswerA : public stcRRAnswer
+    {
+        IPAddress         	m_IPAddress;
+
+        stcRRAnswerA(const stcRRHeader& p_Header,
+                     uint32_t p_u32TTL);
+        ~stcRRAnswerA(void);
+
+        bool clear(void);
+    };
+#endif
+
+    /**
+        stcRRAnswerPTR
+    */
+    struct stcRRAnswerPTR : public stcRRAnswer
+    {
+        stcRRDomain  		m_PTRDomain;
+
+        stcRRAnswerPTR(const stcRRHeader& p_Header,
+                       uint32_t p_u32TTL);
+        ~stcRRAnswerPTR(void);
+
+        bool clear(void);
+    };
+
+    /**
+        stcRRAnswerTXT
+    */
+    struct stcRRAnswerTXT : public stcRRAnswer
+    {
+        stcServiceTxts 		m_Txts;
+
+        stcRRAnswerTXT(const stcRRHeader& p_Header,
+                       uint32_t p_u32TTL);
+        ~stcRRAnswerTXT(void);
+
+        bool clear(void);
+    };
+
+#ifdef MDNS_IPV6_SUPPORT
+    /**
+        stcRRAnswerAAAA
+    */
+    struct stcRRAnswerAAAA : public stcRRAnswer
+    {
+        IPAddress           m_IPAddress;
+
+        stcRRAnswerAAAA(const stcRRHeader& p_Header,
+                        uint32_t p_u32TTL);
+        ~stcRRAnswerAAAA(void);
+
+        bool clear(void);
+    };
+#endif
+
+    /**
+        stcRRAnswerSRV
+    */
+    struct stcRRAnswerSRV : public stcRRAnswer
+    {
+        uint16_t            m_u16Priority;
+        uint16_t            m_u16Weight;
+        uint16_t            m_u16Port;
+        stcRRDomain    		m_SRVDomain;
+
+        stcRRAnswerSRV(const stcRRHeader& p_Header,
+                       uint32_t p_u32TTL);
+        ~stcRRAnswerSRV(void);
+
+        bool clear(void);
+    };
+
+    /**
+        stcRRAnswerGeneric
+    */
+    struct stcRRAnswerGeneric : public stcRRAnswer
+    {
+        uint16_t            m_u16RDLength;  // Length of variable answer
+        uint8_t*            m_pu8RDData;    // Offset of start of variable answer in packet
+
+        stcRRAnswerGeneric(const stcRRHeader& p_Header,
+                           uint32_t p_u32TTL);
+        ~stcRRAnswerGeneric(void);
+
+        bool clear(void);
+    };
+
+
+    /**
+        stcSendParameter
+    */
+    struct stcSendParameter
+    {
+    protected:
+        /**
+            stcDomainCacheItem
+        */
+        struct stcDomainCacheItem
+        {
+            stcDomainCacheItem*     m_pNext;
+            const void*             m_pHostNameOrService;   // Opaque id for host or service domain (pointer)
+            bool                    m_bAdditionalData;      // Opaque flag for special info (service domain included)
+            uint16_t                m_u16Offset;            // Offset in UDP output buffer
+
+            stcDomainCacheItem(const void* p_pHostNameOrService,
+                               bool p_bAdditionalData,
+                               uint32_t p_u16Offset);
+        };
+
+    public:
+        /**
+            typeResponseType & enuResponseType
+        */
+        using typeResponseType = uint8_t;
+        enum class enuResponseType : typeResponseType
+        {
+            None,
+            Response,
+            Unsolicited
+        };
+
+        uint16_t                m_u16ID;                    // Query ID (used only in lagacy queries)
+        stcRRQuestion*     		m_pQuestions;               // A list of queries
+        uint32_t                m_u32HostReplyMask;         // Flags for reply components/answers
+        bool                    m_bLegacyQuery;             // Flag: Legacy query
+        enuResponseType         m_Response;                 // Enum: Response to a query
+        bool                    m_bAuthorative;             // Flag: Authorative (owner) response
+        bool                    m_bCacheFlush;              // Flag: Clients should flush their caches
+        bool                    m_bUnicast;                 // Flag: Unicast response
+        bool                    m_bUnannounce;              // Flag: Unannounce service
+
+        // Temp content; created while processing _prepareMessage
+        uint16_t                m_u16Offset;                // Current offset in UDP write buffer (mainly for domain cache)
+        stcDomainCacheItem*     m_pDomainCacheItems;        // Cached host and service domains
+
+        stcSendParameter(void);
+        ~stcSendParameter(void);
+
+        bool clear(void);
+        bool flushQuestions(void);
+        bool flushDomainCache(void);
+        bool flushTempContent(void);
+
+        bool shiftOffset(uint16_t p_u16Shift);
+
+        bool addDomainCacheItem(const void* p_pHostNameOrService,
+                                bool p_bAdditionalData,
+                                uint16_t p_u16Offset);
+        uint16_t findCachedDomainOffset(const void* p_pHostNameOrService,
+                                        bool p_bAdditionalData) const;
+    };
+
+
+    // QUERIES & ANSWERS
+    /**
+        typeQueryAnswerType & enuQueryAnswerType
+    */
+    using typeQueryAnswerType = uint8_t;
+    enum class enuQueryAnswerType : typeQueryAnswerType
+    {
+        Unknown             = 0x00,
+        ServiceDomain       = 0x01,     // Service domain
+        HostDomain          = 0x02,     // Host domain
+        Port                = 0x04,     // Port
+        Txts                = 0x08,     // TXT items
+#ifdef MDNS_IPV4_SUPPORT
+        IPv4Address         = 0x10,     // IPv4 address
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+        IPv6Address         = 0x20,     // IPv6 address
+#endif
+    };
+
+    /**
+        stcQuery
+    */
+    struct stcQuery
+    {
+        /**
+            stcAnswer
+        */
+        struct stcAnswer
+        {
+            /**
+                stcTTL
+            */
+            struct stcTTL
+            {
+                /**
+                    typeTimeoutLevel & enuTimeoutLevel
+                */
+                using typeTimeoutLevel = uint8_t;
+                enum class enuTimeoutLevel : typeTimeoutLevel
+                {
+                    None        = 0,
+                    Base        = 80,
+                    Interval    = 5,
+                    Final       = 100
+                };
+
+                uint32_t                        m_u32TTL;
+                esp8266::polledTimeout::oneShot m_TTLTimeout;
+                typeTimeoutLevel                m_TimeoutLevel;
+
+                stcTTL(void);
+                bool set(uint32_t p_u32TTL);
+
+                bool flagged(void) const;
+                bool restart(void);
+
+                bool prepareDeletion(void);
+                bool finalTimeoutLevel(void) const;
+
+                unsigned long timeout(void) const;
+            };
+            /**
+                stcIPAddress
+            */
+            struct stcIPAddress
+            {
+                stcIPAddress*   m_pNext;
+                IPAddress       m_IPAddress;
+                stcTTL          m_TTL;
+
+                stcIPAddress(IPAddress p_IPAddress,
+                             uint32_t p_u32TTL = 0);
+            };
+
+            stcAnswer*        	m_pNext;
+            // The service domain is the first 'answer' (from PTR answer, using service and protocol) to be set
+            // Defines the key for additional answer, like host domain, etc.
+            stcRRDomain        	m_ServiceDomain;    // 1. level answer (PTR), eg. MyESP._http._tcp.local
+            stcTTL              m_TTLServiceDomain;
+            stcRRDomain        	m_HostDomain;       // 2. level answer (SRV, using service domain), eg. esp8266.local
+            uint16_t            m_u16Port;          // 2. level answer (SRV, using service domain), eg. 5000
+            stcTTL              m_TTLHostDomainAndPort;
+            stcServiceTxts      m_Txts;             // 2. level answer (TXT, using service domain), eg. c#=1
+            stcTTL              m_TTLTxts;
+#ifdef MDNS_IPV4_SUPPORT
+            stcIPAddress*       m_pIPv4Addresses;   // 3. level answer (A, using host domain), eg. 123.456.789.012
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+            stcIPAddress*       m_pIPv6Addresses;   // 3. level answer (AAAA, using host domain), eg. 1234::09
+#endif
+            typeQueryAnswerType m_QueryAnswerFlags; // enuQueryAnswerType
+
+            stcAnswer(void);
+            ~stcAnswer(void);
+
+            bool clear(void);
+
+#ifdef MDNS_IPV4_SUPPORT
+            bool releaseIPv4Addresses(void);
+            bool addIPv4Address(stcIPAddress* p_pIPAddress);
+            bool removeIPv4Address(stcIPAddress* p_pIPAddress);
+            const stcIPAddress* findIPv4Address(const IPAddress& p_IPAddress) const;
+            stcIPAddress* findIPv4Address(const IPAddress& p_IPAddress);
+            uint32_t IPv4AddressCount(void) const;
+            const stcIPAddress* IPv4AddressAtIndex(uint32_t p_u32Index) const;
+            stcIPAddress* IPv4AddressAtIndex(uint32_t p_u32Index);
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+            bool releaseIPv6Addresses(void);
+            bool addIPv6Address(stcIPAddress* p_pIPAddress);
+            bool removeIPv6Address(stcIPAddress* p_pIPAddress);
+            const stcIPAddress* findIPv6Address(const IPAddress& p_IPAddress) const;
+            stcIPAddress* findIPv6Address(const IPAddress& p_IPAddress);
+            uint32_t IPv6AddressCount(void) const;
+            const stcIPAddress* IPv6AddressAtIndex(uint32_t p_u32Index) const;
+            stcIPAddress* IPv6AddressAtIndex(uint32_t p_u32Index);
+#endif
+        };  //stcAnswer
+
+        /**
+            typeQueryType & enuQueryType
+        */
+        using   typeQueryType = uint8_t;
+        enum class enuQueryType : typeQueryType
+        {
+            None,
+            Service,
+            Host
+        };
+        using _QueryCallbackFn = std::function<void(clsHost& p_rHost,
+                                                    const stcQuery& p_Query,
+                                                    const stcAnswer& p_Answer,
+                                                    typeQueryAnswerType p_QueryAnswerTypeFlags, // flags for the updated answer item
+                                                    bool p_bSetContent)>;                       // true: Answer component set, false: component deleted
+
+        stcQuery*                   	m_pNext;
+        enuQueryType                    m_QueryType;
+        stcRRDomain                		m_Domain;		// Type:Service -> _http._tcp.local; Type:Host -> esp8266.local
+        _QueryCallbackFn                m_fnCallback;
+        bool                            m_bLegacyQuery;
+        uint8_t                         m_u8SentCount;
+        esp8266::polledTimeout::oneShot m_ResendTimeout;
+        bool                            m_bAwaitingAnswers;
+        stcAnswer*                      m_pAnswers;
+
+        stcQuery(const enuQueryType p_QueryType);
+        ~stcQuery(void);
+
+        bool clear(void);
+
+        uint32_t answerCount(void) const;
+        const stcAnswer* answerAtIndex(uint32_t p_u32Index) const;
+        stcAnswer* answerAtIndex(uint32_t p_u32Index);
+        uint32_t indexOfAnswer(const stcAnswer* p_pAnswer) const;
+
+        bool addAnswer(stcAnswer* p_pAnswer);
+        bool removeAnswer(stcAnswer* p_pAnswer);
+
+        stcAnswer* findAnswerForServiceDomain(const stcRRDomain& p_ServiceDomain);
+        stcAnswer* findAnswerForHostDomain(const stcRRDomain& p_HostDomain);
+    };
+    /**
+        QueryCallbackFn
+
+        Callback function for received answers for dynamic queries
+    */
+    using QueryCallbackFn   = stcQuery::_QueryCallbackFn;
+
+public:
+    clsHost(netif& p_rNetIf,
+            UdpContext& p_rUDPContext);
+    ~clsHost(void);
+
+    bool init(void);
+
+    // HOST
+    bool setHostName(const char* p_pcHostName);
+    const char* hostName(void) const;
+
+    bool setHostProbeResultCallback(HostProbeResultCallbackFn p_fnCallback);
+
+    // Returns 'true' is host domain probing is done
+    bool probeStatus(void) const;
+
+    // SERVICE
+    bool setInstanceName(const char* p_pcInstanceName);
+    const char* instanceName(void) const;
+
+    stcService* addService(const char* p_pcInstanceName,
+                           const char* p_pcServiceType,
+						   const char* p_pcProtocol,
+						   uint16_t p_u16Port);
+    bool removeService(stcService* p_pMDNSService);
+
+    const stcService* findService(const char* p_pcInstanceName,
+                                  const char* p_pcServiceType,
+								  const char* p_pcProtocol,
+								  uint16_t p_u16Port = 0) const;
+    stcService* findService(const char* p_pcInstanceName,
+                            const char* p_pcServiceType,
+                            const char* p_pcProtocol,
+                            uint16_t p_u16Port = 0);
+    bool validateService(const stcService* p_pService) const;
+
+    bool setServiceName(stcService* p_pMDNSService,
+                        const char* p_pcInstanceName);
+    const char* serviceName(const stcService* p_pMDNSService) const;
+    const char* serviceType(const stcService* p_pMDNSService) const;
+    const char* serviceProtocol(const stcService* p_pMDNSService) const;
+    uint16_t servicePort(const stcService* p_pMDNSService) const;
+
+    // Set a service specific probe result callcack
+    bool setServiceProbeResultCallback(stcService* p_pMDNSService,
+                                       ServiceProbeResultCallbackFn p_fnCallback);
+
+    bool serviceProbeStatus(const stcService* p_pMDNSService) const;
+
+    // SERVICE TXT
+    // Add a (static) MDNS TXT item ('key' = 'value') to the service
+    stcServiceTxt* addServiceTxt(stcService* p_pMDNSService,
+                                 const char* p_pcKey,
+								 const char* p_pcValue);
+    bool removeServiceTxt(stcService* p_pMDNSService,
+                          stcServiceTxt* p_pTxt);
+    const stcServiceTxt* findServiceTxt(stcService* p_pMDNSService,
+                                        const char* p_pcKey) const;
+    stcServiceTxt* findServiceTxt(stcService* p_pMDNSService,
+                                  const char* p_pcKey);
+
+    bool setDynamicServiceTxtCallback(DynamicServiceTxtCallbackFn p_fnCallback);
+    bool setDynamicServiceTxtCallback(stcService* p_pMDNSService,
+                                      DynamicServiceTxtCallbackFn p_fnCallback);
+
+    // Add a (dynamic) MDNS TXT item ('key' = 'value') to the service
+    // Dynamic TXT items are removed right after one-time use. So they need to be added
+    // every time the value s needed (via callback).
+    stcServiceTxt* addDynamicServiceTxt(stcService* p_pMDNSService,
+                                        const char* p_pcKey,
+                                        const char* p_pcValue);
+
+    // QUERIES
+
+    // - STATIC
+    // Perform a (static) service/host query. The function returns after p_u16Timeout milliseconds
+    // The answers (the number of received answers is returned) can be retrieved by calling
+    // - answerHostName (or hostname)
+    // - answerIP (or IP)
+    // - answerPort (or port)
+    uint32_t queryService(const char* p_pcService,
+                          const char* p_pcProtocol,
+                          const uint16_t p_u16Timeout = MDNS_QUERYSERVICES_WAIT_TIME);
+    uint32_t queryHost(const char* p_pcHostName,
+                       const uint16_t p_u16Timeout = MDNS_QUERYSERVICES_WAIT_TIME);
+    bool removeQuery(void);
+    bool hasQuery(void);
+    stcQuery* getQuery(void);
+
+    // - DYNAMIC
+    // Install a dynamic service/host query. For every received answer (part) the given callback
+    // function is called. The query will be updated every time, the TTL for an answer
+    // has timed-out.
+    // The answers can also be retrieved by calling
+    // - answerCount                                service/host (for host queries, this should never be >1)
+    // - answerServiceDomain                        service
+    // - hasAnswerHostDomain/answerHostDomain       service/host
+    // - hasAnswerIPv4Address/answerIPv4Address     service/host
+    // - hasAnswerIPv6Address/answerIPv6Address     service/host
+    // - hasAnswerPort/answerPort                   service
+    // - hasAnswerTxts/answerTxts                   service
+    stcQuery* installServiceQuery(const char* p_pcServiceType,
+                                  const char* p_pcProtocol,
+                                  QueryCallbackFn p_fnCallback);
+    stcQuery* installHostQuery(const char* p_pcHostName,
+                               QueryCallbackFn p_fnCallback);
+    // Remove a dynamic service query
+    bool removeQuery(stcQuery* p_pMDNSQuery);
+
+
+
+
+
+    // PROCESSING
+    bool processUDPInput(void);
+    bool update(void);
+
+    bool announce(bool p_bAnnounce,
+                  bool p_bIncludeServices);
+    bool announceService(stcService* p_pService,
+                         bool p_bAnnounce = true);
+
+    bool restart(void);
+
+protected:
+    // File: ..._Host
+    bool _close(void);
+
+    // NETIF
+    typeNetIfState _getNetIfState(void) const;
+    bool _checkNetIfState(void);
+
+    // DOMAIN NAMES
+    bool _allocDomainName(const char* p_pcNewDomainName,
+                          char*& p_rpcDomainName);
+    bool _releaseDomainName(char*& p_rpcDomainName);
+    bool _allocHostName(const char* p_pcHostName);
+    bool _releaseHostName(void);
+    bool _allocInstanceName(const char* p_pcInstanceName);
+    bool _releaseInstanceName(void);
+
+    // SERVICE
+    stcService* _allocService(const char* p_pcName,
+                              const char* p_pcServiceType,
+                              const char* p_pcProtocol,
+                              uint16_t p_u16Port);
+    bool _releaseService(stcService* p_pService);
+
+    // SERVICE TXT
+    stcServiceTxt* _allocServiceTxt(stcService* p_pService,
+                                    const char* p_pcKey,
+                                    const char* p_pcValue,
+                                    bool p_bTemp);
+    bool _releaseServiceTxt(stcService* p_pService,
+                            stcServiceTxt* p_pTxt);
+    stcServiceTxt* _updateServiceTxt(stcService* p_pService,
+                                     stcServiceTxt* p_pTxt,
+									 const char* p_pcValue,
+									 bool p_bTemp);
+    stcServiceTxt* _findServiceTxt(stcService* p_pService,
+                                   const char* p_pcKey);
+    stcServiceTxt* _addServiceTxt(stcService* p_pService,
+                                  const char* p_pcKey,
+								  const char* p_pcValue,
+								  bool p_bTemp);
+    stcServiceTxt* _answerKeyValue(const stcQuery p_pQuery,
+                                   const uint32_t p_u32AnswerIndex);
+    bool _collectServiceTxts(stcService& p_rService);
+    bool _releaseTempServiceTxts(stcService& p_rService);
+
+    // QUERIES
+    stcQuery* _allocQuery(stcQuery::enuQueryType p_QueryType);
+    bool _removeQuery(stcQuery* p_pQuery);
+    bool _removeLegacyQuery(void);
+    stcQuery* _findLegacyQuery(void);
+    bool _releaseQueries(void);
+    stcQuery* _findNextQueryByDomain(const stcRRDomain& p_Domain,
+                                     const stcQuery::enuQueryType p_QueryType,
+									 const stcQuery* p_pPrevQuery);
+    stcQuery* _installDomainQuery(stcRRDomain& p_Domain,
+                                  stcQuery::enuQueryType p_QueryType,
+                                  QueryCallbackFn p_fnCallback);
+    bool _hasQueriesWaitingForAnswers(void) const;
+    bool _executeQueryCallback(const stcQuery& p_Query,
+                               const stcQuery::stcAnswer& p_Answer,
+                               typeQueryAnswerType p_QueryAnswerTypeFlags,
+                               bool p_SetContent);
+
+
+    // File: ..._Host_Control
+    // RECEIVING
+    bool _parseMessage(void);
+    bool _parseQuery(const stcMsgHeader& p_Header);
+
+    bool _parseResponse(const stcMsgHeader& p_Header);
+    bool _processAnswers(const stcRRAnswer* p_pPTRAnswers);
+    bool _processPTRAnswer(const stcRRAnswerPTR* p_pPTRAnswer,
+                           bool& p_rbFoundNewKeyAnswer);
+    bool _processSRVAnswer(const stcRRAnswerSRV* p_pSRVAnswer,
+                           bool& p_rbFoundNewKeyAnswer);
+    bool _processTXTAnswer(const stcRRAnswerTXT* p_pTXTAnswer);
+#ifdef MDNS_IPV4_SUPPORT
+    bool _processAAnswer(const stcRRAnswerA* p_pAAnswer);
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+    bool _processAAAAAnswer(const stcRRAnswerAAAA* p_pAAAAAnswer);
+#endif
+
+    // PROBING
+    bool _updateProbeStatus(void);
+    bool _resetProbeStatus(bool p_bRestart = true);
+    bool _hasProbesWaitingForAnswers(void) const;
+    bool _sendHostProbe(void);
+    bool _sendServiceProbe(stcService& p_rService);
+    bool _cancelProbingForHost(void);
+    bool _cancelProbingForService(stcService& p_rService);
+    bool _callHostProbeResultCallback(bool p_bResult);
+    bool _callServiceProbeResultCallback(stcService& p_rService,
+                                         bool p_bResult);
+
+    // ANNOUNCE
+    bool _announce(bool p_bAnnounce,
+                   bool p_bIncludeServices);
+    bool _announceService(stcService& p_pService,
+                          bool p_bAnnounce = true);
+
+    // QUERY CACHE
+    bool _checkQueryCache(void);
+
+    uint32_t _replyMaskForHost(const stcRRHeader& p_RRHeader,
+                               bool* p_pbFullNameMatch = 0) const;
+    uint32_t _replyMaskForService(const stcRRHeader& p_RRHeader,
+                                  const stcService& p_Service,
+                                  bool* p_pbFullNameMatch = 0) const;
+
+
+    // File: ..._Host_Transfer
+    // SENDING
+    bool _sendMDNSMessage(stcSendParameter& p_SendParameter);
+    bool _sendMDNSMessage_Multicast(stcSendParameter& p_rSendParameter,
+                                    uint8_t p_IPProtocolTypes);
+    bool _prepareMDNSMessage(stcSendParameter& p_SendParameter);
+    bool _addMDNSQueryRecord(stcSendParameter& p_rSendParameter,
+                             const stcRRDomain& p_QueryDomain,
+                             uint16_t p_u16QueryType);
+    bool _sendMDNSQuery(const stcQuery& p_Query,
+                        stcQuery::stcAnswer* p_pKnownAnswers = 0);
+    bool _sendMDNSQuery(const stcRRDomain& p_QueryDomain,
+                        uint16_t p_u16RecordType,
+                        stcQuery::stcAnswer* p_pKnownAnswers = 0);
+
+    IPAddress _getResponderIPAddress(enuIPProtocolType p_IPProtocolType) const;
+
+    // RESOURCE RECORD
+    bool _readRRQuestion(stcRRQuestion& p_rQuestion);
+    bool _readRRAnswer(stcRRAnswer*& p_rpAnswer);
+#ifdef MDNS_IPV4_SUPPORT
+    bool _readRRAnswerA(stcRRAnswerA& p_rRRAnswerA,
+                        uint16_t p_u16RDLength);
+#endif
+    bool _readRRAnswerPTR(stcRRAnswerPTR& p_rRRAnswerPTR,
+                          uint16_t p_u16RDLength);
+    bool _readRRAnswerTXT(stcRRAnswerTXT& p_rRRAnswerTXT,
+                          uint16_t p_u16RDLength);
+#ifdef MDNS_IPV6_SUPPORT
+    bool _readRRAnswerAAAA(stcRRAnswerAAAA& p_rRRAnswerAAAA,
+                           uint16_t p_u16RDLength);
+#endif
+    bool _readRRAnswerSRV(stcRRAnswerSRV& p_rRRAnswerSRV,
+                          uint16_t p_u16RDLength);
+    bool _readRRAnswerGeneric(stcRRAnswerGeneric& p_rRRAnswerGeneric,
+                              uint16_t p_u16RDLength);
+
+    bool _readRRHeader(stcRRHeader& p_rHeader);
+    bool _readRRDomain(stcRRDomain& p_rRRDomain);
+    bool _readRRDomain_Loop(stcRRDomain& p_rRRDomain,
+                            uint8_t p_u8Depth);
+    bool _readRRAttributes(stcRRAttributes& p_rAttributes);
+
+    // DOMAIN NAMES
+    bool _buildDomainForHost(const char* p_pcHostName,
+                             stcRRDomain& p_rHostDomain) const;
+    bool _buildDomainForDNSSD(stcRRDomain& p_rDNSSDDomain) const;
+    bool _buildDomainForService(const stcService& p_Service,
+                                bool p_bIncludeName,
+                                stcRRDomain& p_rServiceDomain) const;
+    bool _buildDomainForService(const char* p_pcService,
+                                const char* p_pcProtocol,
+                                stcRRDomain& p_rServiceDomain) const;
+#ifdef MDNS_IPV4_SUPPORT
+    bool _buildDomainForReverseIPv4(IPAddress p_IPv4Address,
+                                    stcRRDomain& p_rReverseIPv4Domain) const;
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+    bool _buildDomainForReverseIPv6(IPAddress p_IPv4Address,
+                                    stcRRDomain& p_rReverseIPv6Domain) const;
+#endif
+
+    // UDP
+    bool _udpReadBuffer(unsigned char* p_pBuffer,
+                        size_t p_stLength);
+    bool _udpRead8(uint8_t& p_ru8Value);
+    bool _udpRead16(uint16_t& p_ru16Value);
+    bool _udpRead32(uint32_t& p_ru32Value);
+
+    bool _udpAppendBuffer(const unsigned char* p_pcBuffer,
+                          size_t p_stLength);
+    bool _udpAppend8(uint8_t p_u8Value);
+    bool _udpAppend16(uint16_t p_u16Value);
+    bool _udpAppend32(uint32_t p_u32Value);
+
+#if not defined ESP_8266_MDNS_INCLUDE || defined DEBUG_ESP_MDNS_RESPONDER
+    bool _udpDump(bool p_bMovePointer = false);
+    bool _udpDump(unsigned p_uOffset,
+                  unsigned p_uLength);
+#endif
+
+    // READ/WRITE MDNS STRUCTS
+    bool _readMDNSMsgHeader(stcMsgHeader& p_rMsgHeader);
+
+    bool _write8(uint8_t p_u8Value,
+                 stcSendParameter& p_rSendParameter);
+    bool _write16(uint16_t p_u16Value,
+                  stcSendParameter& p_rSendParameter);
+    bool _write32(uint32_t p_u32Value,
+                  stcSendParameter& p_rSendParameter);
+
+    bool _writeMDNSMsgHeader(const stcMsgHeader& p_MsgHeader,
+                             stcSendParameter& p_rSendParameter);
+    bool _writeMDNSRRAttributes(const stcRRAttributes& p_Attributes,
+                                stcSendParameter& p_rSendParameter);
+    bool _writeMDNSRRDomain(const stcRRDomain& p_Domain,
+                            stcSendParameter& p_rSendParameter);
+    bool _writeMDNSHostDomain(const char* m_pcHostName,
+                              bool p_bPrependRDLength,
+                              uint16_t p_u16AdditionalLength,
+                              stcSendParameter& p_rSendParameter);
+    bool _writeMDNSServiceDomain(const stcService& p_Service,
+                                 bool p_bIncludeName,
+                                 bool p_bPrependRDLength,
+                                 uint16_t p_u16AdditionalLength,
+                                 stcSendParameter& p_rSendParameter);
+
+    bool _writeMDNSQuestion(stcRRQuestion& p_Question,
+                            stcSendParameter& p_rSendParameter);
+
+#ifdef MDNS_IPV4_SUPPORT
+    bool _writeMDNSAnswer_A(IPAddress p_IPAddress,
+                            stcSendParameter& p_rSendParameter);
+    bool _writeMDNSAnswer_PTR_IPv4(IPAddress p_IPAddress,
+                                   stcSendParameter& p_rSendParameter);
+#endif
+    bool _writeMDNSAnswer_PTR_TYPE(stcService& p_rService,
+                                   stcSendParameter& p_rSendParameter);
+    bool _writeMDNSAnswer_PTR_NAME(stcService& p_rService,
+                                   stcSendParameter& p_rSendParameter);
+    bool _writeMDNSAnswer_TXT(stcService& p_rService,
+                              stcSendParameter& p_rSendParameter);
+#ifdef MDNS_IPV6_SUPPORT
+    bool _writeMDNSAnswer_AAAA(IPAddress p_IPAddress,
+                               stcSendParameter& p_rSendParameter);
+    bool _writeMDNSAnswer_PTR_IPv6(IPAddress p_IPAddress,
+                                   stcSendParameter& p_rSendParameter);
+#endif
+    bool _writeMDNSAnswer_SRV(stcService& p_rService,
+                              stcSendParameter& p_rSendParameter);
+    stcNSECBitmap* _createNSECBitmap(uint32_t p_u32NSECContent);
+    bool _writeMDNSNSECBitmap(const stcNSECBitmap& p_NSECBitmap,
+                              stcSendParameter& p_rSendParameter);
+    bool _writeMDNSAnswer_NSEC(uint32_t p_u32NSECContent,
+                               stcSendParameter& p_rSendParameter);
+#ifdef MDNS_IPV4_SUPPORT
+    bool _writeMDNSAnswer_NSEC_PTR_IPv4(IPAddress p_IPAddress,
+                                        stcSendParameter& p_rSendParameter);
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+    bool _writeMDNSAnswer_NSEC_PTR_IPv6(IPAddress p_IPAddress,
+                                        stcSendParameter& p_rSendParameter);
+#endif
+    bool _writeMDNSAnswer_NSEC(stcService& p_rService,
+                               uint32_t p_u32NSECContent,
+                               stcSendParameter& p_rSendParameter);
+
+
+    // File: ..._Host_Debug
+#if not defined ESP_8266_MDNS_INCLUDE || defined DEBUG_ESP_MDNS_RESPONDER
+    const char* _DH(const stcService* p_pMDNSService = 0) const;
+    const char* _service2String(const stcService* p_pMDNSService) const;
+
+    bool _printRRDomain(const stcRRDomain& p_rRRDomain) const;
+    bool _printRRAnswer(const stcRRAnswer& p_RRAnswer) const;
+    const char* _RRType2Name(uint16_t p_u16RRType) const;
+    const char* _RRClass2String(uint16_t p_u16RRClass,
+                                bool p_bIsQuery) const;
+    const char* _replyFlags2String(uint32_t p_u32ReplyFlags) const;
+    const char* _NSECBitmap2String(const stcNSECBitmap* p_pNSECBitmap) const;
+#endif
+
+
+public:
+    netif&                      m_rNetIf;
+    typeNetIfState              m_NetIfState;
+    UdpContext&                 m_rUDPContext;
+
+    char*                       m_pcHostName;
+    char*                       m_pcInstanceName;
+    stcService*                 m_pServices;
+    stcQuery*                   m_pQueries;
+    DynamicServiceTxtCallbackFn m_fnServiceTxtCallback;
+    stcProbeInformation_Host    m_HostProbeInformation;
+};
+using clsHostList = std::list<clsHost*>;
+

--- a/libraries/ESP8266mDNS/src/LEAmDNS2_Host_Control.cpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS2_Host_Control.cpp
@@ -1,0 +1,2207 @@
+/*
+    LEAmDNS2_Host_Control.cpp
+
+    License (MIT license):
+      Permission is hereby granted, free of charge, to any person obtaining a copy
+      of this software and associated documentation files (the "Software"), to deal
+      in the Software without restriction, including without limitation the rights
+      to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+      copies of the Software, and to permit persons to whom the Software is
+      furnished to do so, subject to the following conditions:
+
+      The above copyright notice and this permission notice shall be included in
+      all copies or substantial portions of the Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+      THE SOFTWARE.
+
+*/
+
+#include <arch/cc.h>
+#include <sys/time.h>
+#include <HardwareSerial.h>
+#include <IPAddress.h>
+#include <lwip/ip_addr.h>
+#include <WString.h>
+#include <cstdint>
+
+/*
+    ESP8266mDNS Control.cpp
+*/
+
+extern "C" {
+#include "user_interface.h"
+}
+
+#include "LEAmDNS2_lwIPdefs.h"
+#include "LEAmDNS2_Priv.h"
+
+namespace esp8266
+{
+/*
+    LEAmDNS
+*/
+namespace experimental
+{
+
+/**
+    RECEIVING
+*/
+
+/*
+    MDNSResponder::clsHost::_parseMessage
+*/
+bool MDNSResponder::clsHost::_parseMessage(void)
+{
+    DEBUG_EX_INFO(
+        unsigned long   ulStartTime = millis();
+        unsigned        uStartMemory = ESP.getFreeHeap();
+        DEBUG_OUTPUT.printf_P(PSTR("%s _parseMessage (Time: %lu ms, heap: %u bytes, from %s, to %s)\n"), _DH(), ulStartTime, uStartMemory,
+                              m_rUDPContext.getRemoteAddress().toString().c_str(),
+                              m_rUDPContext.getDestAddress().toString().c_str());
+    );
+    //DEBUG_EX_INFO(_udpDump(););
+
+    bool    bResult = false;
+
+    stcMsgHeader   header;
+    if (_readMDNSMsgHeader(header))
+    {
+        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _parseMessage: ID:%u QR:%u OP:%u AA:%u TC:%u RD:%u RA:%u R:%u QD:%u AN:%u NS:%u AR:%u\n"),
+                                            _DH(),
+                                            (unsigned)header.m_u16ID,
+                                            (unsigned)header.m_1bQR, (unsigned)header.m_4bOpcode, (unsigned)header.m_1bAA, (unsigned)header.m_1bTC, (unsigned)header.m_1bRD,
+                                            (unsigned)header.m_1bRA, (unsigned)header.m_4bRCode,
+                                            (unsigned)header.m_u16QDCount,
+                                            (unsigned)header.m_u16ANCount,
+                                            (unsigned)header.m_u16NSCount,
+                                            (unsigned)header.m_u16ARCount));
+        if (0 == header.m_4bOpcode)     // A standard query
+        {
+            if (header.m_1bQR)          // Received a response -> answers to a query
+            {
+                //DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("%s _parseMessage: Reading answers: ID:%u, Q:%u, A:%u, NS:%u, AR:%u\n"), _DH(), header.m_u16ID, header.m_u16QDCount, header.m_u16ANCount, header.m_u16NSCount, header.m_u16ARCount););
+                bResult = _parseResponse(header);
+            }
+            else                        // Received a query (Questions)
+            {
+                //DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("%s _parseMessage: Reading query: ID:%u, Q:%u, A:%u, NS:%u, AR:%u\n"), _DH(), header.m_u16ID, header.m_u16QDCount, header.m_u16ANCount, header.m_u16NSCount, header.m_u16ARCount););
+                bResult = _parseQuery(header);
+            }
+        }
+        else
+        {
+            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _parseMessage: Received UNEXPECTED opcode:%u. Ignoring message!\n"), _DH(), header.m_4bOpcode););
+            m_rUDPContext.flush();
+        }
+    }
+    else
+    {
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _parseMessage: FAILED to read header\n"), _DH()););
+        m_rUDPContext.flush();
+    }
+    DEBUG_EX_INFO(
+        unsigned    uFreeHeap = ESP.getFreeHeap();
+        DEBUG_OUTPUT.printf_P(PSTR("%s _parseMessage: Done (%s after %lu ms, ate %i bytes, remaining %u)\n\n"), _DH(), (bResult ? "Succeeded" : "FAILED"), (millis() - ulStartTime), (uStartMemory - uFreeHeap), uFreeHeap);
+    );
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::_parseQuery
+
+    Queries are of interest in two cases:
+    1. allow for tiebreaking while probing in the case of a race condition between two instances probing for
+      the same name at the same time
+    2. provide answers to questions for our host domain or any presented service
+
+    When reading the questions, a set of (planned) responses is created, eg. a reverse PTR question for the host domain
+    gets an A (IP address) response, a PTR question for the _services._dns-sd domain gets a PTR (type) response for any
+    registered service, ...
+
+    As any mDNS responder should be able to handle 'legacy' queries (from DNS clients), this case is handled here also.
+    Legacy queries have got only one (unicast) question and are directed to the local DNS port (not the multicast port).
+
+    1.
+*/
+bool MDNSResponder::clsHost::_parseQuery(const MDNSResponder::clsHost::stcMsgHeader& p_MsgHeader)
+{
+    bool    bResult = true;
+
+    stcSendParameter    sendParameter;
+    uint32_t                u32HostOrServiceReplies = 0;
+    for (uint16_t qd = 0; ((bResult) && (qd < p_MsgHeader.m_u16QDCount)); ++qd)
+    {
+        stcRRQuestion  questionRR;
+        if ((bResult = _readRRQuestion(questionRR)))
+        {
+            // Define host replies, BUT only answer queries after probing is done
+            u32HostOrServiceReplies =
+                sendParameter.m_u32HostReplyMask |= ((probeStatus())
+                                                     ? _replyMaskForHost(questionRR.m_Header, 0)
+                                                     : 0);
+            DEBUG_EX_INFO(if (u32HostOrServiceReplies) DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Host reply needed %s\n"), _DH(), _replyFlags2String(u32HostOrServiceReplies)););
+
+            // Check tiebreak need for host domain
+            if (enuProbingStatus::InProgress == m_HostProbeInformation.m_ProbingStatus)
+            {
+                bool    bFullNameMatch = false;
+                if ((_replyMaskForHost(questionRR.m_Header, &bFullNameMatch)) &&
+                    (bFullNameMatch))
+                {
+                    // We're in 'probing' state and someone is asking for our host domain: this might be
+                    // a race-condition: Two host with the same domain names try simutanously to probe their domains
+                    // See: RFC 6762, 8.2 (Tiebraking)
+                    // However, we're using a max. reduced approach for tiebreaking here: The higher IP-address wins!
+                    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Possible race-condition for host domain detected while probing.\n"), _DH()););
+                    Serial.printf_P(PSTR("%s _parseQuery: Possible race-condition for host domain detected while probing.\n"), _DH());
+
+                    m_HostProbeInformation.m_bTiebreakNeeded = true;
+                }
+            }
+
+            // Define service replies
+            for (stcService* pService = m_pServices; pService; pService = pService->m_pNext)
+            {
+                // Define service replies, BUT only answer queries after probing is done
+                uint32_t u32ReplyMaskForQuestion = ((pService->probeStatus())
+                                                    ? _replyMaskForService(questionRR.m_Header, *pService, 0)
+                                                    : 0);
+                u32HostOrServiceReplies |= (pService->m_u32ReplyMask |= u32ReplyMaskForQuestion);
+                DEBUG_EX_INFO(if (u32ReplyMaskForQuestion) DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Service reply needed: %s\n"), _DH(pService), _replyFlags2String(u32ReplyMaskForQuestion)););
+
+                // Check tiebreak need for service domain
+                if (enuProbingStatus::InProgress == pService->m_ProbeInformation.m_ProbingStatus)
+                {
+                    bool    bFullNameMatch = false;
+                    if ((_replyMaskForService(questionRR.m_Header, *pService, &bFullNameMatch)) &&
+                        (bFullNameMatch))
+                    {
+                        // We're in 'probing' state and someone is asking for this service domain: this might be
+                        // a race-condition: Two services with the same domain names try simutanously to probe their domains
+                        // See: RFC 6762, 8.2 (Tiebraking)
+                        // However, we're using a max. reduced approach for tiebreaking here: The 'higher' SRV host wins!
+                        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Possible race-condition for service domain detected while probing.\n"), _DH(pService)););
+                        Serial.printf_P(PSTR("%s _parseQuery: Possible race-condition for service domain detected while probing.\n"), _DH(pService));
+
+                        pService->m_ProbeInformation.m_bTiebreakNeeded = true;
+                    }
+                }
+            }
+
+            // Handle unicast and legacy specialities
+            // If only one question asks for unicast reply, the whole reply packet is send unicast
+            if (((DNS_MQUERY_PORT != m_rUDPContext.getRemotePort()) ||     // Unicast (maybe legacy) query OR
+                 (questionRR.m_bUnicast)) &&                                // Expressivly unicast query
+                (!sendParameter.m_bUnicast))
+            {
+
+                sendParameter.m_bUnicast = true;
+                //sendParameter.m_bCacheFlush = false;
+                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Unicast response asked for %s!\n"), _DH(), m_rUDPContext.getRemoteAddress().toString().c_str()););
+                //Serial.printf_P(PSTR("%s _parseQuery: Ignored Unicast response asked for by %s!\n"), _DH(), IPAddress(m_pUDPContext->getRemoteAddress()).toString().c_str());
+
+                if ((DNS_MQUERY_PORT != m_rUDPContext.getRemotePort()) &&  // Unicast (maybe legacy) query AND
+                    (1 == p_MsgHeader.m_u16QDCount) &&                          // Only one question AND
+                    ((sendParameter.m_u32HostReplyMask) ||                      //  Host replies OR
+                     (u32HostOrServiceReplies)))                                //  Host or service replies available
+                {
+                    // Local host check
+                    // We're a match for this legacy query, BUT
+                    // make sure, that the query comes from a local host
+#ifdef MDNS_IPV4_SUPPORT
+                    ip_info IPInfo_Local;
+#endif
+                    if (
+#ifdef MDNS_IPV4_SUPPORT
+                        (m_rUDPContext.getRemoteAddress().isV4()) &&
+                        ((wifi_get_ip_info(netif_get_index(&m_rNetIf), &IPInfo_Local))) &&
+                        (ip4_addr_netcmp(ip_2_ip4((const ip_addr_t*)m_rUDPContext.getRemoteAddress()), &IPInfo_Local.ip, &IPInfo_Local.netmask))
+#else
+                        (true)
+#endif
+                        &&
+#ifdef MDNS_IPV6_SUPPORT
+                        (m_rUDPContext.getRemoteAddress().isV6()) &&
+                        (ip6_addr_islinklocal(ip_2_ip6((const ip_addr_t*)m_rUDPContext.getRemoteAddress())))
+#else
+                        (true)
+#endif
+                    )
+                    {
+                        /*  ip_info IPInfo_Local;
+                            ip_info IPInfo_Remote;
+                            if (((IPInfo_Remote.ip.addr = m_pUDPContext->getRemoteAddress())) &&
+                            (((wifi_get_ip_info(SOFTAP_IF, &IPInfo_Local)) &&
+                              (ip4_addr_netcmp(&IPInfo_Remote.ip, &IPInfo_Local.ip, &IPInfo_Local.netmask))) ||  // Remote IP in SOFTAP's subnet OR
+                             ((wifi_get_ip_info(STATION_IF, &IPInfo_Local)) &&
+                              (ip4_addr_netcmp(&IPInfo_Remote.ip, &IPInfo_Local.ip, &IPInfo_Local.netmask)))))   // Remote IP in STATION's subnet
+                            {*/
+                        Serial.println("\n\n\nUNICAST QUERY\n\n");
+                        DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Legacy query from local host %s!\n"), _DH(), m_rUDPContext.getRemoteAddress().toString().c_str()););
+
+                        sendParameter.m_u16ID = p_MsgHeader.m_u16ID;
+                        sendParameter.m_bLegacyQuery = true;
+                        sendParameter.m_bCacheFlush = false;
+                        sendParameter.m_pQuestions = new stcRRQuestion;
+                        if ((bResult = (0 != sendParameter.m_pQuestions)))
+                        {
+                            sendParameter.m_pQuestions->m_Header.m_Domain = questionRR.m_Header.m_Domain;
+                            sendParameter.m_pQuestions->m_Header.m_Attributes.m_u16Type = questionRR.m_Header.m_Attributes.m_u16Type;
+                            sendParameter.m_pQuestions->m_Header.m_Attributes.m_u16Class = questionRR.m_Header.m_Attributes.m_u16Class;
+                        }
+                        else
+                        {
+                            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: FAILED to add legacy question!\n"), _DH()););
+                        }
+                    }
+                    else
+                    {
+                        Serial.println("\n\n\nINVALID UNICAST QUERY\n\n");
+                        DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Legacy query from NON-LOCAL host!\n"), _DH()););
+                        bResult = false;
+                    }
+                }
+            }
+        }
+        else
+        {
+            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: FAILED to read question!\n"), _DH()););
+        }
+    }   // for questions
+
+    //DEBUG_EX_INFO(if (u8HostOrServiceReplies) DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Reply needed: %u (%s: %s->%s)\n"), _DH(), u8HostOrServiceReplies, clsTimeSyncer::timestr(), IPAddress(m_pUDPContext->getRemoteAddress()).toString().c_str(), IPAddress(m_pUDPContext->getDestAddress()).toString().c_str()););
+
+    // Handle known answers
+    uint32_t    u32Answers = (p_MsgHeader.m_u16ANCount + p_MsgHeader.m_u16NSCount + p_MsgHeader.m_u16ARCount);
+    if ((u32HostOrServiceReplies) &&
+        (u32Answers))
+    {
+        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Reading known answers(%u):\n"), _DH(), u32Answers););
+
+        for (uint32_t an = 0; ((bResult) && (an < u32Answers)); ++an)
+        {
+            stcRRAnswer*   pKnownRRAnswer = 0;
+            if (((bResult = _readRRAnswer(pKnownRRAnswer))) &&
+                (pKnownRRAnswer))
+            {
+
+                if ((DNS_RRTYPE_ANY != pKnownRRAnswer->m_Header.m_Attributes.m_u16Type) &&                  // No ANY type answer
+                    (DNS_RRCLASS_ANY != (pKnownRRAnswer->m_Header.m_Attributes.m_u16Class & (~0x8000))))    // No ANY class answer
+                {
+
+                    // Find match between planned answer (sendParameter.m_u8HostReplyMask) and this 'known answer'
+                    uint32_t u32HostMatchMask = (sendParameter.m_u32HostReplyMask & _replyMaskForHost(pKnownRRAnswer->m_Header));
+                    if ((u32HostMatchMask) &&                                           // The RR in the known answer matches an RR we are planning to send, AND
+                        ((MDNS_HOST_TTL / 2) <= pKnownRRAnswer->m_u32TTL))              // The TTL of the known answer is longer than half of the new host TTL (120s)
+                    {
+
+                        // Compare contents
+                        if (enuAnswerType::PTR == pKnownRRAnswer->answerType())
+                        {
+                            stcRRDomain    hostDomain;
+                            if ((_buildDomainForHost(m_pcHostName, hostDomain)) &&
+                                (((stcRRAnswerPTR*)pKnownRRAnswer)->m_PTRDomain == hostDomain))
+                            {
+                                // Host domain match
+#ifdef MDNS_IPV4_SUPPORT
+                                if (u32HostMatchMask & static_cast<uint32_t>(enuContentFlag::PTR_IPv4))
+                                {
+                                    // IPv4 PTR was asked for, but is already known -> skipping
+                                    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: IPv4 PTR already known... skipping!\n"), _DH()););
+                                    sendParameter.m_u32HostReplyMask &= ~static_cast<uint32_t>(enuContentFlag::PTR_IPv4);
+                                }
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+                                if (u32HostMatchMask & static_cast<uint32_t>(enuContentFlag::PTR_IPv6))
+                                {
+                                    // IPv6 PTR was asked for, but is already known -> skipping
+                                    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: IPv6 PTR already known... skipping!\n"), _DH()););
+                                    sendParameter.m_u32HostReplyMask &= ~static_cast<uint32_t>(enuContentFlag::PTR_IPv6);
+                                }
+#endif
+                            }
+                        }
+                        else if (u32HostMatchMask & static_cast<uint32_t>(enuContentFlag::A))
+                        {
+                            // IPv4 address was asked for
+#ifdef MDNS_IPV4_SUPPORT
+                            if ((enuAnswerType::A == pKnownRRAnswer->answerType()) &&
+                                (((stcRRAnswerA*)pKnownRRAnswer)->m_IPAddress == _getResponderIPAddress(enuIPProtocolType::V4)))
+                            {
+
+                                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: IPv4 address already known... skipping!\n"), _DH()););
+                                sendParameter.m_u32HostReplyMask &= ~static_cast<uint32_t>(enuContentFlag::A);
+                            }   // else: RData NOT IPv4 length !!
+#endif
+                        }
+                        else if (u32HostMatchMask & static_cast<uint32_t>(enuContentFlag::AAAA))
+                        {
+                            // IPv6 address was asked for
+#ifdef MDNS_IPV6_SUPPORT
+                            if ((enuAnswerType::AAAA == pKnownRRAnswer->answerType()) &&
+                                (((stcRRAnswerAAAA*)pKnownRRAnswer)->m_IPAddress == _getResponderIPAddress(enuIPProtocolType::V6)))
+                            {
+
+                                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: IPv6 address already known... skipping!\n"), _DH()););
+                                sendParameter.m_u32HostReplyMask &= ~static_cast<uint32_t>(enuContentFlag::AAAA);
+                            }   // else: RData NOT IPv6 length !!
+#endif
+                        }
+                    }   // Host match /*and TTL*/
+
+                    //
+                    // Check host tiebreak possibility
+                    if (m_HostProbeInformation.m_bTiebreakNeeded)
+                    {
+                        stcRRDomain    hostDomain;
+                        if ((_buildDomainForHost(m_pcHostName, hostDomain)) &&
+                            (pKnownRRAnswer->m_Header.m_Domain == hostDomain))
+                        {
+                            // Host domain match
+#ifdef MDNS_IPV4_SUPPORT
+                            if (enuAnswerType::A == pKnownRRAnswer->answerType())
+                            {
+                                // CHECK
+                                IPAddress   localIPAddress(_getResponderIPAddress(enuIPProtocolType::V4));
+                                if (((stcRRAnswerA*)pKnownRRAnswer)->m_IPAddress == localIPAddress)
+                                {
+                                    // SAME IP address -> We've received an old message from ourselfs (same IP)
+                                    DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Tiebreak (IPv4) WON (was an old message)!\n"), _DH()););
+                                    m_HostProbeInformation.m_bTiebreakNeeded = false;
+                                }
+                                else
+                                {
+                                    if ((uint32_t)(((stcRRAnswerA*)pKnownRRAnswer)->m_IPAddress) > (uint32_t)localIPAddress)   // The OTHER IP is 'higher' -> LOST
+                                    {
+                                        // LOST tiebreak
+                                        DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Tiebreak (IPv4) LOST (lower)!\n"), _DH()););
+                                        _cancelProbingForHost();
+                                        m_HostProbeInformation.m_bTiebreakNeeded = false;
+                                    }
+                                    else    // WON tiebreak
+                                    {
+                                        //TiebreakState = TiebreakState_Won;    // We received an 'old' message from ourselfs -> Just ignore
+                                        DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Tiebreak (IPv4) WON (higher IP)!\n"), _DH()););
+                                        m_HostProbeInformation.m_bTiebreakNeeded = false;
+                                    }
+                                }
+                            }
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+                            if (enuAnswerType::AAAA == pKnownRRAnswer->answerType())
+                            {
+                                // TODO / CHECK
+                                IPAddress   localIPAddress(_getResponderIPAddress(enuIPProtocolType::V6));
+                                if (((stcRRAnswerAAAA*)pKnownRRAnswer)->m_IPAddress == localIPAddress)
+                                {
+                                    // SAME IP address -> We've received an old message from ourselfs (same IP)
+                                    DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Tiebreak (IPv6) WON (was an old message)!\n"), _DH()););
+                                    m_HostProbeInformation.m_bTiebreakNeeded = false;
+                                }
+                                else
+                                {
+                                    if ((uint32_t)(((stcRRAnswerAAAA*)pKnownRRAnswer)->m_IPAddress) > (uint32_t)localIPAddress)   // The OTHER IP is 'higher' -> LOST
+                                    {
+                                        // LOST tiebreak
+                                        DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Tiebreak (IPv6) LOST (lower)!\n"), _DH()););
+                                        _cancelProbingForHost();
+                                        m_HostProbeInformation.m_bTiebreakNeeded = false;
+                                    }
+                                    else    // WON tiebreak
+                                    {
+                                        //TiebreakState = TiebreakState_Won;    // We received an 'old' message from ourselfs -> Just ignore
+                                        DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Tiebreak (IPv6) WON (higher IP)!\n"), _DH()););
+                                        m_HostProbeInformation.m_bTiebreakNeeded = false;
+                                    }
+                                }
+                            }
+#endif
+                        }
+                    }   // Host tiebreak possibility
+
+                    // Check service answers
+                    for (stcService* pService = m_pServices; pService; pService = pService->m_pNext)
+                    {
+
+                        uint32_t    u32ServiceMatchMask = (pService->m_u32ReplyMask & _replyMaskForService(pKnownRRAnswer->m_Header, *pService));
+
+                        if ((u32ServiceMatchMask) &&                                // The RR in the known answer matches an RR we are planning to send, AND
+                            ((MDNS_SERVICE_TTL / 2) <= pKnownRRAnswer->m_u32TTL))   // The TTL of the known answer is longer than half of the new service TTL (4500s)
+                        {
+
+                            if (enuAnswerType::PTR == pKnownRRAnswer->answerType())
+                            {
+                                stcRRDomain    serviceDomain;
+                                if ((u32ServiceMatchMask & static_cast<uint32_t>(enuContentFlag::PTR_TYPE)) &&
+                                    (_buildDomainForService(*pService, false, serviceDomain)) &&
+                                    (serviceDomain == ((stcRRAnswerPTR*)pKnownRRAnswer)->m_PTRDomain))
+                                {
+                                    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Service type PTR already known... skipping!\n"), _DH()););
+                                    pService->m_u32ReplyMask &= ~static_cast<uint32_t>(enuContentFlag::PTR_TYPE);
+                                }
+                                if ((u32ServiceMatchMask & static_cast<uint32_t>(enuContentFlag::PTR_NAME)) &&
+                                    (_buildDomainForService(*pService, true, serviceDomain)) &&
+                                    (serviceDomain == ((stcRRAnswerPTR*)pKnownRRAnswer)->m_PTRDomain))
+                                {
+                                    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Service name PTR already known... skipping!\n"), _DH()););
+                                    pService->m_u32ReplyMask &= ~static_cast<uint32_t>(enuContentFlag::PTR_NAME);
+                                }
+                            }
+                            else if (u32ServiceMatchMask & static_cast<uint32_t>(enuContentFlag::SRV))
+                            {
+                                DEBUG_EX_ERR(if (enuAnswerType::SRV != pKnownRRAnswer->answerType()) DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: ERROR! INVALID answer type (SRV)!\n"), _DH()););
+                                stcRRDomain    hostDomain;
+                                if ((_buildDomainForHost(m_pcHostName, hostDomain)) &&
+                                    (hostDomain == ((stcRRAnswerSRV*)pKnownRRAnswer)->m_SRVDomain))    // Host domain match
+                                {
+
+                                    if ((MDNS_SRV_PRIORITY == ((stcRRAnswerSRV*)pKnownRRAnswer)->m_u16Priority) &&
+                                        (MDNS_SRV_WEIGHT == ((stcRRAnswerSRV*)pKnownRRAnswer)->m_u16Weight) &&
+                                        (pService->m_u16Port == ((stcRRAnswerSRV*)pKnownRRAnswer)->m_u16Port))
+                                    {
+
+                                        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Service SRV answer already known... skipping!\n"), _DH()););
+                                        pService->m_u32ReplyMask &= ~static_cast<uint32_t>(enuContentFlag::SRV);
+                                    }   // else: Small differences -> send update message
+                                }
+                            }
+                            else if (u32ServiceMatchMask & static_cast<uint32_t>(enuContentFlag::TXT))
+                            {
+                                DEBUG_EX_ERR(if (enuAnswerType::TXT != pKnownRRAnswer->answerType()) DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: ERROR! INVALID answer type (TXT)!\n"), _DH()););
+                                _collectServiceTxts(*pService);
+                                if (pService->m_Txts == ((stcRRAnswerTXT*)pKnownRRAnswer)->m_Txts)
+                                {
+                                    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Service TXT answer already known... skipping!\n"), _DH()););
+                                    pService->m_u32ReplyMask &= ~static_cast<uint32_t>(enuContentFlag::TXT);
+                                }
+                                _releaseTempServiceTxts(*pService);
+                            }
+                        }   // Service match and enough TTL
+
+                        //
+                        // Check service tiebreak possibility
+                        if (pService->m_ProbeInformation.m_bTiebreakNeeded)
+                        {
+                            stcRRDomain    serviceDomain;
+                            if ((_buildDomainForService(*pService, true, serviceDomain)) &&
+                                (pKnownRRAnswer->m_Header.m_Domain == serviceDomain))
+                            {
+                                // Service domain match
+                                if (enuAnswerType::SRV == pKnownRRAnswer->answerType())
+                                {
+                                    stcRRDomain    hostDomain;
+                                    if ((_buildDomainForHost(m_pcHostName, hostDomain)) &&
+                                        (hostDomain == ((stcRRAnswerSRV*)pKnownRRAnswer)->m_SRVDomain))    // Host domain match
+                                    {
+
+                                        // We've received an old message from ourselfs (same SRV)
+                                        DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Tiebreak (SRV) won (was an old message)!\n"), _DH()););
+                                        pService->m_ProbeInformation.m_bTiebreakNeeded = false;
+                                    }
+                                    else
+                                    {
+                                        if (((stcRRAnswerSRV*)pKnownRRAnswer)->m_SRVDomain > hostDomain)   // The OTHER domain is 'higher' -> LOST
+                                        {
+                                            // LOST tiebreak
+                                            DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Tiebreak (SRV) LOST (lower)!\n"), _DH()););
+                                            _cancelProbingForService(*pService);
+                                            pService->m_ProbeInformation.m_bTiebreakNeeded = false;
+                                        }
+                                        else    // WON tiebreak
+                                        {
+                                            //TiebreakState = TiebreakState_Won;    // We received an 'old' message from ourselfs -> Just ignore
+                                            DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Tiebreak (SRV) won (higher)!\n"), _DH()););
+                                            pService->m_ProbeInformation.m_bTiebreakNeeded = false;
+                                        }
+                                    }
+                                }
+                            }
+                        }   // service tiebreak possibility
+                    }   // for services
+                }   // ANY answers
+            }
+            else
+            {
+                DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: FAILED to read known answer!\n"), _DH()););
+            }
+
+            if (pKnownRRAnswer)
+            {
+                delete pKnownRRAnswer;
+                pKnownRRAnswer = 0;
+            }
+        }   // for answers
+    }
+    else
+    {
+        DEBUG_EX_INFO(if (u32Answers) DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Skipped %u known answers!\n"), _DH(), u32Answers););
+        m_rUDPContext.flush();
+    }
+
+    if (bResult)
+    {
+        // Check, if a reply is needed
+        uint32_t    u32ReplyNeeded = sendParameter.m_u32HostReplyMask;
+        for (stcService* pService = m_pServices; pService; pService = pService->m_pNext)
+        {
+            u32ReplyNeeded |= pService->m_u32ReplyMask;
+        }
+
+        if (u32ReplyNeeded)
+        {
+            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Sending answer(%s)...\n"), _DH(), _replyFlags2String(u32ReplyNeeded)););
+
+            sendParameter.m_Response = stcSendParameter::enuResponseType::Response;
+            sendParameter.m_bAuthorative = true;
+
+            bResult = _sendMDNSMessage(sendParameter);
+        }
+        DEBUG_EX_INFO(
+            else
+        {
+            DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: No reply needed\n"), _DH());
+        }
+        );
+    }
+    else
+    {
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: Something FAILED!\n"), _DH()););
+        m_rUDPContext.flush();
+    }
+
+    //
+    // Check and reset tiebreak-states
+    if (m_HostProbeInformation.m_bTiebreakNeeded)
+    {
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: UNSOLVED tiebreak-need for host domain!\n"), _DH()););
+        m_HostProbeInformation.m_bTiebreakNeeded = false;
+    }
+    for (stcService* pService = m_pServices; pService; pService = pService->m_pNext)
+    {
+        if (pService->m_ProbeInformation.m_bTiebreakNeeded)
+        {
+            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: UNSOLVED tiebreak-need for service domain '%s')\n"), _DH(), _service2String(pService)););
+            pService->m_ProbeInformation.m_bTiebreakNeeded = false;
+        }
+    }
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _parseQuery: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::_parseResponse
+
+    Responses are of interest in two cases:
+    1. find domain name conflicts while probing
+    2. get answers to service queries
+
+    In both cases any included questions are ignored
+
+    1. If any answer has a domain name similar to one of the domain names we're planning to use (and are probing for),
+      then we've got a 'probing conflict'. The conflict has to be solved on our side of the conflict (eg. by
+      setting a new hostname and restart probing). The callback 'm_fnProbeResultCallback' is called with
+      'p_bProbeResult=false' in this case.
+
+    2. Service queries like '_http._tcp.local' will (if available) produce PTR, SRV, TXT and A/AAAA answers.
+      All stored answers are pivoted by the service instance name (from the PTR record). Other answer parts,
+      like host domain or IP address are than attached to this element.
+      Any answer part carries a TTL, this is also stored (incl. the reception time); if the TTL is '0' the
+      answer (part) is withdrawn by the sender and should be removed from any cache. RFC 6762, 10.1 proposes to
+      set the caches TTL-value to 1 second in such a case and to delete the item only, if no update has
+      has taken place in this second.
+      Answer parts may arrive in 'unsorted' order, so they are grouped into three levels:
+      Level 1: PRT - names the service instance (and is used as pivot), voids all other parts if is withdrawn or outdates
+      Level 2: SRV - links the instance name to a host domain and port, voids A/AAAA parts if is withdrawn or outdates
+               TXT - links the instance name to services TXTs
+      Level 3: A/AAAA - links the host domain to an IP address
+*/
+bool MDNSResponder::clsHost::_parseResponse(const MDNSResponder::clsHost::stcMsgHeader& p_MsgHeader)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _parseResponse\n")););
+    //DEBUG_EX_INFO(_udpDump(););
+
+    bool    bResult = false;
+
+    // A response should be the result of a query or a probe
+    if ((_hasQueriesWaitingForAnswers()) ||     // Waiting for query answers OR
+        (_hasProbesWaitingForAnswers()))        // Probe responses
+    {
+
+        DEBUG_EX_INFO(
+            DEBUG_OUTPUT.printf_P(PSTR("%s _parseResponse: Received a response\n"), _DH());
+            //_udpDump();
+        );
+
+        bResult = true;
+        //
+        // Ignore questions here
+        stcRRQuestion  dummyRRQ;
+        for (uint16_t qd = 0; ((bResult) && (qd < p_MsgHeader.m_u16QDCount)); ++qd)
+        {
+            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _parseResponse: Received a response containing a question... ignoring!\n"), _DH()););
+            bResult = _readRRQuestion(dummyRRQ);
+        }   // for queries
+
+        //
+        // Read and collect answers
+        stcRRAnswer*   pCollectedRRAnswers = 0;
+        uint32_t            u32NumberOfAnswerRRs = (p_MsgHeader.m_u16ANCount + p_MsgHeader.m_u16NSCount + p_MsgHeader.m_u16ARCount);
+        for (uint32_t an = 0; ((bResult) && (an < u32NumberOfAnswerRRs)); ++an)
+        {
+            stcRRAnswer*   pRRAnswer = 0;
+            if (((bResult = _readRRAnswer(pRRAnswer))) &&
+                (pRRAnswer))
+            {
+                //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _parseResponse: ADDING answer!\n")););
+                pRRAnswer->m_pNext = pCollectedRRAnswers;
+                pCollectedRRAnswers = pRRAnswer;
+            }
+            else
+            {
+                DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _parseResponse: FAILED to read answer!\n"), _DH()););
+                if (pRRAnswer)
+                {
+                    delete pRRAnswer;
+                    pRRAnswer = 0;
+                }
+                bResult = false;
+            }
+        }   // for answers
+
+        //
+        // Process answers
+        if (bResult)
+        {
+            bResult = ((!pCollectedRRAnswers) ||
+                       (_processAnswers(pCollectedRRAnswers)));
+        }
+        else    // Some failure while reading answers
+        {
+            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _parseResponse: FAILED to read answers!\n"), _DH()););
+            m_rUDPContext.flush();
+        }
+
+        // Delete collected answers
+        while (pCollectedRRAnswers)
+        {
+            //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _parseResponse: DELETING answer!\n"), _DH()););
+            stcRRAnswer*   pNextAnswer = pCollectedRRAnswers->m_pNext;
+            delete pCollectedRRAnswers;
+            pCollectedRRAnswers = pNextAnswer;
+        }
+    }
+    else    // Received an unexpected response -> ignore
+    {
+        DEBUG_EX_INFO(
+            DEBUG_OUTPUT.printf_P(PSTR("%s _parseResponse: Received an unexpected response... ignoring!\n"), _DH());
+            /*
+                DEBUG_OUTPUT.printf_P(PSTR("%s _parseResponse: Received an unexpected response... ignoring!\nDUMP:\n"), _DH());
+                bool    bDumpResult = true;
+                for (uint16_t qd=0; ((bDumpResult) && (qd<p_MsgHeader.m_u16QDCount)); ++qd) {
+                stcRRQuestion  questionRR;
+                bDumpResult = _readRRQuestion(questionRR);
+                }   // for questions
+                // Handle known answers
+                uint32_t    u32Answers = (p_MsgHeader.m_u16ANCount + p_MsgHeader.m_u16NSCount + p_MsgHeader.m_u16ARCount);
+                for (uint32_t an=0; ((bDumpResult) && (an<u32Answers)); ++an) {
+                stcRRAnswer*   pRRAnswer = 0;
+                bDumpResult = _readRRAnswer(pRRAnswer);
+                if (pRRAnswer) {
+                    delete pRRAnswer;
+                    pRRAnswer = 0;
+                }
+                }
+            */
+        );
+        m_rUDPContext.flush();
+        bResult = true;
+    }
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _parseResponse: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::_processAnswers
+    Host:
+    A (0x01):               eg. esp8266.local A OP TTL 123.456.789.012
+    AAAA (01Cx):            eg. esp8266.local AAAA OP TTL 1234:5678::90
+    PTR (0x0C, IPv4):       eg. 012.789.456.123.in-addr.arpa PTR OP TTL esp8266.local
+    PTR (0x0C, IPv6):       eg. 90.0.0.0.0.0.0.0.0.0.0.0.78.56.34.12.ip6.arpa PTR OP TTL esp8266.local
+    Service:
+    PTR (0x0C, srv name):   eg. _http._tcp.local PTR OP TTL MyESP._http._tcp.local
+    PTR (0x0C, srv type):   eg. _services._dns-sd._udp.local PTR OP TTL _http._tcp.local
+    SRV (0x21):             eg. MyESP._http._tcp.local SRV OP TTL PRIORITY WEIGHT PORT esp8266.local
+    TXT (0x10):             eg. MyESP._http._tcp.local TXT OP TTL c#=1
+
+*/
+bool MDNSResponder::clsHost::_processAnswers(const MDNSResponder::clsHost::stcRRAnswer* p_pAnswers)
+{
+    bool    bResult = false;
+
+    if (p_pAnswers)
+    {
+        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _processAnswers: Processing answers...\n"), _DH()););
+        bResult = true;
+
+        // Answers may arrive in an unexpected order. So we loop our answers as long, as we
+        // can connect new information to service queries
+        bool    bFoundNewKeyAnswer;
+        do
+        {
+            bFoundNewKeyAnswer = false;
+
+            const stcRRAnswer* pRRAnswer = p_pAnswers;
+            while ((pRRAnswer) &&
+                   (bResult))
+            {
+                // 1. level answer (PTR)
+                if (enuAnswerType::PTR == pRRAnswer->answerType())
+                {
+                    // eg. _http._tcp.local PTR xxxx xx MyESP._http._tcp.local
+                    bResult = _processPTRAnswer((stcRRAnswerPTR*)pRRAnswer, bFoundNewKeyAnswer);   // May 'enable' new SRV or TXT answers to be linked to queries
+                }
+                // 2. level answers
+                // SRV -> host domain and port
+                else if (enuAnswerType::SRV == pRRAnswer->answerType())
+                {
+                    // eg. MyESP._http._tcp.local SRV xxxx xx yy zz 5000 esp8266.local
+                    bResult = _processSRVAnswer((stcRRAnswerSRV*)pRRAnswer, bFoundNewKeyAnswer);   // May 'enable' new A/AAAA answers to be linked to queries
+                }
+                // TXT -> Txts
+                else if (enuAnswerType::TXT == pRRAnswer->answerType())
+                {
+                    // eg. MyESP_http._tcp.local TXT xxxx xx c#=1
+                    bResult = _processTXTAnswer((stcRRAnswerTXT*)pRRAnswer);
+                }
+                // 3. level answers
+#ifdef MDNS_IPV4_SUPPORT
+                // A -> IPv4Address
+                else if (enuAnswerType::A == pRRAnswer->answerType())
+                {
+                    // eg. esp8266.local A xxxx xx 192.168.2.120
+                    bResult = _processAAnswer((stcRRAnswerA*)pRRAnswer);
+                }
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+                // AAAA -> IPv6Address
+                else if (enuAnswerType::AAAA == pRRAnswer->answerType())
+                {
+                    // eg. esp8266.local AAAA xxxx xx 09cf::0c
+                    bResult = _processAAAAAnswer((stcRRAnswerAAAA*)pRRAnswer);
+                }
+#endif
+
+                // Finally check for probing conflicts
+                // Host domain
+                if ((enuProbingStatus::InProgress == m_HostProbeInformation.m_ProbingStatus) &&
+                    ((enuAnswerType::A == pRRAnswer->answerType()) ||
+                     (enuAnswerType::AAAA == pRRAnswer->answerType())))
+                {
+
+                    stcRRDomain    hostDomain;
+                    if ((_buildDomainForHost(m_pcHostName, hostDomain)) &&
+                        (pRRAnswer->m_Header.m_Domain == hostDomain))
+                    {
+
+                        bool    bPossibleEcho = false;
+#ifdef MDNS_IPV4_SUPPORT
+                        if ((enuAnswerType::A == pRRAnswer->answerType()) &&
+                            (((stcRRAnswerA*)pRRAnswer)->m_IPAddress == _getResponderIPAddress(enuIPProtocolType::V4)))
+                        {
+
+                            bPossibleEcho = true;
+                        }
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+                        if ((enuAnswerType::AAAA == pRRAnswer->answerType()) &&
+                            (((stcRRAnswerAAAA*)pRRAnswer)->m_IPAddress == _getResponderIPAddress(enuIPProtocolType::V6)))
+                        {
+
+                            bPossibleEcho = true;
+                        }
+#endif
+                        if (!bPossibleEcho)
+                        {
+                            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _processAnswers: Probing CONFLICT found with '%s.local'\n"), _DH(), m_pcHostName););
+                            _cancelProbingForHost();
+                        }
+                        else
+                        {
+                            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _processAnswers: Ignoring CONFLICT found with '%s.local' as echo!\n"), _DH(), m_pcHostName););
+                        }
+                    }
+                }
+                // Service domains
+                for (stcService* pService = m_pServices; pService; pService = pService->m_pNext)
+                {
+                    if ((enuProbingStatus::InProgress == pService->m_ProbeInformation.m_ProbingStatus) &&
+                        ((enuAnswerType::TXT == pRRAnswer->answerType()) ||
+                         (enuAnswerType::SRV == pRRAnswer->answerType())))
+                    {
+
+                        stcRRDomain    serviceDomain;
+                        if ((_buildDomainForService(*pService, true, serviceDomain)) &&
+                            (pRRAnswer->m_Header.m_Domain == serviceDomain))
+                        {
+
+                            // TODO: Echo management needed?
+                            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _processAnswers: Probing CONFLICT found with '%s'\n"), _DH(), _service2String(pService)););
+                            _cancelProbingForService(*pService);
+                        }
+                    }
+                }
+
+                pRRAnswer = pRRAnswer->m_pNext; // Next collected answer
+            }   // while (answers)
+        } while ((bFoundNewKeyAnswer) &&
+                 (bResult));
+    }   // else: No answers provided
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _processAnswers: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::_processPTRAnswer (level 1)
+*/
+bool MDNSResponder::clsHost::_processPTRAnswer(const MDNSResponder::clsHost::stcRRAnswerPTR* p_pPTRAnswer,
+                                               bool& p_rbFoundNewKeyAnswer)
+{
+    bool    bResult = false;
+
+    if ((bResult = (0 != p_pPTRAnswer)))
+    {
+        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _processPTRAnswer: Processing PTR answers...\n"), _DH()););
+        // eg. _http._tcp.local PTR xxxx xx MyESP._http._tcp.local
+        // Check pending service queries for eg. '_http._tcp'
+
+        stcQuery*    pQuery = _findNextQueryByDomain(p_pPTRAnswer->m_Header.m_Domain, stcQuery::enuQueryType::Service, 0);
+        while (pQuery)
+        {
+            if (pQuery->m_bAwaitingAnswers)
+            {
+                // Find answer for service domain (eg. MyESP._http._tcp.local)
+                stcQuery::stcAnswer* pSQAnswer = pQuery->findAnswerForServiceDomain(p_pPTRAnswer->m_PTRDomain);
+                if (pSQAnswer)      // existing answer
+                {
+                    if (p_pPTRAnswer->m_u32TTL)     // Received update message
+                    {
+                        pSQAnswer->m_TTLServiceDomain.set(p_pPTRAnswer->m_u32TTL);    // Update TTL tag
+                        DEBUG_EX_INFO(
+                            DEBUG_OUTPUT.printf_P(PSTR("%s _processPTRAnswer: Updated TTL(%lu) for "), _DH(), p_pPTRAnswer->m_u32TTL);
+                            _printRRDomain(pSQAnswer->m_ServiceDomain);
+                            DEBUG_OUTPUT.printf_P(PSTR("\n"));
+                        );
+                    }
+                    else                            // received goodbye-message
+                    {
+                        pSQAnswer->m_TTLServiceDomain.prepareDeletion();    // Prepare answer deletion according to RFC 6762, 10.1
+                        DEBUG_EX_INFO(
+                            DEBUG_OUTPUT.printf_P(PSTR("%s _processPTRAnswer: 'Goodbye' received for "), _DH());
+                            _printRRDomain(pSQAnswer->m_ServiceDomain);
+                            DEBUG_OUTPUT.printf_P(PSTR("\n"));
+                        );
+                    }
+                }
+                else if ((p_pPTRAnswer->m_u32TTL) &&                                // Not just a goodbye-message
+                         ((pSQAnswer = new stcQuery::stcAnswer)))        // Not yet included -> add answer
+                {
+                    pSQAnswer->m_ServiceDomain = p_pPTRAnswer->m_PTRDomain;
+                    pSQAnswer->m_QueryAnswerFlags |= static_cast<typeQueryAnswerType>(enuQueryAnswerType::ServiceDomain);
+                    pSQAnswer->m_TTLServiceDomain.set(p_pPTRAnswer->m_u32TTL);
+                    //pSQAnswer->releaseServiceDomain();
+
+                    bResult = pQuery->addAnswer(pSQAnswer);
+
+                    DEBUG_EX_INFO(
+                        DEBUG_OUTPUT.printf_P(PSTR("%s _processPTRAnswer: Added service domain to answer: "), _DH());
+                        _printRRDomain(pSQAnswer->m_ServiceDomain);
+                        DEBUG_OUTPUT.println();
+                    );
+
+                    p_rbFoundNewKeyAnswer = true;
+                    _executeQueryCallback(*pQuery, *pSQAnswer, static_cast<typeQueryAnswerType>(enuQueryAnswerType::ServiceDomain), true);
+                }
+            }
+            pQuery = _findNextQueryByDomain(p_pPTRAnswer->m_Header.m_Domain, stcQuery::enuQueryType::Service, pQuery);
+        }
+    }   // else: No p_pPTRAnswer
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _processPTRAnswer: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::_processSRVAnswer (level 2)
+*/
+bool MDNSResponder::clsHost::_processSRVAnswer(const MDNSResponder::clsHost::stcRRAnswerSRV* p_pSRVAnswer,
+                                               bool& p_rbFoundNewKeyAnswer)
+{
+    bool    bResult = false;
+
+    if ((bResult = (0 != p_pSRVAnswer)))
+    {
+        // eg. MyESP._http._tcp.local SRV xxxx xx yy zz 5000 esp8266.local
+
+        stcQuery*    pQuery = m_pQueries;
+        while (pQuery)
+        {
+            if (pQuery->m_bAwaitingAnswers)
+            {
+                stcQuery::stcAnswer* pSQAnswer = pQuery->findAnswerForServiceDomain(p_pSRVAnswer->m_Header.m_Domain);
+                if (pSQAnswer)      // Answer for this service domain (eg. MyESP._http._tcp.local) available
+                {
+                    if (p_pSRVAnswer->m_u32TTL)     // First or update message (TTL != 0)
+                    {
+                        pSQAnswer->m_TTLHostDomainAndPort.set(p_pSRVAnswer->m_u32TTL);    // Update TTL tag
+                        DEBUG_EX_INFO(
+                            DEBUG_OUTPUT.printf_P(PSTR("%s _processSRVAnswer: Updated TTL(%lu) for "), _DH(), p_pSRVAnswer->m_u32TTL);
+                            _printRRDomain(pSQAnswer->m_ServiceDomain);
+                            DEBUG_OUTPUT.printf_P(PSTR(" host domain and port\n"));
+                        );
+                        // Host domain & Port
+                        if ((pSQAnswer->m_HostDomain != p_pSRVAnswer->m_SRVDomain) ||
+                            (pSQAnswer->m_u16Port != p_pSRVAnswer->m_u16Port))
+                        {
+
+                            pSQAnswer->m_HostDomain = p_pSRVAnswer->m_SRVDomain;
+                            //pSQAnswer->releaseHostDomain();
+                            pSQAnswer->m_u16Port = p_pSRVAnswer->m_u16Port;
+                            pSQAnswer->m_QueryAnswerFlags |= (static_cast<typeQueryAnswerType>(enuQueryAnswerType::HostDomain) | static_cast<typeQueryAnswerType>(enuQueryAnswerType::Port));
+
+                            DEBUG_EX_INFO(
+                                DEBUG_OUTPUT.printf_P(PSTR("%s _processSVRAnswer: Added host domain and port to "), _DH());
+                                _printRRDomain(pSQAnswer->m_ServiceDomain);
+                                DEBUG_OUTPUT.printf_P(PSTR(": "));
+                                _printRRDomain(pSQAnswer->m_HostDomain);
+                                DEBUG_OUTPUT.printf_P(PSTR(": %u\n"), pSQAnswer->m_u16Port);
+                            );
+
+                            p_rbFoundNewKeyAnswer = true;
+                            _executeQueryCallback(*pQuery, *pSQAnswer, (static_cast<typeQueryAnswerType>(enuQueryAnswerType::HostDomain) | static_cast<typeQueryAnswerType>(enuQueryAnswerType::Port)), true);
+                        }
+                    }
+                    else                        // Goodby message
+                    {
+                        pSQAnswer->m_TTLHostDomainAndPort.prepareDeletion();    // Prepare answer deletion according to RFC 6762, 10.1
+                        DEBUG_EX_INFO(
+                            DEBUG_OUTPUT.printf_P(PSTR("%s _processSRVAnswer: 'Goodbye' received for "), _DH());
+                            _printRRDomain(pSQAnswer->m_ServiceDomain);
+                            DEBUG_OUTPUT.printf_P(PSTR(" host domain and port\n"));
+                        );
+                    }
+                }
+            }   // m_bAwaitingAnswers
+            pQuery = pQuery->m_pNext;
+        }   // while(service query)
+    }   // else: No p_pSRVAnswer
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _processSRVAnswer: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::_processTXTAnswer (level 2)
+*/
+bool MDNSResponder::clsHost::_processTXTAnswer(const MDNSResponder::clsHost::stcRRAnswerTXT* p_pTXTAnswer)
+{
+    bool    bResult = false;
+
+    if ((bResult = (0 != p_pTXTAnswer)))
+    {
+        // eg. MyESP._http._tcp.local TXT xxxx xx c#=1
+
+        stcQuery*    pQuery = m_pQueries;
+        while (pQuery)
+        {
+            if (pQuery->m_bAwaitingAnswers)
+            {
+                stcQuery::stcAnswer* pSQAnswer = pQuery->findAnswerForServiceDomain(p_pTXTAnswer->m_Header.m_Domain);
+                if (pSQAnswer)      // Answer for this service domain (eg. MyESP._http._tcp.local) available
+                {
+                    if (p_pTXTAnswer->m_u32TTL)     // First or update message
+                    {
+                        pSQAnswer->m_TTLTxts.set(p_pTXTAnswer->m_u32TTL); // Update TTL tag
+                        DEBUG_EX_INFO(
+                            DEBUG_OUTPUT.printf_P(PSTR("%s _processTXTAnswer: Updated TTL(%lu) for "), _DH(), p_pTXTAnswer->m_u32TTL);
+                            _printRRDomain(pSQAnswer->m_ServiceDomain);
+                            DEBUG_OUTPUT.printf_P(PSTR(" TXTs\n"));
+                        );
+                        if (!pSQAnswer->m_Txts.compare(p_pTXTAnswer->m_Txts))
+                        {
+                            pSQAnswer->m_Txts = p_pTXTAnswer->m_Txts;
+                            pSQAnswer->m_QueryAnswerFlags |= static_cast<typeQueryAnswerType>(enuQueryAnswerType::Txts);
+                            //pSQAnswer->releaseTxts();
+
+                            DEBUG_EX_INFO(
+                                DEBUG_OUTPUT.printf_P(PSTR("%s _processTXTAnswer: Added TXT to "), _DH());
+                                _printRRDomain(pSQAnswer->m_ServiceDomain);
+                                DEBUG_OUTPUT.println();
+                            );
+
+                            _executeQueryCallback(*pQuery, *pSQAnswer, static_cast<typeQueryAnswerType>(enuQueryAnswerType::Txts), true);
+                        }
+                    }
+                    else                        // Goodby message
+                    {
+                        pSQAnswer->m_TTLTxts.prepareDeletion(); // Prepare answer deletion according to RFC 6762, 10.1
+                        DEBUG_EX_INFO(
+                            DEBUG_OUTPUT.printf_P(PSTR("%s _processTXTAnswer: 'Goodbye' received for "), _DH());
+                            _printRRDomain(pSQAnswer->m_ServiceDomain);
+                            DEBUG_OUTPUT.printf_P(PSTR(" TXTs\n"));
+                        );
+                    }
+                }
+            }   // m_bAwaitingAnswers
+            pQuery = pQuery->m_pNext;
+        }   // while(service query)
+    }   // else: No p_pTXTAnswer
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _processTXTAnswer: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+#ifdef MDNS_IPV4_SUPPORT
+/*
+    MDNSResponder::clsHost::_processAAnswer (level 3)
+*/
+bool MDNSResponder::clsHost::_processAAnswer(const MDNSResponder::clsHost::stcRRAnswerA* p_pAAnswer)
+{
+    bool    bResult = false;
+
+    if ((bResult = (0 != p_pAAnswer)))
+    {
+        // eg. esp8266.local A xxxx xx 192.168.2.120
+
+        stcQuery*    pQuery = m_pQueries;
+        while (pQuery)
+        {
+            if (pQuery->m_bAwaitingAnswers)
+            {
+                // Look for answers to host queries
+                if ((p_pAAnswer->m_u32TTL) &&                                       // NOT just a goodbye message
+                    (stcQuery::enuQueryType::Host == pQuery->m_QueryType) &&    // AND a host query
+                    (pQuery->m_Domain == p_pAAnswer->m_Header.m_Domain))            // AND a matching host domain
+                {
+
+                    stcQuery::stcAnswer* pSQAnswer = pQuery->findAnswerForHostDomain(p_pAAnswer->m_Header.m_Domain);
+                    if ((!pSQAnswer) &&
+                        ((pSQAnswer = new stcQuery::stcAnswer)))
+                    {
+                        // Add not yet included answer
+                        pSQAnswer->m_HostDomain = p_pAAnswer->m_Header.m_Domain;
+                        //pSQAnswer->releaseHostDomain();
+
+                        bResult = pQuery->addAnswer(pSQAnswer);
+                        DEBUG_EX_INFO(
+                            DEBUG_OUTPUT.printf_P(PSTR("%s _processAAnswer: Added host query answer for "), _DH());
+                            _printRRDomain(pQuery->m_Domain);
+                            DEBUG_OUTPUT.println();
+                        );
+
+                        pSQAnswer->m_QueryAnswerFlags |= static_cast<typeQueryAnswerType>(enuQueryAnswerType::HostDomain);
+                        _executeQueryCallback(*pQuery, *pSQAnswer, static_cast<typeQueryAnswerType>(enuQueryAnswerType::HostDomain), true);
+                    }
+                }
+
+                // Look for answers to service queries
+                stcQuery::stcAnswer* pSQAnswer = pQuery->findAnswerForHostDomain(p_pAAnswer->m_Header.m_Domain);
+                if (pSQAnswer)      // Answer for this host domain (eg. esp8266.local) available
+                {
+                    stcQuery::stcAnswer::stcIPAddress*  pIPAddress = pSQAnswer->findIPv4Address(p_pAAnswer->m_IPAddress);
+                    if (pIPAddress)
+                    {
+                        // Already known IPv4 address
+                        if (p_pAAnswer->m_u32TTL)   // Valid TTL -> Update answers TTL
+                        {
+                            pIPAddress->m_TTL.set(p_pAAnswer->m_u32TTL);
+                            DEBUG_EX_INFO(
+                                DEBUG_OUTPUT.printf_P(PSTR("%s _processAAnswer: Updated TTL(%lu) for "), _DH(), p_pAAnswer->m_u32TTL);
+                                _printRRDomain(pSQAnswer->m_ServiceDomain);
+                                DEBUG_OUTPUT.printf_P(PSTR(" IPv4 address (%s)\n"), pIPAddress->m_IPAddress.toString().c_str());
+                            );
+                        }
+                        else                        // 'Goodbye' message for known IPv4 address
+                        {
+                            pIPAddress->m_TTL.prepareDeletion();	// Prepare answer deletion according to RFC 6762, 10.1
+                            DEBUG_EX_INFO(
+                                DEBUG_OUTPUT.printf_P(PSTR("%s _processAAnswer: 'Goodbye' received for "), _DH());
+                                _printRRDomain(pSQAnswer->m_ServiceDomain);
+                                DEBUG_OUTPUT.printf_P(PSTR(" IPv4 address (%s)\n"), pIPAddress->m_IPAddress.toString().c_str());
+                            );
+                        }
+                    }
+                    else
+                    {
+                        // Until now unknown IPv4 address -> Add (if the message isn't just a 'Goodbye' note)
+                        if (p_pAAnswer->m_u32TTL)   // NOT just a 'Goodbye' message
+                        {
+                            pIPAddress = new stcQuery::stcAnswer::stcIPAddress(p_pAAnswer->m_IPAddress, p_pAAnswer->m_u32TTL);
+                            if ((pIPAddress) &&
+                                (pSQAnswer->addIPv4Address(pIPAddress)))
+                            {
+
+                                DEBUG_EX_INFO(
+                                    DEBUG_OUTPUT.printf_P(PSTR("%s _processAAnswer: Added IPv4 address to "), _DH());
+                                    _printRRDomain(pSQAnswer->m_ServiceDomain);
+                                    DEBUG_OUTPUT.printf_P(PSTR(": %s\n"), pIPAddress->m_IPAddress.toString().c_str());
+                                );
+
+                                pSQAnswer->m_QueryAnswerFlags |= static_cast<typeQueryAnswerType>(enuQueryAnswerType::IPv4Address);
+                                _executeQueryCallback(*pQuery, *pSQAnswer, static_cast<typeQueryAnswerType>(enuQueryAnswerType::IPv4Address), true);
+                            }
+                            else
+                            {
+                                DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _processAAnswer: FAILED to add IPv4 address (%s)!\n"), _DH(), p_pAAnswer->m_IPAddress.toString().c_str()););
+                            }
+                        }
+                    }
+                }
+            }   // m_bAwaitingAnswers
+            pQuery = pQuery->m_pNext;
+        }   // while(service query)
+    }   // else: No p_pAAnswer
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _processAAnswer: FAILED!\n"), _DH()););
+    return bResult;
+}
+#endif
+
+#ifdef MDNS_IPV6_SUPPORT
+/*
+    MDNSResponder::clsHost::_processAAAAAnswer (level 3)
+*/
+bool MDNSResponder::clsHost::_processAAAAAnswer(const MDNSResponder::clsHost::stcRRAnswerAAAA* p_pAAAAAnswer)
+{
+    bool    bResult = false;
+
+    if ((bResult = (0 != p_pAAAAAnswer)))
+    {
+        // eg. esp8266.local AAAA xxxx xx 0bf3::0c
+
+        stcQuery*	pQuery = m_pQueries;
+        while (pQuery)
+        {
+            if (pQuery->m_bAwaitingAnswers)
+            {
+                // Look for answers to host queries
+                if ((p_pAAAAAnswer->m_u32TTL) &&                                    // NOT just a goodbye message
+                    (stcQuery::enuQueryType::Host == pQuery->m_QueryType) &&    // AND a host query
+                    (pQuery->m_Domain == p_pAAAAAnswer->m_Header.m_Domain))         // AND a matching host domain
+                {
+
+                    stcQuery::stcAnswer* pSQAnswer = pQuery->findAnswerForHostDomain(p_pAAAAAnswer->m_Header.m_Domain);
+                    if ((!pSQAnswer) &&
+                        ((pSQAnswer = new stcQuery::stcAnswer)))
+                    {
+                        // Add not yet included answer
+                        pSQAnswer->m_HostDomain = p_pAAAAAnswer->m_Header.m_Domain;
+                        //pSQAnswer->releaseHostDomain();
+
+                        bResult = pQuery->addAnswer(pSQAnswer);
+                        DEBUG_EX_INFO(
+                            DEBUG_OUTPUT.printf_P(PSTR("%s _processAAAAAnswer: Added host query answer for "), _DH());
+                            _printRRDomain(pQuery->m_Domain);
+                            DEBUG_OUTPUT.println();
+                        );
+
+                        pSQAnswer->m_QueryAnswerFlags |= static_cast<typeQueryAnswerType>(enuQueryAnswerType::HostDomain);
+                        _executeQueryCallback(*pQuery, *pSQAnswer, static_cast<typeQueryAnswerType>(enuQueryAnswerType::HostDomain), true);
+                    }
+                }
+
+                // Look for answers to service queries
+                stcQuery::stcAnswer* pSQAnswer = pQuery->findAnswerForHostDomain(p_pAAAAAnswer->m_Header.m_Domain);
+                if (pSQAnswer)      // Answer for this host domain (eg. esp8266.local) available
+                {
+                    stcQuery::stcAnswer::stcIPAddress*  pIPAddress = pSQAnswer->findIPv6Address(p_pAAAAAnswer->m_IPAddress);
+                    if (pIPAddress)
+                    {
+                        // Already known IPv6 address
+                        if (p_pAAAAAnswer->m_u32TTL)   // Valid TTL -> Update answers TTL
+                        {
+                            pIPAddress->m_TTL.set(p_pAAAAAnswer->m_u32TTL);
+                            DEBUG_EX_INFO(
+                                DEBUG_OUTPUT.printf_P(PSTR("%s _processAAAAAnswer: Updated TTL(%lu) for "), _DH(), p_pAAAAAnswer->m_u32TTL);
+                                _printRRDomain(pSQAnswer->m_ServiceDomain);
+                                DEBUG_OUTPUT.printf_P(PSTR(" IPv6 address (%s)\n"), pIPAddress->m_IPAddress.toString().c_str());
+                            );
+                        }
+                        else                        // 'Goodbye' message for known IPv6 address
+                        {
+                            pIPAddress->m_TTL.prepareDeletion();	// Prepare answer deletion according to RFC 6762, 10.1
+                            DEBUG_EX_INFO(
+                                DEBUG_OUTPUT.printf_P(PSTR("%s _processAAAAAnswer: 'Goodbye' received for "), _DH());
+                                _printRRDomain(pSQAnswer->m_ServiceDomain);
+                                DEBUG_OUTPUT.printf_P(PSTR(" IPv6 address (%s)\n"), pIPAddress->m_IPAddress.toString().c_str());
+                            );
+                        }
+                    }
+                    else
+                    {
+                        // Until now unknown IPv6 address -> Add (if the message isn't just a 'Goodbye' note)
+                        if (p_pAAAAAnswer->m_u32TTL)   // NOT just a 'Goodbye' message
+                        {
+                            pIPAddress = new stcQuery::stcAnswer::stcIPAddress(p_pAAAAAnswer->m_IPAddress, p_pAAAAAnswer->m_u32TTL);
+                            if ((pIPAddress) &&
+                                (pSQAnswer->addIPv6Address(pIPAddress)))
+                            {
+
+                                DEBUG_EX_INFO(
+                                    DEBUG_OUTPUT.printf_P(PSTR("%s _processAAAAAnswer: Added IPv6 address to "), _DH());
+                                    _printRRDomain(pSQAnswer->m_ServiceDomain);
+                                    DEBUG_OUTPUT.printf_P(PSTR(": %s\n"), pIPAddress->m_IPAddress.toString().c_str());
+                                );
+
+                                pSQAnswer->m_QueryAnswerFlags |= static_cast<uint32_t>(enuQueryAnswerType::IPv6Address);
+                                _executeQueryCallback(*pQuery, *pSQAnswer, static_cast<typeQueryAnswerType>(enuQueryAnswerType::IPv6Address), true);
+                            }
+                            else
+                            {
+                                DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _processAAAAAnswer: FAILED to add IPv6 address (%s)!\n"), _DH(), p_pAAAAAnswer->m_IPAddress.toString().c_str()););
+                            }
+                        }
+                    }
+                }
+            }   // m_bAwaitingAnswers
+            pQuery = pQuery->m_pNext;
+        }   // while(service query)
+    }   // else: No p_pAAAAAnswer
+
+    return bResult;
+}
+#endif
+
+
+/*
+    PROBING
+*/
+
+/*
+    MDNSResponder::clsHost::_updateProbeStatus
+
+    Manages the (outgoing) probing process.
+    - If probing has not been started yet (ProbingStatus_NotStarted), the initial delay (see RFC 6762) is determined and
+     the process is started
+    - After timeout (of initial or subsequential delay) a probe message is send out for three times. If the message has
+     already been sent out three times, the probing has been successful and is finished.
+
+    Conflict management is handled in '_parseResponse ff.'
+    Tiebraking is handled in 'parseQuery ff.'
+*/
+bool MDNSResponder::clsHost::_updateProbeStatus(void)
+{
+    bool    bResult = true;
+
+    //
+    // Probe host domain
+    if ((enuProbingStatus::ReadyToStart == m_HostProbeInformation.m_ProbingStatus) &&       // Ready to get started AND
+        ((
+#ifdef MDNS_IPV4_SUPPORT
+             _getResponderIPAddress(enuIPProtocolType::V4).isSet()                             // AND has IPv4 address
+#else
+             true
+#endif
+         ) || (
+#ifdef MDNS_IPV6_SUPPORT
+             _getResponderIPAddress(enuIPProtocolType::V6).isSet()                             // OR has IPv6 address
+#else
+             true
+#endif
+         )))                // Has IP address
+    {
+        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _updateProbeStatus: Starting host probing...\n"), _DH()););
+
+        // First probe delay SHOULD be random 0-250 ms
+        m_HostProbeInformation.m_Timeout.reset(rand() % MDNS_PROBE_DELAY);
+        m_HostProbeInformation.m_ProbingStatus = enuProbingStatus::InProgress;
+    }
+    else if ((enuProbingStatus::InProgress == m_HostProbeInformation.m_ProbingStatus) &&    // Probing AND
+             (m_HostProbeInformation.m_Timeout.expired()))                                  // Time for next probe
+    {
+
+        if (MDNS_PROBE_COUNT > m_HostProbeInformation.m_u8SentCount)                        // Send next probe
+        {
+            if ((bResult = _sendHostProbe()))
+            {
+                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _updateProbeStatus: Did sent host probe for '%s.local'\n\n"), _DH(), (m_pcHostName ? : "")););
+                m_HostProbeInformation.m_Timeout.reset(MDNS_PROBE_DELAY);
+                ++m_HostProbeInformation.m_u8SentCount;
+            }
+        }
+        else                                                                                // Probing finished
+        {
+            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("\n%s _updateProbeStatus: Done host probing for '%s.local'.\n\n\n"), _DH(), (m_pcHostName ? : "")););
+            m_HostProbeInformation.m_ProbingStatus = enuProbingStatus::Done;
+            m_HostProbeInformation.m_Timeout.reset(std::numeric_limits<esp8266::polledTimeout::oneShot::timeType>::max());
+
+            _callHostProbeResultCallback(true);
+
+            // Prepare to announce host
+            m_HostProbeInformation.m_u8SentCount = 0;
+            m_HostProbeInformation.m_Timeout.reset(MDNS_ANNOUNCE_DELAY);
+            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _updateProbeStatus: Prepared host announcing.\n\n"), _DH()););
+        }
+    }   // else: Probing already finished OR waiting for next time slot
+    else if ((enuProbingStatus::Done == m_HostProbeInformation.m_ProbingStatus) &&
+             (m_HostProbeInformation.m_Timeout.expired()))
+    {
+
+        if ((bResult = _announce(true, false)))     // Don't announce services here
+        {
+            ++m_HostProbeInformation.m_u8SentCount; // 1..
+
+            if (MDNS_ANNOUNCE_COUNT > m_HostProbeInformation.m_u8SentCount)
+            {
+                m_HostProbeInformation.m_Timeout.reset(MDNS_ANNOUNCE_DELAY * pow(2, (m_HostProbeInformation.m_u8SentCount - 1))); // 2^(0..) -> 1, 2, 4, ...
+                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _updateProbeStatus: Announcing host '%s.local' (%lu).\n\n"), _DH(), (m_pcHostName ? : ""), m_HostProbeInformation.m_u8SentCount););
+            }
+            else
+            {
+                m_HostProbeInformation.m_Timeout.reset(std::numeric_limits<esp8266::polledTimeout::oneShot::timeType>::max());
+                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _updateProbeStatus: Done host announcing for '%s.local'.\n\n"), _DH(), (m_pcHostName ? : "")););
+            }
+        }
+    }
+
+    //
+    // Probe services
+    for (stcService* pService = m_pServices; ((bResult) && (pService)); pService = pService->m_pNext)
+    {
+        if (enuProbingStatus::ReadyToStart == pService->m_ProbeInformation.m_ProbingStatus)         // Ready to get started
+        {
+
+            pService->m_ProbeInformation.m_Timeout.reset(MDNS_PROBE_DELAY);                         // More or equal than first probe for host domain
+            pService->m_ProbeInformation.m_ProbingStatus = enuProbingStatus::InProgress;
+        }
+        else if ((enuProbingStatus::InProgress == pService->m_ProbeInformation.m_ProbingStatus) &&  // Probing AND
+                 (pService->m_ProbeInformation.m_Timeout.expired()))                                // Time for next probe
+        {
+
+            if (MDNS_PROBE_COUNT > pService->m_ProbeInformation.m_u8SentCount)                      // Send next probe
+            {
+                if ((bResult = _sendServiceProbe(*pService)))
+                {
+                    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _updateProbeStatus: Did sent service probe for '%s' (%u)\n\n"), _DH(), _service2String(pService), (pService->m_ProbeInformation.m_u8SentCount + 1)););
+                    pService->m_ProbeInformation.m_Timeout.reset(MDNS_PROBE_DELAY);
+                    ++pService->m_ProbeInformation.m_u8SentCount;
+                }
+            }
+            else                                                                                    // Probing finished
+            {
+                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("\n%s _updateProbeStatus: Done service probing '%s'\n\n\n"), _DH(), _service2String(pService)););
+                pService->m_ProbeInformation.m_ProbingStatus = enuProbingStatus::Done;
+                pService->m_ProbeInformation.m_Timeout.reset(std::numeric_limits<esp8266::polledTimeout::oneShot::timeType>::max());
+
+                _callServiceProbeResultCallback(*pService, true);
+
+                // Prepare to announce service
+                pService->m_ProbeInformation.m_u8SentCount = 0;
+                pService->m_ProbeInformation.m_Timeout.reset(MDNS_ANNOUNCE_DELAY);
+                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _updateProbeStatus: Prepared service announcing.\n\n"), _DH()););
+            }
+        }   // else: Probing already finished OR waiting for next time slot
+        else if ((enuProbingStatus::Done == pService->m_ProbeInformation.m_ProbingStatus) &&
+                 (pService->m_ProbeInformation.m_Timeout.expired()))
+        {
+
+            if ((bResult = _announceService(*pService)))        // Announce service
+            {
+                ++pService->m_ProbeInformation.m_u8SentCount;   // 1..
+
+                if (MDNS_ANNOUNCE_COUNT > pService->m_ProbeInformation.m_u8SentCount)
+                {
+                    pService->m_ProbeInformation.m_Timeout.reset(MDNS_ANNOUNCE_DELAY * pow(2, (pService->m_ProbeInformation.m_u8SentCount - 1))); // 2^(0..) -> 1, 2, 4, ...
+                    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _updateProbeStatus: Announcing service '%s' (%lu)\n\n"), _DH(), _service2String(pService), pService->m_ProbeInformation.m_u8SentCount););
+                }
+                else
+                {
+                    pService->m_ProbeInformation.m_Timeout.reset(std::numeric_limits<esp8266::polledTimeout::oneShot::timeType>::max());
+                    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _updateProbeStatus: Done service announcing for '%s'\n\n"), _DH(), _service2String(pService)););
+                }
+            }
+        }
+    }
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _updateProbeStatus: FAILED!\n\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::_resetProbeStatus
+
+    Resets the probe status.
+    If 'p_bRestart' is set, the status is set to ProbingStatus_NotStarted. Consequently,
+    when running 'updateProbeStatus' (which is done in every '_update' loop), the probing
+    process is restarted.
+*/
+bool MDNSResponder::clsHost::_resetProbeStatus(bool p_bRestart /*= true*/)
+{
+    m_HostProbeInformation.clear(false);
+    m_HostProbeInformation.m_ProbingStatus = (p_bRestart ? enuProbingStatus::ReadyToStart : enuProbingStatus::Done);
+
+    for (stcService* pService = m_pServices; pService; pService = pService->m_pNext)
+    {
+        pService->m_ProbeInformation.clear(false);
+        pService->m_ProbeInformation.m_ProbingStatus = (p_bRestart ? enuProbingStatus::ReadyToStart : enuProbingStatus::Done);
+    }
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::_hasProbesWaitingForAnswers
+*/
+bool MDNSResponder::clsHost::_hasProbesWaitingForAnswers(void) const
+{
+    bool    bResult = ((enuProbingStatus::InProgress == m_HostProbeInformation.m_ProbingStatus) &&	// Probing
+                       (0 < m_HostProbeInformation.m_u8SentCount));                                 // And really probing
+
+    for (stcService* pService = m_pServices; ((!bResult) && (pService)); pService = pService->m_pNext)
+    {
+        bResult = ((enuProbingStatus::InProgress == pService->m_ProbeInformation.m_ProbingStatus) &&    // Probing
+                   (0 < pService->m_ProbeInformation.m_u8SentCount));                               // And really probing
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::_sendHostProbe
+
+    Asks (probes) in the local network for the planned host domain
+    - (eg. esp8266.local)
+
+    To allow 'tiebreaking' (see '_parseQuery'), the answers for these questions are delivered in
+    the 'knwon answers' section of the query.
+    Host domain:
+    - A/AAAA (eg. esp8266.esp -> 192.168.2.120)
+*/
+bool MDNSResponder::clsHost::_sendHostProbe(void)
+{
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _sendHostProbe (%s.local, %lu)\n"), _DH(), m_pcHostName, millis()););
+
+    bool    bResult = true;
+
+    // Requests for host domain
+    stcSendParameter    sendParameter;
+    sendParameter.m_bCacheFlush = false;    // RFC 6762 10.2
+
+    sendParameter.m_pQuestions = new stcRRQuestion;
+    if (((bResult = (0 != sendParameter.m_pQuestions))) &&
+        ((bResult = _buildDomainForHost(m_pcHostName, sendParameter.m_pQuestions->m_Header.m_Domain))))
+    {
+
+        //sendParameter.m_pQuestions->m_bUnicast = true;
+        sendParameter.m_pQuestions->m_Header.m_Attributes.m_u16Type = DNS_RRTYPE_ANY;
+        sendParameter.m_pQuestions->m_Header.m_Attributes.m_u16Class = (0x8000 | DNS_RRCLASS_IN);   // Unicast & INternet
+
+        // Add known answers
+#ifdef MDNS_IPV4_SUPPORT
+        sendParameter.m_u32HostReplyMask |= static_cast<uint32_t>(enuContentFlag::A);               // Add A answer
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+        sendParameter.m_u32HostReplyMask |= static_cast<uint32_t>(enuContentFlag::AAAA);            // Add AAAA answer
+#endif
+    }
+    else
+    {
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _sendHostProbe: FAILED to create host question!\n"), _DH()););
+        if (sendParameter.m_pQuestions)
+        {
+            delete sendParameter.m_pQuestions;
+            sendParameter.m_pQuestions = 0;
+        }
+    }
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _sendHostProbe: FAILED!\n"), _DH()););
+    return ((bResult) &&
+            (_sendMDNSMessage(sendParameter)));
+}
+
+/*
+    MDNSResponder::clsHost::_sendServiceProbe
+
+    Asks (probes) in the local network for the planned service instance domain
+    - (eg. MyESP._http._tcp.local).
+
+    To allow 'tiebreaking' (see '_parseQuery'), the answers for these questions are delivered in
+    the 'knwon answers' section of the query.
+    Service domain:
+    - SRV (eg. MyESP._http._tcp.local -> 5000 esp8266.local)
+    - PTR NAME (eg. _http._tcp.local -> MyESP._http._tcp.local) (TODO: Check if needed, maybe TXT is better)
+*/
+bool MDNSResponder::clsHost::_sendServiceProbe(stcService& p_rService)
+{
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _sendServiceProbe (%s, %lu)\n"), _DH(), _service2String(&p_rService), millis()););
+
+    bool    bResult = true;
+
+    // Requests for service instance domain
+    stcSendParameter    sendParameter;
+    sendParameter.m_bCacheFlush = false;    // RFC 6762 10.2
+
+    sendParameter.m_pQuestions = new stcRRQuestion;
+    if (((bResult = (0 != sendParameter.m_pQuestions))) &&
+        ((bResult = _buildDomainForService(p_rService, true, sendParameter.m_pQuestions->m_Header.m_Domain))))
+    {
+
+        sendParameter.m_pQuestions->m_bUnicast = true;
+        sendParameter.m_pQuestions->m_Header.m_Attributes.m_u16Type = DNS_RRTYPE_ANY;
+        sendParameter.m_pQuestions->m_Header.m_Attributes.m_u16Class = (0x8000 | DNS_RRCLASS_IN);   // Unicast & INternet
+
+        // Add known answers
+        p_rService.m_u32ReplyMask = (static_cast<uint32_t>(enuContentFlag::SRV) | static_cast<uint32_t>(enuContentFlag::PTR_NAME));	// Add SRV and PTR NAME answers
+    }
+    else
+    {
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _sendServiceProbe: FAILED to create service question!\n"), _DH()););
+        if (sendParameter.m_pQuestions)
+        {
+            delete sendParameter.m_pQuestions;
+            sendParameter.m_pQuestions = 0;
+        }
+    }
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _sendServiceProbe: FAILED!\n"), _DH()););
+    return ((bResult) &&
+            (_sendMDNSMessage(sendParameter)));
+}
+
+/*
+    MDNSResponder::clsHost::_cancelProbingForHost
+*/
+bool MDNSResponder::clsHost::_cancelProbingForHost(void)
+{
+    bool    bResult = false;
+
+    m_HostProbeInformation.clear(false);
+
+    // Send host notification
+    bResult = _callHostProbeResultCallback(false);
+
+    for (stcService* pService = m_pServices; ((!bResult) && (pService)); pService = pService->m_pNext)
+    {
+        bResult = _cancelProbingForService(*pService);
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::_cancelProbingForService
+*/
+bool MDNSResponder::clsHost::_cancelProbingForService(stcService& p_rService)
+{
+    p_rService.m_ProbeInformation.clear(false);
+
+    // Send notification
+    return _callServiceProbeResultCallback(p_rService, false);
+}
+
+/*
+    MDNSResponder::clsHost::_callHostProbeResultCallback
+
+*/
+bool MDNSResponder::clsHost::_callHostProbeResultCallback(bool p_bResult)
+{
+    if (m_HostProbeInformation.m_fnProbeResultCallback)
+    {
+        m_HostProbeInformation.m_fnProbeResultCallback(*this, m_pcHostName, p_bResult);
+    }
+    else if (!p_bResult)
+    {
+        // Auto-Handle failure by changing the host name, use '-' as divider between base name and index
+        char*   pcHostDomainTemp = strdup(m_pcHostName);
+        if (pcHostDomainTemp)
+        {
+            if (MDNSResponder::indexDomain(pcHostDomainTemp, "-", 0))
+            {
+                setHostName(pcHostDomainTemp);
+            }
+            else
+            {
+                DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _callHostProbeResultCallback: FAILED to update host domain '%s'!\n"), _DH(), (m_pcHostName ? : "")););
+            }
+            free(pcHostDomainTemp);
+        }
+        else
+        {
+            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _callHostProbeResultCallback: FAILED to copy host domain '%s'!\n"), _DH(), (m_pcHostName ? : "")););
+        }
+    }
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::_callServiceProbeResultCallback
+
+*/
+bool MDNSResponder::clsHost::_callServiceProbeResultCallback(MDNSResponder::clsHost::stcService& p_rService,
+                                                             bool p_bResult)
+{
+    if (p_rService.m_ProbeInformation.m_fnProbeResultCallback)
+    {
+        p_rService.m_ProbeInformation.m_fnProbeResultCallback(*this, p_rService, p_rService.m_pcName, p_bResult);
+    }
+    else if (!p_bResult)
+    {
+        // Auto-Handle failure by changing the service name, use ' #' as divider between base name and index
+        char*   pcServiceNameTemp = strdup(p_rService.m_pcName);
+        if (pcServiceNameTemp)
+        {
+            if (MDNSResponder::indexDomain(pcServiceNameTemp, " #", 0))
+            {
+                setServiceName(&p_rService, pcServiceNameTemp);
+            }
+            else
+            {
+                DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _callServiceProbeResultCallback: FAILED to update service name for '%s'!\n"), _DH(), _service2String(&p_rService)););
+            }
+            free(pcServiceNameTemp);
+        }
+        else
+        {
+            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _callServiceProbeResultCallback: FAILED to copy service name for '%s'!\n"), _DH(), _service2String(&p_rService)););
+        }
+    }
+    return true;
+}
+
+
+/**
+    ANNOUNCING
+*/
+
+/*
+    MDNSResponder::clsHost::_announce
+
+    Announces the host domain:
+    - A/AAAA (eg. esp8266.local -> 192.168.2.120)
+    - PTR (eg. 192.168.2.120.in-addr.arpa -> esp8266.local)
+
+    and all presented services:
+    - PTR_TYPE (_services._dns-sd._udp.local -> _http._tcp.local)
+    - PTR_NAME (eg. _http._tcp.local -> MyESP8266._http._tcp.local)
+    - SRV (eg. MyESP8266._http._tcp.local -> 5000 esp8266.local)
+    - TXT (eg. MyESP8266._http._tcp.local -> c#=1)
+
+    Goodbye (Un-Announcing) for the host domain and all services is also handled here.
+    Goodbye messages are created by setting the TTL for the answer to 0, this happens
+    inside the '_writeXXXAnswer' procs via 'sendParameter.m_bUnannounce = true'
+*/
+bool MDNSResponder::clsHost::_announce(bool p_bAnnounce,
+                                       bool p_bIncludeServices)
+{
+    bool    bResult = false;
+
+    stcSendParameter    sendParameter;
+    if (enuProbingStatus::Done == m_HostProbeInformation.m_ProbingStatus)
+    {
+        bResult = true;
+
+        sendParameter.m_Response = stcSendParameter::enuResponseType::Unsolicited;  // Announces are 'Unsolicited authorative responses'
+        sendParameter.m_bAuthorative = true;
+        sendParameter.m_bCacheFlush = true;                                             // RFC 6762 8.3
+        sendParameter.m_bUnannounce = !p_bAnnounce;                                     // When unannouncing, the TTL is set to '0' while creating the answers
+
+        // Announce host
+        sendParameter.m_u32HostReplyMask = 0;
+#ifdef MDNS_IPV4_SUPPORT
+        sendParameter.m_u32HostReplyMask |= static_cast<uint32_t>(enuContentFlag::A);                   // A answer
+        sendParameter.m_u32HostReplyMask |= static_cast<uint32_t>(enuContentFlag::PTR_IPv4);            // PTR_IPv4 answer
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+        sendParameter.m_u32HostReplyMask |= static_cast<uint32_t>(enuContentFlag::AAAA);                // AAAA answer
+        sendParameter.m_u32HostReplyMask |= static_cast<uint32_t>(enuContentFlag::PTR_IPv6);            // PTR_IPv6 answer
+#endif
+
+        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _announce: Announcing host %s (content: %s)\n"), _DH(), m_pcHostName, _replyFlags2String(sendParameter.m_u32HostReplyMask)););
+
+        if (p_bIncludeServices)
+        {
+            // Announce services (service type, name, SRV (location) and TXTs)
+            for (stcService* pService = m_pServices; ((bResult) && (pService)); pService = pService->m_pNext)
+            {
+                if (enuProbingStatus::Done == pService->m_ProbeInformation.m_ProbingStatus)
+                {
+                    pService->m_u32ReplyMask = (static_cast<uint32_t>(enuContentFlag::PTR_TYPE) | static_cast<uint32_t>(enuContentFlag::PTR_NAME) | static_cast<uint32_t>(enuContentFlag::SRV) | static_cast<uint32_t>(enuContentFlag::TXT));
+
+                    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _announce: Announcing service '%s' (content %s)\n"), _DH(), _service2String(pService), _replyFlags2String(pService->m_u32ReplyMask)););
+                }
+            }
+        }
+    }
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _announce: FAILED!\n"), _DH()););
+    return ((bResult) &&
+            (_sendMDNSMessage(sendParameter)));
+}
+
+/*
+    MDNSResponder::clsHost::_announceService
+*/
+bool MDNSResponder::clsHost::_announceService(MDNSResponder::clsHost::stcService& p_rService,
+                                              bool p_bAnnounce /*= true*/)
+{
+    bool    bResult = false;
+
+    stcSendParameter    sendParameter;
+    if (enuProbingStatus::Done == p_rService.m_ProbeInformation.m_ProbingStatus)
+    {
+
+        sendParameter.m_Response = stcSendParameter::enuResponseType::Unsolicited;  // Announces are 'Unsolicited authorative responses'
+        sendParameter.m_bAuthorative = true;
+        sendParameter.m_bUnannounce = !p_bAnnounce; // When unannouncing, the TTL is set to '0' while creating the answers
+
+        // DON'T announce host
+        sendParameter.m_u32HostReplyMask = 0;
+
+        // Announce services (service type, name, SRV (location) and TXTs)
+        p_rService.m_u32ReplyMask = (static_cast<uint32_t>(enuContentFlag::PTR_TYPE) | static_cast<uint32_t>(enuContentFlag::PTR_NAME) | static_cast<uint32_t>(enuContentFlag::SRV) | static_cast<uint32_t>(enuContentFlag::TXT));
+        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _announceService: Announcing service '%s' (content: %s)\n"), _DH(), _service2String(&p_rService), _replyFlags2String(p_rService.m_u32ReplyMask)););
+
+        bResult = true;
+    }
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _announceService: FAILED!\n"), _DH()););
+    return ((bResult) &&
+            (_sendMDNSMessage(sendParameter)));
+}
+
+
+/**
+    QUERY CACHE
+*/
+
+/*
+    MDNSResponder::clsHost::_checkQueryCache
+
+    For any 'living' query (m_bAwaitingAnswers == true) all available answers (their components)
+    are checked for topicality based on the stored reception time and the answers TTL.
+    When the components TTL is outlasted by more than 80%, a new question is generated, to get updated information.
+    When no update arrived (in time), the component is removed from the answer (cache).
+
+*/
+bool MDNSResponder::clsHost::_checkQueryCache(void)
+{
+    bool        bResult = true;
+
+    DEBUG_EX_INFO(
+        bool    printedInfo = false;
+    );
+    for (stcQuery* pQuery = m_pQueries; ((bResult) && (pQuery)); pQuery = pQuery->m_pNext)
+    {
+        //
+        // Resend dynamic queries, if not already done often enough
+        if ((!pQuery->m_bLegacyQuery) &&
+            (pQuery->m_ResendTimeout.expired()))
+        {
+
+            if ((bResult = _sendMDNSQuery(*pQuery)))
+            {
+                // The re-query rate is increased to more than one hour (RFC 6762 5.2)
+                ++pQuery->m_u8SentCount;
+                uint32_t    u32NewDelay = (MDNS_DYNAMIC_QUERY_RESEND_DELAY * pow(2, std::min((pQuery->m_u8SentCount - 1), 12)));
+                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _checkQueryCache: Next query in %u seconds!\n"), _DH(), (u32NewDelay)););
+                pQuery->m_ResendTimeout.reset(u32NewDelay);
+            }
+            DEBUG_EX_INFO(
+                DEBUG_OUTPUT.printf_P(PSTR("%s _checkQueryCache: %s to resend query!\n"), _DH(), (bResult ? "Succeeded" : "FAILED"));
+                printedInfo = true;
+            );
+        }
+
+        //
+        // Schedule updates for cached answers
+        if (pQuery->m_bAwaitingAnswers)
+        {
+            stcQuery::stcAnswer* pSQAnswer = pQuery->m_pAnswers;
+            while ((bResult) &&
+                   (pSQAnswer))
+            {
+                stcQuery::stcAnswer* pNextSQAnswer = pSQAnswer->m_pNext;
+
+                // 1. level answer
+                if ((bResult) &&
+                    (pSQAnswer->m_TTLServiceDomain.flagged()))
+                {
+
+                    if (!pSQAnswer->m_TTLServiceDomain.finalTimeoutLevel())
+                    {
+
+                        bResult = ((_sendMDNSQuery(*pQuery)) &&
+                                   (pSQAnswer->m_TTLServiceDomain.restart()));
+                        DEBUG_EX_INFO(
+                            DEBUG_OUTPUT.printf_P(PSTR("%s _checkQueryCache: PTR update scheduled for "), _DH());
+                            _printRRDomain(pSQAnswer->m_ServiceDomain);
+                            DEBUG_OUTPUT.printf_P(PSTR(" %s\n"), (bResult ? "OK" : "FAILURE"));
+                            printedInfo = true;
+                        );
+                    }
+                    else
+                    {
+                        // Timed out! -> Delete
+                        _executeQueryCallback(*pQuery, *pSQAnswer, static_cast<typeQueryAnswerType>(enuQueryAnswerType::ServiceDomain), false);
+                        DEBUG_EX_INFO(
+                            DEBUG_OUTPUT.printf_P(PSTR("%s _checkQueryCache: Will remove PTR answer for "), _DH());
+                            _printRRDomain(pSQAnswer->m_ServiceDomain);
+                            DEBUG_OUTPUT.printf_P(PSTR("\n"));
+                            printedInfo = true;
+                        );
+
+                        bResult = pQuery->removeAnswer(pSQAnswer);
+                        pSQAnswer = 0;
+                        continue;   // Don't use this answer anymore
+                    }
+                }   // ServiceDomain flagged
+
+                // 2. level answers
+                // HostDomain & Port (from SRV)
+                if ((bResult) &&
+                    (pSQAnswer->m_TTLHostDomainAndPort.flagged()))
+                {
+
+                    if (!pSQAnswer->m_TTLHostDomainAndPort.finalTimeoutLevel())
+                    {
+
+                        bResult = ((_sendMDNSQuery(pSQAnswer->m_ServiceDomain, DNS_RRTYPE_SRV)) &&
+                                   (pSQAnswer->m_TTLHostDomainAndPort.restart()));
+                        DEBUG_EX_INFO(
+                            DEBUG_OUTPUT.printf_P(PSTR("%s _checkQueryCache: SRV update scheduled for "), _DH());
+                            _printRRDomain(pSQAnswer->m_ServiceDomain);
+                            DEBUG_OUTPUT.printf_P(PSTR(" host domain and port %s\n"), (bResult ? "OK" : "FAILURE"));
+                            printedInfo = true;
+                        );
+                    }
+                    else
+                    {
+                        // Timed out! -> Delete
+                        DEBUG_EX_INFO(
+                            DEBUG_OUTPUT.printf_P(PSTR("%s _checkQueryCache: Will remove SRV answer for "), _DH());
+                            _printRRDomain(pSQAnswer->m_ServiceDomain);
+                            DEBUG_OUTPUT.printf_P(PSTR(" host domain and port\n"));
+                            printedInfo = true;
+                        );
+                        // Delete
+                        pSQAnswer->m_HostDomain.clear();
+                        //pSQAnswer->releaseHostDomain();
+                        pSQAnswer->m_u16Port = 0;
+                        pSQAnswer->m_TTLHostDomainAndPort.set(0);
+                        typeQueryAnswerType queryAnswerContentFlags = (static_cast<typeQueryAnswerType>(enuQueryAnswerType::HostDomain) | static_cast<typeQueryAnswerType>(enuQueryAnswerType::Port));
+                        // As the host domain is the base for the IPv4- and IPv6Address, remove these too
+#ifdef MDNS_IPV4_SUPPORT
+                        pSQAnswer->releaseIPv4Addresses();
+                        queryAnswerContentFlags |= static_cast<typeQueryAnswerType>(enuQueryAnswerType::IPv4Address);
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+                        pSQAnswer->releaseIPv6Addresses();
+                        queryAnswerContentFlags |= static_cast<typeQueryAnswerType>(enuQueryAnswerType::IPv6Address);
+#endif
+
+                        // Remove content flags for deleted answer parts
+                        pSQAnswer->m_QueryAnswerFlags &= ~queryAnswerContentFlags;
+                        _executeQueryCallback(*pQuery, *pSQAnswer, queryAnswerContentFlags, false);
+                    }
+                }   // HostDomainAndPort flagged
+
+                // Txts (from TXT)
+                if ((bResult) &&
+                    (pSQAnswer->m_TTLTxts.flagged()))
+                {
+
+                    if (!pSQAnswer->m_TTLTxts.finalTimeoutLevel())
+                    {
+
+                        bResult = ((_sendMDNSQuery(pSQAnswer->m_ServiceDomain, DNS_RRTYPE_TXT)) &&
+                                   (pSQAnswer->m_TTLTxts.restart()));
+                        DEBUG_EX_INFO(
+                            DEBUG_OUTPUT.printf_P(PSTR("%s _checkQueryCache: TXT update scheduled for "), _DH());
+                            _printRRDomain(pSQAnswer->m_ServiceDomain);
+                            DEBUG_OUTPUT.printf_P(PSTR(" TXTs %s\n"), (bResult ? "OK" : "FAILURE"));
+                            printedInfo = true;
+                        );
+                    }
+                    else
+                    {
+                        // Timed out! -> Delete
+                        DEBUG_EX_INFO(
+                            DEBUG_OUTPUT.printf_P(PSTR("%s _checkQueryCache: Will remove TXT answer for "), _DH());
+                            _printRRDomain(pSQAnswer->m_ServiceDomain);
+                            DEBUG_OUTPUT.printf_P(PSTR(" TXTs\n"));
+                            printedInfo = true;
+                        );
+                        // Delete
+                        pSQAnswer->m_Txts.clear();
+                        pSQAnswer->m_TTLTxts.set(0);
+
+                        // Remove content flags for deleted answer parts
+                        pSQAnswer->m_QueryAnswerFlags &= ~static_cast<typeQueryAnswerType>(enuQueryAnswerType::Txts);
+                        _executeQueryCallback(*pQuery, *pSQAnswer, static_cast<typeQueryAnswerType>(enuQueryAnswerType::Txts), false);
+                    }
+                }   // TXTs flagged
+
+                // 3. level answers
+#ifdef MDNS_IPV4_SUPPORT
+                // IPv4Address (from A)
+                stcQuery::stcAnswer::stcIPAddress*  pIPv4Address = pSQAnswer->m_pIPv4Addresses;
+                bool                                    bAUpdateQuerySent = false;
+                while ((pIPv4Address) &&
+                       (bResult))
+                {
+
+                    stcQuery::stcAnswer::stcIPAddress*  pNextIPv4Address = pIPv4Address->m_pNext; // Get 'next' early, as 'current' may be deleted at the end...
+
+                    if (pIPv4Address->m_TTL.flagged())
+                    {
+
+                        if (!pIPv4Address->m_TTL.finalTimeoutLevel())    // Needs update
+                        {
+
+                            if ((bAUpdateQuerySent) ||
+                                ((bResult = _sendMDNSQuery(pSQAnswer->m_HostDomain, DNS_RRTYPE_A))))
+                            {
+
+                                pIPv4Address->m_TTL.restart();
+                                bAUpdateQuerySent = true;
+
+                                DEBUG_EX_INFO(
+                                    DEBUG_OUTPUT.printf_P(PSTR("%s _checkQueryCache: IPv4 update scheduled for "), _DH());
+                                    _printRRDomain(pSQAnswer->m_ServiceDomain);
+                                    DEBUG_OUTPUT.printf_P(PSTR(" IPv4 address (%s)\n"), (pIPv4Address->m_IPAddress.toString().c_str()));
+                                    printedInfo = true;
+                                );
+                            }
+                        }
+                        else
+                        {
+                            // Timed out! -> Delete
+                            DEBUG_EX_INFO(
+                                DEBUG_OUTPUT.printf_P(PSTR("%s _checkQueryCache: Will remove IPv4 answer for "), _DH());
+                                _printRRDomain(pSQAnswer->m_ServiceDomain);
+                                DEBUG_OUTPUT.printf_P(PSTR(" IPv4 address\n"));
+                                printedInfo = true;
+                            );
+                            pSQAnswer->removeIPv4Address(pIPv4Address);
+                            if (!pSQAnswer->m_pIPv4Addresses)    // NO IPv4 address left -> remove content flag
+                            {
+                                pSQAnswer->m_QueryAnswerFlags &= ~static_cast<typeQueryAnswerType>(enuQueryAnswerType::IPv4Address);
+                            }
+                            // Notify client
+                            _executeQueryCallback(*pQuery, *pSQAnswer, static_cast<typeQueryAnswerType>(enuQueryAnswerType::IPv4Address), false);
+                        }
+                    }   // IPv4 flagged
+
+                    pIPv4Address = pNextIPv4Address;  // Next
+                }   // while
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+                // IPv6Address (from AAAA)
+                stcQuery::stcAnswer::stcIPAddress*  pIPv6Address = pSQAnswer->m_pIPv6Addresses;
+                bool                                    bAAAAUpdateQuerySent = false;
+                while ((pIPv6Address) &&
+                       (bResult))
+                {
+
+                    stcQuery::stcAnswer::stcIPAddress*  pNextIPv6Address = pIPv6Address->m_pNext; // Get 'next' early, as 'current' may be deleted at the end...
+
+                    if (pIPv6Address->m_TTL.flagged())
+                    {
+
+                        if (!pIPv6Address->m_TTL.finalTimeoutLevel())    // Needs update
+                        {
+
+                            if ((bAAAAUpdateQuerySent) ||
+                                ((bResult = _sendMDNSQuery(pSQAnswer->m_HostDomain, DNS_RRTYPE_AAAA))))
+                            {
+
+                                pIPv6Address->m_TTL.restart();
+                                bAAAAUpdateQuerySent = true;
+
+                                DEBUG_EX_INFO(
+                                    DEBUG_OUTPUT.printf_P(PSTR("%s _checkQueryCache: IPv6 update scheduled for "), _DH());
+                                    _printRRDomain(pSQAnswer->m_ServiceDomain);
+                                    DEBUG_OUTPUT.printf_P(PSTR(" IPv6 address (%s)\n"), (pIPv6Address->m_IPAddress.toString().c_str()));
+                                    printedInfo = true;
+                                );
+                            }
+                        }
+                        else
+                        {
+                            // Timed out! -> Delete
+                            DEBUG_EX_INFO(
+                                DEBUG_OUTPUT.printf_P(PSTR("%s _checkQueryCache: Will remove answer for "), _DH());
+                                _printRRDomain(pSQAnswer->m_ServiceDomain);
+                                DEBUG_OUTPUT.printf_P(PSTR(" IPv6 address\n"));
+                                printedInfo = true;
+                            );
+                            pSQAnswer->removeIPv6Address(pIPv6Address);
+                            if (!pSQAnswer->m_pIPv6Addresses)    // NO IPv6 address left -> remove content flag
+                            {
+                                pSQAnswer->m_QueryAnswerFlags &= ~static_cast<typeQueryAnswerType>(enuQueryAnswerType::IPv6Address);
+                            }
+                            // Notify client
+                            _executeQueryCallback(*pQuery, *pSQAnswer, static_cast<typeQueryAnswerType>(enuQueryAnswerType::IPv6Address), false);
+                        }
+                    }   // IPv6 flagged
+
+                    pIPv6Address = pNextIPv6Address;  // Next
+                }   // while
+#endif
+                pSQAnswer = pNextSQAnswer;
+            }
+        }
+    }
+    DEBUG_EX_INFO(if (printedInfo) DEBUG_OUTPUT.printf_P(PSTR("\n")););
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _checkQueryCache: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+
+/*
+    MDNSResponder::clsHost::_replyMaskForHost
+
+    Determines the relavant host answers for the given question.
+    - A question for the hostname (eg. esp8266.local) will result in an A/AAAA (eg. 192.168.2.129) reply.
+    - A question for the reverse IP address (eg. 192-168.2.120.inarpa.arpa) will result in an PTR_IPv4 (eg. esp8266.local) reply.
+
+    In addition, a full name match (question domain == host domain) is marked.
+*/
+uint32_t MDNSResponder::clsHost::_replyMaskForHost(const MDNSResponder::clsHost::stcRRHeader& p_RRHeader,
+                                                   bool* p_pbFullNameMatch /*= 0*/) const
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _replyMaskForHost\n")););
+
+    uint32_t    u32ReplyMask = 0;
+    (p_pbFullNameMatch ? *p_pbFullNameMatch = false : 0);
+
+    if ((DNS_RRCLASS_IN == (p_RRHeader.m_Attributes.m_u16Class & (~0x8000))) ||
+        (DNS_RRCLASS_ANY == (p_RRHeader.m_Attributes.m_u16Class & (~0x8000))))
+    {
+
+        if ((DNS_RRTYPE_PTR == p_RRHeader.m_Attributes.m_u16Type) ||
+            (DNS_RRTYPE_ANY == p_RRHeader.m_Attributes.m_u16Type))
+        {
+            // PTR request
+#ifdef MDNS_IPV4_SUPPORT
+            stcRRDomain    reverseIPv4Domain;
+            if ((_getResponderIPAddress(enuIPProtocolType::V4).isSet()) &&
+                (_buildDomainForReverseIPv4(_getResponderIPAddress(enuIPProtocolType::V4), reverseIPv4Domain)) &&
+                (p_RRHeader.m_Domain == reverseIPv4Domain))
+            {
+                // Reverse domain match
+                u32ReplyMask |= static_cast<uint32_t>(enuContentFlag::PTR_IPv4);
+            }
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+            stcRRDomain    reverseIPv6Domain;
+            if ((_getResponderIPAddress(enuIPProtocolType::V6).isSet()) &&
+                (_buildDomainForReverseIPv6(_getResponderIPAddress(enuIPProtocolType::V6), reverseIPv6Domain)) &&
+                (p_RRHeader.m_Domain == reverseIPv6Domain))
+            {
+                // Reverse domain match
+                u32ReplyMask |= static_cast<uint32_t>(enuContentFlag::PTR_IPv6);
+            }
+#endif
+        }   // Address qeuest
+
+        stcRRDomain    hostDomain;
+        if ((_buildDomainForHost(m_pcHostName, hostDomain)) &&
+            (p_RRHeader.m_Domain == hostDomain))    // Host domain match
+        {
+
+            (p_pbFullNameMatch ? (*p_pbFullNameMatch = true) : (0));
+
+#ifdef MDNS_IPV4_SUPPORT
+            if ((DNS_RRTYPE_A == p_RRHeader.m_Attributes.m_u16Type) ||
+                (DNS_RRTYPE_ANY == p_RRHeader.m_Attributes.m_u16Type))
+            {
+                // IPv4 address request
+                u32ReplyMask |= static_cast<uint32_t>(enuContentFlag::A);
+            }
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+            if ((DNS_RRTYPE_AAAA == p_RRHeader.m_Attributes.m_u16Type) ||
+                (DNS_RRTYPE_ANY == p_RRHeader.m_Attributes.m_u16Type))
+            {
+                // IPv6 address request
+                u32ReplyMask |= static_cast<uint32_t>(enuContentFlag::AAAA);
+            }
+#endif
+        }
+    }
+    else
+    {
+        //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _replyMaskForHost: INVALID RR-class (0x%04X)!\n"), p_RRHeader.m_Attributes.m_u16Class););
+    }
+    DEBUG_EX_INFO(if (u32ReplyMask) DEBUG_OUTPUT.printf_P(PSTR("%s _replyMaskForHost: %s\n"), _DH(), _replyFlags2String(u32ReplyMask)););
+    return u32ReplyMask;
+}
+
+/*
+    MDNSResponder::clsHost::_replyMaskForService
+
+    Determines the relevant service answers for the given question
+    - A PTR dns-sd service enum question (_services.dns-sd._udp.local) will result into an PTR_TYPE (eg. _http._tcp.local) answer
+    - A PTR service type question (eg. _http._tcp.local) will result into an PTR_NAME (eg. MyESP._http._tcp.local) answer
+    - A PTR service name question (eg. MyESP._http._tcp.local) will result into an PTR_NAME (eg. MyESP._http._tcp.local) answer
+    - A SRV service name question (eg. MyESP._http._tcp.local) will result into an SRV (eg. 5000 MyESP.local) answer
+    - A TXT service name question (eg. MyESP._http._tcp.local) will result into an TXT (eg. c#=1) answer
+
+    In addition, a full name match (question domain == service instance domain) is marked.
+*/
+uint32_t MDNSResponder::clsHost::_replyMaskForService(const MDNSResponder::clsHost::stcRRHeader& p_RRHeader,
+                                                      const MDNSResponder::clsHost::stcService& p_Service,
+                                                      bool* p_pbFullNameMatch /*= 0*/) const
+{
+    uint32_t    u32ReplyMask = 0;
+    (p_pbFullNameMatch ? *p_pbFullNameMatch = false : 0);
+
+    if ((DNS_RRCLASS_IN == (p_RRHeader.m_Attributes.m_u16Class & (~0x8000))) ||
+        (DNS_RRCLASS_ANY == (p_RRHeader.m_Attributes.m_u16Class & (~0x8000))))
+    {
+
+        stcRRDomain    DNSSDDomain;
+        if ((_buildDomainForDNSSD(DNSSDDomain)) &&                          // _services._dns-sd._udp.local
+            (p_RRHeader.m_Domain == DNSSDDomain) &&
+            ((DNS_RRTYPE_PTR == p_RRHeader.m_Attributes.m_u16Type) ||
+             (DNS_RRTYPE_ANY == p_RRHeader.m_Attributes.m_u16Type)))
+        {
+            // Common service info requested
+            u32ReplyMask |= static_cast<uint32_t>(enuContentFlag::PTR_TYPE);
+        }
+
+        stcRRDomain    serviceDomain;
+        if ((_buildDomainForService(p_Service, false, serviceDomain)) &&    // eg. _http._tcp.local
+            (p_RRHeader.m_Domain == serviceDomain) &&
+            ((DNS_RRTYPE_PTR == p_RRHeader.m_Attributes.m_u16Type) ||
+             (DNS_RRTYPE_ANY == p_RRHeader.m_Attributes.m_u16Type)))
+        {
+            // Special service info requested
+            u32ReplyMask |= static_cast<uint32_t>(enuContentFlag::PTR_NAME);
+        }
+
+        if ((_buildDomainForService(p_Service, true, serviceDomain)) &&     // eg. MyESP._http._tcp.local
+            (p_RRHeader.m_Domain == serviceDomain))
+        {
+
+            (p_pbFullNameMatch ? (*p_pbFullNameMatch = true) : (0));
+
+            if ((DNS_RRTYPE_SRV == p_RRHeader.m_Attributes.m_u16Type) ||
+                (DNS_RRTYPE_ANY == p_RRHeader.m_Attributes.m_u16Type))
+            {
+                // Instance info SRV requested
+                u32ReplyMask |= static_cast<uint32_t>(enuContentFlag::SRV);
+            }
+            if ((DNS_RRTYPE_TXT == p_RRHeader.m_Attributes.m_u16Type) ||
+                (DNS_RRTYPE_ANY == p_RRHeader.m_Attributes.m_u16Type))
+            {
+                // Instance info TXT requested
+                u32ReplyMask |= static_cast<uint32_t>(enuContentFlag::TXT);
+            }
+        }
+    }
+    else
+    {
+        //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _replyMaskForService: INVALID RR-class (0x%04X)!\n"), p_RRHeader.m_Attributes.m_u16Class););
+    }
+    DEBUG_EX_INFO(if (u32ReplyMask) DEBUG_OUTPUT.printf_P(PSTR("%s _replyMaskForService(%s.%s.%s): %s\n"), _DH(), p_Service.m_pcName, p_Service.m_pcServiceType, p_Service.m_pcProtocol, _replyFlags2String(u32ReplyMask)););
+    return u32ReplyMask;
+}
+
+} // namespace MDNSImplementation
+
+} // namespace esp8266

--- a/libraries/ESP8266mDNS/src/LEAmDNS2_Host_Debug.cpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS2_Host_Debug.cpp
@@ -1,0 +1,327 @@
+/*
+    LEAmDNS2_Host_Debug.h
+
+    License (MIT license):
+      Permission is hereby granted, free of charge, to any person obtaining a copy
+      of this software and associated documentation files (the "Software"), to deal
+      in the Software without restriction, including without limitation the rights
+      to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+      copies of the Software, and to permit persons to whom the Software is
+      furnished to do so, subject to the following conditions:
+
+      The above copyright notice and this permission notice shall be included in
+      all copies or substantial portions of the Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+      THE SOFTWARE.
+
+*/
+
+//#include <arch/cc.h>
+//#include <sys/time.h>
+//#include <HardwareSerial.h>
+//#include <IPAddress.h>
+//#include <lwip/ip_addr.h>
+//#include <lwip/netif.h>
+//#include <WString.h>
+//#include <cstdint>
+
+/*
+    ESP8266mDNS Control.cpp
+*/
+
+extern "C" {
+    //#include "user_interface.h"
+}
+
+#include "LEAmDNS2_lwIPdefs.h"
+#include "LEAmDNS2_Priv.h"
+
+#ifdef MDNS_IPV4_SUPPORT
+//#include <lwip/igmp.h>
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+//#include <lwip/mld6.h>
+#endif
+
+
+namespace esp8266
+{
+
+/*
+    LEAmDNS
+*/
+namespace experimental
+{
+
+#ifdef DEBUG_ESP_MDNS_RESPONDER
+
+/*
+    MDNSResponder::clsHost::_DH
+*/
+const char* MDNSResponder::clsHost::_DH(const MDNSResponder::clsHost::stcService* p_pMDNSService /*= 0*/) const
+{
+    static char acBuffer[16 + 64];
+
+    *acBuffer = 0;
+    if (p_pMDNSService)
+    {
+        sprintf_P(acBuffer, PSTR("[MDNSResponder (%c%c%u)->%s]"), m_rNetIf.name[0], m_rNetIf.name[1], m_rNetIf.num, _service2String(p_pMDNSService));
+    }
+    else
+    {
+        sprintf_P(acBuffer, PSTR("[MDNSResponder (%c%c%u)]"), m_rNetIf.name[0], m_rNetIf.name[1], m_rNetIf.num);
+    }
+    return acBuffer;
+}
+
+/*
+    MDNSResponder::clsHost::_service2String
+*/
+const char* MDNSResponder::clsHost::_service2String(const MDNSResponder::clsHost::stcService* p_pMDNSService) const
+{
+    static  char acBuffer[64];
+
+    *acBuffer = 0;
+    if (p_pMDNSService)
+    {
+        sprintf_P(acBuffer, PSTR("%s.%s%s.%s%s.local"),
+                  (p_pMDNSService->m_pcName ? : "-"),
+                  (p_pMDNSService->m_pcServiceType ? ('_' == *(p_pMDNSService->m_pcServiceType) ? "" : "_") : "-"),
+                  (p_pMDNSService->m_pcServiceType ? : "-"),
+                  (p_pMDNSService->m_pcProtocol ? ('_' == *(p_pMDNSService->m_pcProtocol) ? "" : "_") : "-"),
+                  (p_pMDNSService->m_pcProtocol ? : "-"));
+    }
+    return acBuffer;
+}
+
+/*
+    MDNSResponder::clsHost::_printRRDomain
+*/
+bool MDNSResponder::clsHost::_printRRDomain(const MDNSResponder::clsHost::stcRRDomain& p_RRDomain) const
+{
+    //DEBUG_OUTPUT.printf_P(PSTR("Domain: "));
+
+    const char* pCursor = p_RRDomain.m_acName;
+    uint8_t     u8Length = *pCursor++;
+    if (u8Length)
+    {
+        while (u8Length)
+        {
+            for (uint8_t u = 0; u < u8Length; ++u)
+            {
+                DEBUG_OUTPUT.printf_P(PSTR("%c"), *(pCursor++));
+            }
+            u8Length = *pCursor++;
+            if (u8Length)
+            {
+                DEBUG_OUTPUT.printf_P(PSTR("."));
+            }
+        }
+    }
+    else    // empty domain
+    {
+        DEBUG_OUTPUT.printf_P(PSTR("-empty-"));
+    }
+    //DEBUG_OUTPUT.printf_P(PSTR("\n"));
+
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::_printRRAnswer
+*/
+bool MDNSResponder::clsHost::_printRRAnswer(const MDNSResponder::clsHost::stcRRAnswer& p_RRAnswer) const
+{
+    DEBUG_OUTPUT.printf_P(PSTR("%s RRAnswer: "), _DH());
+    _printRRDomain(p_RRAnswer.m_Header.m_Domain);
+    DEBUG_OUTPUT.printf_P(PSTR(" Type:0x%04X Class:0x%04X TTL:%u, "), p_RRAnswer.m_Header.m_Attributes.m_u16Type, p_RRAnswer.m_Header.m_Attributes.m_u16Class, p_RRAnswer.m_u32TTL);
+    switch (p_RRAnswer.m_Header.m_Attributes.m_u16Type & (~0x8000))     // Topmost bit might carry 'cache flush' flag
+    {
+#ifdef MDNS_IPV4_SUPPORT
+    case DNS_RRTYPE_A:
+        DEBUG_OUTPUT.printf_P(PSTR("A IP:%s"), ((const stcRRAnswerA*)&p_RRAnswer)->m_IPAddress.toString().c_str());
+        break;
+#endif
+    case DNS_RRTYPE_PTR:
+        DEBUG_OUTPUT.printf_P(PSTR("PTR "));
+        _printRRDomain(((const stcRRAnswerPTR*)&p_RRAnswer)->m_PTRDomain);
+        break;
+    case DNS_RRTYPE_TXT:
+    {
+        size_t  stTxtLength = ((const stcRRAnswerTXT*)&p_RRAnswer)->m_Txts.c_strLength();
+        char*   pTxts = new char[stTxtLength];
+        if (pTxts)
+        {
+            ((/*const c_str()!!*/stcRRAnswerTXT*)&p_RRAnswer)->m_Txts.c_str(pTxts);
+            DEBUG_OUTPUT.printf_P(PSTR("TXT(%u) %s"), stTxtLength, pTxts);
+            delete[] pTxts;
+        }
+        break;
+    }
+#ifdef MDNS_IPV6_SUPPORT
+    case DNS_RRTYPE_AAAA:
+        DEBUG_OUTPUT.printf_P(PSTR("AAAA IP:%s"), ((stcRRAnswerAAAA*&)p_RRAnswer)->m_IPAddress.toString().c_str());
+        break;
+#endif
+    case DNS_RRTYPE_SRV:
+        DEBUG_OUTPUT.printf_P(PSTR("SRV Port:%u "), ((const stcRRAnswerSRV*)&p_RRAnswer)->m_u16Port);
+        _printRRDomain(((const stcRRAnswerSRV*)&p_RRAnswer)->m_SRVDomain);
+        break;
+    default:
+        DEBUG_OUTPUT.printf_P(PSTR("generic "));
+        break;
+    }
+    DEBUG_OUTPUT.printf_P(PSTR("\n"));
+
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::_RRType2Name
+*/
+const char* MDNSResponder::clsHost::_RRType2Name(uint16_t p_u16RRType) const
+{
+    static char acRRName[16];
+    *acRRName = 0;
+
+    switch (p_u16RRType & (~0x8000))    // Topmost bit might carry 'cache flush' flag
+    {
+    case DNS_RRTYPE_A:      strcpy(acRRName, "A");      break;
+    case DNS_RRTYPE_PTR:    strcpy(acRRName, "PTR");    break;
+    case DNS_RRTYPE_TXT:    strcpy(acRRName, "TXT");    break;
+    case DNS_RRTYPE_AAAA:   strcpy(acRRName, "AAAA");   break;
+    case DNS_RRTYPE_SRV:    strcpy(acRRName, "SRV");    break;
+    case DNS_RRTYPE_NSEC:   strcpy(acRRName, "NSEC");   break;
+    case DNS_RRTYPE_ANY:    strcpy(acRRName, "ANY");    break;
+    default:
+        sprintf(acRRName, "Unknown(0x%04X)", p_u16RRType);  // MAX 15!
+    }
+    return acRRName;
+}
+
+/*
+    MDNSResponder::clsHost::_RRClass2String
+*/
+const char* MDNSResponder::clsHost::_RRClass2String(uint16_t p_u16RRClass,
+                                                    bool p_bIsQuery) const
+{
+    static char acClassString[16];
+    *acClassString = 0;
+
+    if (p_u16RRClass & 0x0001)
+    {
+        strcat(acClassString, "IN ");    //  3
+    }
+    if (p_u16RRClass & 0x8000)
+    {
+        strcat(acClassString, (p_bIsQuery ? "UNICAST " : "FLUSH "));    //  8/6
+    }
+
+    return acClassString;                                                                       // 11
+}
+
+/*
+    MDNSResponder::clsHost::_replyFlags2String
+*/
+const char* MDNSResponder::clsHost::_replyFlags2String(uint32_t p_u32ReplyFlags) const
+{
+    static char acFlagsString[64];
+
+    *acFlagsString = 0;
+    if (p_u32ReplyFlags & static_cast<uint32_t>(enuContentFlag::A))
+    {
+        strcat(acFlagsString, "A ");    //  2
+    }
+    if (p_u32ReplyFlags & static_cast<uint32_t>(enuContentFlag::PTR_IPv4))
+    {
+        strcat(acFlagsString, "PTR_IPv4 ");    //  7
+    }
+    if (p_u32ReplyFlags & static_cast<uint32_t>(enuContentFlag::PTR_IPv6))
+    {
+        strcat(acFlagsString, "PTR_IPv6 ");    //  7
+    }
+    if (p_u32ReplyFlags & static_cast<uint32_t>(enuContentFlag::AAAA))
+    {
+        strcat(acFlagsString, "AAAA ");    //  5
+    }
+    if (p_u32ReplyFlags & static_cast<uint32_t>(enuContentFlag::PTR_TYPE))
+    {
+        strcat(acFlagsString, "PTR_TYPE ");    //  9
+    }
+    if (p_u32ReplyFlags & static_cast<uint32_t>(enuContentFlag::PTR_NAME))
+    {
+        strcat(acFlagsString, "PTR_NAME ");    //  9
+    }
+    if (p_u32ReplyFlags & static_cast<uint32_t>(enuContentFlag::TXT))
+    {
+        strcat(acFlagsString, "TXT ");    //  4
+    }
+    if (p_u32ReplyFlags & static_cast<uint32_t>(enuContentFlag::SRV))
+    {
+        strcat(acFlagsString, "SRV ");    //  4
+    }
+    if (p_u32ReplyFlags & static_cast<uint32_t>(enuContentFlag::NSEC))
+    {
+        strcat(acFlagsString, "NSEC ");    //  5
+    }
+
+    if (0 == p_u32ReplyFlags)
+    {
+        strcpy(acFlagsString, "none");
+    }
+
+    return acFlagsString;                                                                           // 63
+}
+
+/*
+    MDNSResponder::clsHost::_NSECBitmap2String
+*/
+const char* MDNSResponder::clsHost::_NSECBitmap2String(const stcNSECBitmap* p_pNSECBitmap) const
+{
+    static char acFlagsString[32];
+
+    *acFlagsString = 0;
+    if (p_pNSECBitmap->getBit(DNS_RRTYPE_A))
+    {
+        strcat(acFlagsString, "A ");    //  2
+    }
+    if (p_pNSECBitmap->getBit(DNS_RRTYPE_PTR))
+    {
+        strcat(acFlagsString, "PTR ");  //  4
+    }
+    if (p_pNSECBitmap->getBit(DNS_RRTYPE_AAAA))
+    {
+        strcat(acFlagsString, "AAAA "); //  5
+    }
+    if (p_pNSECBitmap->getBit(DNS_RRTYPE_TXT))
+    {
+        strcat(acFlagsString, "TXT ");  //  4
+    }
+    if (p_pNSECBitmap->getBit(DNS_RRTYPE_SRV))
+    {
+        strcat(acFlagsString, "SRV ");  //  4
+    }
+    if (p_pNSECBitmap->getBit(DNS_RRTYPE_NSEC))
+    {
+        strcat(acFlagsString, "NSEC "); //  5
+    }
+
+    if (!*acFlagsString)
+    {
+        strcpy(acFlagsString, "none");
+    }
+
+    return acFlagsString;               // 31
+}
+
+#endif  // DEBUG_ESP_MDNS_RESPONDER
+
+}   // namespace MDNSImplementation
+
+}   // namespace esp8266

--- a/libraries/ESP8266mDNS/src/LEAmDNS2_Host_Structs.cpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS2_Host_Structs.cpp
@@ -1,0 +1,2435 @@
+/*
+    LEAmDNS2_Host_Structs.cpp
+
+    License (MIT license):
+      Permission is hereby granted, free of charge, to any person obtaining a copy
+      of this software and associated documentation files (the "Software"), to deal
+      in the Software without restriction, including without limitation the rights
+      to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+      copies of the Software, and to permit persons to whom the Software is
+      furnished to do so, subject to the following conditions:
+
+      The above copyright notice and this permission notice shall be included in
+      all copies or substantial portions of the Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+      THE SOFTWARE.
+
+*/
+
+#include "LEAmDNS2_Priv.h"
+#include "LEAmDNS2_lwIPdefs.h"
+
+namespace esp8266
+{
+
+/*
+    LEAmDNS
+*/
+namespace experimental
+{
+
+/**
+    Internal CLASSES & STRUCTS
+*/
+
+/**
+    MDNSResponder::clsHost::stcServiceTxt
+
+    One MDNS TXT item.
+    m_pcValue may be '\0'.
+    Objects can be chained together (list, m_pNext).
+    A 'm_bTemp' flag differentiates between static and dynamic items.
+    Output as byte array 'c#=1' is supported.
+*/
+
+/*
+    MDNSResponder::clsHost::stcServiceTxt::stcServiceTxt constructor
+*/
+MDNSResponder::clsHost::stcServiceTxt::stcServiceTxt(const char* p_pcKey /*= 0*/,
+                                                     const char* p_pcValue /*= 0*/,
+                                                     bool p_bTemp /*= false*/)
+    :   m_pNext(0),
+        m_pcKey(0),
+        m_pcValue(0),
+        m_bTemp(p_bTemp)
+{
+    setKey(p_pcKey);
+    setValue(p_pcValue);
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxt::stcServiceTxt copy-constructor
+*/
+MDNSResponder::clsHost::stcServiceTxt::stcServiceTxt(const MDNSResponder::clsHost::stcServiceTxt& p_Other)
+    :   m_pNext(0),
+        m_pcKey(0),
+        m_pcValue(0),
+        m_bTemp(false)
+{
+    operator=(p_Other);
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxt::~stcServiceTxt destructor
+*/
+MDNSResponder::clsHost::stcServiceTxt::~stcServiceTxt(void)
+{
+    clear();
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxt::operator=
+*/
+MDNSResponder::clsHost::stcServiceTxt& MDNSResponder::clsHost::stcServiceTxt::operator=(const MDNSResponder::clsHost::stcServiceTxt& p_Other)
+{
+    if (&p_Other != this)
+    {
+        clear();
+        set(p_Other.m_pcKey, p_Other.m_pcValue, p_Other.m_bTemp);
+    }
+    return *this;
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxt::clear
+*/
+bool MDNSResponder::clsHost::stcServiceTxt::clear(void)
+{
+    releaseKey();
+    releaseValue();
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxt::allocKey
+*/
+char* MDNSResponder::clsHost::stcServiceTxt::allocKey(size_t p_stLength)
+{
+    releaseKey();
+    if (p_stLength)
+    {
+        m_pcKey = new char[p_stLength + 1];
+    }
+    return m_pcKey;
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxt::setKey
+*/
+bool MDNSResponder::clsHost::stcServiceTxt::setKey(const char* p_pcKey,
+                                                   size_t p_stLength)
+{
+    bool bResult = false;
+
+    releaseKey();
+    if (p_stLength)
+    {
+        if (allocKey(p_stLength))
+        {
+            strncpy(m_pcKey, p_pcKey, p_stLength);
+            m_pcKey[p_stLength] = 0;
+            bResult = true;
+        }
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxt::setKey
+*/
+bool MDNSResponder::clsHost::stcServiceTxt::setKey(const char* p_pcKey)
+{
+    return setKey(p_pcKey, (p_pcKey ? strlen(p_pcKey) : 0));
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxt::releaseKey
+*/
+bool MDNSResponder::clsHost::stcServiceTxt::releaseKey(void)
+{
+    if (m_pcKey)
+    {
+        delete[] m_pcKey;
+        m_pcKey = 0;
+    }
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxt::allocValue
+*/
+char* MDNSResponder::clsHost::stcServiceTxt::allocValue(size_t p_stLength)
+{
+    releaseValue();
+    if (p_stLength)
+    {
+        m_pcValue = new char[p_stLength + 1];
+    }
+    return m_pcValue;
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxt::setValue
+*/
+bool MDNSResponder::clsHost::stcServiceTxt::setValue(const char* p_pcValue,
+                                                     size_t p_stLength)
+{
+    bool bResult = false;
+
+    releaseValue();
+    if (p_stLength)
+    {
+        if (allocValue(p_stLength))
+        {
+            strncpy(m_pcValue, p_pcValue, p_stLength);
+            m_pcValue[p_stLength] = 0;
+            bResult = true;
+        }
+    }
+    else    // No value -> also OK
+    {
+        bResult = true;
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxt::setValue
+*/
+bool MDNSResponder::clsHost::stcServiceTxt::setValue(const char* p_pcValue)
+{
+    return setValue(p_pcValue, (p_pcValue ? strlen(p_pcValue) : 0));
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxt::releaseValue
+*/
+bool MDNSResponder::clsHost::stcServiceTxt::releaseValue(void)
+{
+    if (m_pcValue)
+    {
+        delete[] m_pcValue;
+        m_pcValue = 0;
+    }
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxt::set
+*/
+bool MDNSResponder::clsHost::stcServiceTxt::set(const char* p_pcKey,
+                                                const char* p_pcValue,
+                                                bool p_bTemp /*= false*/)
+{
+    m_bTemp = p_bTemp;
+    return ((setKey(p_pcKey)) &&
+            (setValue(p_pcValue)));
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxt::update
+*/
+bool MDNSResponder::clsHost::stcServiceTxt::update(const char* p_pcValue)
+{
+    return setValue(p_pcValue);
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxt::length
+
+    length of eg. 'c#=1' without any closing '\0'
+*/
+size_t MDNSResponder::clsHost::stcServiceTxt::length(void) const
+{
+    size_t  stLength = 0;
+    if (m_pcKey)
+    {
+        stLength += strlen(m_pcKey);                     // Key
+        stLength += 1;                                      // '='
+        stLength += (m_pcValue ? strlen(m_pcValue) : 0); // Value
+    }
+    return stLength;
+}
+
+
+/**
+    MDNSResponder::clsHost::stcServiceTxts
+
+    A list of zero or more MDNS TXT items.
+    Dynamic TXT items can be removed by 'removeTempTxts'.
+    A TXT item can be looke up by its 'key' member.
+    Export as ';'-separated byte array is supported.
+    Export as 'length byte coded' byte array is supported.
+    Comparision ((all A TXT items in B and equal) AND (all B TXT items in A and equal)) is supported.
+
+*/
+
+/*
+    MDNSResponder::clsHost::stcServiceTxts::stcServiceTxts contructor
+*/
+MDNSResponder::clsHost::stcServiceTxts::stcServiceTxts(void)
+    :   m_pTxts(0),
+        m_pcCache(0)
+{
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxts::stcServiceTxts copy-constructor
+*/
+MDNSResponder::clsHost::stcServiceTxts::stcServiceTxts(const stcServiceTxts& p_Other)
+    :   m_pTxts(0),
+        m_pcCache(0)
+{
+    operator=(p_Other);
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxts::~stcServiceTxts destructor
+*/
+MDNSResponder::clsHost::stcServiceTxts::~stcServiceTxts(void)
+{
+    clear();
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxts::operator=
+*/
+MDNSResponder::clsHost::stcServiceTxts& MDNSResponder::clsHost::stcServiceTxts::operator=(const stcServiceTxts& p_Other)
+{
+    if (this != &p_Other)
+    {
+        clear();
+
+        for (stcServiceTxt* pOtherTxt = p_Other.m_pTxts; pOtherTxt; pOtherTxt = pOtherTxt->m_pNext)
+        {
+            add(new stcServiceTxt(*pOtherTxt));
+        }
+    }
+    return *this;
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxts::clear
+*/
+bool MDNSResponder::clsHost::stcServiceTxts::clear(void)
+{
+    while (m_pTxts)
+    {
+        stcServiceTxt* pNext = m_pTxts->m_pNext;
+        delete m_pTxts;
+        m_pTxts = pNext;
+    }
+    return clearCache();
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxts::clearCache
+*/
+bool MDNSResponder::clsHost::stcServiceTxts::clearCache(void)
+{
+    if (m_pcCache)
+    {
+        delete[] m_pcCache;
+        m_pcCache = 0;
+    }
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxts::add
+*/
+bool MDNSResponder::clsHost::stcServiceTxts::add(MDNSResponder::clsHost::stcServiceTxt* p_pTxt)
+{
+    bool bResult = false;
+
+    if (p_pTxt)
+    {
+        p_pTxt->m_pNext = m_pTxts;
+        m_pTxts = p_pTxt;
+        bResult = true;
+    }
+    return ((clearCache()) &&
+            (bResult));
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxts::remove
+*/
+bool MDNSResponder::clsHost::stcServiceTxts::remove(stcServiceTxt* p_pTxt)
+{
+    bool    bResult = false;
+
+    if (p_pTxt)
+    {
+        stcServiceTxt*  pPred = m_pTxts;
+        while ((pPred) &&
+               (pPred->m_pNext != p_pTxt))
+        {
+            pPred = pPred->m_pNext;
+        }
+        if (pPred)
+        {
+            pPred->m_pNext = p_pTxt->m_pNext;
+            delete p_pTxt;
+            bResult = true;
+        }
+        else if (m_pTxts == p_pTxt)     // No predecesor, but first item
+        {
+            m_pTxts = p_pTxt->m_pNext;
+            delete p_pTxt;
+            bResult = true;
+        }
+    }
+    return ((clearCache()) &&
+            (bResult));
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxts::removeTempTxts
+*/
+bool MDNSResponder::clsHost::stcServiceTxts::removeTempTxts(void)
+{
+    bool    bResult = true;
+
+    stcServiceTxt*  pTxt = m_pTxts;
+    while ((bResult) &&
+           (pTxt))
+    {
+        stcServiceTxt*  pNext = pTxt->m_pNext;
+        if (pTxt->m_bTemp)
+        {
+            bResult = remove(pTxt);
+        }
+        pTxt = pNext;
+    }
+    return ((clearCache()) &&
+            (bResult));
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxts::find
+*/
+MDNSResponder::clsHost::stcServiceTxt* MDNSResponder::clsHost::stcServiceTxts::find(const char* p_pcKey)
+{
+    stcServiceTxt* pResult = 0;
+
+    for (stcServiceTxt* pTxt = m_pTxts; pTxt; pTxt = pTxt->m_pNext)
+    {
+        if ((p_pcKey) &&
+            (0 == strcmp(pTxt->m_pcKey, p_pcKey)))
+        {
+            pResult = pTxt;
+            break;
+        }
+    }
+    return pResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxts::find
+*/
+const MDNSResponder::clsHost::stcServiceTxt* MDNSResponder::clsHost::stcServiceTxts::find(const char* p_pcKey) const
+{
+    const stcServiceTxt*   pResult = 0;
+
+    for (const stcServiceTxt* pTxt = m_pTxts; pTxt; pTxt = pTxt->m_pNext)
+    {
+        if ((p_pcKey) &&
+            (0 == strcmp(pTxt->m_pcKey, p_pcKey)))
+        {
+
+            pResult = pTxt;
+            break;
+        }
+    }
+    return pResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxts::find
+*/
+MDNSResponder::clsHost::stcServiceTxt* MDNSResponder::clsHost::stcServiceTxts::find(const stcServiceTxt* p_pTxt)
+{
+    stcServiceTxt* pResult = 0;
+
+    for (stcServiceTxt* pTxt = m_pTxts; pTxt; pTxt = pTxt->m_pNext)
+    {
+        if (p_pTxt == pTxt)
+        {
+            pResult = pTxt;
+            break;
+        }
+    }
+    return pResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxts::length
+*/
+uint16_t MDNSResponder::clsHost::stcServiceTxts::length(void) const
+{
+    uint16_t    u16Length = 0;
+
+    stcServiceTxt*  pTxt = m_pTxts;
+    while (pTxt)
+    {
+        u16Length += 1;                 // Length byte
+        u16Length += pTxt->length();    // Text
+        pTxt = pTxt->m_pNext;
+    }
+    return u16Length;
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxts::c_strLength
+
+    (incl. closing '\0'). Length bytes place is used for delimiting ';' and closing '\0'
+*/
+size_t MDNSResponder::clsHost::stcServiceTxts::c_strLength(void) const
+{
+    return length();
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxts::c_str
+*/
+bool MDNSResponder::clsHost::stcServiceTxts::c_str(char* p_pcBuffer)
+{
+    bool bResult = false;
+
+    if (p_pcBuffer)
+    {
+        bResult = true;
+
+        *p_pcBuffer = 0;
+        for (stcServiceTxt* pTxt = m_pTxts; ((bResult) && (pTxt)); pTxt = pTxt->m_pNext)
+        {
+            size_t  stLength;
+            if ((bResult = (0 != (stLength = (pTxt->m_pcKey ? strlen(pTxt->m_pcKey) : 0)))))
+            {
+                if (pTxt != m_pTxts)
+                {
+                    *p_pcBuffer++ = ';';
+                }
+                strncpy(p_pcBuffer, pTxt->m_pcKey, stLength); p_pcBuffer[stLength] = 0;
+                p_pcBuffer += stLength;
+                *p_pcBuffer++ = '=';
+                if ((stLength = (pTxt->m_pcValue ? strlen(pTxt->m_pcValue) : 0)))
+                {
+                    strncpy(p_pcBuffer, pTxt->m_pcValue, stLength); p_pcBuffer[stLength] = 0;
+                    p_pcBuffer += stLength;
+                }
+            }
+        }
+        *p_pcBuffer++ = 0;
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxts::c_str
+*/
+const char* MDNSResponder::clsHost::stcServiceTxts::c_str(void) const
+{
+
+    if ((!m_pcCache) &&
+        (m_pTxts) &&
+        ((((stcServiceTxts*)this)->m_pcCache = new char[c_strLength()])))   // TRANSPARENT caching
+    {
+        ((stcServiceTxts*)this)->c_str(m_pcCache);
+    }
+    return m_pcCache;
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxts::bufferLength
+
+    (incl. closing '\0').
+*/
+size_t MDNSResponder::clsHost::stcServiceTxts::bufferLength(void) const
+{
+    return (length() + 1);
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxts::toBuffer
+*/
+bool MDNSResponder::clsHost::stcServiceTxts::buffer(char* p_pcBuffer)
+{
+    bool bResult = false;
+
+    if (p_pcBuffer)
+    {
+        bResult = true;
+
+        *p_pcBuffer = 0;
+        for (stcServiceTxt* pTxt = m_pTxts; ((bResult) && (pTxt)); pTxt = pTxt->m_pNext)
+        {
+            *(unsigned char*)p_pcBuffer++ = pTxt->length();
+            size_t  stLength;
+            if ((bResult = (0 != (stLength = (pTxt->m_pcKey ? strlen(pTxt->m_pcKey) : 0)))))
+            {
+                memcpy(p_pcBuffer, pTxt->m_pcKey, stLength);
+                p_pcBuffer += stLength;
+                *p_pcBuffer++ = '=';
+                if ((stLength = (pTxt->m_pcValue ? strlen(pTxt->m_pcValue) : 0)))
+                {
+                    memcpy(p_pcBuffer, pTxt->m_pcValue, stLength);
+                    p_pcBuffer += stLength;
+                }
+            }
+        }
+        *p_pcBuffer++ = 0;
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxts::compare
+*/
+bool MDNSResponder::clsHost::stcServiceTxts::compare(const MDNSResponder::clsHost::stcServiceTxts& p_Other) const
+{
+    bool    bResult = false;
+
+    if ((bResult = (length() == p_Other.length())))
+    {
+        // Compare A->B
+        for (const stcServiceTxt* pTxt = m_pTxts; ((bResult) && (pTxt)); pTxt = pTxt->m_pNext)
+        {
+            const stcServiceTxt*    pOtherTxt = p_Other.find(pTxt->m_pcKey);
+            bResult = ((pOtherTxt) &&
+                       (pTxt->m_pcValue) &&
+                       (pOtherTxt->m_pcValue) &&
+                       (strlen(pTxt->m_pcValue) == strlen(pOtherTxt->m_pcValue)) &&
+                       (0 == strcmp(pTxt->m_pcValue, pOtherTxt->m_pcValue)));
+        }
+        // Compare B->A
+        for (const stcServiceTxt* pOtherTxt = p_Other.m_pTxts; ((bResult) && (pOtherTxt)); pOtherTxt = pOtherTxt->m_pNext)
+        {
+            const stcServiceTxt*    pTxt = find(pOtherTxt->m_pcKey);
+            bResult = ((pTxt) &&
+                       (pOtherTxt->m_pcValue) &&
+                       (pTxt->m_pcValue) &&
+                       (strlen(pOtherTxt->m_pcValue) == strlen(pTxt->m_pcValue)) &&
+                       (0 == strcmp(pOtherTxt->m_pcValue, pTxt->m_pcValue)));
+        }
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxts::operator==
+*/
+bool MDNSResponder::clsHost::stcServiceTxts::operator==(const stcServiceTxts& p_Other) const
+{
+    return compare(p_Other);
+}
+
+/*
+    MDNSResponder::clsHost::stcServiceTxts::operator!=
+*/
+bool MDNSResponder::clsHost::stcServiceTxts::operator!=(const stcServiceTxts& p_Other) const
+{
+    return !compare(p_Other);
+}
+
+
+/**
+    MDNSResponder::clsHost::stcProbeInformation_Base
+
+    Probing status information for a host or service domain
+
+*/
+
+/*
+    MDNSResponder::clsHost::stcProbeInformation_Base::stcProbeInformation_Base constructor
+*/
+MDNSResponder::clsHost::stcProbeInformation_Base::stcProbeInformation_Base(void)
+    :   m_ProbingStatus(enuProbingStatus::WaitingForData),
+        m_u8SentCount(0),
+        m_Timeout(std::numeric_limits<esp8266::polledTimeout::oneShot::timeType>::max()),
+        m_bConflict(false),
+        m_bTiebreakNeeded(false)
+{
+}
+
+/*
+    MDNSResponder::clsHost::stcProbeInformation_Base::clear
+*/
+bool MDNSResponder::clsHost::stcProbeInformation_Base::clear(void)
+{
+    m_ProbingStatus = enuProbingStatus::WaitingForData;
+    m_u8SentCount = 0;
+    m_Timeout.reset(std::numeric_limits<esp8266::polledTimeout::oneShot::timeType>::max());
+    m_bConflict = false;
+    m_bTiebreakNeeded = false;
+
+    return true;
+}
+
+
+/**
+    MDNSResponder::clsHost::stcProbeInformation_Host
+
+    Probing status information for a host or service domain
+
+*/
+
+/*
+    MDNSResponder::clsHost::stcProbeInformation_Host::stcProbeInformation_Host constructor
+*/
+MDNSResponder::clsHost::stcProbeInformation_Host::stcProbeInformation_Host(void)
+    :   m_fnProbeResultCallback(0)
+{
+}
+
+/*
+    MDNSResponder::clsHost::stcProbeInformation_Host::clear
+*/
+bool MDNSResponder::clsHost::stcProbeInformation_Host::clear(bool p_bClearUserdata /*= false*/)
+{
+    if (p_bClearUserdata)
+    {
+        m_fnProbeResultCallback = 0;
+    }
+    return stcProbeInformation_Base::clear();
+}
+
+
+/**
+    MDNSResponder::clsHost::stcProbeInformation_Service
+
+    Probing status information for a host or service domain
+
+*/
+
+/*
+    MDNSResponder::clsHost::stcProbeInformation_Service::stcProbeInformation_Service constructor
+*/
+MDNSResponder::clsHost::stcProbeInformation_Service::stcProbeInformation_Service(void)
+    :   m_fnProbeResultCallback(0)
+{
+}
+
+/*
+    MDNSResponder::clsHost::stcProbeInformation_Service::clear
+*/
+bool MDNSResponder::clsHost::stcProbeInformation_Service::clear(bool p_bClearUserdata /*= false*/)
+{
+    if (p_bClearUserdata)
+    {
+        m_fnProbeResultCallback = 0;
+    }
+    return stcProbeInformation_Base::clear();
+}
+
+
+/**
+    MDNSResponder::clsHost::stcService
+
+    A MDNS service object (to be announced by the MDNS responder)
+    The service instance may be '\0'; in this case the hostname is used
+    and the flag m_bAutoName is set. If the hostname changes, all 'auto-
+    named' services are renamed also.
+    m_u8Replymask is used while preparing a response to a MDNS query. It is
+    resetted in '_sendMDNSMessage' afterwards.
+*/
+
+/*
+    MDNSResponder::clsHost::stcService::stcService constructor
+*/
+MDNSResponder::clsHost::stcService::stcService(const char* p_pcName /*= 0*/,
+                                               const char* p_pcServiceType /*= 0*/,
+                                               const char* p_pcProtocol /*= 0*/)
+    :   m_pNext(0),
+        m_pcName(0),
+        m_bAutoName(false),
+        m_pcServiceType(0),
+        m_pcProtocol(0),
+        m_u16Port(0),
+        m_u32ReplyMask(0),
+        m_fnTxtCallback(0)
+{
+    setName(p_pcName);
+    setServiceType(p_pcServiceType);
+    setProtocol(p_pcProtocol);
+}
+
+/*
+    MDNSResponder::clsHost::stcService::~stcService destructor
+*/
+MDNSResponder::clsHost::stcService::~stcService(void)
+{
+    releaseName();
+    releaseServiceType();
+    releaseProtocol();
+}
+
+/*
+    MDNSResponder::clsHost::stcService::setName
+*/
+bool MDNSResponder::clsHost::stcService::setName(const char* p_pcName)
+{
+    bool bResult = false;
+
+    releaseName();
+    size_t stLength = (p_pcName ? strlen(p_pcName) : 0);
+    if (stLength)
+    {
+        if ((bResult = (0 != (m_pcName = new char[stLength + 1]))))
+        {
+            strncpy(m_pcName, p_pcName, stLength);
+            m_pcName[stLength] = 0;
+        }
+    }
+    else
+    {
+        bResult = true;
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcService::releaseName
+*/
+bool MDNSResponder::clsHost::stcService::releaseName(void)
+{
+    if (m_pcName)
+    {
+        delete[] m_pcName;
+        m_pcName = 0;
+    }
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::stcService::setServiceType
+*/
+bool MDNSResponder::clsHost::stcService::setServiceType(const char* p_pcServiceType)
+{
+    bool bResult = false;
+
+    releaseServiceType();
+    size_t stLength = (p_pcServiceType ? strlen(p_pcServiceType) : 0);
+    if (stLength)
+    {
+        if ((bResult = (0 != (m_pcServiceType = new char[stLength + 1]))))
+        {
+            strncpy(m_pcServiceType, p_pcServiceType, stLength);
+            m_pcServiceType[stLength] = 0;
+        }
+    }
+    else
+    {
+        bResult = true;
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcService::releaseServiceType
+*/
+bool MDNSResponder::clsHost::stcService::releaseServiceType(void)
+{
+    if (m_pcServiceType)
+    {
+        delete[] m_pcServiceType;
+        m_pcServiceType = 0;
+    }
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::stcService::setProtocol
+*/
+bool MDNSResponder::clsHost::stcService::setProtocol(const char* p_pcProtocol)
+{
+    bool bResult = false;
+
+    releaseProtocol();
+    size_t stLength = (p_pcProtocol ? strlen(p_pcProtocol) : 0);
+    if (stLength)
+    {
+        if ((bResult = (0 != (m_pcProtocol = new char[stLength + 1]))))
+        {
+            strncpy(m_pcProtocol, p_pcProtocol, stLength);
+            m_pcProtocol[stLength] = 0;
+        }
+    }
+    else
+    {
+        bResult = true;
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcService::releaseProtocol
+*/
+bool MDNSResponder::clsHost::stcService::releaseProtocol(void)
+{
+    if (m_pcProtocol)
+    {
+        delete[] m_pcProtocol;
+        m_pcProtocol = 0;
+    }
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::stcService::probeStatus
+*/
+bool MDNSResponder::clsHost::stcService::probeStatus(void) const
+{
+    return (enuProbingStatus::Done == m_ProbeInformation.m_ProbingStatus);
+}
+
+
+/**
+    MDNSResponder::clsHost::stcMsgHeader
+
+    A MDNS message haeder.
+
+*/
+
+/*
+    MDNSResponder::clsHost::stcMsgHeader::stcMsgHeader
+*/
+MDNSResponder::clsHost::stcMsgHeader::stcMsgHeader(uint16_t p_u16ID /*= 0*/,
+                                                   bool p_bQR /*= false*/,
+                                                   uint8_t p_u8Opcode /*= 0*/,
+                                                   bool p_bAA /*= false*/,
+                                                   bool p_bTC /*= false*/,
+                                                   bool p_bRD /*= false*/,
+                                                   bool p_bRA /*= false*/,
+                                                   uint8_t p_u8RCode /*= 0*/,
+                                                   uint16_t p_u16QDCount /*= 0*/,
+                                                   uint16_t p_u16ANCount /*= 0*/,
+                                                   uint16_t p_u16NSCount /*= 0*/,
+                                                   uint16_t p_u16ARCount /*= 0*/)
+    :   m_u16ID(p_u16ID),
+        m_1bQR(p_bQR), m_4bOpcode(p_u8Opcode), m_1bAA(p_bAA), m_1bTC(p_bTC), m_1bRD(p_bRD),
+        m_1bRA(p_bRA), m_3bZ(0), m_4bRCode(p_u8RCode),
+        m_u16QDCount(p_u16QDCount),
+        m_u16ANCount(p_u16ANCount),
+        m_u16NSCount(p_u16NSCount),
+        m_u16ARCount(p_u16ARCount)
+{
+}
+
+
+/**
+    MDNSResponder::clsHost::stcRRDomain
+
+    A MDNS domain object.
+    The labels of the domain are stored (DNS-like encoded) in 'm_acName':
+    [length byte]varlength label[length byte]varlength label[0]
+    'm_u16NameLength' stores the used length of 'm_acName'.
+    Dynamic label addition is supported.
+    Comparison is supported.
+    Export as byte array 'esp8266.local' is supported.
+
+*/
+
+/*
+    MDNSResponder::clsHost::stcRRDomain::stcRRDomain constructor
+*/
+MDNSResponder::clsHost::stcRRDomain::stcRRDomain(void)
+    :   m_u16NameLength(0),
+        m_pcDecodedName(0)
+{
+    clear();
+}
+
+/*
+    MDNSResponder::clsHost::stcRRDomain::stcRRDomain copy-constructor
+*/
+MDNSResponder::clsHost::stcRRDomain::stcRRDomain(const stcRRDomain& p_Other)
+    :   m_u16NameLength(0),
+        m_pcDecodedName(0)
+{
+    operator=(p_Other);
+}
+
+/*
+    MDNSResponder::clsHost::stcRRDomain::stcRRDomain destructor
+*/
+MDNSResponder::clsHost::stcRRDomain::~stcRRDomain(void)
+{
+    clear();
+}
+
+/*
+    MDNSResponder::clsHost::stcRRDomain::operator =
+*/
+MDNSResponder::clsHost::stcRRDomain& MDNSResponder::clsHost::stcRRDomain::operator=(const stcRRDomain& p_Other)
+{
+    if (&p_Other != this)
+    {
+        clear();
+        memcpy(m_acName, p_Other.m_acName, sizeof(m_acName));
+        m_u16NameLength = p_Other.m_u16NameLength;
+    }
+    return *this;
+}
+
+/*
+    MDNSResponder::clsHost::stcRRDomain::clear
+*/
+bool MDNSResponder::clsHost::stcRRDomain::clear(void)
+{
+    memset(m_acName, 0, sizeof(m_acName));
+    m_u16NameLength = 0;
+    return clearNameCache();
+}
+
+/*
+    MDNSResponder::clsHost::stcRRDomain::clearNameCache
+*/
+bool MDNSResponder::clsHost::stcRRDomain::clearNameCache(void)
+{
+    if (m_pcDecodedName)
+    {
+        delete[] m_pcDecodedName;
+        m_pcDecodedName = 0;
+    }
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::stcRRDomain::addLabel
+*/
+bool MDNSResponder::clsHost::stcRRDomain::addLabel(const char* p_pcLabel,
+                                                   bool p_bPrependUnderline /*= false*/)
+{
+    bool    bResult = false;
+
+    size_t  stLength = (p_pcLabel
+                        ? (strlen(p_pcLabel) + (p_bPrependUnderline ? 1 : 0))
+                        : 0);
+    if ((MDNS_DOMAIN_LABEL_MAXLENGTH >= stLength) &&
+        (MDNS_DOMAIN_MAXLENGTH >= (m_u16NameLength + (1 + stLength))))
+    {
+        // Length byte
+        m_acName[m_u16NameLength] = (unsigned char)stLength;    // Might be 0!
+        ++m_u16NameLength;
+        // Label
+        if (stLength)
+        {
+            if (p_bPrependUnderline)
+            {
+                m_acName[m_u16NameLength++] = '_';
+                --stLength;
+            }
+            strncpy(&(m_acName[m_u16NameLength]), p_pcLabel, stLength); m_acName[m_u16NameLength + stLength] = 0;
+            m_u16NameLength += stLength;
+        }
+        bResult = clearNameCache();
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcRRDomain::compare
+*/
+bool MDNSResponder::clsHost::stcRRDomain::compare(const stcRRDomain& p_Other) const
+{
+    bool    bResult = false;
+
+    if (m_u16NameLength == p_Other.m_u16NameLength)
+    {
+        const char* pT = m_acName;
+        const char* pO = p_Other.m_acName;
+        while ((pT) &&
+               (pO) &&
+               (*((unsigned char*)pT) == *((unsigned char*)pO)) &&                  // Same length AND
+               (0 == strncasecmp((pT + 1), (pO + 1), *((unsigned char*)pT))))     // Same content
+        {
+            if (*((unsigned char*)pT))              // Not 0
+            {
+                pT += (1 + * ((unsigned char*)pT)); // Shift by length byte and lenght
+                pO += (1 + * ((unsigned char*)pO));
+            }
+            else                                    // Is 0 -> Successfully reached the end
+            {
+                bResult = true;
+                break;
+            }
+        }
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcRRDomain::operator ==
+*/
+bool MDNSResponder::clsHost::stcRRDomain::operator==(const stcRRDomain& p_Other) const
+{
+    return compare(p_Other);
+}
+
+/*
+    MDNSResponder::clsHost::stcRRDomain::operator !=
+*/
+bool MDNSResponder::clsHost::stcRRDomain::operator!=(const stcRRDomain& p_Other) const
+{
+    return !compare(p_Other);
+}
+
+/*
+    MDNSResponder::clsHost::stcRRDomain::operator >
+*/
+bool MDNSResponder::clsHost::stcRRDomain::operator>(const stcRRDomain& p_Other) const
+{
+    // TODO: Check, if this is a good idea...
+    return !compare(p_Other);
+}
+
+/*
+    MDNSResponder::clsHost::stcRRDomain::c_strLength
+*/
+size_t MDNSResponder::clsHost::stcRRDomain::c_strLength(void) const
+{
+    size_t          stLength = 0;
+
+    unsigned char*  pucLabelLength = (unsigned char*)m_acName;
+    while (*pucLabelLength)
+    {
+        stLength += (*pucLabelLength + 1 /* +1 for '.' or '\0'*/);
+        pucLabelLength += (*pucLabelLength + 1);
+    }
+    return stLength;
+}
+
+/*
+    MDNSResponder::clsHost::stcRRDomain::c_str (const)
+*/
+bool MDNSResponder::clsHost::stcRRDomain::c_str(char* p_pcBuffer) const
+{
+    bool bResult = false;
+
+    if (p_pcBuffer)
+    {
+        *p_pcBuffer = 0;
+        unsigned char* pucLabelLength = (unsigned char*)m_acName;
+        while (*pucLabelLength)
+        {
+            memcpy(p_pcBuffer, (const char*)(pucLabelLength + 1), *pucLabelLength);
+            p_pcBuffer += *pucLabelLength;
+            pucLabelLength += (*pucLabelLength + 1);
+            *p_pcBuffer++ = (*pucLabelLength ? '.' : '\0');
+        }
+        bResult = true;
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcRRDomain::c_str
+*/
+const char* MDNSResponder::clsHost::stcRRDomain::c_str(void) const
+{
+    if ((!m_pcDecodedName) &&
+        (m_u16NameLength) &&
+        ((((stcRRDomain*)this)->m_pcDecodedName = new char[c_strLength()])))   // TRANSPARENT caching
+    {
+        ((stcRRDomain*)this)->c_str(m_pcDecodedName);
+    }
+    return m_pcDecodedName;
+}
+
+
+/**
+    MDNSResponder::clsHost::stcRRAttributes
+
+    A MDNS attributes object.
+
+*/
+
+/*
+    MDNSResponder::clsHost::stcRRAttributes::stcRRAttributes constructor
+*/
+MDNSResponder::clsHost::stcRRAttributes::stcRRAttributes(uint16_t p_u16Type /*= 0*/,
+                                                         uint16_t p_u16Class /*= 1 DNS_RRCLASS_IN Internet*/)
+    :   m_u16Type(p_u16Type),
+        m_u16Class(p_u16Class)
+{
+}
+
+/*
+    MDNSResponder::clsHost::stcRRAttributes::stcRRAttributes copy-constructor
+*/
+MDNSResponder::clsHost::stcRRAttributes::stcRRAttributes(const MDNSResponder::clsHost::stcRRAttributes& p_Other)
+{
+    operator=(p_Other);
+}
+
+/*
+    MDNSResponder::clsHost::stcRRAttributes::operator =
+*/
+MDNSResponder::clsHost::stcRRAttributes& MDNSResponder::clsHost::stcRRAttributes::operator=(const MDNSResponder::clsHost::stcRRAttributes& p_Other)
+{
+    if (&p_Other != this)
+    {
+        m_u16Type = p_Other.m_u16Type;
+        m_u16Class = p_Other.m_u16Class;
+    }
+    return *this;
+}
+
+
+/**
+    MDNSResponder::clsHost::stcRRHeader
+
+    A MDNS record header (domain and attributes) object.
+
+*/
+
+/*
+    MDNSResponder::clsHost::stcRRHeader::stcRRHeader constructor
+*/
+MDNSResponder::clsHost::stcRRHeader::stcRRHeader(void)
+{
+}
+
+/*
+    MDNSResponder::clsHost::stcRRHeader::stcRRHeader copy-constructor
+*/
+MDNSResponder::clsHost::stcRRHeader::stcRRHeader(const stcRRHeader& p_Other)
+{
+    operator=(p_Other);
+}
+
+/*
+    MDNSResponder::clsHost::stcRRHeader::operator =
+*/
+MDNSResponder::clsHost::stcRRHeader& MDNSResponder::clsHost::stcRRHeader::operator=(const MDNSResponder::clsHost::stcRRHeader& p_Other)
+{
+    if (&p_Other != this)
+    {
+        m_Domain = p_Other.m_Domain;
+        m_Attributes = p_Other.m_Attributes;
+    }
+    return *this;
+}
+
+/*
+    MDNSResponder::clsHost::stcRRHeader::clear
+*/
+bool MDNSResponder::clsHost::stcRRHeader::clear(void)
+{
+    m_Domain.clear();
+    return true;
+}
+
+
+/**
+    MDNSResponder::clsHost::stcRRQuestion
+
+    A MDNS question record object (header + question flags)
+
+*/
+
+/*
+    MDNSResponder::clsHost::stcRRQuestion::stcRRQuestion constructor
+*/
+MDNSResponder::clsHost::stcRRQuestion::stcRRQuestion(void)
+    :   m_pNext(0),
+        m_bUnicast(false)
+{
+}
+
+
+/**
+    MDNSResponder::clsHost::stcNSECBitmap
+
+    A MDNS question record object (header + question flags)
+
+*/
+
+/*
+    MDNSResponder::clsHost::stcNSECBitmap::stcNSECBitmap constructor
+*/
+MDNSResponder::clsHost::stcNSECBitmap::stcNSECBitmap(void)
+{
+    clear();
+}
+
+/*
+    MDNSResponder::clsHost::stcNSECBitmap::stcNSECBitmap destructor
+*/
+bool MDNSResponder::clsHost::stcNSECBitmap::clear(void)
+{
+    memset(m_au8BitmapData, 0, sizeof(m_au8BitmapData));
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::stcNSECBitmap::length
+*/
+uint16_t MDNSResponder::clsHost::stcNSECBitmap::length(void) const
+{
+    return sizeof(m_au8BitmapData); // 6
+}
+
+/*
+    MDNSResponder::clsHost::stcNSECBitmap::setBit
+*/
+bool MDNSResponder::clsHost::stcNSECBitmap::setBit(uint16_t p_u16Bit)
+{
+    bool    bResult = false;
+
+    if ((p_u16Bit) &&
+        (length() > (p_u16Bit / 8)))                    // bit between 0..47(2F)
+    {
+
+        uint8_t&    ru8Byte = m_au8BitmapData[p_u16Bit / 8];
+        uint8_t     u8Flag = 1 << (7 - (p_u16Bit % 8)); // (7 - (0..7)) = 7..0
+
+        ru8Byte |= u8Flag;
+
+        bResult = true;
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcNSECBitmap::getBit
+*/
+bool MDNSResponder::clsHost::stcNSECBitmap::getBit(uint16_t p_u16Bit) const
+{
+    bool    bResult = false;
+
+    if ((p_u16Bit) &&
+        (length() > (p_u16Bit / 8)))                    // bit between 0..47(2F)
+    {
+
+        uint8_t u8Byte = m_au8BitmapData[p_u16Bit / 8];
+        uint8_t u8Flag = 1 << (7 - (p_u16Bit % 8));     // (7 - (0..7)) = 7..0
+
+        bResult = (u8Byte & u8Flag);
+    }
+    return bResult;
+}
+
+
+/**
+    MDNSResponder::clsHost::stcRRAnswer
+
+    A MDNS answer record object (header + answer content).
+    This is a 'virtual' base class for all other MDNS answer classes.
+
+*/
+
+/*
+    MDNSResponder::clsHost::stcRRAnswer::stcRRAnswer constructor
+*/
+MDNSResponder::clsHost::stcRRAnswer::stcRRAnswer(enuAnswerType p_AnswerType,
+                                                 const MDNSResponder::clsHost::stcRRHeader& p_Header,
+                                                 uint32_t p_u32TTL)
+    :   m_pNext(0),
+        m_AnswerType(p_AnswerType),
+        m_Header(p_Header),
+        m_u32TTL(p_u32TTL)
+{
+    // Extract 'cache flush'-bit
+    m_bCacheFlush = (m_Header.m_Attributes.m_u16Class & 0x8000);
+    m_Header.m_Attributes.m_u16Class &= (~0x8000);
+}
+
+/*
+    MDNSResponder::clsHost::stcRRAnswer::~stcRRAnswer destructor
+*/
+MDNSResponder::clsHost::stcRRAnswer::~stcRRAnswer(void)
+{
+}
+
+/*
+    MDNSResponder::clsHost::stcRRAnswer::answerType
+*/
+MDNSResponder::clsHost::enuAnswerType MDNSResponder::clsHost::stcRRAnswer::answerType(void) const
+{
+    return m_AnswerType;
+}
+
+/*
+    MDNSResponder::clsHost::stcRRAnswer::clear
+*/
+bool MDNSResponder::clsHost::stcRRAnswer::clear(void)
+{
+    m_pNext = 0;
+    m_Header.clear();
+    return true;
+}
+
+
+/**
+    MDNSResponder::clsHost::stcRRAnswerA
+
+    A MDNS A answer object.
+    Extends the base class by an IPv4 address member.
+
+*/
+
+#ifdef MDNS_IPV4_SUPPORT
+/*
+    MDNSResponder::clsHost::stcRRAnswerA::stcRRAnswerA constructor
+*/
+MDNSResponder::clsHost::stcRRAnswerA::stcRRAnswerA(const MDNSResponder::clsHost::stcRRHeader& p_Header,
+                                                   uint32_t p_u32TTL)
+    :   stcRRAnswer(enuAnswerType::A, p_Header, p_u32TTL),
+        m_IPAddress()
+{
+}
+
+/*
+    MDNSResponder::clsHost::stcRRAnswerA::stcRRAnswerA destructor
+*/
+MDNSResponder::clsHost::stcRRAnswerA::~stcRRAnswerA(void)
+{
+    clear();
+}
+
+/*
+    MDNSResponder::clsHost::stcRRAnswerA::clear
+*/
+bool MDNSResponder::clsHost::stcRRAnswerA::clear(void)
+{
+    m_IPAddress = IPAddress();
+    return true;
+}
+#endif
+
+
+/**
+    MDNSResponder::clsHost::stcRRAnswerPTR
+
+    A MDNS PTR answer object.
+    Extends the base class by a MDNS domain member.
+
+*/
+
+/*
+    MDNSResponder::clsHost::stcRRAnswerPTR::stcRRAnswerPTR constructor
+*/
+MDNSResponder::clsHost::stcRRAnswerPTR::stcRRAnswerPTR(const MDNSResponder::clsHost::stcRRHeader& p_Header,
+                                                       uint32_t p_u32TTL)
+    :   stcRRAnswer(enuAnswerType::PTR, p_Header, p_u32TTL)
+{
+}
+
+/*
+    MDNSResponder::clsHost::stcRRAnswerPTR::~stcRRAnswerPTR destructor
+*/
+MDNSResponder::clsHost::stcRRAnswerPTR::~stcRRAnswerPTR(void)
+{
+    clear();
+}
+
+/*
+    MDNSResponder::clsHost::stcRRAnswerPTR::clear
+*/
+bool MDNSResponder::clsHost::stcRRAnswerPTR::clear(void)
+{
+    m_PTRDomain.clear();
+    return true;
+}
+
+
+/**
+    MDNSResponder::clsHost::stcRRAnswerTXT
+
+    A MDNS TXT answer object.
+    Extends the base class by a MDNS TXT items list member.
+
+*/
+
+/*
+    MDNSResponder::clsHost::stcRRAnswerTXT::stcRRAnswerTXT constructor
+*/
+MDNSResponder::clsHost::stcRRAnswerTXT::stcRRAnswerTXT(const MDNSResponder::clsHost::stcRRHeader& p_Header,
+                                                       uint32_t p_u32TTL)
+    :   stcRRAnswer(enuAnswerType::TXT, p_Header, p_u32TTL)
+{
+}
+
+/*
+    MDNSResponder::clsHost::stcRRAnswerTXT::~stcRRAnswerTXT destructor
+*/
+MDNSResponder::clsHost::stcRRAnswerTXT::~stcRRAnswerTXT(void)
+{
+    clear();
+}
+
+/*
+    MDNSResponder::clsHost::stcRRAnswerTXT::clear
+*/
+bool MDNSResponder::clsHost::stcRRAnswerTXT::clear(void)
+{
+    m_Txts.clear();
+    return true;
+}
+
+
+/**
+    MDNSResponder::clsHost::stcRRAnswerAAAA
+
+    A MDNS AAAA answer object.
+    Extends the base class by an IPv6 address member.
+
+*/
+
+#ifdef MDNS_IPV6_SUPPORT
+/*
+    MDNSResponder::clsHost::stcRRAnswerAAAA::stcRRAnswerAAAA constructor
+*/
+MDNSResponder::clsHost::stcRRAnswerAAAA::stcRRAnswerAAAA(const MDNSResponder::clsHost::stcRRHeader& p_Header,
+                                                         uint32_t p_u32TTL)
+    :   stcRRAnswer(enuAnswerType::AAAA, p_Header, p_u32TTL),
+        m_IPAddress()
+{
+}
+
+/*
+    MDNSResponder::clsHost::stcRRAnswerAAAA::~stcRRAnswerAAAA destructor
+*/
+MDNSResponder::clsHost::stcRRAnswerAAAA::~stcRRAnswerAAAA(void)
+{
+    clear();
+}
+
+/*
+    MDNSResponder::clsHost::stcRRAnswerAAAA::clear
+*/
+bool MDNSResponder::clsHost::stcRRAnswerAAAA::clear(void)
+{
+    m_IPAddress = IPAddress();
+    return true;
+}
+#endif
+
+
+/**
+    MDNSResponder::clsHost::stcRRAnswerSRV
+
+    A MDNS SRV answer object.
+    Extends the base class by a port member.
+
+*/
+
+/*
+    MDNSResponder::clsHost::stcRRAnswerSRV::stcRRAnswerSRV constructor
+*/
+MDNSResponder::clsHost::stcRRAnswerSRV::stcRRAnswerSRV(const MDNSResponder::clsHost::stcRRHeader& p_Header,
+                                                       uint32_t p_u32TTL)
+    :   stcRRAnswer(enuAnswerType::SRV, p_Header, p_u32TTL),
+        m_u16Priority(0),
+        m_u16Weight(0),
+        m_u16Port(0)
+{
+}
+
+/*
+    MDNSResponder::clsHost::stcRRAnswerSRV::~stcRRAnswerSRV destructor
+*/
+MDNSResponder::clsHost::stcRRAnswerSRV::~stcRRAnswerSRV(void)
+{
+    clear();
+}
+
+/*
+    MDNSResponder::clsHost::stcRRAnswerSRV::clear
+*/
+bool MDNSResponder::clsHost::stcRRAnswerSRV::clear(void)
+{
+    m_u16Priority = 0;
+    m_u16Weight = 0;
+    m_u16Port = 0;
+    m_SRVDomain.clear();
+    return true;
+}
+
+
+/**
+    MDNSResponder::clsHost::stcRRAnswerGeneric
+
+    An unknown (generic) MDNS answer object.
+    Extends the base class by a RDATA buffer member.
+
+*/
+
+/*
+    MDNSResponder::clsHost::stcRRAnswerGeneric::stcRRAnswerGeneric constructor
+*/
+MDNSResponder::clsHost::stcRRAnswerGeneric::stcRRAnswerGeneric(const stcRRHeader& p_Header,
+                                                               uint32_t p_u32TTL)
+    :   stcRRAnswer(enuAnswerType::Generic, p_Header, p_u32TTL),
+        m_u16RDLength(0),
+        m_pu8RDData(0)
+{
+}
+
+/*
+    MDNSResponder::clsHost::stcRRAnswerGeneric::~stcRRAnswerGeneric destructor
+*/
+MDNSResponder::clsHost::stcRRAnswerGeneric::~stcRRAnswerGeneric(void)
+{
+    clear();
+}
+
+/*
+    MDNSResponder::clsHost::stcRRAnswerGeneric::clear
+*/
+bool MDNSResponder::clsHost::stcRRAnswerGeneric::clear(void)
+{
+    if (m_pu8RDData)
+    {
+        delete[] m_pu8RDData;
+        m_pu8RDData = 0;
+    }
+    m_u16RDLength = 0;
+
+    return true;
+}
+
+
+/**
+    MDNSResponder::clsHost::stcSendParameter
+
+    A 'collection' of properties and flags for one MDNS query or response.
+    Mainly managed by the 'Control' functions.
+    The current offset in the UPD output buffer is tracked to be able to do
+    a simple host or service domain compression.
+
+*/
+
+/**
+    MDNSResponder::clsHost::stcSendParameter::stcDomainCacheItem
+
+    A cached host or service domain, incl. the offset in the UDP output buffer.
+
+*/
+
+/*
+    MDNSResponder::clsHost::stcSendParameter::stcDomainCacheItem::stcDomainCacheItem constructor
+*/
+MDNSResponder::clsHost::stcSendParameter::stcDomainCacheItem::stcDomainCacheItem(const void* p_pHostNameOrService,
+                                                                                 bool p_bAdditionalData,
+                                                                                 uint32_t p_u16Offset)
+    :   m_pNext(0),
+        m_pHostNameOrService(p_pHostNameOrService),
+        m_bAdditionalData(p_bAdditionalData),
+        m_u16Offset(p_u16Offset)
+{
+}
+
+/**
+    MDNSResponder::clsHost::stcSendParameter
+*/
+
+/*
+    MDNSResponder::clsHost::stcSendParameter::stcSendParameter constructor
+*/
+MDNSResponder::clsHost::stcSendParameter::stcSendParameter(void)
+    :   m_pQuestions(0),
+        m_Response(enuResponseType::None),
+        m_pDomainCacheItems(0)
+{
+    clear();
+}
+
+/*
+    MDNSResponder::clsHost::stcSendParameter::~stcSendParameter destructor
+*/
+MDNSResponder::clsHost::stcSendParameter::~stcSendParameter(void)
+{
+    clear();
+}
+
+/*
+    MDNSResponder::clsHost::stcSendParameter::clear
+*/
+bool MDNSResponder::clsHost::stcSendParameter::clear(void)
+{
+    m_u16ID = 0;
+    flushQuestions();
+    m_u32HostReplyMask = 0;
+
+    m_bLegacyQuery = false;
+    m_Response = enuResponseType::None;
+    m_bAuthorative = false;
+    m_bCacheFlush = true;
+    m_bUnicast = false;
+    m_bUnannounce = false;
+
+    m_u16Offset = 0;
+    flushDomainCache();
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::stcSendParameter::flushQuestions
+*/
+bool MDNSResponder::clsHost::stcSendParameter::flushQuestions(void)
+{
+    while (m_pQuestions)
+    {
+        stcRRQuestion* pNext = m_pQuestions->m_pNext;
+        delete m_pQuestions;
+        m_pQuestions = pNext;
+    }
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::stcSendParameter::flushDomainCache
+*/
+bool MDNSResponder::clsHost::stcSendParameter::flushDomainCache(void)
+{
+    while (m_pDomainCacheItems)
+    {
+        stcDomainCacheItem* pNext = m_pDomainCacheItems->m_pNext;
+        delete m_pDomainCacheItems;
+        m_pDomainCacheItems = pNext;
+    }
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::stcSendParameter::flushTempContent
+*/
+bool MDNSResponder::clsHost::stcSendParameter::flushTempContent(void)
+{
+    m_u16Offset = 0;
+    flushDomainCache();
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::stcSendParameter::shiftOffset
+*/
+bool MDNSResponder::clsHost::stcSendParameter::shiftOffset(uint16_t p_u16Shift)
+{
+    m_u16Offset += p_u16Shift;
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::stcSendParameter::addDomainCacheItem
+*/
+bool MDNSResponder::clsHost::stcSendParameter::addDomainCacheItem(const void* p_pHostNameOrService,
+                                                                  bool p_bAdditionalData,
+                                                                  uint16_t p_u16Offset)
+{
+    bool    bResult = false;
+
+    stcDomainCacheItem* pNewItem = 0;
+    if ((p_pHostNameOrService) &&
+        (p_u16Offset) &&
+        ((pNewItem = new stcDomainCacheItem(p_pHostNameOrService, p_bAdditionalData, p_u16Offset))))
+    {
+
+        pNewItem->m_pNext = m_pDomainCacheItems;
+        bResult = ((m_pDomainCacheItems = pNewItem));
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcSendParameter::findCachedDomainOffset
+*/
+uint16_t MDNSResponder::clsHost::stcSendParameter::findCachedDomainOffset(const void* p_pHostNameOrService,
+                                                                          bool p_bAdditionalData) const
+{
+    const stcDomainCacheItem*   pCacheItem = m_pDomainCacheItems;
+
+    for (; pCacheItem; pCacheItem = pCacheItem->m_pNext)
+    {
+        if ((pCacheItem->m_pHostNameOrService == p_pHostNameOrService) &&
+            (pCacheItem->m_bAdditionalData == p_bAdditionalData))   // Found cache item
+        {
+            break;
+        }
+    }
+    return (pCacheItem ? pCacheItem->m_u16Offset : 0);
+}
+
+
+/**
+    MDNSResponder::clsHost::stcQuery
+
+    A MDNS service query object.
+    Service queries may be static or dynamic.
+    As the static service query is processed in the blocking function 'queryService',
+    only one static service service may exist. The processing of the answers is done
+    on the WiFi-stack side of the ESP stack structure (via 'UDPContext.onRx(_update)').
+
+*/
+
+/**
+    MDNSResponder::clsHost::stcQuery::stcAnswer
+
+    One answer for a service query.
+    Every answer must contain
+    - a service instance entry (pivot),
+    and may contain
+    - a host domain,
+    - a port
+    - an IPv4 address
+    (- an IPv6 address)
+    - a MDNS TXTs
+    The existance of a component is flaged in 'm_u32ContentFlags'.
+    For every answer component a TTL value is maintained.
+    Answer objects can be connected to a linked list.
+
+    For the host domain, service domain and TXTs components, a char array
+    representation can be retrieved (which is created on demand).
+
+*/
+
+/**
+    MDNSResponder::clsHost::stcQuery::stcAnswer::stcTTL
+
+    The TTL (Time-To-Live) for an specific answer content.
+    The 80% and outdated states are calculated based on the current time (millis)
+    and the 'set' time (also millis).
+    If the answer is scheduled for an update, the corresponding flag should be set.
+
+*/
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::stcTTL::stcTTL constructor
+*/
+MDNSResponder::clsHost::stcQuery::stcAnswer::stcTTL::stcTTL(void)
+    :   m_u32TTL(0),
+        m_TTLTimeout(std::numeric_limits<esp8266::polledTimeout::oneShot::timeType>::max()),
+        m_TimeoutLevel(static_cast<typeTimeoutLevel>(enuTimeoutLevel::None))
+{
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::stcTTL::set
+*/
+bool MDNSResponder::clsHost::stcQuery::stcAnswer::stcTTL::set(uint32_t p_u32TTL)
+{
+    m_u32TTL = p_u32TTL;
+    if (m_u32TTL)
+    {
+        m_TimeoutLevel = static_cast<typeTimeoutLevel>(enuTimeoutLevel::Base);  // Set to 80%
+        m_TTLTimeout.reset(timeout());
+    }
+    else
+    {
+        m_TimeoutLevel = static_cast<typeTimeoutLevel>(enuTimeoutLevel::None);  // undef
+        m_TTLTimeout.reset(std::numeric_limits<esp8266::polledTimeout::oneShot::timeType>::max());
+    }
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::stcTTL::flagged
+*/
+bool MDNSResponder::clsHost::stcQuery::stcAnswer::stcTTL::flagged(void) const
+{
+    return ((m_u32TTL) &&
+            (static_cast<typeTimeoutLevel>(enuTimeoutLevel::None) != m_TimeoutLevel) &&
+            (((esp8266::polledTimeout::timeoutTemplate<false>*)&m_TTLTimeout)->expired())); // Cast-away the const; in case of oneShot-timer OK (but ugly...)
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::stcTTL::restart
+*/
+bool MDNSResponder::clsHost::stcQuery::stcAnswer::stcTTL::restart(void)
+{
+    bool    bResult = true;
+
+    if ((static_cast<typeTimeoutLevel>(enuTimeoutLevel::Base) <= m_TimeoutLevel) &&     // >= 80% AND
+        (static_cast<typeTimeoutLevel>(enuTimeoutLevel::Final) > m_TimeoutLevel))       // < 100%
+    {
+
+        m_TimeoutLevel += static_cast<typeTimeoutLevel>(enuTimeoutLevel::Interval);     // increment by 5%
+        m_TTLTimeout.reset(timeout());
+    }
+    else
+    {
+        bResult = false;
+        m_TTLTimeout.reset(std::numeric_limits<esp8266::polledTimeout::oneShot::timeType>::max());
+        m_TimeoutLevel = static_cast<typeTimeoutLevel>(enuTimeoutLevel::None);
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::stcTTL::prepareDeletion
+*/
+bool MDNSResponder::clsHost::stcQuery::stcAnswer::stcTTL::prepareDeletion(void)
+{
+    m_TimeoutLevel = static_cast<typeTimeoutLevel>(enuTimeoutLevel::Final);
+    m_TTLTimeout.reset(1 * 1000);   // See RFC 6762, 10.1
+
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::stcTTL::finalTimeoutLevel
+*/
+bool MDNSResponder::clsHost::stcQuery::stcAnswer::stcTTL::finalTimeoutLevel(void) const
+{
+    return (static_cast<typeTimeoutLevel>(enuTimeoutLevel::Final) == m_TimeoutLevel);
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::stcTTL::timeout
+*/
+unsigned long MDNSResponder::clsHost::stcQuery::stcAnswer::stcTTL::timeout(void) const
+{
+    uint32_t    u32Timeout = std::numeric_limits<esp8266::polledTimeout::oneShot::timeType>::max();
+
+    if (static_cast<typeTimeoutLevel>(enuTimeoutLevel::Base) == m_TimeoutLevel)             // 80%
+    {
+        u32Timeout = (m_u32TTL * 800);                                                      // to milliseconds
+    }
+    else if ((static_cast<typeTimeoutLevel>(enuTimeoutLevel::Base) < m_TimeoutLevel) &&     // >80% AND
+             (static_cast<typeTimeoutLevel>(enuTimeoutLevel::Final) >= m_TimeoutLevel))     // <= 100%
+    {
+
+        u32Timeout = (m_u32TTL * 50);
+    }   // else: invalid
+    return u32Timeout;
+}
+
+
+/**
+    MDNSResponder::clsHost::stcQuery::stcAnswer::stcIPAddress
+
+*/
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::stcIPAddress::stcIPAddress constructor
+*/
+MDNSResponder::clsHost::stcQuery::stcAnswer::stcIPAddress::stcIPAddress(IPAddress p_IPAddress,
+                                                                        uint32_t p_u32TTL /*= 0*/)
+    :   m_pNext(0),
+        m_IPAddress(p_IPAddress)
+{
+    m_TTL.set(p_u32TTL);
+}
+
+
+/**
+    MDNSResponder::clsHost::stcQuery::stcAnswer
+*/
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::stcAnswer constructor
+*/
+MDNSResponder::clsHost::stcQuery::stcAnswer::stcAnswer(void)
+    :   m_pNext(0),
+        m_u16Port(0),
+#ifdef MDNS_IPV4_SUPPORT
+        m_pIPv4Addresses(0),
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+        m_pIPv6Addresses(0),
+#endif
+        m_QueryAnswerFlags(0)
+{
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::~stcAnswer destructor
+*/
+MDNSResponder::clsHost::stcQuery::stcAnswer::~stcAnswer(void)
+{
+    clear();
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::clear
+*/
+bool MDNSResponder::clsHost::stcQuery::stcAnswer::clear(void)
+{
+    return (
+#ifdef MDNS_IPV4_SUPPORT
+               (releaseIPv4Addresses()) &&
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+               (releaseIPv6Addresses())
+#endif
+           );
+}
+
+#ifdef MDNS_IPV4_SUPPORT
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::releaseIPv4Addresses
+*/
+bool MDNSResponder::clsHost::stcQuery::stcAnswer::releaseIPv4Addresses(void)
+{
+    while (m_pIPv4Addresses)
+    {
+        stcIPAddress*	pNext = m_pIPv4Addresses->m_pNext;
+        delete m_pIPv4Addresses;
+        m_pIPv4Addresses = pNext;
+    }
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::addIPv4Address
+*/
+bool MDNSResponder::clsHost::stcQuery::stcAnswer::addIPv4Address(MDNSResponder::clsHost::stcQuery::stcAnswer::stcIPAddress* p_pIPv4Address)
+{
+    bool bResult = false;
+
+    if (p_pIPv4Address)
+    {
+        p_pIPv4Address->m_pNext = m_pIPv4Addresses;
+        m_pIPv4Addresses = p_pIPv4Address;
+        bResult = true;
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::removeIPv4Address
+*/
+bool MDNSResponder::clsHost::stcQuery::stcAnswer::removeIPv4Address(MDNSResponder::clsHost::stcQuery::stcAnswer::stcIPAddress* p_pIPv4Address)
+{
+    bool    bResult = false;
+
+    if (p_pIPv4Address)
+    {
+        stcIPAddress*   pPred = m_pIPv4Addresses;
+        while ((pPred) &&
+               (pPred->m_pNext != p_pIPv4Address))
+        {
+            pPred = pPred->m_pNext;
+        }
+        if (pPred)
+        {
+            pPred->m_pNext = p_pIPv4Address->m_pNext;
+            delete p_pIPv4Address;
+            bResult = true;
+        }
+        else if (m_pIPv4Addresses == p_pIPv4Address)     // No predecesor, but first item
+        {
+            m_pIPv4Addresses = p_pIPv4Address->m_pNext;
+            delete p_pIPv4Address;
+            bResult = true;
+        }
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::findIPv4Address (const)
+*/
+const MDNSResponder::clsHost::stcQuery::stcAnswer::stcIPAddress* MDNSResponder::clsHost::stcQuery::stcAnswer::findIPv4Address(const IPAddress& p_IPAddress) const
+{
+    return (stcIPAddress*)(((const stcAnswer*)this)->findIPv4Address(p_IPAddress));
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::findIPv4Address
+*/
+MDNSResponder::clsHost::stcQuery::stcAnswer::stcIPAddress* MDNSResponder::clsHost::stcQuery::stcAnswer::findIPv4Address(const IPAddress& p_IPAddress)
+{
+    stcIPAddress*	pIPv4Address = m_pIPv4Addresses;
+    while (pIPv4Address)
+    {
+        if (pIPv4Address->m_IPAddress == p_IPAddress)
+        {
+            break;
+        }
+        pIPv4Address = pIPv4Address->m_pNext;
+    }
+    return pIPv4Address;
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::IPv4AddressCount
+*/
+uint32_t MDNSResponder::clsHost::stcQuery::stcAnswer::IPv4AddressCount(void) const
+{
+    uint32_t        u32Count = 0;
+
+    stcIPAddress*   pIPv4Address = m_pIPv4Addresses;
+    while (pIPv4Address)
+    {
+        ++u32Count;
+        pIPv4Address = pIPv4Address->m_pNext;
+    }
+    return u32Count;
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::IPv4AddressAtIndex
+*/
+MDNSResponder::clsHost::stcQuery::stcAnswer::stcIPAddress* MDNSResponder::clsHost::stcQuery::stcAnswer::IPv4AddressAtIndex(uint32_t p_u32Index)
+{
+    return (stcIPAddress*)(((const stcAnswer*)this)->IPv4AddressAtIndex(p_u32Index));
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::IPv4AddressAtIndex (const)
+*/
+const MDNSResponder::clsHost::stcQuery::stcAnswer::stcIPAddress* MDNSResponder::clsHost::stcQuery::stcAnswer::IPv4AddressAtIndex(uint32_t p_u32Index) const
+{
+    const stcIPAddress*	pIPv4Address = 0;
+
+    if (((uint32_t)(-1) != p_u32Index) &&
+        (m_pIPv4Addresses))
+    {
+
+        uint32_t    u32Index;
+        for (pIPv4Address = m_pIPv4Addresses, u32Index = 0; ((pIPv4Address) && (u32Index < p_u32Index)); pIPv4Address = pIPv4Address->m_pNext, ++u32Index);
+    }
+    return pIPv4Address;
+}
+#endif
+
+#ifdef MDNS_IPV6_SUPPORT
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::releaseIPv6Addresses
+*/
+bool MDNSResponder::clsHost::stcQuery::stcAnswer::releaseIPv6Addresses(void)
+{
+    while (m_pIPv6Addresses)
+    {
+        stcIPAddress*	pNext = m_pIPv6Addresses->m_pNext;
+        delete m_pIPv6Addresses;
+        m_pIPv6Addresses = pNext;
+    }
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::addIPv6Address
+*/
+bool MDNSResponder::clsHost::stcQuery::stcAnswer::addIPv6Address(MDNSResponder::clsHost::stcQuery::stcAnswer::stcIPAddress* p_pIPv6Address)
+{
+    bool bResult = false;
+
+    if (p_pIPv6Address)
+    {
+        p_pIPv6Address->m_pNext = m_pIPv6Addresses;
+        m_pIPv6Addresses = p_pIPv6Address;
+        bResult = true;
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::removeIPv6Address
+*/
+bool MDNSResponder::clsHost::stcQuery::stcAnswer::removeIPv6Address(MDNSResponder::clsHost::stcQuery::stcAnswer::stcIPAddress* p_pIPv6Address)
+{
+    bool    bResult = false;
+
+    if (p_pIPv6Address)
+    {
+        stcIPAddress*	pPred = m_pIPv6Addresses;
+        while ((pPred) &&
+               (pPred->m_pNext != p_pIPv6Address))
+        {
+            pPred = pPred->m_pNext;
+        }
+        if (pPred)
+        {
+            pPred->m_pNext = p_pIPv6Address->m_pNext;
+            delete p_pIPv6Address;
+            bResult = true;
+        }
+        else if (m_pIPv6Addresses == p_pIPv6Address)     // No predecesor, but first item
+        {
+            m_pIPv6Addresses = p_pIPv6Address->m_pNext;
+            delete p_pIPv6Address;
+            bResult = true;
+        }
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::findIPv6Address
+*/
+MDNSResponder::clsHost::stcQuery::stcAnswer::stcIPAddress* MDNSResponder::clsHost::stcQuery::stcAnswer::findIPv6Address(const IPAddress& p_IPAddress)
+{
+    return (stcIPAddress*)(((const stcAnswer*)this)->findIPv6Address(p_IPAddress));
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::findIPv6Address (const)
+*/
+const MDNSResponder::clsHost::stcQuery::stcAnswer::stcIPAddress* MDNSResponder::clsHost::stcQuery::stcAnswer::findIPv6Address(const IPAddress& p_IPAddress) const
+{
+    const stcIPAddress*	pIPv6Address = m_pIPv6Addresses;
+    while (pIPv6Address)
+    {
+        if (pIPv6Address->m_IPAddress == p_IPAddress)
+        {
+            break;
+        }
+        pIPv6Address = pIPv6Address->m_pNext;
+    }
+    return pIPv6Address;
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::IPv6AddressCount
+*/
+uint32_t MDNSResponder::clsHost::stcQuery::stcAnswer::IPv6AddressCount(void) const
+{
+    uint32_t        u32Count = 0;
+
+    stcIPAddress*	pIPv6Address = m_pIPv6Addresses;
+    while (pIPv6Address)
+    {
+        ++u32Count;
+        pIPv6Address = pIPv6Address->m_pNext;
+    }
+    return u32Count;
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::IPv6AddressAtIndex (const)
+*/
+const MDNSResponder::clsHost::stcQuery::stcAnswer::stcIPAddress* MDNSResponder::clsHost::stcQuery::stcAnswer::IPv6AddressAtIndex(uint32_t p_u32Index) const
+{
+    return (stcIPAddress*)(((const stcAnswer*)this)->IPv6AddressAtIndex(p_u32Index));
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcAnswer::IPv6AddressAtIndex
+*/
+MDNSResponder::clsHost::stcQuery::stcAnswer::stcIPAddress* MDNSResponder::clsHost::stcQuery::stcAnswer::IPv6AddressAtIndex(uint32_t p_u32Index)
+{
+    stcIPAddress*	pIPv6Address = 0;
+
+    if (((uint32_t)(-1) != p_u32Index) &&
+        (m_pIPv6Addresses))
+    {
+
+        uint32_t    u32Index;
+        for (pIPv6Address = m_pIPv6Addresses, u32Index = 0; ((pIPv6Address) && (u32Index < p_u32Index)); pIPv6Address = pIPv6Address->m_pNext, ++u32Index);
+    }
+    return pIPv6Address;
+}
+#endif
+
+
+/**
+    MDNSResponder::clsHost::stcQuery
+
+    A service query object.
+    A static query is flaged via 'm_bLegacyQuery'; while the function 'queryService'
+    is waiting for answers, the internal flag 'm_bAwaitingAnswers' is set. When the
+    timeout is reached, the flag is removed. These two flags are only used for static
+    service queries.
+    All answers to the service query are stored in 'm_pAnswers' list.
+    Individual answers may be addressed by index (in the list of answers).
+    Every time a answer component is added (or changes) in a dynamic service query,
+    the callback 'm_fnCallback' is called.
+    The answer list may be searched by service and host domain.
+
+    Service query object may be connected to a linked list.
+*/
+
+/*
+    MDNSResponder::clsHost::stcQuery::stcQuery constructor
+*/
+MDNSResponder::clsHost::stcQuery::stcQuery(const enuQueryType p_QueryType)
+    :   m_pNext(0),
+        m_QueryType(p_QueryType),
+        m_fnCallback(0),
+        m_bLegacyQuery(false),
+        m_u8SentCount(0),
+        m_ResendTimeout(std::numeric_limits<esp8266::polledTimeout::oneShot::timeType>::max()),
+        m_bAwaitingAnswers(true),
+        m_pAnswers(0)
+{
+    clear();
+    m_QueryType = p_QueryType;
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::~stcQuery destructor
+*/
+MDNSResponder::clsHost::stcQuery::~stcQuery(void)
+{
+    clear();
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::clear
+*/
+bool MDNSResponder::clsHost::stcQuery::clear(void)
+{
+    m_pNext = 0;
+    m_QueryType = enuQueryType::None;
+    m_fnCallback = 0;
+    m_bLegacyQuery = false;
+    m_u8SentCount = 0;
+    m_ResendTimeout.reset(std::numeric_limits<esp8266::polledTimeout::oneShot::timeType>::max());
+    m_bAwaitingAnswers = true;
+    while (m_pAnswers)
+    {
+        stcAnswer*  pNext = m_pAnswers->m_pNext;
+        delete m_pAnswers;
+        m_pAnswers = pNext;
+    }
+    return true;
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::answerCount
+*/
+uint32_t MDNSResponder::clsHost::stcQuery::answerCount(void) const
+{
+    uint32_t    u32Count = 0;
+
+    stcAnswer*  pAnswer = m_pAnswers;
+    while (pAnswer)
+    {
+        ++u32Count;
+        pAnswer = pAnswer->m_pNext;
+    }
+    return u32Count;
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::answerAtIndex
+*/
+const MDNSResponder::clsHost::stcQuery::stcAnswer* MDNSResponder::clsHost::stcQuery::answerAtIndex(uint32_t p_u32Index) const
+{
+    const stcAnswer*    pAnswer = 0;
+
+    if (((uint32_t)(-1) != p_u32Index) &&
+        (m_pAnswers))
+    {
+
+        uint32_t    u32Index;
+        for (pAnswer = m_pAnswers, u32Index = 0; ((pAnswer) && (u32Index < p_u32Index)); pAnswer = pAnswer->m_pNext, ++u32Index);
+    }
+    return pAnswer;
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::answerAtIndex
+*/
+MDNSResponder::clsHost::stcQuery::stcAnswer* MDNSResponder::clsHost::stcQuery::answerAtIndex(uint32_t p_u32Index)
+{
+    return (stcAnswer*)(((const stcQuery*)this)->answerAtIndex(p_u32Index));
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::indexOfAnswer
+*/
+uint32_t MDNSResponder::clsHost::stcQuery::indexOfAnswer(const MDNSResponder::clsHost::stcQuery::stcAnswer* p_pAnswer) const
+{
+    uint32_t    u32Index = 0;
+
+    for (const stcAnswer* pAnswer = m_pAnswers; pAnswer; pAnswer = pAnswer->m_pNext, ++u32Index)
+    {
+        if (pAnswer == p_pAnswer)
+        {
+            return u32Index;
+        }
+    }
+    return ((uint32_t)(-1));
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::addAnswer
+*/
+bool MDNSResponder::clsHost::stcQuery::addAnswer(MDNSResponder::clsHost::stcQuery::stcAnswer* p_pAnswer)
+{
+    bool    bResult = false;
+
+    if (p_pAnswer)
+    {
+        p_pAnswer->m_pNext = m_pAnswers;
+        m_pAnswers = p_pAnswer;
+        bResult = true;
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::removeAnswer
+*/
+bool MDNSResponder::clsHost::stcQuery::removeAnswer(MDNSResponder::clsHost::stcQuery::stcAnswer* p_pAnswer)
+{
+    bool    bResult = false;
+
+    if (p_pAnswer)
+    {
+        stcAnswer*  pPred = m_pAnswers;
+        while ((pPred) &&
+               (pPred->m_pNext != p_pAnswer))
+        {
+            pPred = pPred->m_pNext;
+        }
+        if (pPred)
+        {
+            pPred->m_pNext = p_pAnswer->m_pNext;
+            delete p_pAnswer;
+            bResult = true;
+        }
+        else if (m_pAnswers == p_pAnswer)   // No predecesor, but first item
+        {
+            m_pAnswers = p_pAnswer->m_pNext;
+            delete p_pAnswer;
+            bResult = true;
+        }
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::findAnswerForServiceDomain
+*/
+MDNSResponder::clsHost::stcQuery::stcAnswer* MDNSResponder::clsHost::stcQuery::findAnswerForServiceDomain(const MDNSResponder::clsHost::stcRRDomain& p_ServiceDomain)
+{
+    stcAnswer*  pAnswer = m_pAnswers;
+    while (pAnswer)
+    {
+        if (pAnswer->m_ServiceDomain == p_ServiceDomain)
+        {
+            break;
+        }
+        pAnswer = pAnswer->m_pNext;
+    }
+    return pAnswer;
+}
+
+/*
+    MDNSResponder::clsHost::stcQuery::findAnswerForHostDomain
+*/
+MDNSResponder::clsHost::stcQuery::stcAnswer* MDNSResponder::clsHost::stcQuery::findAnswerForHostDomain(const MDNSResponder::clsHost::stcRRDomain& p_HostDomain)
+{
+    stcAnswer*  pAnswer = m_pAnswers;
+    while (pAnswer)
+    {
+        if (pAnswer->m_HostDomain == p_HostDomain)
+        {
+            break;
+        }
+        pAnswer = pAnswer->m_pNext;
+    }
+    return pAnswer;
+}
+
+
+}   // namespace MDNSImplementation
+
+} // namespace esp8266
+
+
+

--- a/libraries/ESP8266mDNS/src/LEAmDNS2_Host_Transfer.cpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS2_Host_Transfer.cpp
@@ -1,0 +1,2390 @@
+/*
+    LEAmDNS2_Host_Transfer.cpp
+
+    License (MIT license):
+      Permission is hereby granted, free of charge, to any person obtaining a copy
+      of this software and associated documentation files (the "Software"), to deal
+      in the Software without restriction, including without limitation the rights
+      to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+      copies of the Software, and to permit persons to whom the Software is
+      furnished to do so, subject to the following conditions:
+
+      The above copyright notice and this permission notice shall be included in
+      all copies or substantial portions of the Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+      THE SOFTWARE.
+
+*/
+
+extern "C" {
+#include "user_interface.h"
+}
+
+#include "lwip/netif.h"
+
+#include "LEAmDNS2_lwIPdefs.h"
+#include "LEAmDNS2_Priv.h"
+
+
+namespace esp8266
+{
+
+/*
+    LEAmDNS
+*/
+namespace experimental
+{
+
+/**
+    CONST STRINGS
+*/
+static const char*                  scpcLocal               = "local";
+static const char*                  scpcServices            = "services";
+static const char*                  scpcDNSSD               = "dns-sd";
+static const char*                  scpcUDP                 = "udp";
+//static const char*                scpcTCP                 = "tcp";
+
+#ifdef MDNS_IPV4_SUPPORT
+static const char*                  scpcReverseIPv4Domain   = "in-addr";
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+static const char*                  scpcReverseIPv6Domain   = "ip6";
+#endif
+static const char*                  scpcReverseTopDomain    = "arpa";
+
+/**
+    TRANSFER
+*/
+
+
+/**
+    SENDING
+*/
+
+/*
+    MDNSResponder::_sendMDNSMessage
+
+    Unicast responses are prepared and sent directly to the querier.
+    Multicast responses or queries are transferred to _sendMDNSMessage_Multicast
+
+    Any reply flags in installed services are removed at the end!
+
+*/
+bool MDNSResponder::clsHost::_sendMDNSMessage(MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    bool    bResult = false;
+
+    uint8_t	u8AvailableProtocols = 0;
+#ifdef MDNS_IPV4_SUPPORT
+    // Only send out IPv4 messages, if we've got an IPv4 address
+    if (_getResponderIPAddress(enuIPProtocolType::V4).isSet())
+    {
+        u8AvailableProtocols |= static_cast<uint8_t>(enuIPProtocolType::V4);
+    }
+    DEBUG_EX_INFO(else
+    {
+        DEBUG_OUTPUT.printf_P(PSTR("%s _sendMDNSMessage: No IPv4 address available!\n"), _DH());
+    });
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+    // Only send out IPv6 messages, if we've got an IPv6 address
+    if (_getResponderIPAddress(enuIPProtocolType::V6).isSet())
+    {
+        u8AvailableProtocols |= static_cast<uint8_t>(enuIPProtocolType::V6);
+    }
+    DEBUG_EX_INFO(else
+    {
+        DEBUG_OUTPUT.printf_P(PSTR("%s _sendMDNSMessage: No IPv6 address available!\n"), _DH());
+    });
+#endif
+
+    if (stcSendParameter::enuResponseType::None != p_rSendParameter.m_Response)
+    {
+        IPAddress   ipRemote = ((stcSendParameter::enuResponseType::Response == p_rSendParameter.m_Response)
+                                ? m_rUDPContext.getRemoteAddress()
+                                : IPAddress());
+
+        if (p_rSendParameter.m_bUnicast)    // Unicast response  -> Send to querier
+        {
+            DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _sendMDNSMessage: Will send unicast to '%s'.\n"), _DH(), ipRemote.toString().c_str()););
+            DEBUG_EX_ERR(if (!ipRemote.isSet()) DEBUG_OUTPUT.printf_P(PSTR("%s _sendMDNSMessage: MISSING remote address for unicast response!\n"), _DH()););
+
+            bResult = ((ipRemote.isSet()) &&
+                       (_prepareMDNSMessage(p_rSendParameter)) &&
+                       (m_rUDPContext.send(ipRemote, m_rUDPContext.getRemotePort())));
+        }
+        else                                // Multicast response -> Send via the same network interface, that received the query
+        {
+#ifdef MDNS_IPV4_SUPPORT
+            if (((!ipRemote.isSet()) ||                                                 // NO remote IP
+                 (ipRemote.isV4())) &&                                                  // OR  IPv4
+                (u8AvailableProtocols & static_cast<uint8_t>(enuIPProtocolType::V4)))   // AND IPv4 protocol available
+            {
+
+                bResult = _sendMDNSMessage_Multicast(p_rSendParameter, static_cast<uint8_t>(enuIPProtocolType::V4));
+            }
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+            if (((!ipRemote.isSet()) ||                                                 // NO remote IP
+                 (ipRemote.isV6())) &&                                                  // OR  IPv6
+                (u8AvailableProtocols & static_cast<uint8_t>(enuIPProtocolType::V6)))   // AND IPv6 protocol available
+            {
+
+                bResult = _sendMDNSMessage_Multicast(p_rSendParameter, static_cast<uint8_t>(enuIPProtocolType::V6));
+            }
+#endif
+        }
+    }
+    else                                    // Multicast query -> Send by all available protocols
+    {
+        bResult = ((u8AvailableProtocols) &&
+                   (_sendMDNSMessage_Multicast(p_rSendParameter, u8AvailableProtocols)));
+    }
+
+    // Finally clear service reply masks
+    for (stcService* pService = m_pServices; pService; pService = pService->m_pNext)
+    {
+        pService->m_u32ReplyMask = 0;
+    }
+
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _sendMDNSMessage: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+#include "cont.h"
+/*
+    MDNSResponder::_sendMDNSMessage_Multicast
+
+    Fills the UDP output buffer (via _prepareMDNSMessage) and sends the buffer
+    via the selected WiFi protocols
+*/
+bool MDNSResponder::clsHost::_sendMDNSMessage_Multicast(MDNSResponder::clsHost::stcSendParameter& p_rSendParameter,
+                                                        uint8_t p_IPProtocolTypes)
+{
+    bool    bIPv4Result = true;
+    bool    bIPv6Result = true;
+
+#ifdef MDNS_IPV4_SUPPORT
+    if (p_IPProtocolTypes & static_cast<uint8_t>(enuIPProtocolType::V4))
+    {
+        IPAddress   ip4MulticastAddress(DNS_MQUERY_IPV4_GROUP_INIT);
+
+        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _sendMDNSMessage_Multicast v4: Will send to '%s'.\n"), _DH(), ip4MulticastAddress.toString().c_str()););
+        DEBUG_EX_INFO(if (!_getResponderIPAddress(enuIPProtocolType::V4)) DEBUG_OUTPUT.printf_P(PSTR("%s _sendMDNSMessage_Multicast v4: NO IPv4 address!.\n"), _DH()););
+        bIPv4Result = ((_prepareMDNSMessage(p_rSendParameter)) &&
+                       (m_rUDPContext.setMulticastInterface(&m_rNetIf), true) &&
+                       (m_rUDPContext.send(ip4MulticastAddress, DNS_MQUERY_PORT)) &&
+                       (m_rUDPContext.setMulticastInterface(0), true));
+        DEBUG_EX_ERR(if (!bIPv4Result) DEBUG_OUTPUT.printf_P(PSTR("%s _sendMDNSMessage_Multicast (V4): FAILED!\n"), _DH()););
+    }
+#endif
+
+#ifdef MDNS_IPV6_SUPPORT
+    if (p_IPProtocolTypes & static_cast<uint8_t>(enuIPProtocolType::V6))
+    {
+        IPAddress   ip6MulticastAddress(DNS_MQUERY_IPV6_GROUP_INIT);
+
+        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _sendMDNSMessage_Multicast v6: Will send to '%s'.\n"), _DH(), ip6MulticastAddress.toString().c_str()););
+        DEBUG_EX_INFO(if (!_getResponderIPAddress(enuIPProtocolType::V6)) DEBUG_OUTPUT.printf_P(PSTR("%s _sendMDNSMessage_Multicast v6: NO IPv6 address!.\n"), _DH()););
+        DEBUG_EX_ERR(
+            bool    bPrepareMessage = false;
+            bool    bUDPContextSend = false;
+        );
+        bIPv6Result = ((DEBUG_EX_ERR(bPrepareMessage =)_prepareMDNSMessage(p_rSendParameter)) &&
+                       (m_rUDPContext.setMulticastInterface(&m_rNetIf), true) &&
+                       (DEBUG_EX_ERR(bUDPContextSend =)m_rUDPContext.send(ip6MulticastAddress, DNS_MQUERY_PORT)) &&
+                       (m_rUDPContext.setMulticastInterface(0), true));
+        DEBUG_EX_ERR(if (!bIPv6Result) DEBUG_OUTPUT.printf_P(PSTR("%s _sendMDNSMessage_Multicast (V6): FAILED! (%s, %s, %s)\n"), _DH(), (_getResponderIPAddress(enuIPProtocolType::V6).isSet() ? "1" : "0"), (bPrepareMessage ? "1" : "0"), (bUDPContextSend ? "1" : "0")););
+    }
+#endif
+
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _sendMDNSMessage_Multicast: %s!\n\n"), _DH(), ((bIPv4Result && bIPv6Result) ? "Succeeded" : "FAILED")););
+    DEBUG_EX_ERR(if (!(bIPv4Result && bIPv6Result)) DEBUG_OUTPUT.printf_P(PSTR("%s _sendMDNSMessage_Multicast: FAILED!\n"), _DH()););
+    return (bIPv4Result && bIPv6Result);
+}
+
+/*
+    MDNSResponder::_prepareMDNSMessage
+
+    The MDNS message is composed in a two-step process.
+    In the first loop 'only' the header informations (mainly number of answers) are collected,
+    while in the seconds loop, the header and all queries and answers are written to the UDP
+    output buffer.
+
+*/
+bool MDNSResponder::clsHost::_prepareMDNSMessage(MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _prepareMDNSMessage\n")););
+    bool    bResult = true;
+
+    // Prepare output buffer for potential reuse
+    p_rSendParameter.flushTempContent();
+
+    // Prepare header; count answers
+    stcMsgHeader  msgHeader(p_rSendParameter.m_u16ID,
+                            (static_cast<stcSendParameter::enuResponseType>(stcSendParameter::enuResponseType::None) != p_rSendParameter.m_Response),
+                            0,
+                            p_rSendParameter.m_bAuthorative);
+    // If this is a response, the answers are anwers,
+    // else this is a query or probe and the answers go into auth section
+    uint16_t&           ru16Answers = ((stcSendParameter::enuResponseType::None != p_rSendParameter.m_Response)
+                                       ? msgHeader.m_u16ANCount    // Usual answers
+                                       : msgHeader.m_u16NSCount);  // Authorative answers
+
+    /**
+        enuSequence
+    */
+    using typeSequence = uint8_t;
+    enum class enuSequence : typeSequence
+    {
+        Count   = 0,
+        Send    = 1
+    };
+
+    // Two step sequence: 'Count' and 'Send'
+    for (typeSequence sequence = static_cast<typeSequence>(enuSequence::Count); ((bResult) && (sequence <= static_cast<typeSequence>(enuSequence::Send))); ++sequence)
+    {
+        DEBUG_EX_INFO(
+            if (static_cast<typeSequence>(enuSequence::Send) == sequence)
+            DEBUG_OUTPUT.printf_P(PSTR("%s _prepareMDNSMessage: ID:%u QR:%u OP:%u AA:%u TC:%u RD:%u RA:%u R:%u QD:%u AN:%u NS:%u AR:%u\n"),
+                                  _DH(),
+                                  (unsigned)msgHeader.m_u16ID,
+                                  (unsigned)msgHeader.m_1bQR, (unsigned)msgHeader.m_4bOpcode, (unsigned)msgHeader.m_1bAA, (unsigned)msgHeader.m_1bTC, (unsigned)msgHeader.m_1bRD,
+                                  (unsigned)msgHeader.m_1bRA, (unsigned)msgHeader.m_4bRCode,
+                                  (unsigned)msgHeader.m_u16QDCount,
+                                  (unsigned)msgHeader.m_u16ANCount,
+                                  (unsigned)msgHeader.m_u16NSCount,
+                                  (unsigned)msgHeader.m_u16ARCount);
+        );
+        // Count/send
+        // Header
+        bResult = ((static_cast<typeSequence>(enuSequence::Count) == sequence)
+                   ? true
+                   : _writeMDNSMsgHeader(msgHeader, p_rSendParameter));
+        DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _prepareMDNSMessage: _writeMDNSMsgHeader FAILED!\n"), _DH()););
+        // Questions
+        for (stcRRQuestion* pQuestion = p_rSendParameter.m_pQuestions; ((bResult) && (pQuestion)); pQuestion = pQuestion->m_pNext)
+        {
+            ((static_cast<typeSequence>(enuSequence::Count) == sequence)
+             ? ++msgHeader.m_u16QDCount
+             : (bResult = _writeMDNSQuestion(*pQuestion, p_rSendParameter)));
+            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _prepareMDNSMessage: _writeMDNSQuestion FAILED!\n"), _DH()););
+        }
+
+        // Answers and authorative answers
+        // NSEC host (part 1)
+        uint32_t    u32NSECContent = 0;
+#ifdef MDNS_IPV4_SUPPORT
+        // A
+        if ((bResult) &&
+            (p_rSendParameter.m_u32HostReplyMask & static_cast<uint32_t>(enuContentFlag::A)) &&
+            (_getResponderIPAddress(enuIPProtocolType::V4).isSet()))
+        {
+
+            u32NSECContent |= static_cast<uint32_t>(enuContentFlag::A);
+            ((static_cast<typeSequence>(enuSequence::Count) == sequence)
+             ? ++ru16Answers
+             : (bResult = _writeMDNSAnswer_A(_getResponderIPAddress(enuIPProtocolType::V4), p_rSendParameter)));
+            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _prepareMDNSMessage: _writeMDNSAnswer_A(A) FAILED!\n"), _DH()););
+        }
+        // PTR_IPv4
+        if ((bResult) &&
+            (p_rSendParameter.m_u32HostReplyMask & static_cast<uint32_t>(enuContentFlag::PTR_IPv4)) &&
+            (_getResponderIPAddress(enuIPProtocolType::V4).isSet()))
+        {
+
+            u32NSECContent |= static_cast<uint32_t>(enuContentFlag::PTR_IPv4);
+            ((static_cast<typeSequence>(enuSequence::Count) == sequence)
+             ? ++ru16Answers
+             : (bResult = _writeMDNSAnswer_PTR_IPv4(_getResponderIPAddress(enuIPProtocolType::V4), p_rSendParameter)));
+            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _prepareMDNSMessage: _writeMDNSAnswer_PTR_IPv4 FAILED!\n"), _DH()););
+        }
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+        // AAAA
+        if ((bResult) &&
+            (p_rSendParameter.m_u32HostReplyMask & static_cast<uint32_t>(enuContentFlag::AAAA)) &&
+            (_getResponderIPAddress(enuIPProtocolType::V6).isSet()))
+        {
+
+            u32NSECContent |= static_cast<uint32_t>(enuContentFlag::AAAA);
+            ((static_cast<typeSequence>(enuSequence::Count) == sequence)
+             ? ++ru16Answers
+             : (bResult = _writeMDNSAnswer_AAAA(_getResponderIPAddress(enuIPProtocolType::V6), p_rSendParameter)));
+            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _prepareMDNSMessage: _writeMDNSAnswer_AAAA(A) FAILED!\n"), _DH()););
+        }
+        // PTR_IPv6
+        if ((bResult) &&
+            (p_rSendParameter.m_u32HostReplyMask & static_cast<uint32_t>(enuContentFlag::PTR_IPv6)) &&
+            (_getResponderIPAddress(enuIPProtocolType::V6).isSet()))
+        {
+
+            u32NSECContent |= static_cast<uint32_t>(enuContentFlag::PTR_IPv6);
+            ((static_cast<typeSequence>(enuSequence::Count) == sequence)
+             ? ++ru16Answers
+             : (bResult = _writeMDNSAnswer_PTR_IPv6(_getResponderIPAddress(enuIPProtocolType::V6), p_rSendParameter)));
+            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _prepareMDNSMessage: _writeMDNSAnswer_PTR_IPv6 FAILED!\n"), _DH()););
+        }
+#endif
+
+        for (stcService* pService = m_pServices; ((bResult) && (pService)); pService = pService->m_pNext)
+        {
+            // PTR_TYPE
+            if ((bResult) &&
+                (pService->m_u32ReplyMask & static_cast<uint32_t>(enuContentFlag::PTR_TYPE)))
+            {
+                ((static_cast<typeSequence>(enuSequence::Count) == sequence)
+                 ? ++ru16Answers
+                 : (bResult = _writeMDNSAnswer_PTR_TYPE(*pService, p_rSendParameter)));
+                DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _prepareMDNSMessage: _writeMDNSAnswer_PTR_TYPE FAILED!\n"), _DH()););
+            }
+            // PTR_NAME
+            if ((bResult) &&
+                (pService->m_u32ReplyMask & static_cast<uint32_t>(enuContentFlag::PTR_NAME)))
+            {
+                ((static_cast<typeSequence>(enuSequence::Count) == sequence)
+                 ? ++ru16Answers
+                 : (bResult = _writeMDNSAnswer_PTR_NAME(*pService, p_rSendParameter)));
+                DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _prepareMDNSMessage: _writeMDNSAnswer_PTR_NAME FAILED!\n"), _DH()););
+            }
+            // SRV
+            if ((bResult) &&
+                (pService->m_u32ReplyMask & static_cast<uint32_t>(enuContentFlag::SRV)))
+            {
+                ((static_cast<typeSequence>(enuSequence::Count) == sequence)
+                 ? ++ru16Answers
+                 : (bResult = _writeMDNSAnswer_SRV(*pService, p_rSendParameter)));
+                DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _prepareMDNSMessage: _writeMDNSAnswer_SRV(A) FAILED!\n"), _DH()););
+            }
+            // TXT
+            if ((bResult) &&
+                (pService->m_u32ReplyMask & static_cast<uint32_t>(enuContentFlag::TXT)))
+            {
+                ((static_cast<typeSequence>(enuSequence::Count) == sequence)
+                 ? ++ru16Answers
+                 : (bResult = _writeMDNSAnswer_TXT(*pService, p_rSendParameter)));
+                DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _prepareMDNSMessage: _writeMDNSAnswer_TXT(A) FAILED!\n"), _DH()););
+            }
+        }   // for services
+
+        // Additional answers
+        uint16_t&   ru16AdditionalAnswers = msgHeader.m_u16ARCount;
+
+#ifdef MDNS_IPV4_SUPPORT
+        bool    bNeedsAdditionalAnswerA = false;
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+        bool    bNeedsAdditionalAnswerAAAA = false;
+#endif
+        for (stcService* pService = m_pServices; ((bResult) && (pService)); pService = pService->m_pNext)
+        {
+            if ((bResult) &&
+                (pService->m_u32ReplyMask & static_cast<uint32_t>(enuContentFlag::PTR_NAME)) &&    // If PTR_NAME is requested, AND
+                (!(pService->m_u32ReplyMask & static_cast<uint32_t>(enuContentFlag::SRV))))        // NOT SRV -> add SRV as additional answer
+            {
+
+                ((static_cast<typeSequence>(enuSequence::Count) == sequence)
+                 ? ++ru16AdditionalAnswers
+                 : (bResult = _writeMDNSAnswer_SRV(*pService, p_rSendParameter)));
+                DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _prepareMDNSMessage: _writeMDNSAnswer_SRV(B) FAILED!\n"), _DH()););
+            }
+            /*  AppleTV doesn't add TXT
+                if ((bResult) &&
+                (pService->m_u32ReplyMask & ContentFlag_PTR_NAME) &&    // If PTR_NAME is requested, AND
+                (!(pService->m_u32ReplyMask & ContentFlag_TXT))) {      // NOT TXT -> add TXT as additional answer
+                ((static_cast<typeSequence>(enuSequence::Count) == sequence)
+                    ? ++ru16AdditionalAnswers
+                    : (bResult = _writeMDNSAnswer_TXT(*pService, p_rSendParameter)));
+                DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _prepareMDNSMessage: _writeMDNSAnswer_TXT(B) FAILED!\n")););
+                }
+            */
+            if ((pService->m_u32ReplyMask & (static_cast<uint32_t>(enuContentFlag::PTR_NAME) | static_cast<uint32_t>(enuContentFlag::SRV))) ||          // If service instance name or SRV OR
+                (p_rSendParameter.m_u32HostReplyMask & (static_cast<uint32_t>(enuContentFlag::A) | static_cast<uint32_t>(enuContentFlag::AAAA))))       // any host IP address is requested
+            {
+#ifdef MDNS_IPV4_SUPPORT
+                if ((bResult) &&
+                    (!(p_rSendParameter.m_u32HostReplyMask & static_cast<uint32_t>(enuContentFlag::A))))                   // Add IPv4 address
+                {
+                    bNeedsAdditionalAnswerA = true;
+                }
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+                if ((bResult) &&
+                    (!(p_rSendParameter.m_u32HostReplyMask & static_cast<uint32_t>(enuContentFlag::AAAA))))                // Add IPv6 address
+                {
+                    bNeedsAdditionalAnswerAAAA = true;
+                }
+#endif
+            }
+            // NSEC record for service
+            if ((bResult) &&
+                (pService->m_u32ReplyMask) &&
+                ((stcSendParameter::enuResponseType::None != p_rSendParameter.m_Response)))
+            {
+
+                ((static_cast<typeSequence>(enuSequence::Count) == sequence)
+                 ? ++ru16AdditionalAnswers
+                 : (bResult = _writeMDNSAnswer_NSEC(*pService, (static_cast<uint32_t>(enuContentFlag::TXT) | static_cast<uint32_t>(enuContentFlag::SRV)), p_rSendParameter)));
+                DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _prepareMDNSMessage: _writeMDNSAnswer_NSEC(Service) FAILED!\n"), _DH()););
+            }
+        }   // for services
+
+#ifdef MDNS_IPV4_SUPPORT
+        // Answer A needed?
+        if ((bResult) &&
+            (bNeedsAdditionalAnswerA) &&
+            (_getResponderIPAddress(enuIPProtocolType::V4).isSet()))
+        {
+            // Additional A
+            u32NSECContent |= static_cast<uint32_t>(enuContentFlag::A);
+            ((static_cast<typeSequence>(enuSequence::Count) == sequence)
+             ? ++ru16AdditionalAnswers
+             : (bResult = _writeMDNSAnswer_A(_getResponderIPAddress(enuIPProtocolType::V4), p_rSendParameter)));
+
+            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _prepareMDNSMessage: _writeMDNSAnswer_A(B) FAILED!\n"), _DH()););
+        }
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+        // Answer AAAA needed?
+        if ((bResult) &&
+            (bNeedsAdditionalAnswerAAAA) &&
+            (_getResponderIPAddress(enuIPProtocolType::V6).isSet()))
+        {
+            // Additional AAAA
+            u32NSECContent |= static_cast<uint32_t>(enuContentFlag::AAAA);
+            ((static_cast<typeSequence>(enuSequence::Count) == sequence)
+             ? ++ru16AdditionalAnswers
+             : (bResult = _writeMDNSAnswer_AAAA(_getResponderIPAddress(enuIPProtocolType::V6), p_rSendParameter)));
+
+            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _prepareMDNSMessage: _writeMDNSAnswer_AAAA(B) FAILED!\n"), _DH()););
+        }
+#endif
+
+        // NSEC host (part 2)
+        if ((bResult) &&
+            ((stcSendParameter::enuResponseType::None != p_rSendParameter.m_Response)) &&
+            (u32NSECContent))
+        {
+
+            // NSEC PTR IPv4/IPv6 are separate answers; make sure, that this is counted for
+#ifdef MDNS_IPV4_SUPPORT
+            uint32_t    u32NSECContent_PTR_IPv4 = (u32NSECContent & static_cast<uint32_t>(enuContentFlag::PTR_IPv4));
+            u32NSECContent &= ~static_cast<uint32_t>(enuContentFlag::PTR_IPv4);
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+            uint32_t    u32NSECContent_PTR_IPv6 = (u32NSECContent & static_cast<uint32_t>(enuContentFlag::PTR_IPv6));
+            u32NSECContent &= ~static_cast<uint32_t>(enuContentFlag::PTR_IPv6);
+#endif
+
+            ((static_cast<typeSequence>(enuSequence::Count) == sequence)
+             ? (ru16AdditionalAnswers += ((u32NSECContent ? 1 : 0)
+#ifdef MDNS_IPV4_SUPPORT
+                                          + (u32NSECContent_PTR_IPv4 ? 1 : 0)
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+                                          + (u32NSECContent_PTR_IPv6 ? 1 : 0)
+#endif
+                                         ))
+             : (bResult = (((!u32NSECContent) ||
+                            // Write host domain NSEC answer
+                            (_writeMDNSAnswer_NSEC(u32NSECContent, p_rSendParameter)))
+#ifdef MDNS_IPV4_SUPPORT
+                           // Write separate answer for host PTR IPv4
+                           && ((!u32NSECContent_PTR_IPv4) ||
+                               ((!_getResponderIPAddress(enuIPProtocolType::V4).isSet()) ||
+                                (_writeMDNSAnswer_NSEC_PTR_IPv4(_getResponderIPAddress(enuIPProtocolType::V4), p_rSendParameter))))
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+                           // Write separate answer for host PTR IPv6
+                           && ((!u32NSECContent_PTR_IPv6) ||
+                               ((!_getResponderIPAddress(enuIPProtocolType::V6).isSet()) ||
+                                (_writeMDNSAnswer_NSEC_PTR_IPv6(_getResponderIPAddress(enuIPProtocolType::V6), p_rSendParameter))))
+#endif
+                          )));
+
+            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _prepareMDNSMessage: _writeMDNSAnswer_NSEC(Host) FAILED!\n"), _DH()););
+        }
+
+        DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _prepareMDNSMessage: Loop %i FAILED!\n"), _DH(), sequence););
+    }   // for sequence
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _prepareMDNSMessage: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_addMDNSQueryRecord
+
+    Adds a query for the given domain and query type.
+
+*/
+bool MDNSResponder::clsHost::_addMDNSQueryRecord(MDNSResponder::clsHost::stcSendParameter& p_rSendParameter,
+                                                 const MDNSResponder::clsHost::stcRRDomain& p_QueryDomain,
+                                                 uint16_t p_u16RecordType)
+{
+    bool    bResult = false;
+
+    stcRRQuestion* pQuestion = new stcRRQuestion;
+    if ((bResult = (0 != pQuestion)))
+    {
+        // Link to list of questions
+        pQuestion->m_pNext = p_rSendParameter.m_pQuestions;
+        p_rSendParameter.m_pQuestions = pQuestion;
+
+        pQuestion->m_Header.m_Domain = p_QueryDomain;
+
+        pQuestion->m_Header.m_Attributes.m_u16Type = p_u16RecordType;
+        // It seems, that some mDNS implementations don't support 'unicast response' questions...
+        pQuestion->m_Header.m_Attributes.m_u16Class = (/*0x8000 |*/ DNS_RRCLASS_IN);   // /*Unicast &*/ INternet
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::_sendMDNSQuery
+
+    Creates and sends a query for the given domain and query type.
+
+*/
+bool MDNSResponder::clsHost::_sendMDNSQuery(const MDNSResponder::clsHost::stcQuery& p_Query,
+                                            MDNSResponder::clsHost::stcQuery::stcAnswer* p_pKnownAnswers /*= 0*/)
+{
+    bool                    bResult = false;
+
+    stcSendParameter    sendParameter;
+    switch (p_Query.m_QueryType)
+    {
+    case stcQuery::enuQueryType::Host:
+#ifdef MDNS_IPV4_SUPPORT
+        bResult = _addMDNSQueryRecord(sendParameter, p_Query.m_Domain, DNS_RRTYPE_A);
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+        bResult = _addMDNSQueryRecord(sendParameter, p_Query.m_Domain, DNS_RRTYPE_AAAA);
+#endif
+        break;
+
+    case stcQuery::enuQueryType::Service:
+        bResult = _addMDNSQueryRecord(sendParameter, p_Query.m_Domain, DNS_RRTYPE_PTR);
+        break;
+
+    case stcQuery::enuQueryType::None:
+    default:
+        break;
+    }
+
+    // TODO: Add known answers to query
+    (void)p_pKnownAnswers;
+
+    bResult = ((bResult) &&
+               (_sendMDNSMessage(sendParameter)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _sendMDNSQuery: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_sendMDNSQuery
+
+    Creates and sends a query for the given domain and record type.
+
+*/
+bool MDNSResponder::clsHost::_sendMDNSQuery(const MDNSResponder::clsHost::stcRRDomain& p_QueryDomain,
+                                            uint16_t p_u16RecordType,
+                                            MDNSResponder::clsHost::stcQuery::stcAnswer* p_pKnownAnswers /*= 0*/)
+{
+    bool                    bResult = false;
+
+    stcSendParameter    sendParameter;
+    bResult = ((_addMDNSQueryRecord(sendParameter, p_QueryDomain, p_u16RecordType)) &&
+               (_sendMDNSMessage(sendParameter)));
+
+    // TODO: Add known answer records
+    (void) p_pKnownAnswers;
+
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _sendMDNSQuery: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_getResponderIPAddress
+*/
+IPAddress MDNSResponder::clsHost::_getResponderIPAddress(enuIPProtocolType p_IPProtocolType) const
+{
+    IPAddress	ipResponder;
+#ifdef MDNS_IPV4_SUPPORT
+    if (enuIPProtocolType::V4 == p_IPProtocolType)
+    {
+        ipResponder = netif_ip_addr4(&m_rNetIf);
+    }
+#endif
+#ifdef MDNS_IPV6_SUPPORT
+    if (enuIPProtocolType::V6 == p_IPProtocolType)
+    {
+        bool	bCheckLinkLocal = true;
+        for (int i = 0; ((!ipResponder.isSet()) && (i < 2)); ++i)  	// Two loops: First with link-local check, second without
+        {
+            for (int idx = 0; idx < LWIP_IPV6_NUM_ADDRESSES; ++idx)
+            {
+                //DEBUG_EX_INFO(if ip6_addr_isvalid(netif_ip6_addr_state(&m_rNetIf, idx)) DEBUG_OUTPUT.printf_P(PSTR("%s _getResponderIPAddress: Checking IPv6 address %s (LL: %s)\n"), _DH(), IPAddress(netif_ip_addr6(&m_rNetIf, idx)).toString().c_str(), (bCheckLinkLocal ? "YES" : "NO")););
+                if ((ip6_addr_isvalid(netif_ip6_addr_state(&m_rNetIf, idx))) &&
+                    (((!bCheckLinkLocal) ||
+                      (ip6_addr_islinklocal(netif_ip6_addr(&m_rNetIf, idx))))))
+                {
+                    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _getResponderIPAddress: Selected IPv6 address %s (LL: %s)\n"), _DH(), IPAddress(netif_ip_addr6(&m_rNetIf, idx)).toString().c_str(), (bCheckLinkLocal ? "YES" : "NO")););
+                    ipResponder = netif_ip_addr6(&m_rNetIf, idx);
+                    break;
+                }
+            }
+            bCheckLinkLocal = false;
+        }
+    }
+#endif
+    return ipResponder;
+}
+
+
+/**
+    HELPERS
+*/
+
+/**
+    RESOURCE RECORDS
+*/
+
+/*
+    MDNSResponder::_readRRQuestion
+
+    Reads a question (eg. MyESP._http._tcp.local ANY IN) from the UPD input buffer.
+
+*/
+bool MDNSResponder::clsHost::_readRRQuestion(MDNSResponder::clsHost::stcRRQuestion& p_rRRQuestion)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _readRRQuestion\n")););
+
+    bool    bResult = false;
+
+    if ((bResult = _readRRHeader(p_rRRQuestion.m_Header)))
+    {
+        // Extract unicast flag from class field
+        p_rRRQuestion.m_bUnicast = (p_rRRQuestion.m_Header.m_Attributes.m_u16Class & 0x8000);
+        //p_rRRQuestion.m_Header.m_Attributes.m_u16Class &= (~0x8000);
+
+        DEBUG_EX_INFO(
+            DEBUG_OUTPUT.printf_P(PSTR("%s _readRRQuestion "), _DH());
+            _printRRDomain(p_rRRQuestion.m_Header.m_Domain);
+            DEBUG_OUTPUT.printf_P(PSTR(" Type:%s Class:%s\n"), _RRType2Name(p_rRRQuestion.m_Header.m_Attributes.m_u16Type), _RRClass2String(p_rRRQuestion.m_Header.m_Attributes.m_u16Class, true));
+        );
+    }
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _readRRQuestion: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_readRRAnswer
+
+    Reads an answer (eg. _http._tcp.local PTR OP TTL MyESP._http._tcp.local)
+    from the UDP input buffer.
+    After reading the domain and type info, the further processing of the answer
+    is transferred the answer specific reading functions.
+    Unknown answer types are processed by the generic answer reader (to remove them
+    from the input buffer).
+
+*/
+bool MDNSResponder::clsHost::_readRRAnswer(MDNSResponder::clsHost::stcRRAnswer*& p_rpRRAnswer)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _readRRAnswer\n")););
+
+    bool    bResult = false;
+
+    stcRRHeader    header;
+    uint32_t            u32TTL;
+    uint16_t            u16RDLength;
+    if ((_readRRHeader(header)) &&
+        (_udpRead32(u32TTL)) &&
+        (_udpRead16(u16RDLength)))
+    {
+
+        /*  DEBUG_EX_INFO(
+                DEBUG_OUTPUT.printf_P(PSTR("%s _readRRAnswer: Reading 0x%04X answer (class:0x%04X, TTL:%u, RDLength:%u) for "), header.m_Attributes.m_u16Type, header.m_Attributes.m_u16Class, u32TTL, u16RDLength);
+                _printRRDomain(header.m_Domain);
+                DEBUG_OUTPUT.printf_P(PSTR("\n"));
+                );*/
+
+        switch (header.m_Attributes.m_u16Type /*& (~0x8000)*/)      // Topmost bit might carry 'cache flush' flag
+        {
+#ifdef MDNS_IPV4_SUPPORT
+        case DNS_RRTYPE_A:
+            p_rpRRAnswer = new stcRRAnswerA(header, u32TTL);
+            bResult = _readRRAnswerA(*(stcRRAnswerA*&)p_rpRRAnswer, u16RDLength);
+            break;
+#endif
+        case DNS_RRTYPE_PTR:
+            p_rpRRAnswer = new stcRRAnswerPTR(header, u32TTL);
+            bResult = _readRRAnswerPTR(*(stcRRAnswerPTR*&)p_rpRRAnswer, u16RDLength);
+            break;
+        case DNS_RRTYPE_TXT:
+            p_rpRRAnswer = new stcRRAnswerTXT(header, u32TTL);
+            bResult = _readRRAnswerTXT(*(stcRRAnswerTXT*&)p_rpRRAnswer, u16RDLength);
+            break;
+#ifdef MDNS_IPV6_SUPPORT
+        case DNS_RRTYPE_AAAA:
+            p_rpRRAnswer = new stcRRAnswerAAAA(header, u32TTL);
+            bResult = _readRRAnswerAAAA(*(stcRRAnswerAAAA*&)p_rpRRAnswer, u16RDLength);
+            break;
+#endif
+        case DNS_RRTYPE_SRV:
+            p_rpRRAnswer = new stcRRAnswerSRV(header, u32TTL);
+            bResult = _readRRAnswerSRV(*(stcRRAnswerSRV*&)p_rpRRAnswer, u16RDLength);
+            break;
+        default:
+            p_rpRRAnswer = new stcRRAnswerGeneric(header, u32TTL);
+            bResult = _readRRAnswerGeneric(*(stcRRAnswerGeneric*&)p_rpRRAnswer, u16RDLength);
+            break;
+        }
+        DEBUG_EX_INFO(
+            if ((bResult) &&
+                (p_rpRRAnswer))
+    {
+        DEBUG_OUTPUT.printf_P(PSTR("%s _readRRAnswer: "), _DH());
+            _printRRDomain(p_rpRRAnswer->m_Header.m_Domain);
+            DEBUG_OUTPUT.printf_P(PSTR(" Type:%s Class:0x%04X TTL:%u, RDLength:%u "),
+                                  _RRType2Name(p_rpRRAnswer->m_Header.m_Attributes.m_u16Type),
+                                  (p_rpRRAnswer->m_Header.m_Attributes.m_u16Class | (p_rpRRAnswer->m_bCacheFlush ? 0x8000 : 0)),
+                                  p_rpRRAnswer->m_u32TTL,
+                                  u16RDLength);
+            switch (header.m_Attributes.m_u16Type /*& (~0x8000)*/)      // Topmost bit might carry 'cache flush' flag
+            {
+#ifdef MDNS_IPV4_SUPPORT
+            case DNS_RRTYPE_A:
+                DEBUG_OUTPUT.printf_P(PSTR("A IP:%s"), ((stcRRAnswerA*&)p_rpRRAnswer)->m_IPAddress.toString().c_str());
+                break;
+#endif
+            case DNS_RRTYPE_PTR:
+                DEBUG_OUTPUT.printf_P(PSTR("PTR "));
+                _printRRDomain(((stcRRAnswerPTR*&)p_rpRRAnswer)->m_PTRDomain);
+                break;
+            case DNS_RRTYPE_TXT:
+            {
+                size_t  stTxtLength = ((stcRRAnswerTXT*&)p_rpRRAnswer)->m_Txts.c_strLength();
+                char*   pTxts = new char[stTxtLength];
+                if (pTxts)
+                {
+                    ((stcRRAnswerTXT*&)p_rpRRAnswer)->m_Txts.c_str(pTxts);
+                    DEBUG_OUTPUT.printf_P(PSTR("TXT(%u) %s"), stTxtLength, pTxts);
+                    delete[] pTxts;
+                }
+                break;
+            }
+#ifdef MDNS_IPV6_SUPPORT
+            case DNS_RRTYPE_AAAA:
+                DEBUG_OUTPUT.printf_P(PSTR("AAAA IP:%s"), ((stcRRAnswerAAAA*&)p_rpRRAnswer)->m_IPAddress.toString().c_str());
+                break;
+#endif
+            case DNS_RRTYPE_SRV:
+                DEBUG_OUTPUT.printf_P(PSTR("SRV Port:%u "), ((stcRRAnswerSRV*&)p_rpRRAnswer)->m_u16Port);
+                _printRRDomain(((stcRRAnswerSRV*&)p_rpRRAnswer)->m_SRVDomain);
+                break;
+            /*  case DNS_RRTYPE_NSEC:
+                DEBUG_OUTPUT.printf_P(PSTR("NSEC "));
+                _printRRDomain(((stcRRAnswerNSEC*&)p_rpRRAnswer)->m_NSECDomain);
+                for (uint32_t u=0; u<(((stcRRAnswerNSEC*&)p_rpRRAnswer)->m_pNSECBitmap->m_u16BitmapLength * 8); ++u) {
+                    uint8_t byte = ((stcRRAnswerNSEC*&)p_rpRRAnswer)->m_pNSECBitmap->m_pu8BitmapData[u / 8];
+                    uint8_t flag = 1 << (7 - (u % 8)); // (7 - (0..7)) = 7..0
+                    if (byte & flag) {
+                        DEBUG_OUTPUT.printf_P(PSTR(" %s"), _RRType2Name(u));
+                    }
+                }
+                break;*/
+            default:
+                DEBUG_OUTPUT.printf_P(PSTR("generic "));
+                break;
+            }
+            DEBUG_OUTPUT.printf_P(PSTR("\n"));
+        }
+        else
+        {
+            DEBUG_OUTPUT.printf_P(PSTR("%s _readRRAnswer: FAILED to read specific answer of type 0x%04X!\n"), _DH(), p_rpRRAnswer->m_Header.m_Attributes.m_u16Type);
+        }
+        );  // DEBUG_EX_INFO
+    }
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _readRRAnswer: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+#ifdef MDNS_IPV4_SUPPORT
+/*
+    MDNSResponder::_readRRAnswerA
+*/
+bool MDNSResponder::clsHost::_readRRAnswerA(MDNSResponder::clsHost::stcRRAnswerA& p_rRRAnswerA,
+                                            uint16_t p_u16RDLength)
+{
+
+    uint32_t    u32IPv4Address;
+    bool        bResult = ((MDNS_IPV4_SIZE == p_u16RDLength) &&
+                           (_udpReadBuffer((unsigned char*)&u32IPv4Address, MDNS_IPV4_SIZE)) &&
+                           ((p_rRRAnswerA.m_IPAddress = IPAddress(u32IPv4Address))));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _readRRAnswerA: FAILED!\n"), _DH()););
+    return bResult;
+}
+#endif
+
+/*
+    MDNSResponder::_readRRAnswerPTR
+*/
+bool MDNSResponder::clsHost::_readRRAnswerPTR(MDNSResponder::clsHost::stcRRAnswerPTR& p_rRRAnswerPTR,
+                                              uint16_t p_u16RDLength)
+{
+    bool    bResult = ((p_u16RDLength) &&
+                       (_readRRDomain(p_rRRAnswerPTR.m_PTRDomain)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _readRRAnswerPTR: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_readRRAnswerTXT
+
+    Read TXT items from a buffer like 4c#=15ff=20
+*/
+bool MDNSResponder::clsHost::_readRRAnswerTXT(MDNSResponder::clsHost::stcRRAnswerTXT& p_rRRAnswerTXT,
+                                              uint16_t p_u16RDLength)
+{
+    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _readRRAnswerTXT: RDLength:%u\n"), _DH(), p_u16RDLength););
+    bool    bResult = true;
+
+    p_rRRAnswerTXT.clear();
+    if (p_u16RDLength)
+    {
+        bResult = false;
+
+        unsigned char*  pucBuffer = new unsigned char[p_u16RDLength];
+        if (pucBuffer)
+        {
+            if (_udpReadBuffer(pucBuffer, p_u16RDLength))
+            {
+                bResult = true;
+
+                const unsigned char*    pucCursor = pucBuffer;
+                while ((pucCursor < (pucBuffer + p_u16RDLength)) &&
+                       (bResult))
+                {
+                    bResult = false;
+
+                    stcServiceTxt*      pTxt = 0;
+                    unsigned char   ucLength = *pucCursor++;    // Length of the next txt item
+                    if (ucLength)
+                    {
+                        DEBUG_EX_INFO(
+                            static char sacBuffer[64]; *sacBuffer = 0;
+                            uint8_t u8MaxLength = ((ucLength > (sizeof(sacBuffer) - 1)) ? (sizeof(sacBuffer) - 1) : ucLength);
+                            os_strncpy(sacBuffer, (const char*)pucCursor, u8MaxLength); sacBuffer[u8MaxLength] = 0;
+                            DEBUG_OUTPUT.printf_P(PSTR("%s _readRRAnswerTXT: Item(%u): %s\n"), _DH(), ucLength, sacBuffer);
+                        );
+
+                        unsigned char*  pucEqualSign = (unsigned char*)os_strchr((const char*)pucCursor, '=');  // Position of the '=' sign
+                        unsigned char   ucKeyLength;
+                        if ((pucEqualSign) &&
+                            ((ucKeyLength = (pucEqualSign - pucCursor))))
+                        {
+                            unsigned char   ucValueLength = (ucLength - (pucEqualSign - pucCursor + 1));
+                            bResult = (((pTxt = new stcServiceTxt)) &&
+                                       (pTxt->setKey((const char*)pucCursor, ucKeyLength)) &&
+                                       (pTxt->setValue((const char*)(pucEqualSign + 1), ucValueLength)));
+                        }
+                        else
+                        {
+                            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _readRRAnswerTXT: INVALID TXT format (No '=')!\n"), _DH()););
+                        }
+                        pucCursor += ucLength;
+                    }
+                    else    // no/zero length TXT
+                    {
+                        DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _readRRAnswerTXT: TXT answer contains no items.\n"), _DH()););
+                        bResult = true;
+                    }
+
+                    if ((bResult) &&
+                        (pTxt))     // Everythings fine so far
+                    {
+                        // Link TXT item to answer TXTs
+                        pTxt->m_pNext = p_rRRAnswerTXT.m_Txts.m_pTxts;
+                        p_rRRAnswerTXT.m_Txts.m_pTxts = pTxt;
+                    }
+                    else            // At least no TXT (migth be OK, if length was 0) OR an error
+                    {
+                        if (!bResult)
+                        {
+                            DEBUG_EX_ERR(
+                                DEBUG_OUTPUT.printf_P(PSTR("%s _readRRAnswerTXT: FAILED to read TXT item!\n"), _DH());
+                                DEBUG_OUTPUT.printf_P(PSTR("RData dump:\n"));
+                                _udpDump((m_rUDPContext.tell() - p_u16RDLength), p_u16RDLength);
+                                DEBUG_OUTPUT.printf_P(PSTR("\n"));
+                            );
+                        }
+                        if (pTxt)
+                        {
+                            delete pTxt;
+                            pTxt = 0;
+                        }
+                        p_rRRAnswerTXT.clear();
+                    }
+                }   // while
+
+                DEBUG_EX_ERR(
+                    if (!bResult)   // Some failure
+            {
+                DEBUG_OUTPUT.printf_P(PSTR("RData dump:\n"));
+                    _udpDump((m_rUDPContext.tell() - p_u16RDLength), p_u16RDLength);
+                    DEBUG_OUTPUT.printf_P(PSTR("\n"));
+                }
+                );
+            }
+            else
+            {
+                DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _readRRAnswerTXT: FAILED to read TXT content!\n"), _DH()););
+            }
+            // Clean up
+            delete[] pucBuffer;
+        }
+        else
+        {
+            DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _readRRAnswerTXT: FAILED to alloc buffer for TXT content!\n"), _DH()););
+        }
+    }
+    else
+    {
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _readRRAnswerTXT: WARNING! No content!\n"), _DH()););
+    }
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _readRRAnswerTXT: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+#ifdef MDNS_IPV6_SUPPORT
+bool MDNSResponder::clsHost::_readRRAnswerAAAA(MDNSResponder::clsHost::stcRRAnswerAAAA& p_rRRAnswerAAAA,
+                                               uint16_t p_u16RDLength)
+{
+    bool	bResult = false;
+
+    uint32_t	au32IPv6Address[4];	// 16 bytes
+    if ((bResult = ((MDNS_IPV6_SIZE == p_u16RDLength) &&
+                    (_udpReadBuffer((uint8_t*)&au32IPv6Address[0], MDNS_IPV6_SIZE)))))
+    {
+
+        // ?? IPADDR6_INIT_HOST ??
+        ip_addr_t	addr = IPADDR6_INIT(au32IPv6Address[0], au32IPv6Address[1], au32IPv6Address[2], au32IPv6Address[3]);
+        p_rRRAnswerAAAA.m_IPAddress = IPAddress(addr);
+    }
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _readRRAnswerAAAA: FAILED!\n"), _DH()););
+    return bResult;
+}
+#endif
+
+/*
+    MDNSResponder::_readRRAnswerSRV
+*/
+bool MDNSResponder::clsHost::_readRRAnswerSRV(MDNSResponder::clsHost::stcRRAnswerSRV& p_rRRAnswerSRV,
+                                              uint16_t p_u16RDLength)
+{
+    bool    bResult = (((3 * sizeof(uint16_t)) < p_u16RDLength) &&
+                       (_udpRead16(p_rRRAnswerSRV.m_u16Priority)) &&
+                       (_udpRead16(p_rRRAnswerSRV.m_u16Weight)) &&
+                       (_udpRead16(p_rRRAnswerSRV.m_u16Port)) &&
+                       (_readRRDomain(p_rRRAnswerSRV.m_SRVDomain)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _readRRAnswerSRV: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_readRRAnswerGeneric
+*/
+bool MDNSResponder::clsHost::_readRRAnswerGeneric(MDNSResponder::clsHost::stcRRAnswerGeneric& p_rRRAnswerGeneric,
+                                                  uint16_t p_u16RDLength)
+{
+    bool    bResult = (0 == p_u16RDLength);
+
+    p_rRRAnswerGeneric.clear();
+    if (((p_rRRAnswerGeneric.m_u16RDLength = p_u16RDLength)) &&
+        ((p_rRRAnswerGeneric.m_pu8RDData = new unsigned char[p_rRRAnswerGeneric.m_u16RDLength])))
+    {
+
+        bResult = _udpReadBuffer(p_rRRAnswerGeneric.m_pu8RDData, p_rRRAnswerGeneric.m_u16RDLength);
+    }
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _readRRAnswerGeneric: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_readRRHeader
+*/
+bool MDNSResponder::clsHost::_readRRHeader(MDNSResponder::clsHost::stcRRHeader& p_rRRHeader)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _readRRHeader\n")););
+
+    bool    bResult = ((_readRRDomain(p_rRRHeader.m_Domain)) &&
+                       (_readRRAttributes(p_rRRHeader.m_Attributes)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _readRRHeader: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_readRRDomain
+
+    Reads a (maybe multilevel compressed) domain from the UDP input buffer.
+
+*/
+bool MDNSResponder::clsHost::_readRRDomain(MDNSResponder::clsHost::stcRRDomain& p_rRRDomain)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _readRRDomain\n")););
+
+    bool    bResult = ((p_rRRDomain.clear()) &&
+                       (_readRRDomain_Loop(p_rRRDomain, 0)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _readRRDomain: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_readRRDomain_Loop
+
+    Reads a domain from the UDP input buffer. For every compression level, the functions
+    calls itself recursively. To avoid endless recursion because of malformed MDNS records,
+    the maximum recursion depth is set by MDNS_DOMAIN_MAX_REDIRCTION.
+
+*/
+bool MDNSResponder::clsHost::_readRRDomain_Loop(MDNSResponder::clsHost::stcRRDomain& p_rRRDomain,
+                                                uint8_t p_u8Depth)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _readRRDomain_Loop(%u)\n"), _DH(), p_u8Depth););
+
+    bool    bResult = false;
+
+    if (MDNS_DOMAIN_MAX_REDIRCTION >= p_u8Depth)
+    {
+        bResult = true;
+
+        uint8_t u8Len = 0;
+        do
+        {
+            //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _readRRDomain_Loop(%u): Offset:%u p0:%02x\n"), _DH(), p_u8Depth, m_rUDPContext.tell(), m_rUDPContext.peek()););
+            _udpRead8(u8Len);
+
+            if (u8Len & MDNS_DOMAIN_COMPRESS_MARK)
+            {
+                // Compressed label(s)
+                uint16_t    u16Offset = ((u8Len & ~MDNS_DOMAIN_COMPRESS_MARK) << 8);    // Implicit BE to LE conversion!
+                _udpRead8(u8Len);
+                u16Offset |= u8Len;
+
+                if (m_rUDPContext.isValidOffset(u16Offset))
+                {
+                    size_t  stCurrentPosition = m_rUDPContext.tell();      // Prepare return from recursion
+
+                    //DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("%s _readRRDomain_Loop(%u): Redirecting from %u to %u!\n"), _DH(), p_u8Depth, stCurrentPosition, u16Offset););
+                    m_rUDPContext.seek(u16Offset);
+                    if (_readRRDomain_Loop(p_rRRDomain, p_u8Depth + 1))     // Do recursion
+                    {
+                        //DEBUG_EX_RX(DEBUG_OUTPUT.printf_P(PSTR("%s _readRRDomain_Loop(%u): Succeeded to read redirected label! Returning to %u\n"), _DH(), p_u8Depth, stCurrentPosition););
+                        m_rUDPContext.seek(stCurrentPosition);             // Restore after recursion
+                    }
+                    else
+                    {
+                        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _readRRDomain_Loop(%u): FAILED to read redirected label!\n"), _DH(), p_u8Depth););
+                        bResult = false;
+                    }
+                }
+                else
+                {
+                    DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _readRRDomain_Loop(%u): INVALID offset in redirection!\n"), _DH(), p_u8Depth););
+                    bResult = false;
+                }
+                break;
+            }
+            else
+            {
+                // Normal (uncompressed) label (maybe '\0' only)
+                if (MDNS_DOMAIN_MAXLENGTH > (p_rRRDomain.m_u16NameLength + u8Len))
+                {
+                    // Add length byte
+                    p_rRRDomain.m_acName[p_rRRDomain.m_u16NameLength] = u8Len;
+                    ++(p_rRRDomain.m_u16NameLength);
+                    if (u8Len)      // Add name
+                    {
+                        if ((bResult = _udpReadBuffer((unsigned char*) & (p_rRRDomain.m_acName[p_rRRDomain.m_u16NameLength]), u8Len)))
+                        {
+                            /*  DEBUG_EX_INFO(
+                                    p_rRRDomain.m_acName[p_rRRDomain.m_u16NameLength + u8Len] = 0;  // Closing '\0' for printing
+                                    DEBUG_OUTPUT.printf_P(PSTR("%s _readRRDomain_Loop(%u): Domain label (%u): %s\n"), _DH(), p_u8Depth, (unsigned)(p_rRRDomain.m_acName[p_rRRDomain.m_u16NameLength - 1]), &(p_rRRDomain.m_acName[p_rRRDomain.m_u16NameLength]));
+                                    );*/
+
+                            p_rRRDomain.m_u16NameLength += u8Len;
+                        }
+                    }
+                    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _readRRDomain_Loop(2) offset:%u p0:%x\n"), _DH(), m_rUDPContext.tell(), m_rUDPContext.peek()););
+                }
+                else
+                {
+                    DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _readRRDomain_Loop(%u): ERROR! Domain name too long (%u + %u)!\n"), _DH(), p_u8Depth, p_rRRDomain.m_u16NameLength, u8Len););
+                    bResult = false;
+                    break;
+                }
+            }
+        } while ((bResult) &&
+                 (0 != u8Len));
+    }
+    else
+    {
+        DEBUG_EX_ERR(DEBUG_OUTPUT.printf_P(PSTR("%s _readRRDomain_Loop(%u): ERROR! Too many redirections!\n"), _DH(), p_u8Depth););
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::_readRRAttributes
+*/
+bool MDNSResponder::clsHost::_readRRAttributes(MDNSResponder::clsHost::stcRRAttributes& p_rRRAttributes)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _readRRAttributes\n")););
+
+    bool    bResult = ((_udpRead16(p_rRRAttributes.m_u16Type)) &&
+                       (_udpRead16(p_rRRAttributes.m_u16Class)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _readRRAttributes: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+
+/*
+    DOMAIN NAMES
+*/
+
+/*
+    MDNSResponder::_buildDomainForHost
+
+    Builds a MDNS host domain (eg. esp8266.local) for the given hostname.
+
+*/
+bool MDNSResponder::clsHost::_buildDomainForHost(const char* p_pcHostName,
+                                                 MDNSResponder::clsHost::stcRRDomain& p_rHostDomain) const
+{
+
+    p_rHostDomain.clear();
+    bool    bResult = ((p_pcHostName) &&
+                       (*p_pcHostName) &&
+                       (p_rHostDomain.addLabel(p_pcHostName)) &&
+                       (p_rHostDomain.addLabel(scpcLocal)) &&
+                       (p_rHostDomain.addLabel(0)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _buildDomainForHost: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_buildDomainForDNSSD
+
+    Builds the '_services._dns-sd._udp.local' domain.
+    Used while detecting generic service enum question (DNS-SD) and answering these questions.
+
+*/
+bool MDNSResponder::clsHost::_buildDomainForDNSSD(MDNSResponder::clsHost::stcRRDomain& p_rDNSSDDomain) const
+{
+    p_rDNSSDDomain.clear();
+    bool    bResult = ((p_rDNSSDDomain.addLabel(scpcServices, true)) &&
+                       (p_rDNSSDDomain.addLabel(scpcDNSSD, true)) &&
+                       (p_rDNSSDDomain.addLabel(scpcUDP, true)) &&
+                       (p_rDNSSDDomain.addLabel(scpcLocal)) &&
+                       (p_rDNSSDDomain.addLabel(0)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _buildDomainForDNSSD: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_buildDomainForService
+
+    Builds the domain for the given service (eg. _http._tcp.local or
+    MyESP._http._tcp.local (if p_bIncludeName is set)).
+
+*/
+bool MDNSResponder::clsHost::_buildDomainForService(const MDNSResponder::clsHost::stcService& p_Service,
+                                                    bool p_bIncludeName,
+                                                    MDNSResponder::clsHost::stcRRDomain& p_rServiceDomain) const
+{
+    p_rServiceDomain.clear();
+    bool    bResult = (((!p_bIncludeName) ||
+                        (p_rServiceDomain.addLabel(p_Service.m_pcName))) &&
+                       (p_rServiceDomain.addLabel(p_Service.m_pcServiceType, ('_' != *p_Service.m_pcServiceType))) &&
+                       (p_rServiceDomain.addLabel(p_Service.m_pcProtocol, ('_' != *p_Service.m_pcProtocol))) &&
+                       (p_rServiceDomain.addLabel(scpcLocal)) &&
+                       (p_rServiceDomain.addLabel(0)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _buildDomainForService: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_buildDomainForService
+
+    Builds the domain for the given service properties (eg. _http._tcp.local).
+    The usual prepended '_' are added, if missing in the input strings.
+
+*/
+bool MDNSResponder::clsHost::_buildDomainForService(const char* p_pcServiceType,
+                                                    const char* p_pcProtocol,
+                                                    MDNSResponder::clsHost::stcRRDomain& p_rServiceDomain) const
+{
+    p_rServiceDomain.clear();
+    bool    bResult = ((p_pcServiceType) &&
+                       (p_pcProtocol) &&
+                       (p_rServiceDomain.addLabel(p_pcServiceType, ('_' != *p_pcServiceType))) &&
+                       (p_rServiceDomain.addLabel(p_pcProtocol, ('_' != *p_pcProtocol))) &&
+                       (p_rServiceDomain.addLabel(scpcLocal)) &&
+                       (p_rServiceDomain.addLabel(0)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _buildDomainForService: FAILED for (%s.%s)!\n"), _DH(), (p_pcServiceType ? : "-"), (p_pcProtocol ? : "-")););
+    return bResult;
+}
+
+#ifdef MDNS_IPV4_SUPPORT
+/*
+    MDNSResponder::_buildDomainForReverseIPv4
+
+    The IPv4 address is stringized by printing the four address bytes into a char buffer in reverse order
+    and adding 'in-addr.arpa' (eg. 012.789.456.123.in-addr.arpa).
+    Used while detecting reverse IPv4 questions and answering these
+*/
+bool MDNSResponder::clsHost::_buildDomainForReverseIPv4(IPAddress p_IPv4Address,
+                                                        MDNSResponder::clsHost::stcRRDomain& p_rReverseIPv4Domain) const
+{
+    bool    bResult = ((p_IPv4Address.isSet()) &&
+                       (p_IPv4Address.isV4()));
+
+    p_rReverseIPv4Domain.clear();
+
+    char    acBuffer[32];
+    for (int i = MDNS_IPV4_SIZE; ((bResult) && (i >= 1)); --i)
+    {
+        itoa(p_IPv4Address[i - 1], acBuffer, 10);
+        bResult = p_rReverseIPv4Domain.addLabel(acBuffer);
+    }
+    bResult = ((bResult) &&
+               (p_rReverseIPv4Domain.addLabel(scpcReverseIPv4Domain)) &&
+               (p_rReverseIPv4Domain.addLabel(scpcReverseTopDomain)) &&
+               (p_rReverseIPv4Domain.addLabel(0)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _buildDomainForReverseIPv4: FAILED!\n"), _DH()););
+    return bResult;
+}
+#endif
+
+#ifdef MDNS_IPV6_SUPPORT
+/*
+    MDNSResponder::_buildDomainForReverseIPv6
+
+    The IPv6 address is stringized by printing the 16 address bytes (32 nibbles) into a char buffer in reverse order
+    and adding 'ip6.arpa' (eg. 3.B.6.E.A.1.B.B.A.B.F.7.F.8.0.1.0.0.0.0.0.0.0.0.0.0.0.0.0.8.E.F.ip6.arpa).
+    Used while detecting reverse IPv6 questions and answering these
+*/
+bool MDNSResponder::clsHost::_buildDomainForReverseIPv6(IPAddress p_IPv6Address,
+                                                        MDNSResponder::clsHost::stcRRDomain& p_rReverseIPv6Domain) const
+{
+    bool    bResult = ((p_IPv6Address.isSet()) &&
+                       (p_IPv6Address.isV6()));
+
+    p_rReverseIPv6Domain.clear();
+
+    const uint16_t* pRaw = p_IPv6Address.raw6();
+    for (int8_t i8 = (MDNS_IPV6_SIZE / 2); ((bResult) && (i8 > 0)); --i8) // 8..1
+    {
+        uint16_t	u16Part = ntohs(pRaw[i8 - 1] & 0xFFFF);
+        char        acBuffer[2];
+        for (uint8_t u8 = 0; ((bResult) && (u8 < 4)); ++u8)             // 0..3
+        {
+            itoa((u16Part & 0xF), acBuffer, 16);
+            bResult = p_rReverseIPv6Domain.addLabel(acBuffer);
+            u16Part >>= 4;
+        }
+    }
+    bResult = ((bResult) &&
+               (p_rReverseIPv6Domain.addLabel(scpcReverseIPv6Domain)) &&    // .ip6.arpa
+               (p_rReverseIPv6Domain.addLabel(scpcReverseTopDomain)) &&     // .local
+               (p_rReverseIPv6Domain.addLabel(0)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _buildDomainForReverseIPv6: FAILED!\n"), _DH()););
+    return bResult;
+}
+#endif
+
+
+/*
+    UDP
+*/
+
+/*
+    MDNSResponder::_udpReadBuffer
+*/
+bool MDNSResponder::clsHost::_udpReadBuffer(unsigned char* p_pBuffer,
+                                            size_t p_stLength)
+{
+    bool    bResult = ((true/*m_rUDPContext.getSize() > p_stLength*/) &&
+                       (p_pBuffer) &&
+                       (p_stLength) &&
+                       ((p_stLength == m_rUDPContext.read((char*)p_pBuffer, p_stLength))));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _udpReadBuffer: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_udpRead8
+*/
+bool MDNSResponder::clsHost::_udpRead8(uint8_t& p_ru8Value)
+{
+    return _udpReadBuffer((unsigned char*)&p_ru8Value, sizeof(p_ru8Value));
+}
+
+/*
+    MDNSResponder::_udpRead16
+*/
+bool MDNSResponder::clsHost::_udpRead16(uint16_t& p_ru16Value)
+{
+    bool    bResult = false;
+
+    if (_udpReadBuffer((unsigned char*)&p_ru16Value, sizeof(p_ru16Value)))
+    {
+        p_ru16Value = lwip_ntohs(p_ru16Value);
+        bResult = true;
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::_udpRead32
+*/
+bool MDNSResponder::clsHost::_udpRead32(uint32_t& p_ru32Value)
+{
+    bool    bResult = false;
+
+    if (_udpReadBuffer((unsigned char*)&p_ru32Value, sizeof(p_ru32Value)))
+    {
+        p_ru32Value = lwip_ntohl(p_ru32Value);
+        bResult = true;
+    }
+    return bResult;
+}
+
+/*
+    MDNSResponder::_udpAppendBuffer
+*/
+bool MDNSResponder::clsHost::_udpAppendBuffer(const unsigned char* p_pcBuffer,
+                                              size_t p_stLength)
+{
+    bool bResult = ((p_pcBuffer) &&
+                    (p_stLength) &&
+                    (p_stLength == m_rUDPContext.append((const char*)p_pcBuffer, p_stLength)));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _udpAppendBuffer: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_udpAppend8
+*/
+bool MDNSResponder::clsHost::_udpAppend8(uint8_t p_u8Value)
+{
+    return (_udpAppendBuffer((unsigned char*)&p_u8Value, sizeof(p_u8Value)));
+}
+
+/*
+    MDNSResponder::_udpAppend16
+*/
+bool MDNSResponder::clsHost::_udpAppend16(uint16_t p_u16Value)
+{
+    p_u16Value = lwip_htons(p_u16Value);
+    return (_udpAppendBuffer((unsigned char*)&p_u16Value, sizeof(p_u16Value)));
+}
+
+/*
+    MDNSResponder::_udpAppend32
+*/
+bool MDNSResponder::clsHost::_udpAppend32(uint32_t p_u32Value)
+{
+    p_u32Value = lwip_htonl(p_u32Value);
+    return (_udpAppendBuffer((unsigned char*)&p_u32Value, sizeof(p_u32Value)));
+}
+
+#ifdef DEBUG_ESP_MDNS_RESPONDER
+/*
+    MDNSResponder::_udpDump
+*/
+bool MDNSResponder::clsHost::_udpDump(bool p_bMovePointer /*= false*/)
+{
+    const uint8_t   cu8BytesPerLine = 16;
+
+    uint32_t        u32StartPosition = m_rUDPContext.tell();
+    DEBUG_OUTPUT.println("UDP Context Dump:");
+    uint32_t    u32Counter = 0;
+    uint8_t     u8Byte = 0;
+
+    while (_udpRead8(u8Byte))
+    {
+        DEBUG_OUTPUT.printf_P(PSTR("%02x %s"), u8Byte, ((++u32Counter % cu8BytesPerLine) ? "" : "\n"));
+    }
+    DEBUG_OUTPUT.printf_P(PSTR("%sDone: %u bytes\n"), (((u32Counter) && (u32Counter % cu8BytesPerLine)) ? "\n" : ""), u32Counter);
+
+    if (!p_bMovePointer)    // Restore
+    {
+        m_rUDPContext.seek(u32StartPosition);
+    }
+    return true;
+}
+
+/*
+    MDNSResponder::_udpDump
+*/
+bool MDNSResponder::clsHost::_udpDump(unsigned p_uOffset,
+                                      unsigned p_uLength)
+{
+    if (m_rUDPContext.isValidOffset(p_uOffset))
+    {
+        unsigned    uCurrentPosition = m_rUDPContext.tell();   // Remember start position
+
+        m_rUDPContext.seek(p_uOffset);
+        uint8_t u8Byte;
+        for (unsigned u = 0; ((u < p_uLength) && (_udpRead8(u8Byte))); ++u)
+        {
+            DEBUG_OUTPUT.printf_P(PSTR("%02x "), u8Byte);
+        }
+        // Return to start position
+        m_rUDPContext.seek(uCurrentPosition);
+    }
+    return true;
+}
+#endif
+
+
+/**
+    READ/WRITE MDNS STRUCTS
+*/
+
+/*
+    MDNSResponder::_readMDNSMsgHeader
+
+    Read a MDNS header from the UDP input buffer.
+     |   8    |   8    |   8    |   8    |
+    00|   Identifier    |  Flags & Codes  |
+    01| Question count  |  Answer count   |
+    02| NS answer count | Ad answer count |
+
+    All 16-bit and 32-bit elements need to be translated form network coding to host coding (done in _udpRead16 and _udpRead32)
+    In addition, bitfield memory order is undefined in C standard (GCC doesn't order them in the coded direction...), so they
+    need some mapping here
+*/
+bool MDNSResponder::clsHost::_readMDNSMsgHeader(MDNSResponder::clsHost::stcMsgHeader& p_rMsgHeader)
+{
+    bool    bResult = false;
+
+    uint8_t u8B1;
+    uint8_t u8B2;
+    if ((_udpRead16(p_rMsgHeader.m_u16ID)) &&
+        (_udpRead8(u8B1)) &&
+        (_udpRead8(u8B2)) &&
+        (_udpRead16(p_rMsgHeader.m_u16QDCount)) &&
+        (_udpRead16(p_rMsgHeader.m_u16ANCount)) &&
+        (_udpRead16(p_rMsgHeader.m_u16NSCount)) &&
+        (_udpRead16(p_rMsgHeader.m_u16ARCount)))
+    {
+
+        p_rMsgHeader.m_1bQR     = (u8B1 & 0x80);    // Query/Responde flag
+        p_rMsgHeader.m_4bOpcode = (u8B1 & 0x78);    // Operation code (0: Standard query, others ignored)
+        p_rMsgHeader.m_1bAA     = (u8B1 & 0x04);    // Authorative answer
+        p_rMsgHeader.m_1bTC     = (u8B1 & 0x02);    // Truncation flag
+        p_rMsgHeader.m_1bRD     = (u8B1 & 0x01);    // Recursion desired
+
+        p_rMsgHeader.m_1bRA     = (u8B2 & 0x80);    // Recursion available
+        p_rMsgHeader.m_3bZ      = (u8B2 & 0x70);    // Zero
+        p_rMsgHeader.m_4bRCode  = (u8B2 & 0x0F);    // Response code
+
+        /*  DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _readMDNSMsgHeader: ID:%u QR:%u OP:%u AA:%u TC:%u RD:%u RA:%u R:%u QD:%u AN:%u NS:%u AR:%u\n"),
+                _DH(),
+                (unsigned)p_rMsgHeader.m_u16ID,
+                (unsigned)p_rMsgHeader.m_1bQR, (unsigned)p_rMsgHeader.m_4bOpcode, (unsigned)p_rMsgHeader.m_1bAA, (unsigned)p_rMsgHeader.m_1bTC, (unsigned)p_rMsgHeader.m_1bRD,
+                (unsigned)p_rMsgHeader.m_1bRA, (unsigned)p_rMsgHeader.m_4bRCode,
+                (unsigned)p_rMsgHeader.m_u16QDCount,
+                (unsigned)p_rMsgHeader.m_u16ANCount,
+                (unsigned)p_rMsgHeader.m_u16NSCount,
+                (unsigned)p_rMsgHeader.m_u16ARCount););*/
+        bResult = true;
+    }
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _readMDNSMsgHeader: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_write8
+*/
+bool MDNSResponder::clsHost::_write8(uint8_t p_u8Value,
+                                     MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    return ((_udpAppend8(p_u8Value)) &&
+            (p_rSendParameter.shiftOffset(sizeof(p_u8Value))));
+}
+
+/*
+    MDNSResponder::_write16
+*/
+bool MDNSResponder::clsHost::_write16(uint16_t p_u16Value,
+                                      MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    return ((_udpAppend16(p_u16Value)) &&
+            (p_rSendParameter.shiftOffset(sizeof(p_u16Value))));
+}
+
+/*
+    MDNSResponder::_write32
+*/
+bool MDNSResponder::clsHost::_write32(uint32_t p_u32Value,
+                                      MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    return ((_udpAppend32(p_u32Value)) &&
+            (p_rSendParameter.shiftOffset(sizeof(p_u32Value))));
+}
+
+/*
+    MDNSResponder::_writeMDNSMsgHeader
+
+    Write MDNS header to the UDP output buffer.
+
+    All 16-bit and 32-bit elements need to be translated form host coding to network coding (done in _udpAppend16 and _udpAppend32)
+    In addition, bitfield memory order is undefined in C standard (GCC doesn't order them in the coded direction...), so they
+    need some mapping here
+*/
+bool MDNSResponder::clsHost::_writeMDNSMsgHeader(const MDNSResponder::clsHost::stcMsgHeader& p_MsgHeader,
+                                                 MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    /*  DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSMsgHeader: ID:%u QR:%u OP:%u AA:%u TC:%u RD:%u RA:%u R:%u QD:%u AN:%u NS:%u AR:%u\n"),
+            _DH(),
+            (unsigned)p_MsgHeader.m_u16ID,
+            (unsigned)p_MsgHeader.m_1bQR, (unsigned)p_MsgHeader.m_4bOpcode, (unsigned)p_MsgHeader.m_1bAA, (unsigned)p_MsgHeader.m_1bTC, (unsigned)p_MsgHeader.m_1bRD,
+            (unsigned)p_MsgHeader.m_1bRA, (unsigned)p_MsgHeader.m_4bRCode,
+            (unsigned)p_MsgHeader.m_u16QDCount,
+            (unsigned)p_MsgHeader.m_u16ANCount,
+            (unsigned)p_MsgHeader.m_u16NSCount,
+            (unsigned)p_MsgHeader.m_u16ARCount););*/
+
+    uint8_t u8B1((p_MsgHeader.m_1bQR << 7) | (p_MsgHeader.m_4bOpcode << 3) | (p_MsgHeader.m_1bAA << 2) | (p_MsgHeader.m_1bTC << 1) | (p_MsgHeader.m_1bRD));
+    uint8_t u8B2((p_MsgHeader.m_1bRA << 7) | (p_MsgHeader.m_3bZ << 4) | (p_MsgHeader.m_4bRCode));
+    bool    bResult = ((_write16(p_MsgHeader.m_u16ID, p_rSendParameter)) &&
+                       (_write8(u8B1, p_rSendParameter)) &&
+                       (_write8(u8B2, p_rSendParameter)) &&
+                       (_write16(p_MsgHeader.m_u16QDCount, p_rSendParameter)) &&
+                       (_write16(p_MsgHeader.m_u16ANCount, p_rSendParameter)) &&
+                       (_write16(p_MsgHeader.m_u16NSCount, p_rSendParameter)) &&
+                       (_write16(p_MsgHeader.m_u16ARCount, p_rSendParameter)));
+
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSMsgHeader: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_writeRRAttributes
+*/
+bool MDNSResponder::clsHost::_writeMDNSRRAttributes(const MDNSResponder::clsHost::stcRRAttributes& p_Attributes,
+                                                    MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    bool    bResult = ((_write16(p_Attributes.m_u16Type, p_rSendParameter)) &&
+                       (_write16(p_Attributes.m_u16Class, p_rSendParameter)));
+
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSRRAttributes: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_writeMDNSRRDomain
+*/
+bool MDNSResponder::clsHost::_writeMDNSRRDomain(const MDNSResponder::clsHost::stcRRDomain& p_Domain,
+                                                MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    bool    bResult = ((_udpAppendBuffer((const unsigned char*)p_Domain.m_acName, p_Domain.m_u16NameLength)) &&
+                       (p_rSendParameter.shiftOffset(p_Domain.m_u16NameLength)));
+
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSRRDomain: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_writeMDNSHostDomain
+
+    Write a host domain to the UDP output buffer.
+    If the domain record is part of the answer, the records length is
+    prepended (p_bPrependRDLength is set).
+
+    A very simple form of name compression is applied here:
+    If the domain is written to the UDP output buffer, the write offset is stored
+    together with a domain id (the pointer) in a p_rSendParameter substructure (cache).
+    If the same domain (pointer) should be written to the UDP output later again,
+    the old offset is retrieved from the cache, marked as a compressed domain offset
+    and written to the output buffer.
+
+*/
+bool MDNSResponder::clsHost::_writeMDNSHostDomain(const char* p_pcHostName,
+                                                  bool p_bPrependRDLength,
+                                                  uint16_t p_u16AdditionalLength,
+                                                  MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    // The 'skip-compression' version is handled in '_writeMDNSAnswer_SRV'
+    uint16_t            u16CachedDomainOffset = p_rSendParameter.findCachedDomainOffset((const void*)p_pcHostName, false);
+
+    stcRRDomain    hostDomain;
+    bool    bResult = (u16CachedDomainOffset
+                       // Found cached domain -> mark as compressed domain
+                       ? ((MDNS_DOMAIN_COMPRESS_MARK > ((u16CachedDomainOffset >> 8) & ~MDNS_DOMAIN_COMPRESS_MARK)) && // Valid offset
+                          ((!p_bPrependRDLength) ||
+                           (_write16((2 + p_u16AdditionalLength), p_rSendParameter))) &&                               // Length of 'Cxxx'
+                          (_write8(((u16CachedDomainOffset >> 8) | MDNS_DOMAIN_COMPRESS_MARK), p_rSendParameter)) &&   // Compression mark (and offset)
+                          (_write8((uint8_t)(u16CachedDomainOffset & 0xFF), p_rSendParameter)))
+                       // No cached domain -> add this domain to cache and write full domain name
+                       : ((_buildDomainForHost(p_pcHostName, hostDomain)) &&                                           // eg. esp8266.local
+                          ((!p_bPrependRDLength) ||
+                           (_write16((hostDomain.m_u16NameLength + p_u16AdditionalLength), p_rSendParameter))) &&      // RDLength (if needed)
+                          (p_rSendParameter.addDomainCacheItem((const void*)p_pcHostName, false, p_rSendParameter.m_u16Offset)) &&
+                          (_writeMDNSRRDomain(hostDomain, p_rSendParameter))));
+
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSHostDomain: FAILED!\n"), _DH()););
+    return bResult;
+
+}
+
+/*
+    MDNSResponder::_writeMDNSServiceDomain
+
+    Write a service domain to the UDP output buffer.
+    If the domain record is part of the answer, the records length is
+    prepended (p_bPrependRDLength is set).
+
+    A very simple form of name compression is applied here: see '_writeMDNSHostDomain'
+    The cache differentiates of course between service domains which includes
+    the instance name (p_bIncludeName is set) and thoose who don't.
+
+*/
+bool MDNSResponder::clsHost::_writeMDNSServiceDomain(const MDNSResponder::clsHost::stcService& p_Service,
+                                                     bool p_bIncludeName,
+                                                     bool p_bPrependRDLength,
+                                                     uint16_t p_u16AdditionalLength,
+                                                     MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    // The 'skip-compression' version is handled in '_writeMDNSAnswer_SRV'
+    uint16_t            u16CachedDomainOffset = p_rSendParameter.findCachedDomainOffset((const void*)&p_Service, p_bIncludeName);
+
+    stcRRDomain    serviceDomain;
+    bool    bResult = (u16CachedDomainOffset
+                       // Found cached domain -> mark as compressed domain
+                       ? ((MDNS_DOMAIN_COMPRESS_MARK > ((u16CachedDomainOffset >> 8) & ~MDNS_DOMAIN_COMPRESS_MARK)) && // Valid offset
+                          ((!p_bPrependRDLength) ||
+                           (_write16((2 + p_u16AdditionalLength), p_rSendParameter))) &&                               // Lenght of 'Cxxx'
+                          (_write8(((u16CachedDomainOffset >> 8) | MDNS_DOMAIN_COMPRESS_MARK), p_rSendParameter)) &&   // Compression mark (and offset)
+                          (_write8((uint8_t)(u16CachedDomainOffset & 0xFF), p_rSendParameter)))
+                       // No cached domain -> add this domain to cache and write full domain name
+                       : ((_buildDomainForService(p_Service, p_bIncludeName, serviceDomain)) &&                        // eg. MyESP._http._tcp.local
+                          ((!p_bPrependRDLength) ||
+                           (_write16((serviceDomain.m_u16NameLength + p_u16AdditionalLength), p_rSendParameter))) &&   // RDLength (if needed)
+                          (p_rSendParameter.addDomainCacheItem((const void*)&p_Service, p_bIncludeName, p_rSendParameter.m_u16Offset)) &&
+                          (_writeMDNSRRDomain(serviceDomain, p_rSendParameter))));
+
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSServiceDomain: FAILED!\n"), _DH()););
+    return bResult;
+
+}
+
+/*
+    MDNSResponder::_writeMDNSQuestion
+
+    Write a MDNS question to the UDP output buffer
+
+    QNAME  (host/service domain, eg. esp8266.local)
+    QTYPE  (16bit, eg. ANY)
+    QCLASS (16bit, eg. IN)
+
+*/
+bool MDNSResponder::clsHost::_writeMDNSQuestion(MDNSResponder::clsHost::stcRRQuestion& p_Question,
+                                                MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSQuestion\n")););
+
+    bool    bResult = ((_writeMDNSRRDomain(p_Question.m_Header.m_Domain, p_rSendParameter)) &&
+                       (_writeMDNSRRAttributes(p_Question.m_Header.m_Attributes, p_rSendParameter)));
+
+    DEBUG_EX_INFO(if (bResult)
+{
+    DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSQuestion "), _DH());
+        _printRRDomain(p_Question.m_Header.m_Domain);
+        DEBUG_OUTPUT.printf_P(PSTR(" Type:%s Class:0x%04X\n"),
+                              _RRType2Name(p_Question.m_Header.m_Attributes.m_u16Type),
+                              p_Question.m_Header.m_Attributes.m_u16Class);
+    });
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSQuestion: FAILED!\n"), _DH()););
+    return bResult;
+
+}
+
+
+#ifdef MDNS_IPV4_SUPPORT
+/*
+    MDNSResponder::_writeMDNSAnswer_A
+
+    Write a MDNS A answer to the UDP output buffer.
+
+    NAME     (var, host/service domain, eg. esp8266.local
+    TYPE     (16bit, eg. A)
+    CLASS    (16bit, eg. IN)
+    TTL      (32bit, eg. 120)
+    RDLENGTH (16bit, eg 4)
+    RDATA    (var, eg. 123.456.789.012)
+
+    eg. esp8266.local A 0x8001 120 4 123.456.789.012
+    Ref: http://www.zytrax.com/books/dns/ch8/a.html
+*/
+bool MDNSResponder::clsHost::_writeMDNSAnswer_A(IPAddress p_IPAddress,
+                                                MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_A (%s)%s\n"), p_IPAddress.toString().c_str(), (p_rSendParameter.m_bCacheFlush ? "" : " nF")););
+
+    stcRRAttributes    attributes(DNS_RRTYPE_A,
+                                  ((p_rSendParameter.m_bCacheFlush ? 0x8000 : 0) | DNS_RRCLASS_IN));   // Cache flush? & INternet
+    const unsigned char     aucIPAddress[MDNS_IPV4_SIZE] = { p_IPAddress[0], p_IPAddress[1], p_IPAddress[2], p_IPAddress[3] };
+    bool    bResult = ((p_IPAddress.isV4()) &&
+                       (_writeMDNSHostDomain(m_pcHostName, false, 0, p_rSendParameter)) &&
+                       (_writeMDNSRRAttributes(attributes, p_rSendParameter)) &&        // TYPE & CLASS
+                       (_write32((p_rSendParameter.m_bUnannounce
+                                  ? 0
+                                  : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_HOST_TTL)), p_rSendParameter)) &&    // TTL
+                       (_write16(MDNS_IPV4_SIZE, p_rSendParameter)) &&                  // RDLength
+                       (_udpAppendBuffer(aucIPAddress, MDNS_IPV4_SIZE)) &&              // RData
+                       (p_rSendParameter.shiftOffset(MDNS_IPV4_SIZE)));
+
+    DEBUG_EX_INFO(if (bResult)
+                  DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_A %s.local Type:%s Class:0x%04X TTL:%u %s\n"),
+                                        _DH(),
+                                        m_pcHostName,
+                                        _RRType2Name(attributes.m_u16Type),
+                                        attributes.m_u16Class,
+                                        (p_rSendParameter.m_bUnannounce
+                                         ? 0
+                                         : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_HOST_TTL)),
+                                        p_IPAddress.toString().c_str());
+                 );
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_A: FAILED!\n"), _DH()););
+    return bResult;
+
+}
+
+/*
+    MDNSResponder::_writeMDNSAnswer_PTR_IPv4
+
+    Write a MDNS reverse IPv4 PTR answer to the UDP output buffer.
+    See: '_writeMDNSAnswer_A'
+
+    eg. 012.789.456.123.in-addr.arpa PTR 0x8001 120 15 esp8266.local
+    Used while answering reverse IPv4 questions
+*/
+bool MDNSResponder::clsHost::_writeMDNSAnswer_PTR_IPv4(IPAddress p_IPAddress,
+                                                       MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_PTR_IPv4 (%s)%s\n"), p_IPAddress.toString().c_str(), (p_rSendParameter.m_bCacheFlush ? "" : " nF")););
+
+    stcRRDomain        reverseIPv4Domain;
+    stcRRAttributes    attributes(DNS_RRTYPE_PTR,
+                                  ((p_rSendParameter.m_bCacheFlush ? 0x8000 : 0) | DNS_RRCLASS_IN));   // Cache flush? & INternet
+    stcRRDomain        hostDomain;
+    bool    bResult = ((p_IPAddress.isV4()) &&
+                       (_buildDomainForReverseIPv4(p_IPAddress, reverseIPv4Domain)) &&	// 012.789.456.123.in-addr.arpa
+                       (_writeMDNSRRDomain(reverseIPv4Domain, p_rSendParameter)) &&
+                       (_writeMDNSRRAttributes(attributes, p_rSendParameter)) &&        // TYPE & CLASS
+                       (_write32((p_rSendParameter.m_bUnannounce
+                                  ? 0
+                                  : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_HOST_TTL)), p_rSendParameter)) &&    // TTL
+                       (_writeMDNSHostDomain(m_pcHostName, true, 0, p_rSendParameter)));   // RDLength & RData (host domain, eg. esp8266.local)
+
+    DEBUG_EX_INFO(if (bResult)
+                  DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_PTR_IPv4 "), _DH());
+                  _printRRDomain(reverseIPv4Domain);
+                  DEBUG_OUTPUT.printf_P(PSTR(" Type:%s Class:0x%04X TTL:%u %s.local\n"),
+                                        _RRType2Name(attributes.m_u16Type),
+                                        attributes.m_u16Class,
+                                        (p_rSendParameter.m_bUnannounce
+                                         ? 0
+                                         : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_HOST_TTL)),
+                                        m_pcHostName);
+                 );
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_PTR_IPv4: FAILED!\n"), _DH()););
+    return bResult;
+}
+#endif
+
+/*
+    MDNSResponder::_writeMDNSAnswer_PTR_TYPE
+
+    Write a MDNS PTR answer to the UDP output buffer.
+    See: '_writeMDNSAnswer_A'
+
+    PTR all-services -> service type
+    eg. _services._dns-sd._udp.local PTR 0x8001 5400 xx _http._tcp.local
+    http://www.zytrax.com/books/dns/ch8/ptr.html
+*/
+bool MDNSResponder::clsHost::_writeMDNSAnswer_PTR_TYPE(MDNSResponder::clsHost::stcService& p_rService,
+                                                       MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_PTR_TYPE\n")););
+
+    stcRRDomain        dnssdDomain;
+    stcRRDomain        serviceDomain;
+    stcRRAttributes    attributes(DNS_RRTYPE_PTR, DNS_RRCLASS_IN);                    	// No cache flush for shared records! only INternet
+    bool    bResult = ((_buildDomainForDNSSD(dnssdDomain)) &&                               // _services._dns-sd._udp.local
+                       (_writeMDNSRRDomain(dnssdDomain, p_rSendParameter)) &&
+                       (_writeMDNSRRAttributes(attributes, p_rSendParameter)) &&            // TYPE & CLASS
+                       (_write32((p_rSendParameter.m_bUnannounce
+                                  ? 0
+                                  : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_SERVICE_TTL)), p_rSendParameter)) && // TTL
+                       (_writeMDNSServiceDomain(p_rService, false, true, 0, p_rSendParameter)));    // RDLength & RData (service domain, eg. _http._tcp.local)
+
+    DEBUG_EX_INFO(if (bResult)
+                  DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_PTR_TYPE "), _DH());
+                  _printRRDomain(dnssdDomain);
+                  DEBUG_OUTPUT.printf_P(PSTR(" Type:%s Class:0x%04X TTL:%u _%s._%s.local\n"),
+                                        _RRType2Name(attributes.m_u16Type),
+                                        attributes.m_u16Class,
+                                        (p_rSendParameter.m_bUnannounce
+                                         ? 0
+                                         : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_SERVICE_TTL)),
+                                        p_rService.m_pcServiceType,
+                                        p_rService.m_pcProtocol);
+                 );
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_PTR_TYPE: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_writeMDNSAnswer_PTR_NAME
+
+    Write a MDNS PTR answer to the UDP output buffer.
+    See: '_writeMDNSAnswer_A'
+
+    PTR service type -> service name
+    eg. _http.tcp.local PTR 0x8001 120 xx myESP._http._tcp.local
+    http://www.zytrax.com/books/dns/ch8/ptr.html
+*/
+bool MDNSResponder::clsHost::_writeMDNSAnswer_PTR_NAME(MDNSResponder::clsHost::stcService& p_rService,
+                                                       MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_PTR_NAME\n"), _DH()););
+
+    stcRRAttributes    attributes(DNS_RRTYPE_PTR, DNS_RRCLASS_IN);	                            // No cache flush for shared records! only INternet
+    bool    bResult = ((_writeMDNSServiceDomain(p_rService, false, false, 0, p_rSendParameter)) &&  // _http._tcp.local
+                       (_writeMDNSRRAttributes(attributes, p_rSendParameter)) &&                    // TYPE & CLASS
+                       (_write32((p_rSendParameter.m_bUnannounce
+                                  ? 0
+                                  : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_SERVICE_TTL)), p_rSendParameter)) && // TTL
+                       (_writeMDNSServiceDomain(p_rService, true, true, 0, p_rSendParameter)));     // RDLength & RData (service domain, eg. MyESP._http._tcp.local)
+
+    DEBUG_EX_INFO(if (bResult)
+                  DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_PTR_NAME _%s._%s.local Type:%s Class:0x%04X TTL:%u %s._%s._%s.local\n"),
+                                        _DH(),
+                                        p_rService.m_pcServiceType,
+                                        p_rService.m_pcProtocol,
+                                        _RRType2Name(attributes.m_u16Type),
+                                        attributes.m_u16Class,
+                                        (p_rSendParameter.m_bUnannounce
+                                         ? 0
+                                         : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_SERVICE_TTL)),
+                                        p_rService.m_pcName,
+                                        p_rService.m_pcServiceType,
+                                        p_rService.m_pcProtocol);
+                 );
+    DEBUG_EX_ERR(if (!bResult)DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_PTR_NAME: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+
+/*
+    MDNSResponder::_writeMDNSAnswer_TXT
+
+    Write a MDNS TXT answer to the UDP output buffer.
+    See: '_writeMDNSAnswer_A'
+
+    The TXT items in the RDATA block are 'length byte encoded': [len]vardata
+
+    eg. myESP._http._tcp.local TXT 0x8001 120 4 c#=1
+    http://www.zytrax.com/books/dns/ch8/txt.html
+*/
+bool MDNSResponder::clsHost::_writeMDNSAnswer_TXT(MDNSResponder::clsHost::stcService& p_rService,
+                                                  MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_TXT%s\n"), (p_rSendParameter.m_bCacheFlush ? "" : " nF"), _DH()););
+
+    bool                    bResult = false;
+
+    stcRRAttributes    attributes(DNS_RRTYPE_TXT,
+                                  ((p_rSendParameter.m_bCacheFlush ? 0x8000 : 0) | DNS_RRCLASS_IN));   // Cache flush? & INternet
+
+    if ((_collectServiceTxts(p_rService)) &&
+        (_writeMDNSServiceDomain(p_rService, true, false, 0, p_rSendParameter)) &&	// MyESP._http._tcp.local
+        (_writeMDNSRRAttributes(attributes, p_rSendParameter)) &&                   // TYPE & CLASS
+        (_write32((p_rSendParameter.m_bUnannounce
+                   ? 0
+                   : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_SERVICE_TTL)), p_rSendParameter)) &&    // TTL
+        (_write16(p_rService.m_Txts.length(), p_rSendParameter)))                   // RDLength
+    {
+
+        bResult = true;
+        // RData    Txts
+        for (stcServiceTxt* pTxt = p_rService.m_Txts.m_pTxts; ((bResult) && (pTxt)); pTxt = pTxt->m_pNext)
+        {
+            unsigned char       ucLengthByte = pTxt->length();
+            bResult = ((_udpAppendBuffer((unsigned char*)&ucLengthByte, sizeof(ucLengthByte))) &&   // Length
+                       (p_rSendParameter.shiftOffset(sizeof(ucLengthByte))) &&
+                       ((size_t)os_strlen(pTxt->m_pcKey) == m_rUDPContext.append(pTxt->m_pcKey, os_strlen(pTxt->m_pcKey))) &&          // Key
+                       (p_rSendParameter.shiftOffset((size_t)os_strlen(pTxt->m_pcKey))) &&
+                       (1 == m_rUDPContext.append("=", 1)) &&                                                                          // =
+                       (p_rSendParameter.shiftOffset(1)) &&
+                       ((!pTxt->m_pcValue) ||
+                        (((size_t)os_strlen(pTxt->m_pcValue) == m_rUDPContext.append(pTxt->m_pcValue, os_strlen(pTxt->m_pcValue))) &&  // Value
+                         (p_rSendParameter.shiftOffset((size_t)os_strlen(pTxt->m_pcValue))))));
+
+            DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_TXT: FAILED to write %sTxt %s=%s!\n"), _DH(), (pTxt->m_bTemp ? "temp. " : ""), (pTxt->m_pcKey ? : "?"), (pTxt->m_pcValue ? : "?")););
+        }
+    }
+
+    DEBUG_EX_INFO(if (bResult)
+                  DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_TXT %s._%s._%s.local Type:%s Class:0x%04X TTL:%u \n"),
+                                        _DH(),
+                                        p_rService.m_pcName,
+                                        p_rService.m_pcServiceType,
+                                        p_rService.m_pcProtocol,
+                                        _RRType2Name(attributes.m_u16Type),
+                                        attributes.m_u16Class,
+                                        (p_rSendParameter.m_bUnannounce
+                                         ? 0
+                                         : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_SERVICE_TTL)),
+                                        p_rService.m_pcName,
+                                        p_rService.m_pcServiceType,
+                                        p_rService.m_pcProtocol);
+                 );
+
+    _releaseTempServiceTxts(p_rService);
+
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_TXT: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+#ifdef MDNS_IPV6_SUPPORT
+/*
+    MDNSResponder::_writeMDNSAnswer_AAAA
+
+    Write a MDNS AAAA answer to the UDP output buffer.
+    See: '_writeMDNSAnswer_AAAA'
+
+    eg. esp8266.local AAAA 0x8001 120 16 xxxx::xx
+    http://www.zytrax.com/books/dns/ch8/aaaa.html
+*/
+bool MDNSResponder::clsHost::_writeMDNSAnswer_AAAA(IPAddress p_IPAddress,
+                                                   MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_AAAA (%s)%s\n"), p_IPAddress.toString().c_str(), (p_rSendParameter.m_bCacheFlush ? "" : " nF")););
+
+    stcRRAttributes    attributes(DNS_RRTYPE_AAAA,
+                                  ((p_rSendParameter.m_bCacheFlush ? 0x8000 : 0) | DNS_RRCLASS_IN));   // Cache flush? & INternet
+    bool    bResult = ((p_IPAddress.isV6()) &&
+                       (_writeMDNSHostDomain(m_pcHostName, false, 0, p_rSendParameter)) &&	// esp8266.local
+                       (_writeMDNSRRAttributes(attributes, p_rSendParameter)) &&            // TYPE & CLASS
+                       (_write32((p_rSendParameter.m_bUnannounce
+                                  ? 0
+                                  : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_HOST_TTL)), p_rSendParameter)) &&    // TTL
+                       (_write16(MDNS_IPV6_SIZE, p_rSendParameter)) &&                     	// RDLength
+                       (_udpAppendBuffer((uint8_t*)p_IPAddress.raw6(), MDNS_IPV6_SIZE)) &&   // RData
+                       (p_rSendParameter.shiftOffset(MDNS_IPV6_SIZE)));
+
+    DEBUG_EX_INFO(if (bResult)
+                  DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_AAAA %s.local Type:%s Class:0x%04X TTL:%u %s\n"),
+                                        _DH(),
+                                        m_pcHostName,
+                                        _RRType2Name(attributes.m_u16Type),
+                                        attributes.m_u16Class,
+                                        (p_rSendParameter.m_bUnannounce
+                                         ? 0
+                                         : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_HOST_TTL)),
+                                        p_IPAddress.toString().c_str());
+                 );
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_AAAA: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_writeMDNSAnswer_PTR_IPv6
+
+    Write a MDNS reverse IPv6 PTR answer to the UDP output buffer.
+    See: '_writeMDNSAnswer_AAAA'
+
+    eg. xxxx::xx.ip6.arpa PTR 0x8001 120 15 esp8266.local
+    Used while answering reverse IPv6 questions
+*/
+bool MDNSResponder::clsHost::_writeMDNSAnswer_PTR_IPv6(IPAddress p_IPAddress,
+                                                       MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_PTR_IPv6%s\n"), (p_rSendParameter.m_bCacheFlush ? "" : " nF")););
+
+    stcRRDomain        reverseIPv6Domain;
+    stcRRAttributes    attributes(DNS_RRTYPE_PTR,
+                                  ((p_rSendParameter.m_bCacheFlush ? 0x8000 : 0) | DNS_RRCLASS_IN));   // Cache flush? & INternet
+    bool    bResult = ((p_IPAddress.isV6()) &&
+                       (_buildDomainForReverseIPv6(p_IPAddress, reverseIPv6Domain)) &&		// xxxx::xx.ip6.arpa
+                       (_writeMDNSRRDomain(reverseIPv6Domain, p_rSendParameter)) &&
+                       (_writeMDNSRRAttributes(attributes, p_rSendParameter)) &&            // TYPE & CLASS
+                       (_write32((p_rSendParameter.m_bUnannounce
+                                  ? 0
+                                  : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_HOST_TTL)), p_rSendParameter)) &&    // TTL
+                       (_writeMDNSHostDomain(m_pcHostName, true, 0, p_rSendParameter)));  	// RDLength & RData (host domain, eg. esp8266.local)
+
+    DEBUG_EX_INFO(if (bResult)
+                  DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_PTR_IPv6 "), _DH());
+                  _printRRDomain(reverseIPv6Domain);
+                  DEBUG_OUTPUT.printf_P(PSTR(" Type:%s Class:0x%04X TTL:%u %s.local\n"),
+                                        _RRType2Name(attributes.m_u16Type),
+                                        attributes.m_u16Class,
+                                        (p_rSendParameter.m_bUnannounce
+                                         ? 0
+                                         : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_HOST_TTL)),
+                                        m_pcHostName);
+                 );
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_PTR_IPv6: FAILED!\n"), _DH()););
+    return bResult;
+}
+#endif
+
+/*
+    MDNSResponder::_writeMDNSAnswer_SRV
+
+    eg. MyESP._http.tcp.local SRV 0x8001 120 0 0 60068 esp8266.local
+    http://www.zytrax.com/books/dns/ch8/srv.html ???? Include instance name ????
+*/
+bool MDNSResponder::clsHost::_writeMDNSAnswer_SRV(MDNSResponder::clsHost::stcService& p_rService,
+                                                  MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_SRV%s\n"), (p_rSendParameter.m_bCacheFlush ? "" : " nF")););
+
+    uint16_t                u16CachedDomainOffset = (p_rSendParameter.m_bLegacyQuery
+                                                     ? 0
+                                                     : p_rSendParameter.findCachedDomainOffset((const void*)m_pcHostName, false));
+
+    stcRRAttributes    attributes(DNS_RRTYPE_SRV,
+                                  ((p_rSendParameter.m_bCacheFlush ? 0x8000 : 0) | DNS_RRCLASS_IN));   // Cache flush? & INternet
+    stcRRDomain        hostDomain;
+    bool    bResult = ((_writeMDNSServiceDomain(p_rService, true, false, 0, p_rSendParameter)) &&  // MyESP._http._tcp.local
+                       (_writeMDNSRRAttributes(attributes, p_rSendParameter)) &&                // TYPE & CLASS
+                       (_write32((p_rSendParameter.m_bUnannounce
+                                  ? 0
+                                  : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_HOST_TTL/*MDNS_SERVICE_TTL*/)), p_rSendParameter)) && // TTL
+                       (!u16CachedDomainOffset
+                        // No cache for domain name (or no compression allowed)
+                        ? ((_buildDomainForHost(m_pcHostName, hostDomain)) &&
+                           (_write16((sizeof(uint16_t /*Prio*/) +                           // RDLength
+                                      sizeof(uint16_t /*Weight*/) +
+                                      sizeof(uint16_t /*Port*/) +
+                                      hostDomain.m_u16NameLength), p_rSendParameter)) &&    // Domain length
+                           (_write16(MDNS_SRV_PRIORITY, p_rSendParameter)) &&               // Priority
+                           (_write16(MDNS_SRV_WEIGHT, p_rSendParameter)) &&                 // Weight
+                           (_write16(p_rService.m_u16Port, p_rSendParameter)) &&            // Port
+                           (p_rSendParameter.addDomainCacheItem((const void*)m_pcHostName, false, p_rSendParameter.m_u16Offset)) &&
+                           (_writeMDNSRRDomain(hostDomain, p_rSendParameter)))              // Host, eg. esp8266.local
+                        // Cache available for domain
+                        : ((MDNS_DOMAIN_COMPRESS_MARK > ((u16CachedDomainOffset >> 8) & ~MDNS_DOMAIN_COMPRESS_MARK)) && // Valid offset
+                           (_write16((sizeof(uint16_t /*Prio*/) +                           // RDLength
+                                      sizeof(uint16_t /*Weight*/) +
+                                      sizeof(uint16_t /*Port*/) +
+                                      2), p_rSendParameter)) &&                             // Length of 'C0xx'
+                           (_write16(MDNS_SRV_PRIORITY, p_rSendParameter)) &&               // Priority
+                           (_write16(MDNS_SRV_WEIGHT, p_rSendParameter)) &&                 // Weight
+                           (_write16(p_rService.m_u16Port, p_rSendParameter)) &&            // Port
+                           (_write8(((u16CachedDomainOffset >> 8) | MDNS_DOMAIN_COMPRESS_MARK), p_rSendParameter)) &&   // Compression mark (and offset)
+                           (_write8((uint8_t)u16CachedDomainOffset, p_rSendParameter)))));  // Offset
+
+    DEBUG_EX_INFO(if (bResult)
+                  DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_SRV %s._%s._%s.local Type:%s Class:0x%04X TTL:%u %u %u %u %s.local\n"),
+                                        _DH(),
+                                        p_rService.m_pcName,
+                                        p_rService.m_pcServiceType,
+                                        p_rService.m_pcProtocol,
+                                        _RRType2Name(attributes.m_u16Type),
+                                        attributes.m_u16Class,
+                                        (p_rSendParameter.m_bUnannounce
+                                         ? 0
+                                         : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_HOST_TTL)),
+                                        MDNS_SRV_PRIORITY,
+                                        MDNS_SRV_WEIGHT,
+                                        p_rService.m_u16Port,
+                                        m_pcHostName);
+                 );
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_SRV: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_createNSECBitmap
+*/
+MDNSResponder::clsHost::stcNSECBitmap* MDNSResponder::clsHost::_createNSECBitmap(uint32_t p_u32NSECContent)
+{
+    // Currently 6 bytes (6*8 -> 0..47) are long enough, and only this is implemented
+    stcNSECBitmap* pNSECBitmap = new stcNSECBitmap;
+    if (pNSECBitmap)
+    {
+        if (p_u32NSECContent & static_cast<uint32_t>(enuContentFlag::A))
+        {
+            pNSECBitmap->setBit(DNS_RRTYPE_A);      // 01/0x01
+        }
+        if ((p_u32NSECContent & static_cast<uint32_t>(enuContentFlag::PTR_IPv4)) ||
+            (p_u32NSECContent & static_cast<uint32_t>(enuContentFlag::PTR_IPv6)))
+        {
+            pNSECBitmap->setBit(DNS_RRTYPE_PTR);    // 12/0x0C
+        }
+        if (p_u32NSECContent & static_cast<uint32_t>(enuContentFlag::AAAA))
+        {
+            pNSECBitmap->setBit(DNS_RRTYPE_AAAA);   // 28/0x1C
+        }
+        if (p_u32NSECContent & static_cast<uint32_t>(enuContentFlag::TXT))
+        {
+            pNSECBitmap->setBit(DNS_RRTYPE_TXT);    // 16/0x10
+        }
+        if (p_u32NSECContent & static_cast<uint32_t>(enuContentFlag::SRV))
+        {
+            pNSECBitmap->setBit(DNS_RRTYPE_SRV);    // 33/0x21
+        }
+        if (p_u32NSECContent & static_cast<uint32_t>(enuContentFlag::NSEC))
+        {
+            pNSECBitmap->setBit(DNS_RRTYPE_NSEC);   // 47/0x2F
+        }
+    }
+    return pNSECBitmap;
+}
+
+/*
+    MDNSResponder::_writeMDNSNSECBitmap
+*/
+bool MDNSResponder::clsHost::_writeMDNSNSECBitmap(const MDNSResponder::clsHost::stcNSECBitmap& p_NSECBitmap,
+                                                  MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    /*  DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("_writeMDNSNSECBitmap: "));
+    			  for (uint16_t u=0; u<p_NSECBitmap.m_u16BitmapLength; ++u) {
+    				  DEBUG_OUTPUT.printf_P(PSTR("0x%02X "), p_NSECBitmap.m_pu8BitmapData[u]);
+    			  }
+    			  DEBUG_OUTPUT.printf_P(PSTR("\n"));
+    			 );*/
+
+    bool    bResult = ((_write16(p_NSECBitmap.length(), p_rSendParameter)) &&
+                       ((_udpAppendBuffer(p_NSECBitmap.m_au8BitmapData, p_NSECBitmap.length())) &&
+                        (p_rSendParameter.shiftOffset(p_NSECBitmap.length()))));
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSNSECBitmap: FAILED!\n"), _DH()););
+    return bResult;
+}
+
+/*
+    MDNSResponder::_writeMDNSAnswer_NSEC(host)
+
+    eg. esp8266.local NSEC 0x8001 120 XX esp8266.local xxx
+    http://www.zytrax.com/books/dns/ch8/nsec.html
+*/
+bool MDNSResponder::clsHost::_writeMDNSAnswer_NSEC(uint32_t p_u32NSECContent,
+                                                   MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_NSEC (host: %s)%s\n"), _replyFlags2String(p_u32NSECContent), (p_rSendParameter.m_bCacheFlush ? "" : " nF")););
+
+    stcRRAttributes    attributes(DNS_RRTYPE_NSEC,
+                                  ((p_rSendParameter.m_bCacheFlush ? 0x8000 : 0) | DNS_RRCLASS_IN));       // Cache flush? & INternet
+    stcNSECBitmap*     pNSECBitmap = _createNSECBitmap(p_u32NSECContent);
+    bool    bResult = ((pNSECBitmap) &&                                                                         // NSEC bitmap created
+                       (_writeMDNSHostDomain(m_pcHostName, false, 0, p_rSendParameter)) &&                      // esp8266.local
+                       (_writeMDNSRRAttributes(attributes, p_rSendParameter)) &&                                // TYPE & CLASS
+                       (_write32((p_rSendParameter.m_bUnannounce
+                                  ? 0
+                                  : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_HOST_TTL)), p_rSendParameter)) &&    // TTL
+                       (_writeMDNSHostDomain(m_pcHostName, true, (2 + pNSECBitmap->length()), p_rSendParameter)) && // XX esp8266.local
+                       (_writeMDNSNSECBitmap(*pNSECBitmap, p_rSendParameter)));                                 // NSEC bitmap
+
+    DEBUG_EX_INFO(if (bResult)
+                  DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_NSEC %s.local Type:%s Class:0x%04X TTL:%u %s %s\n"),
+                                        _DH(),
+                                        m_pcHostName,
+                                        _RRType2Name(attributes.m_u16Type),
+                                        attributes.m_u16Class,
+                                        (p_rSendParameter.m_bUnannounce
+                                         ? 0
+                                         : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_HOST_TTL)),
+                                        m_pcHostName,
+                                        _NSECBitmap2String(pNSECBitmap));
+                 );
+
+    if (pNSECBitmap)
+    {
+        delete pNSECBitmap;
+        pNSECBitmap = 0;
+    }
+
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_NSEC (host): FAILED!\n"), _DH()););
+    return bResult;
+}
+
+
+#ifdef MDNS_IPV4_SUPPORT
+/*
+    MDNSResponder::_writeMDNSAnswer_NSEC_PTR_IPv4(host)
+
+    eg. 012.789.456.123.in-addr.arpa NSEC 0x8001 120 XX 012.789.456.123.in-addr.arpa xxx
+    http://www.zytrax.com/books/dns/ch8/nsec.html
+*/
+bool MDNSResponder::clsHost::_writeMDNSAnswer_NSEC_PTR_IPv4(IPAddress p_IPAddress,
+                                                            stcSendParameter& p_rSendParameter)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_NSEC_PTR_IPv4\n")););
+
+    stcRRAttributes    attributes(DNS_RRTYPE_NSEC,
+                                  ((p_rSendParameter.m_bCacheFlush ? 0x8000 : 0) | DNS_RRCLASS_IN));       // Cache flush? & INternet
+    stcNSECBitmap*     pNSECBitmap = _createNSECBitmap(static_cast<uint32_t>(enuContentFlag::PTR_IPv4));
+    stcRRDomain        reverseIPv4Domain;
+    bool    bResult = ((p_IPAddress.isV4()) &&
+                       (pNSECBitmap) &&                                                                 // NSEC bitmap created
+                       (_buildDomainForReverseIPv4(p_IPAddress, reverseIPv4Domain)) &&                  // 012.789.456.123.in-addr.arpa
+                       (_writeMDNSRRDomain(reverseIPv4Domain, p_rSendParameter)) &&                     // 012.789.456.123.in-addr.arpa
+                       (_writeMDNSRRAttributes(attributes, p_rSendParameter)) &&                        // TYPE & CLASS
+                       (_write32((p_rSendParameter.m_bUnannounce
+                                  ? 0
+                                  : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_HOST_TTL)), p_rSendParameter)) &&    // TTL
+                       (_write16((reverseIPv4Domain.m_u16NameLength + (2 + pNSECBitmap->length())), p_rSendParameter)) &&
+                       (_writeMDNSRRDomain(reverseIPv4Domain, p_rSendParameter)) &&                 	// 012.789.456.123.in-addr.arpa
+                       (_writeMDNSNSECBitmap(*pNSECBitmap, p_rSendParameter)));                         // NSEC bitmap
+
+    DEBUG_EX_INFO(if (bResult)
+{
+    DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_NSEC_PTR_IPv4 "), _DH());
+        _printRRDomain(reverseIPv4Domain);
+        DEBUG_OUTPUT.printf_P(PSTR(" Type:%s Class:0x%04X TTL:%u "),
+                              _RRType2Name(attributes.m_u16Type),
+                              attributes.m_u16Class,
+                              (p_rSendParameter.m_bUnannounce
+                               ? 0
+                               : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_SERVICE_TTL)));
+        _printRRDomain(reverseIPv4Domain);
+        DEBUG_OUTPUT.printf_P(PSTR(" %s\n"), _NSECBitmap2String(pNSECBitmap));
+    });
+
+    if (pNSECBitmap)
+    {
+        delete pNSECBitmap;
+        pNSECBitmap = 0;
+    }
+
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_NSEC_PTR_IPv4 (host): FAILED!\n"), _DH()););
+    return bResult;
+}
+#endif
+
+
+#ifdef MDNS_IPV6_SUPPORT
+/*
+    MDNSResponder::_writeMDNSAnswer_NSEC_PTR_IPv6(host)
+
+    eg. 9.0.0.0.0.0.0.0.0.0.0.0.0.7.8.5.6.3.4.1.2.ip6.arpa NSEC 0x8001 120 XX 9.0.0.0.0.0.0.0.0.0.0.0.0.7.8.5.6.3.4.1.2.ip6.arpa xxx
+    http://www.zytrax.com/books/dns/ch8/nsec.html
+*/
+bool MDNSResponder::clsHost::_writeMDNSAnswer_NSEC_PTR_IPv6(IPAddress p_IPAddress,
+                                                            stcSendParameter& p_rSendParameter)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_NSEC_PTR_IPv6\n")););
+
+    stcRRAttributes    attributes(DNS_RRTYPE_NSEC,
+                                  ((p_rSendParameter.m_bCacheFlush ? 0x8000 : 0) | DNS_RRCLASS_IN));       // Cache flush? & INternet
+    stcNSECBitmap*     pNSECBitmap = _createNSECBitmap(static_cast<uint32_t>(enuContentFlag::PTR_IPv6));
+    stcRRDomain        reverseIPv6Domain;
+    bool    bResult = ((p_IPAddress.isV6()) &&
+                       (pNSECBitmap) &&                                                                 // NSEC bitmap created
+                       (_buildDomainForReverseIPv6(p_IPAddress, reverseIPv6Domain)) &&                  // 9.0.0.0.0.0.0.0.0.0.0.0.0.7.8.5.6.3.4.1.2.ip6.arpa
+                       (_writeMDNSRRDomain(reverseIPv6Domain, p_rSendParameter)) &&                     // 9.0.0.0.0.0.0.0.0.0.0.0.0.7.8.5.6.3.4.1.2.ip6.arpa
+                       (_writeMDNSRRAttributes(attributes, p_rSendParameter)) &&                        // TYPE & CLASS
+                       (_write32((p_rSendParameter.m_bUnannounce
+                                  ? 0
+                                  : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_HOST_TTL)), p_rSendParameter)) &&    // TTL
+                       (_write16((reverseIPv6Domain.m_u16NameLength + (2 + pNSECBitmap->length())), p_rSendParameter)) &&
+                       (_writeMDNSRRDomain(reverseIPv6Domain, p_rSendParameter)) &&                     // 9.0.0.0.0.0.0.0.0.0.0.0.0.7.8.5.6.3.4.1.2.ip6.arpa
+                       (_writeMDNSNSECBitmap(*pNSECBitmap, p_rSendParameter)));                         // NSEC bitmap
+
+    DEBUG_EX_INFO(if (bResult)
+{
+    DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_NSEC_PTR_IPv6 "), _DH());
+        _printRRDomain(reverseIPv6Domain);
+        DEBUG_OUTPUT.printf_P(PSTR(" Type:%s Class:0x%04X TTL:%u "),
+                              _RRType2Name(attributes.m_u16Type),
+                              attributes.m_u16Class,
+                              (p_rSendParameter.m_bUnannounce
+                               ? 0
+                               : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_SERVICE_TTL)));
+        _printRRDomain(reverseIPv6Domain);
+        DEBUG_OUTPUT.printf_P(PSTR(" %s\n"), _NSECBitmap2String(pNSECBitmap));
+    });
+
+    if (pNSECBitmap)
+    {
+        delete pNSECBitmap;
+        pNSECBitmap = 0;
+    }
+
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_NSEC_PTR_IPv6 (host): FAILED!\n"), _DH()););
+    return bResult;
+}
+#endif
+
+/*
+    MDNSResponder::_writeMDNSAnswer_NSEC(service)
+
+    eg. MyESP._http.tcp.local NSEC 0x8001 4500 XX MyESP._http.tcp.local xxx
+    http://www.zytrax.com/books/dns/ch8/nsec.html
+*/
+bool MDNSResponder::clsHost::_writeMDNSAnswer_NSEC(MDNSResponder::clsHost::stcService& p_rService,
+                                                   uint32_t p_u32NSECContent,
+                                                   MDNSResponder::clsHost::stcSendParameter& p_rSendParameter)
+{
+    //DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_NSEC (service: %s)\n"), _DH(), _replyFlags2String(p_u32NSECContent)););
+
+    stcRRAttributes    attributes(DNS_RRTYPE_NSEC,
+                                  ((p_rSendParameter.m_bCacheFlush ? 0x8000 : 0) | DNS_RRCLASS_IN));       // Cache flush? & INternet
+    stcNSECBitmap*     pNSECBitmap = _createNSECBitmap(p_u32NSECContent);
+    bool    bResult = ((pNSECBitmap) &&                                                                         // NSEC bitmap created
+                       (_writeMDNSServiceDomain(p_rService, true, false, 0, p_rSendParameter)) &&               // MyESP._http._tcp.local
+                       (_writeMDNSRRAttributes(attributes, p_rSendParameter)) &&                                // TYPE & CLASS
+                       (_write32((p_rSendParameter.m_bUnannounce
+                                  ? 0
+                                  : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_SERVICE_TTL)), p_rSendParameter)) && // TTL
+                       (_writeMDNSServiceDomain(p_rService, true, true, (2 + pNSECBitmap->length()), p_rSendParameter)) && // XX MyESP._http._tcp.local
+                       (_writeMDNSNSECBitmap(*pNSECBitmap, p_rSendParameter)));                                 // NSEC bitmap
+
+    DEBUG_EX_INFO(if (bResult)
+                  DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_NSEC %s._%s._%s.local Type:%s Class:0x%04X TTL:%u %s\n"),
+                                        _DH(),
+                                        p_rService.m_pcName,
+                                        p_rService.m_pcServiceType,
+                                        p_rService.m_pcProtocol,
+                                        _RRType2Name(attributes.m_u16Type),
+                                        attributes.m_u16Class,
+                                        (p_rSendParameter.m_bUnannounce
+                                         ? 0
+                                         : (p_rSendParameter.m_bLegacyQuery ? MDNS_LEGACY_TTL : MDNS_SERVICE_TTL)),
+                                        _NSECBitmap2String(pNSECBitmap));
+                 );
+
+    if (pNSECBitmap)
+    {
+        delete pNSECBitmap;
+        pNSECBitmap = 0;
+    }
+
+    DEBUG_EX_ERR(if (!bResult) DEBUG_OUTPUT.printf_P(PSTR("%s _writeMDNSAnswer_NSEC (service): FAILED!\n"), _DH()););
+    return bResult;
+}
+
+}   // namespace MDNSImplementation
+
+} // namespace esp8266
+
+
+
+
+
+

--- a/libraries/ESP8266mDNS/src/LEAmDNS2_Priv.h
+++ b/libraries/ESP8266mDNS/src/LEAmDNS2_Priv.h
@@ -1,0 +1,169 @@
+/*
+    LEAmDNS2_Priv.h
+
+    License (MIT license):
+      Permission is hereby granted, free of charge, to any person obtaining a copy
+      of this software and associated documentation files (the "Software"), to deal
+      in the Software without restriction, including without limitation the rights
+      to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+      copies of the Software, and to permit persons to whom the Software is
+      furnished to do so, subject to the following conditions:
+
+      The above copyright notice and this permission notice shall be included in
+      all copies or substantial portions of the Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+      THE SOFTWARE.
+
+*/
+
+#ifndef LEAMDNS2_PRIV_H
+#define LEAMDNS2_PRIV_H
+
+namespace esp8266
+{
+
+/*
+    LEAmDNS
+*/
+
+namespace experimental
+{
+
+// Enable class debug functions
+#define ESP_8266_MDNS_INCLUDE
+#define DEBUG_ESP_MDNS_RESPONDER
+
+
+#ifndef LWIP_OPEN_SRC
+#define LWIP_OPEN_SRC
+#endif
+
+//
+// If ENABLE_ESP_MDNS_RESPONDER_PASSIV_MODE is defined, the mDNS responder ignores a successful probing
+// This allows to drive the responder in a environment, where 'update()' isn't called in the loop
+//#define ENABLE_ESP_MDNS_RESPONDER_PASSIV_MODE
+
+// Enable/disable debug trace macros
+#ifdef DEBUG_ESP_MDNS_RESPONDER
+#define DEBUG_ESP_MDNS_INFO
+#define DEBUG_ESP_MDNS_ERR
+#define DEBUG_ESP_MDNS_TX
+#define DEBUG_ESP_MDNS_RX
+#endif
+
+#ifdef DEBUG_ESP_MDNS_RESPONDER
+#ifdef DEBUG_ESP_MDNS_INFO
+#define DEBUG_EX_INFO(A)    A
+#else
+#define DEBUG_EX_INFO(A)
+#endif
+#ifdef DEBUG_ESP_MDNS_ERR
+#define DEBUG_EX_ERR(A) A
+#else
+#define DEBUG_EX_ERR(A)
+#endif
+#ifdef DEBUG_ESP_MDNS_TX
+#define DEBUG_EX_TX(A)  A
+#else
+#define DEBUG_EX_TX(A)
+#endif
+#ifdef DEBUG_ESP_MDNS_RX
+#define DEBUG_EX_RX(A)  A
+#else
+#define DEBUG_EX_RX(A)
+#endif
+
+#ifdef DEBUG_ESP_PORT
+#define DEBUG_OUTPUT DEBUG_ESP_PORT
+#else
+#define DEBUG_OUTPUT Serial
+#endif
+#else
+#define DEBUG_EX_INFO(A)
+#define DEBUG_EX_ERR(A)
+#define DEBUG_EX_TX(A)
+#define DEBUG_EX_RX(A)
+#endif
+
+/*
+    This is NOT the TTL (Time-To-Live) for MDNS records, but the
+    subnet level distance MDNS records should travel.
+    1 sets the subnet distance to 'local', which is default for MDNS.
+    (Btw.: 255 would set it to 'as far as possible' -> internet)
+
+    However, RFC 3171 seems to force 255 instead
+*/
+#define MDNS_MULTICAST_TTL              255 /* some say 1 is right*/
+
+/*
+    This is the MDNS record TTL
+    Host level records are set to 2min (120s)
+    service level records are set to 75min (4500s)
+*/
+#define MDNS_LEGACY_TTL                 10
+#define MDNS_HOST_TTL                   120
+#define MDNS_SERVICE_TTL                4500
+
+/*
+    Compressed labels are flaged by the two topmost bits of the length byte being set
+*/
+#define MDNS_DOMAIN_COMPRESS_MARK       0xC0
+/*
+    Avoid endless recursion because of malformed compressed labels
+*/
+#define MDNS_DOMAIN_MAX_REDIRCTION      6
+
+/*
+    Default service priority and weight in SRV answers
+*/
+#define MDNS_SRV_PRIORITY               0
+#define MDNS_SRV_WEIGHT                 0
+
+/*
+    Delay between and number of probes for host and service domains
+    Delay between and number of announces for host and service domains
+    Delay between and number of queries; the delay is multiplied by the resent number in '_checkQueryCache'
+*/
+#define MDNS_PROBE_DELAY                250
+#define MDNS_PROBE_COUNT                3
+#define MDNS_ANNOUNCE_DELAY             1000
+#define MDNS_ANNOUNCE_COUNT             3
+#define MDNS_DYNAMIC_QUERY_RESEND_DELAY 1000
+
+
+/*
+    Force host domain to use only lowercase letters
+*/
+//#define MDNS_FORCE_LOWERCASE_HOSTNAME
+
+/*
+    Enable/disable the usage of the F() macro in debug trace printf calls.
+    There needs to be an PGM comptible printf function to use this.
+
+    USE_PGM_PRINTF and F
+*/
+#define USE_PGM_PRINTF
+
+#ifdef USE_PGM_PRINTF
+#else
+#ifdef F
+#undef F
+#endif
+#define F(A)    A
+#endif
+
+}   // namespace MDNSImplementation
+
+} // namespace esp8266
+
+// Include the main header, so the submodlues only need to include this header
+#include "LEAmDNS2.h"
+
+
+#endif  // LEAMDNS2_PRIV_H

--- a/libraries/ESP8266mDNS/src/LEAmDNS2_lwIPdefs.h
+++ b/libraries/ESP8266mDNS/src/LEAmDNS2_lwIPdefs.h
@@ -1,0 +1,44 @@
+/*
+    LEAmDNS2_lwIPdefs.h
+
+    License (MIT license):
+      Permission is hereby granted, free of charge, to any person obtaining a copy
+      of this software and associated documentation files (the "Software"), to deal
+      in the Software without restriction, including without limitation the rights
+      to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+      copies of the Software, and to permit persons to whom the Software is
+      furnished to do so, subject to the following conditions:
+
+      The above copyright notice and this permission notice shall be included in
+      all copies or substantial portions of the Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+      THE SOFTWARE.
+
+*/
+
+#ifndef LEAMDNS2_LWIPDEFS_H
+#define LEAMDNS2_LWIPDEFS_H
+
+#include <lwip/init.h>
+#if LWIP_VERSION_MAJOR == 1
+
+#include <lwip/mdns.h>      // DNS_RRTYPE_xxx
+
+// cherry pick from lwip1 dns.c/mdns.c source files:
+#define DNS_MQUERY_PORT            5353
+#define DNS_MQUERY_IPV4_GROUP_INIT IPAddress(224,0,0,251)     /* resolver1.opendns.com */
+#define DNS_RRCLASS_ANY            255                        /* any class */
+
+#else // lwIP > 1
+
+#include <lwip/prot/dns.h>  // DNS_RRTYPE_xxx, DNS_MQUERY_PORT
+
+#endif
+
+#endif // LEAMDNS2_LWIPDEFS_H


### PR DESCRIPTION
Completely refactored: An inner class (host) implements the mDNS responder functions for each netif that is added to the (outer) controller class. The API is incompatible to the 'old' LEAmDNS. It is planned to create a API-compatible subclass (later).