### PR TITLE
Reduce mem footprint of ESP.getResetInfo()

### DIFF
--- a/cores/esp8266/Esp.cpp
+++ b/cores/esp8266/Esp.cpp
@@ -490,12 +490,14 @@ String EspClass::getResetReason(void) {
 }
 
 String EspClass::getResetInfo(void) {
-    if(resetInfo.reason != 0) {
+    if (resetInfo.reason >= REASON_WDT_RST && resetInfo.reason <= REASON_SOFT_WDT_RST) {
         char buff[200];
-        sprintf(&buff[0], "Fatal exception:%d flag:%d (%s) epc1:0x%08x epc2:0x%08x epc3:0x%08x excvaddr:0x%08x depc:0x%08x", resetInfo.exccause, resetInfo.reason, (resetInfo.reason == 0 ? "DEFAULT" : resetInfo.reason == 1 ? "WDT" : resetInfo.reason == 2 ? "EXCEPTION" : resetInfo.reason == 3 ? "SOFT_WDT" : resetInfo.reason == 4 ? "SOFT_RESTART" : resetInfo.reason == 5 ? "DEEP_SLEEP_AWAKE" : resetInfo.reason == 6 ? "EXT_SYS_RST" : "???"), resetInfo.epc1, resetInfo.epc2, resetInfo.epc3, resetInfo.excvaddr, resetInfo.depc);
+        sprintf_P(buff, PSTR("Fatal exception:%d flag:%d (%s) epc1:0x%08x epc2:0x%08x epc3:0x%08x excvaddr:0x%08x depc:0x%08x"),
+            resetInfo.exccause, resetInfo.reason, getResetReason().c_str(),
+            resetInfo.epc1, resetInfo.epc2, resetInfo.epc3, resetInfo.excvaddr, resetInfo.depc);
         return String(buff);
     }
-    return String("flag: 0");
+    return getResetReason();
 }
 
 struct rst_info * EspClass::getResetInfoPtr(void) {


### PR DESCRIPTION
This function has excessively long datastrings that can
better be stored in flash, reducing runtime memory footprint.

Also detailed formatting only makes sense when there is an
exception or a watchdog. In other cases instead of printing
an unhelpful "flag: 0" we can just return the ResetReason, which
is much more readable.

Saves about 120 bytes of (data) memory.