### PR TITLE
Code size optimisation of ESP.getResetReason()

### DIFF
--- a/cores/esp8266/Esp.cpp
+++ b/cores/esp8266/Esp.cpp
@@ -485,7 +485,7 @@ String EspClass::getResetReason(void) {
         case REASON_DEEP_SLEEP_AWAKE: buff = F("Deep-Sleep Wake"); break;
         // // external system reset
         case REASON_EXT_SYS_RST:      buff = F("External System"); break;
-        default:                      buff = F("Unknown");
+        default:                      buff = F("Unknown"); break;
     }
     return String(buff);
 }

--- a/cores/esp8266/Esp.cpp
+++ b/cores/esp8266/Esp.cpp
@@ -468,23 +468,24 @@ bool EspClass::checkFlashCRC() {
 
 
 String EspClass::getResetReason(void) {
-    char buff[32];
-    if (resetInfo.reason == REASON_DEFAULT_RST) { // normal startup by power on
-      strcpy_P(buff, PSTR("Power on"));
-    } else if (resetInfo.reason == REASON_WDT_RST) { // hardware watch dog reset
-      strcpy_P(buff, PSTR("Hardware Watchdog"));
-    } else if (resetInfo.reason == REASON_EXCEPTION_RST) { // exception reset, GPIO status won’t change
-      strcpy_P(buff, PSTR("Exception"));
-    } else if (resetInfo.reason == REASON_SOFT_WDT_RST) { // software watch dog reset, GPIO status won’t change
-      strcpy_P(buff, PSTR("Software Watchdog"));
-    } else if (resetInfo.reason == REASON_SOFT_RESTART) { // software restart ,system_restart , GPIO status won’t change
-      strcpy_P(buff, PSTR("Software/System restart"));
-    } else if (resetInfo.reason == REASON_DEEP_SLEEP_AWAKE) { // wake up from deep-sleep
-      strcpy_P(buff, PSTR("Deep-Sleep Wake"));
-    } else if (resetInfo.reason == REASON_EXT_SYS_RST) { // external system reset
-      strcpy_P(buff, PSTR("External System"));
-    } else {
-      strcpy_P(buff, PSTR("Unknown"));
+    const __FlashStringHelper* buff;
+
+    switch(resetInfo.reason) {
+        // normal startup by power on
+        case REASON_DEFAULT_RST:      buff = F("Power On"); break;
+        // hardware watch dog reset
+        case REASON_WDT_RST:          buff = F("Hardware Watchdog"); break;
+        // exception reset, GPIO status won’t change
+        case REASON_EXCEPTION_RST:    buff = F("Exception"); break;
+        // software watch dog reset, GPIO status won’t change
+        case REASON_SOFT_WDT_RST:     buff = F("Software Watchdog"); break;
+        // software restart ,system_restart , GPIO status won’t change
+        case REASON_SOFT_RESTART:     buff = F("Software/System restart"); break;
+        // wake up from deep-sleep
+        case REASON_DEEP_SLEEP_AWAKE: buff = F("Deep-Sleep Wake"); break;
+        // // external system reset
+        case REASON_EXT_SYS_RST:      buff = F("External System"); break;
+        default:                      buff = F("Unknown");
     }
     return String(buff);
 }


### PR DESCRIPTION
doing if/else snakes for something that is a switch/case
is wasteful, as it repeatedly evaluates the same if() condition.
Also repeating strcpy_P is adding code bloat.

This simplification reduces size from 111 to 41 bytes.