### PR TITLE
Add SDFS::Dir::fileTime callback

### DIFF
--- a/libraries/SDFS/src/SDFS.h
+++ b/libraries/SDFS/src/SDFS.h
@@ -417,6 +417,16 @@ public:
         return _size;
     }
 
+    time_t fileTime() override
+    {
+        if (!_valid) {
+            return 0;
+        }
+
+        return _time;
+    }
+
+
     bool isFile() const override
     {
         return _valid ? _isFile : false;


### PR DESCRIPTION
Forgot to add a Dir->fileTime override, resulting in it always returning
(time_t)0, or Jan 1, 1970.

Add the override, returning the proper lastWriteTime.

Fixes #6981