### PR TITLE
avoid printing nullptr string

### DIFF
--- a/libraries/esp8266/examples/NTP-TZ-DST/NTP-TZ-DST.ino
+++ b/libraries/esp8266/examples/NTP-TZ-DST/NTP-TZ-DST.ino
@@ -134,7 +134,7 @@ void showTime() {
   Serial.println((uint32_t)now);
 
   // timezone and demo in the future
-  Serial.printf("timezone:  %s\n", getenv("TZ"));
+  Serial.printf("timezone:  %s\n", getenv("TZ") ? : "(none)");
 
   // human readable
   Serial.print("ctime:     ");


### PR DESCRIPTION
Due to recent changes, environment variable `TZ` may not be set up after `configTime()`.
In the example, inform user when it is not defined.
related: #7141 
