### PR TITLE
Skip . and .. on LittleFS::dir::rewind()

### DIFF
--- a/libraries/LittleFS/src/LittleFS.h
+++ b/libraries/LittleFS/src/LittleFS.h
@@ -567,6 +567,10 @@ public:
     bool rewind() override {
         _valid = false;
         int rc = lfs_dir_rewind(_fs->getFS(), _getDir());
+        // Skip the . and .. entries
+        lfs_info dirent;
+        lfs_dir_read(_fs->getFS(), _getDir(), &dirent);
+        lfs_dir_read(_fs->getFS(), _getDir(), &dirent);
         return (rc == 0);
     }
 


### PR DESCRIPTION
Fixes #6958

To match SPIFFS, we get rid of the "." and ".." dirents when we open a
directory on LittleFS.  Do the same on a rewind().