### PR TITLE
Remove memory leak on multiple calls to initCertStore

### DIFF
--- a/libraries/ESP8266WiFi/src/CertStoreBearSSL.cpp
+++ b/libraries/ESP8266WiFi/src/CertStoreBearSSL.cpp
@@ -82,6 +82,10 @@ int CertStore::initCertStore(FS &fs, const char *indexFileName, const char *data
 
   _fs = &fs;
 
+  // In case initCertStore called multiple times, don't leak old filenames
+  free(_indexName);
+  free(_dataName);
+
   // No strdup_P, so manually do it
   _indexName = (char *)malloc(strlen_P(indexFileName) + 1);
   _dataName = (char *)malloc(strlen_P(dataFileName) + 1);


### PR DESCRIPTION
In some cases, `initCertStore` may need to be called multiple times
(i.e. to update certs w/oa reboot).  In that case, the saved file names
leaked when the new ones were `malloc()`'d.

Fix by freeing the old strings, if present.