### PR TITLE
PROGMEM footprint cleanup for responseCodeToString

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
@@ -801,9 +801,6 @@ String ESP8266WebServerTemplate<ServerType>::responseCodeToString(const int code
     case 417:
         r = F("Expectation Failed");
         break;
-    case 418:
-        r = F("I'm a teapot");
-        break;
     case 500:
         r = F("Internal Server Error");
         break;

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
@@ -695,49 +695,136 @@ void ESP8266WebServerTemplate<ServerType>::_finalizeResponse() {
 }
 
 template <typename ServerType>
-const String ESP8266WebServerTemplate<ServerType>::responseCodeToString(const int code) {
-  switch (code) {
-    case 100: return F("Continue");
-    case 101: return F("Switching Protocols");
-    case 200: return F("OK");
-    case 201: return F("Created");
-    case 202: return F("Accepted");
-    case 203: return F("Non-Authoritative Information");
-    case 204: return F("No Content");
-    case 205: return F("Reset Content");
-    case 206: return F("Partial Content");
-    case 300: return F("Multiple Choices");
-    case 301: return F("Moved Permanently");
-    case 302: return F("Found");
-    case 303: return F("See Other");
-    case 304: return F("Not Modified");
-    case 305: return F("Use Proxy");
-    case 307: return F("Temporary Redirect");
-    case 400: return F("Bad Request");
-    case 401: return F("Unauthorized");
-    case 402: return F("Payment Required");
-    case 403: return F("Forbidden");
-    case 404: return F("Not Found");
-    case 405: return F("Method Not Allowed");
-    case 406: return F("Not Acceptable");
-    case 407: return F("Proxy Authentication Required");
-    case 408: return F("Request Time-out");
-    case 409: return F("Conflict");
-    case 410: return F("Gone");
-    case 411: return F("Length Required");
-    case 412: return F("Precondition Failed");
-    case 413: return F("Request Entity Too Large");
-    case 414: return F("Request-URI Too Large");
-    case 415: return F("Unsupported Media Type");
-    case 416: return F("Requested range not satisfiable");
-    case 417: return F("Expectation Failed");
-    case 418: return F("I'm a teapot");
-    case 500: return F("Internal Server Error");
-    case 501: return F("Not Implemented");
-    case 502: return F("Bad Gateway");
-    case 503: return F("Service Unavailable");
-    case 504: return F("Gateway Time-out");
-    case 505: return F("HTTP Version not supported");
-    default:  return F("");
-  }
+String ESP8266WebServerTemplate<ServerType>::responseCodeToString(const int code) {
+    const __FlashStringHelper *r;
+    switch (code)
+    {
+    case 100:
+        r = F("Continue");
+        break;
+    case 101:
+        r = F("Switching Protocols");
+        break;
+    case 200:
+        r = F("OK");
+        break;
+    case 201:
+        r = F("Created");
+        break;
+    case 202:
+        r = F("Accepted");
+        break;
+    case 203:
+        r = F("Non-Authoritative Information");
+        break;
+    case 204:
+        r = F("No Content");
+        break;
+    case 205:
+        r = F("Reset Content");
+        break;
+    case 206:
+        r = F("Partial Content");
+        break;
+    case 300:
+        r = F("Multiple Choices");
+        break;
+    case 301:
+        r = F("Moved Permanently");
+        break;
+    case 302:
+        r = F("Found");
+        break;
+    case 303:
+        r = F("See Other");
+        break;
+    case 304:
+        r = F("Not Modified");
+        break;
+    case 305:
+        r = F("Use Proxy");
+        break;
+    case 307:
+        r = F("Temporary Redirect");
+        break;
+    case 400:
+        r = F("Bad Request");
+        break;
+    case 401:
+        r = F("Unauthorized");
+        break;
+    case 402:
+        r = F("Payment Required");
+        break;
+    case 403:
+        r = F("Forbidden");
+        break;
+    case 404:
+        r = F("Not Found");
+        break;
+    case 405:
+        r = F("Method Not Allowed");
+        break;
+    case 406:
+        r = F("Not Acceptable");
+        break;
+    case 407:
+        r = F("Proxy Authentication Required");
+        break;
+    case 408:
+        r = F("Request Timeout");
+        break;
+    case 409:
+        r = F("Conflict");
+        break;
+    case 410:
+        r = F("Gone");
+        break;
+    case 411:
+        r = F("Length Required");
+        break;
+    case 412:
+        r = F("Precondition Failed");
+        break;
+    case 413:
+        r = F("Request Entity Too Large");
+        break;
+    case 414:
+        r = F("URI Too Long");
+        break;
+    case 415:
+        r = F("Unsupported Media Type");
+        break;
+    case 416:
+        r = F("Range not satisfiable");
+        break;
+    case 417:
+        r = F("Expectation Failed");
+        break;
+    case 418:
+        r = F("I'm a teapot");
+        break;
+    case 500:
+        r = F("Internal Server Error");
+        break;
+    case 501:
+        r = F("Not Implemented");
+        break;
+    case 502:
+        r = F("Bad Gateway");
+        break;
+    case 503:
+        r = F("Service Unavailable");
+        break;
+    case 504:
+        r = F("Gateway Timeout");
+        break;
+    case 505:
+        r = F("HTTP Version not supported");
+        break;
+    default:
+        r = F("");
+        break;
+    }
+    return String(r);
 }

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
@@ -696,6 +696,9 @@ void ESP8266WebServerTemplate<ServerType>::_finalizeResponse() {
 
 template <typename ServerType>
 String ESP8266WebServerTemplate<ServerType>::responseCodeToString(const int code) {
+    // By first determining the pointer to the flash stored string in the switch
+    // statement and then doing String(FlashStringHelper) return reduces the total code
+    // size of this function by over 50%.
     const __FlashStringHelper *r;
     switch (code)
     {

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -169,7 +169,7 @@ public:
     return contentLength;
   }
 
-  static const String responseCodeToString(const int code);
+  static String responseCodeToString(const int code);
 
 protected:
   void _addRequestHandler(RequestHandlerType* handler);


### PR DESCRIPTION
Doing returns with String/FlashStringHelper conversion for every
case means that the code for doing that is duplicated, which
is wasteful. doing it only once saves about 250 bytes (50%) of
code size.