### PR TITLE
Updating _port to really used port and made _port accessible

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiServer.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiServer.cpp
@@ -83,6 +83,7 @@ void WiFiServer::begin(uint16_t port) {
         return;
     }
     _pcb = listen_pcb;
+    _port = _pcb->local_port;
     tcp_accept(listen_pcb, &WiFiServer::_s_accept);
     tcp_arg(listen_pcb, (void*) this);
 }
@@ -124,6 +125,10 @@ uint8_t WiFiServer::status()  {
     if (!_pcb)
         return CLOSED;
     return _pcb->state;
+}
+
+uint16_t WiFiServer::port() const {
+    return _port;
 }
 
 void WiFiServer::close() {

--- a/libraries/ESP8266WiFi/src/WiFiServer.h
+++ b/libraries/ESP8266WiFi/src/WiFiServer.h
@@ -58,6 +58,7 @@ public:
   virtual size_t write(uint8_t);
   virtual size_t write(const uint8_t *buf, size_t size);
   uint8_t status();
+  uint16_t port() const;
   void close();
   void stop();
 


### PR DESCRIPTION
When calling WiFiServer with a 'port = 0', a free port is auto-selected, but this port isn't updated to the '_port' member. In addition, the used port is made accessible.