### PR TITLE
Use 128B chunks instead of 1B writes in Print::print(FlashStringHelper)

### DIFF
--- a/cores/esp8266/Print.cpp
+++ b/cores/esp8266/Print.cpp
@@ -104,11 +104,19 @@ size_t Print::printf_P(PGM_P format, ...) {
 size_t Print::print(const __FlashStringHelper *ifsh) {
     PGM_P p = reinterpret_cast<PGM_P>(ifsh);
 
+    char buff[128] __attribute__ ((aligned(4)));
+    auto len = strlen_P(p);
     size_t n = 0;
-    while (1) {
-        uint8_t c = pgm_read_byte(p++);
-        if (c == 0) break;
-        n += write(c);
+    while (n < len) {
+        int to_write = std::min(sizeof(buff), len - n);
+        memcpy_P(buff, p, to_write);
+        auto written = write(buff, to_write);
+        n += written;
+        p += written;
+        if (!written) {
+            // Some error, write() should write at least 1 byte before returning
+            break;
+        }
     }
     return n;
 }


### PR DESCRIPTION
Fixes #6524

Should help with speed of output when printing large flash strings to
things like a file or a TCP connection.

Use a 128 byte chunk in a temp buffer to send data using write(),
reducing the # of write calls by ~127x.