### PR TITLE
allow ".bin.gz" filter in update server file selector

### DIFF
--- a/libraries/ESP8266HTTPUpdateServer/src/ESP8266HTTPUpdateServer-impl.h
+++ b/libraries/ESP8266HTTPUpdateServer/src/ESP8266HTTPUpdateServer-impl.h
@@ -21,12 +21,12 @@ static const char serverIndex[] PROGMEM =
      <body>
      <form method='POST' action='' enctype='multipart/form-data'>
          Firmware:<br>
-         <input type='file' accept='.bin' name='firmware'>
+         <input type='file' accept='.bin,.bin.gz' name='firmware'>
          <input type='submit' value='Update Firmware'>
      </form>
      <form method='POST' action='' enctype='multipart/form-data'>
          FileSystem:<br>
-         <input type='file' accept='.bin' name='filesystem'>
+         <input type='file' accept='.bin,.bin.gz' name='filesystem'>
          <input type='submit' value='Update FileSystem'>
      </form>
      </body>


### PR DESCRIPTION
Because gzip-compressed OTA is cool