### PR TITLE
Fix redirect support in http client.

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -549,7 +549,8 @@ bool HTTPClient::setURL(const String& url)
         DEBUG_HTTPCLIENT("[HTTP-Client][setURL] new URL not the same protocol, expected '%s', URL: '%s'\n", _protocol.c_str(), url.c_str());
         return false;
     }
-    // disconnect but preserve _client
+    // disconnect but preserve _client (clear _canReuse so disconnect will close the connection)
+    _canReuse = false;
     disconnect(true);
     return beginInternal(url, nullptr);
 }


### PR DESCRIPTION
Looks like this was introduced in #5250 - it missed the need to clear `_canReuse` in `setUrl()` if the new URL has a hostname and is not just a path.  Without it `disconnect()` will assume it can reuse even tho the hostname may be different.

fixes #7033