### PR TITLE
Missing boards in package_esp8266com_index.template.json

### DIFF
--- a/package/package_esp8266com_index.template.json
+++ b/package/package_esp8266com_index.template.json
@@ -63,6 +63,9 @@
                      "name": "SparkFun ESP8266 Thing Dev"
                   },
                   {
+                     "name": "SparkFun Blynk Board"
+                  },
+                  {
                      "name": "SweetPea ESP-210"
                   },
                   {
@@ -106,6 +109,12 @@
                   },
                   {
                      "name": "ESPectro Core"
+                  },
+                  {
+                     "name": "ITEAD Sonoff"
+                  },
+                  {
+                     "name": "DOIT ESP-Mx DevKit (ESP8285)"
                   }
                ],
                "toolsDependencies": [

--- a/tools/boards.txt.py
+++ b/tools/boards.txt.py
@@ -1043,7 +1043,7 @@ macros = {
     'resetmethod_nodtr_nosync': collections.OrderedDict([
         ( '.upload.resetmethod', '--before no_reset_no_sync --after soft_reset' ),
         ]),
-  
+
     ####################### menu.FlashMode
 
     'flashmode_menu': collections.OrderedDict([
@@ -1635,7 +1635,7 @@ def package ():
     # To get consistent indent/formatting read the JSON and write it out programattically
     if packagegen:
         with open(pkgfname, 'w') as package_file:
-            filejson = json.loads(filestr, object_pairs_hook=collections.OrderedDict)
+            filejson = json.loads(newfilestr, object_pairs_hook=collections.OrderedDict)
             package_file.write(json.dumps(filejson, indent=3, separators=(',',': ')))
         print("updated:   %s" % pkgfname)
     else:


### PR DESCRIPTION
Updated `packagegen` to use `newfilestr` instead of `filestr` when writing the JSON file.
Three missing boards are now in package/package_esp8266com_index.template.json.

@d-a-v please check this. I am not sure where this file gets used or how to
test this change. Before making the change, I was seeing a different result
between --package and --packagegen.