### PR TITLE
Completely Detach Servo

### DIFF
--- a/libraries/Servo/src/Servo.cpp
+++ b/libraries/Servo/src/Servo.cpp
@@ -82,9 +82,9 @@ uint8_t Servo::attach(int pin, uint16_t minUs, uint16_t maxUs)
 void Servo::detach()
 {
   if (_attached) {
+    pinMode(_pin, INPUT);
     stopWaveform(_pin);
     _attached = false;
-    digitalWrite(_pin, LOW);
   }
 }
 


### PR DESCRIPTION
In current implementation twitches may occur when calling `Servo.detach()`. 

This is because after `stopwaveform` is performed immediately and then followed by `digitalWrite(_pin, LOW)` causing a different duty-factor on the PWM.

Completely cutting off the pin with` pinMode(_pin, INPUT) `solves this issue.

A welcome side-effect is that `Servo.detach()` would really **detach** the pin (high impedance) instead of setting it to LOW.