### PR TITLE
Allow using custom linker scripts in PlatformIO build script

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -264,6 +264,9 @@ app_ld = env.Command(
         "Generating LD script $TARGET"))
 env.Depends("$BUILD_DIR/$PROGNAME$PROGSUFFIX", app_ld)
 
+if not env.BoardConfig().get("build.ldscript", ""):
+    env.Replace(LDSCRIPT_PATH=env.BoardConfig().get("build.arduino.ldscript", "")) 
+
 #
 # Dynamic core_version.h for staging builds
 #


### PR DESCRIPTION
This will allow users to set any linker script from `platformio.ini` file using the following syntax:
```ini
[env:esp01]
platform = espressif8266
framework = arduino
board = esp01
board_build.ldscript = custom_ldscript.ld
```
This is a more correct way of specifying it in comparison with using the `-Wl,-T` flag.