### PR TITLE
Fixes large payload issues for sendRequest

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -681,7 +681,8 @@ int HTTPClient::sendRequest(const char * type, const uint8_t * payload, size_t s
         if (payload && size > 0) {
             size_t bytesWritten = 0;
             const uint8_t *p = payload;
-            while (bytesWritten < size) {
+            size_t originalSize = size;
+            while (bytesWritten < originalSize) {
                 int written;
                 int towrite = std::min((int)size, (int)HTTP_TCP_BUFFER_SIZE);
                 written = _client->write(p + bytesWritten, towrite);


### PR DESCRIPTION
sendRequest has a major problem when sending a big payload, the comparator in the IF loop has its two operators changed at the same time, so the last part of payload is never sent. This is seen when you try to send a payload that needs more than one operation.

The modification has been tested for a 1500 bytes payload.

*edit from maintainer:* fixes #7049