### PR TITLE
package builder: updates for alpha releases

### DIFF
--- a/package/build_boards_manager_package.sh
+++ b/package/build_boards_manager_package.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
 
 #set -x
 
@@ -168,8 +167,19 @@ curl -L -o $old_json "https://github.com/esp8266/Arduino/releases/download/${bas
 new_json=package_esp8266com_index.json
 
 set +e
-# Merge the old and new, then drop any obsolete package versions
-python3 ../../merge_packages.py $new_json $old_json | python3 ../../drop_versions.py - tools 1.20.0-26-gb404fb9 >tmp && mv tmp $new_json && rm $old_json
+# Merge the old and new
+python3 ../../merge_packages.py $new_json $old_json > tmp
+
+# additional json to merge (for experimental releases)
+for json in ${MOREJSONPACKAGES}; do
+    if [ ! -z "$json" -a -r "$json" ]; then
+        python3 ../../merge_packages.py tmp $json > tmp2
+        mv tmp2 tmp
+    fi
+done
+
+# drop any obsolete package versions
+python3 ../../drop_versions.py - tools 1.20.0-26-gb404fb9 < tmp > tmp2 && mv tmp2 $new_json && rm $old_json tmp
 
 # Verify the JSON file can be read, fail if it's not OK
 set -e

--- a/package/build_boards_manager_package.sh
+++ b/package/build_boards_manager_package.sh
@@ -5,9 +5,10 @@
 
 ver=`git describe --tag`
 visiblever=$ver
-if [ "$ver" = 0.0.1 ]; then
+# match 0.0.*
+if [ "${ver%.*}" = 0.0 ]; then
 
-    git tag -d 0.0.1
+    git tag -d ${ver}
     ver=`git describe --tag HEAD`
     plain_ver=$ver
 

--- a/package/build_boards_manager_package.sh
+++ b/package/build_boards_manager_package.sh
@@ -171,8 +171,10 @@ set +e
 python3 ../../merge_packages.py $new_json $old_json > tmp
 
 # additional json to merge (for experimental releases)
+echo "Additional json package files: ${MOREJSONPACKAGES}"
 for json in ${MOREJSONPACKAGES}; do
     if [ ! -z "$json" -a -r "$json" ]; then
+        echo "- merging $json"
         python3 ../../merge_packages.py tmp $json > tmp2
         mv tmp2 tmp
     fi


### PR DESCRIPTION
This PR allows the package builder to generate more than one alpha release version.
Previously only version 0.0.1 was considered as an alpha version.
With these changes, any 0.0.x version will be generated as experimental and it will be easy to integrate unmerged-yet pull requests into an alpha release to help testing without using git.

These changes are transparent for the regular release process.
