### PR TITLE
Add LittleFS support to ESP8266WebServer.serveStatic()

### DIFF
--- a/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
@@ -70,7 +70,15 @@ public:
     , _path(path)
     , _cache_header(cache_header)
     {
-        _isFile = fs.exists(path);
+        if (fs.exists(path)) {
+            File file = fs.open(path, "r");
+            _isFile = file && file.isFile();
+            file.close();
+        }
+        else {
+            _isFile = false;
+        }
+        
         DEBUGV("StaticRequestHandler: path=%s uri=%s isFile=%d, cache_header=%s\r\n", path, uri, _isFile, cache_header);
         _baseUriLength = _uri.length();
     }

--- a/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
@@ -96,7 +96,7 @@ public:
         if (!_isFile) {
             // Base URI doesn't point to a file.
             // If a directory is requested, look for index file.
-            if (requestUri.endsWith("/")) 
+            if (requestUri.endsWith("/"))
               requestUri += "index.htm";
 
             // Append whatever follows this URI in request to get the file path.


### PR DESCRIPTION
The problem was that the library was assuming that `FS::exists()` would return false for directories, which is true for SPIFFS, but not for LittleFS. I changed the implementation to be compatible with both.

I don't like using `fs.open()`, but I couldn't find any better way to check if something is a directory or a file. If there is such a thing, please point me in the right direction and I will be happy to use that instead.