### PR TITLE
Fix for windows

### DIFF
--- a/tools/signing.py
+++ b/tools/signing.py
@@ -22,7 +22,7 @@ def sign_and_write(data, priv_key, out_file):
     """Save the signed firmware to out_file (file path)."""
 
     signcmd = [ 'openssl', 'dgst', '-sha256', '-sign', priv_key ]
-    proc = subprocess.Popen(signcmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc = subprocess.Popen(signcmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     signout, signerr = proc.communicate(input=data)
     if proc.returncode:
         sys.stderr.write("OpenSSL returned an error signing the binary: " + str(proc.returncode) + "\nSTDERR: " + str(signerr))


### PR DESCRIPTION
signing.py:
Adding ", shell=True" to line 25 seams to correct an issue with signing a binary on windows. Someone would need to test whether that change brakes it on linux or other OSs.