### PR TITLE
Only update LittleFS timestamp when opened write

### DIFF
--- a/libraries/LittleFS/src/LittleFS.cpp
+++ b/libraries/LittleFS/src/LittleFS.cpp
@@ -72,9 +72,9 @@ FileImplPtr LittleFSImpl::open(const char* path, OpenMode openMode, AccessMode a
     if (rc == LFS_ERR_ISDIR) {
         // To support the SD.openNextFile, a null FD indicates to the LittleFSFile this is just
         // a directory whose name we are carrying around but which cannot be read or written
-        return std::make_shared<LittleFSFileImpl>(this, path, nullptr);
+        return std::make_shared<LittleFSFileImpl>(this, path, nullptr, flags);
     } else if (rc == 0) {
-        return std::make_shared<LittleFSFileImpl>(this, path, fd);
+        return std::make_shared<LittleFSFileImpl>(this, path, fd, flags);
     } else {
         DEBUGV("LittleFSDirImpl::openFile: rc=%d fd=%p path=`%s` openMode=%d accessMode=%d err=%d\n",
                rc, fd.get(), path, openMode, accessMode, rc);

--- a/libraries/LittleFS/src/LittleFS.h
+++ b/libraries/LittleFS/src/LittleFS.h
@@ -323,7 +323,7 @@ protected:
 class LittleFSFileImpl : public FileImpl
 {
 public:
-    LittleFSFileImpl(LittleFSImpl* fs, const char *name, std::shared_ptr<lfs_file_t> fd) : _fs(fs), _fd(fd), _opened(true) {
+    LittleFSFileImpl(LittleFSImpl* fs, const char *name, std::shared_ptr<lfs_file_t> fd, int flags) : _fs(fs), _fd(fd), _opened(true), _flags(flags) {
         _name = std::shared_ptr<char>(new char[strlen(name) + 1], std::default_delete<char[]>());
         strcpy(_name.get(), name);
     }
@@ -419,7 +419,7 @@ public:
             lfs_file_close(_fs->getFS(), _getFD());
             _opened = false;
             DEBUGV("lfs_file_close: fd=%p\n", _getFD());
-	    if (timeCallback) {
+	    if (timeCallback && (_flags & LFS_O_WRONLY)) {
                 // Add metadata with last write time
                 time_t now = timeCallback();
                 int rc = lfs_setattr(_fs->getFS(), _name.get(), 't', (const void *)&now, sizeof(now));
@@ -483,6 +483,7 @@ protected:
     std::shared_ptr<lfs_file_t>  _fd;
     std::shared_ptr<char>        _name;
     bool                         _opened;
+    int                          _flags;
 };
 
 class LittleFSDirImpl : public DirImpl


### PR DESCRIPTION
Fixes #6955

LittleFS was updating the timestamp on any close, not only for files
when they were opened for writing.  This could lead to excessive writes
to the flash.

Preserve the LFS flags, and only update the timestamp if the file was
opened for writing.