### PR TITLE
Fix WMath's map() implementation for inverse/round-trip mapping

### DIFF
--- a/cores/esp8266/WMath.cpp
+++ b/cores/esp8266/WMath.cpp
@@ -70,11 +70,11 @@ long secureRandom(long howsmall, long howbig) {
 }
 
 long map(long x, long in_min, long in_max, long out_min, long out_max) {
-    long divisor = (in_max - in_min);
-    if(divisor == 0){
-        return -1; //AVR returns -1, SAM returns 0
-    }
-    return (x - in_min) * (out_max - out_min) / divisor + out_min;
+    const long dividend = out_max - out_min;
+    const long divisor = in_max - in_min;
+    const long delta = x - in_min;
+
+    return (delta * dividend + (divisor / 2)) / divisor + out_min;
 }
 
 unsigned int makeWord(unsigned int w) {


### PR DESCRIPTION
Inspired by Servo.cpp's `improved_map`, this superseded that code, and has better performance (identical to prior WMath implementation).
I expect this is better used to replace the core implementation, then drop "improved_map" from Servo.cpp, than keep it local and have a map() function that may be compatible but works horribly ;-)