### PR TITLE
Made changes to include "ESP8266_" with ITEAD board names…

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -6637,18 +6637,18 @@ espectro.menu.baud.3000000.upload.speed=3000000
 
 ##############################################################
 sonoff.name=ITEAD Sonoff
-sonoff.build.board=SONOFF_SV
+sonoff.build.board=ESP8266_SONOFF_SV
 sonoff.build.extra_flags=-DESP8266
 sonoff.build.flash_size=1M
 sonoff.build.variant=itead
 sonoff.menu.BoardModel.sonoffBasic=ITEAD Sonoff Basic
-sonoff.menu.BoardModel.sonoffBasic.build.board=SONOFF_BASIC
+sonoff.menu.BoardModel.sonoffBasic.build.board=ESP8266_SONOFF_BASIC
 sonoff.menu.BoardModel.sonoffS20=ITEAD Sonoff S20
-sonoff.menu.BoardModel.sonoffS20.build.board=SONOFF_S20
+sonoff.menu.BoardModel.sonoffS20.build.board=ESP8266_SONOFF_S20
 sonoff.menu.BoardModel.sonoffSV=ITEAD Sonoff SV
-sonoff.menu.BoardModel.sonoffSV.build.board=SONOFF_SV
+sonoff.menu.BoardModel.sonoffSV.build.board=ESP8266_SONOFF_SV
 sonoff.menu.BoardModel.sonoffTH=ITEAD Sonoff TH
-sonoff.menu.BoardModel.sonoffTH.build.board=SONOFF_TH
+sonoff.menu.BoardModel.sonoffTH.build.board=ESP8266_SONOFF_TH
 sonoff.upload.tool=esptool
 sonoff.upload.maximum_data_size=81920
 sonoff.upload.wait_for_upload_port=true

--- a/tools/boards.txt.py
+++ b/tools/boards.txt.py
@@ -866,18 +866,18 @@ boards = collections.OrderedDict([
     ( 'sonoff', {
         'name': 'ITEAD Sonoff',
         'opts': {
-            '.build.board': 'SONOFF_SV',
+            '.build.board': 'ESP8266_SONOFF_SV',
             '.build.variant': 'itead',
             '.build.extra_flags': '-DESP8266',
             '.build.flash_size': '1M',
             '.menu.BoardModel.sonoffSV': 'ITEAD Sonoff SV',
-            '.menu.BoardModel.sonoffSV.build.board': 'SONOFF_SV',
+            '.menu.BoardModel.sonoffSV.build.board': 'ESP8266_SONOFF_SV',
             '.menu.BoardModel.sonoffTH': 'ITEAD Sonoff TH',
-            '.menu.BoardModel.sonoffTH.build.board': 'SONOFF_TH',
+            '.menu.BoardModel.sonoffTH.build.board': 'ESP8266_SONOFF_TH',
             '.menu.BoardModel.sonoffBasic': 'ITEAD Sonoff Basic',
-            '.menu.BoardModel.sonoffBasic.build.board': 'SONOFF_BASIC',
+            '.menu.BoardModel.sonoffBasic.build.board': 'ESP8266_SONOFF_BASIC',
             '.menu.BoardModel.sonoffS20': 'ITEAD Sonoff S20',
-            '.menu.BoardModel.sonoffS20.build.board': 'SONOFF_S20',
+            '.menu.BoardModel.sonoffS20.build.board': 'ESP8266_SONOFF_S20',
              },
         'macro': [
             'resetmethod_none',

--- a/variants/itead/pins_arduino.h
+++ b/variants/itead/pins_arduino.h
@@ -26,17 +26,17 @@
 #ifndef Pins_Arduino_h
 #define Pins_Arduino_h
 
-#if defined(ARDUINO_SONOFF_SV)
+#if defined(ARDUINO_ESP8266_SONOFF_SV)
 #define PIN_WIRE_SCL (5)
 static const uint8_t SCL = PIN_WIRE_SCL;
 #endif
 
-#if defined(ARDUINO_SONOFF_TH) || defined(ARDUINO_SONOFF_BASIC)
+#if defined(ARDUINO_ESP8266_SONOFF_TH) || defined(ARDUINO_ESP8266_SONOFF_BASIC)
 #define PIN_WIRE_SCL (14)
 static const uint8_t SCL = PIN_WIRE_SCL;
 #endif
 
-#if defined(ARDUINO_SONOFF_TH) || defined(ARDUINO_SONOFF_SV)
+#if defined(ARDUINO_ESP8266_SONOFF_TH) || defined(ARDUINO_ESP8266_SONOFF_SV)
 #define PIN_WIRE_SDA (4)
 static const uint8_t SDA = PIN_WIRE_SDA;
 #endif


### PR DESCRIPTION
…, `{build.board}`,

as proposed by https://github.com/esp8266/Arduino/pull/6972#issue-358508056.
@ttytyper 's changes have been incorporate into this PR
The build flag ARDUINO_SONOFF_... should now appear as ARDUINO_ESP8266_SONOFF_...
@ttytyper, @mcspr, and @d-a-v thanks!