### PR TITLE
Delay(0) is an obfuscation of yield() or esp_schedule(); esp_yield()

### DIFF
--- a/cores/esp8266/PolledTimeout.h
+++ b/cores/esp8266/PolledTimeout.h
@@ -44,7 +44,7 @@ struct DoNothing
 
 struct YieldOrSkip
 {
-  static void execute() {delay(0);}
+  static void execute() {yield();}
 };
 
 template <unsigned long delayMs>

--- a/cores/esp8266/core_esp8266_main.cpp
+++ b/cores/esp8266/core_esp8266_main.cpp
@@ -113,12 +113,9 @@ extern "C" IRAM_ATTR void esp_schedule() {
 }
 
 extern "C" void __yield() {
+    esp_schedule();
     if (can_yield()) {
-        esp_schedule();
         esp_yield_within_cont();
-    }
-    else {
-        panic();
     }
 }
 

--- a/cores/esp8266/core_esp8266_waveform.cpp
+++ b/cores/esp8266/core_esp8266_waveform.cpp
@@ -139,7 +139,7 @@ int startWaveform(uint8_t pin, uint32_t timeHighUS, uint32_t timeLowUS, uint32_t
       }
     }
     while (waveformToEnable) {
-      delay(0); // Wait for waveform to update
+      yield(); // Wait for waveform to update
     }
   }
 

--- a/cores/esp8266/uart.cpp
+++ b/cores/esp8266/uart.cpp
@@ -528,7 +528,7 @@ uart_wait_tx_empty(uart_t* uart)
         return;
 
     while(uart_tx_fifo_available(uart->uart_nr) > 0)
-        delay(0);
+        yield();
 
 }
 
@@ -892,7 +892,7 @@ inline void
 uart_write_char_delay(const int uart_nr, char c)
 {
     while(uart_tx_fifo_full(uart_nr))
-        delay(0);
+        yield();
 
     USF(uart_nr) = c;
 

--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -854,7 +854,7 @@ int HTTPClient::sendRequest(const char * type, Stream * stream, size_t size)
                     len -= readBytes;
                 }
 
-                delay(0);
+                yield();
             } else {
                 delay(1);
             }
@@ -1000,7 +1000,7 @@ int HTTPClient::writeToStream(Stream * stream)
                 return returnError(HTTPC_ERROR_READ_TIMEOUT);
             }
 
-            delay(0);
+            yield();
         }
     } else {
         return returnError(HTTPC_ERROR_ENCODING);
@@ -1387,7 +1387,7 @@ int HTTPClient::handleHeaderResponse()
             if((millis() - lastDataTime) > _tcpTimeout) {
                 return HTTPC_ERROR_READ_TIMEOUT;
             }
-            delay(0);
+            yield();
         }
     }
 
@@ -1483,7 +1483,7 @@ int HTTPClient::writeToStreamDataBlock(Stream * stream, int size)
             len -= bytesRead;
         }
 
-        delay(0);
+        yield();
     }
 
     free(buff);

--- a/libraries/ESP8266HTTPUpdateServer/src/ESP8266HTTPUpdateServer-impl.h
+++ b/libraries/ESP8266HTTPUpdateServer/src/ESP8266HTTPUpdateServer-impl.h
@@ -119,7 +119,7 @@ void ESP8266HTTPUpdateServerTemplate<ServerType>::setup(ESP8266WebServerTemplate
         Update.end();
         if (_serial_output) Serial.println("Update was aborted");
       }
-      delay(0);
+      yield();
     });
 }
 

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -523,9 +523,9 @@ bool ESP8266WiFiGenericClass::forceSleepBegin(uint32 sleepUs) {
     }
 
     wifi_fpm_set_sleep_type(MODEM_SLEEP_T);
-    delay(0);
+    yield();
     wifi_fpm_open();
-    delay(0);
+    yield();
     auto ret = wifi_fpm_do_sleep(sleepUs);
     if (ret != 0)
     {

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp
@@ -65,7 +65,7 @@ wl_status_t ESP8266WiFiMulti::run(void) {
             DEBUG_WIFI_MULTI("[WIFI] no networks found\n");
             WiFi.scanDelete();
             DEBUG_WIFI_MULTI("\n\n");
-            delay(0);
+            yield();
             WiFi.disconnect();
             DEBUG_WIFI_MULTI("[WIFI] start scan\n");
             // scan wifi async mode
@@ -81,7 +81,7 @@ wl_status_t ESP8266WiFiMulti::run(void) {
             int32_t bestChannel;
 
             DEBUG_WIFI_MULTI("[WIFI] scan done\n");
-            delay(0);
+            yield();
 
             DEBUG_WIFI_MULTI("[WIFI] %d networks found\n", scanResult);
             for(int8_t i = 0; i < scanResult; ++i) {
@@ -118,14 +118,14 @@ wl_status_t ESP8266WiFiMulti::run(void) {
                 }
 
                 DEBUG_WIFI_MULTI(" %d: [%d][%02X:%02X:%02X:%02X:%02X:%02X] %s (%d) %c\n", i, chan_scan, BSSID_scan[0], BSSID_scan[1], BSSID_scan[2], BSSID_scan[3], BSSID_scan[4], BSSID_scan[5], ssid_scan.c_str(), rssi_scan, (sec_scan == ENC_TYPE_NONE) ? ' ' : '*');
-                delay(0);
+                yield();
             }
 
             // clean up ram
             WiFi.scanDelete();
 
             DEBUG_WIFI_MULTI("\n\n");
-            delay(0);
+            yield();
 
             if(bestNetwork.ssid) {
                 DEBUG_WIFI_MULTI("[WIFI] Connecting BSSID: %02X:%02X:%02X:%02X:%02X:%02X SSID: %s Channel: %d (%d)\n", bestBSSID[0], bestBSSID[1], bestBSSID[2], bestBSSID[3], bestBSSID[4], bestBSSID[5], bestNetwork.ssid, bestChannel, bestNetworkDb);

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiScan.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiScan.cpp
@@ -94,7 +94,7 @@ int8_t ESP8266WiFiScanClass::scanNetworks(bool async, bool show_hidden, uint8 ch
         ESP8266WiFiScanClass::_scanStarted = true;
 
         if(ESP8266WiFiScanClass::_scanAsync) {
-            delay(0); // time for the OS to trigger the scan
+            yield(); // time for the OS to trigger the scan
             return WIFI_SCAN_RUNNING;
         }
 

--- a/libraries/ESP8266WiFi/src/include/ClientContext.h
+++ b/libraries/ESP8266WiFi/src/include/ClientContext.h
@@ -342,7 +342,7 @@ public:
                 last_sent = millis();
             }
 
-            delay(0); // from sys or os context
+            yield(); // from sys or os context
 
             if ((state() != ESTABLISHED) || (sndbuf == TCP_SND_BUF)) {
                 break;

--- a/libraries/SDFS/src/SDFSFormatter.h
+++ b/libraries/SDFS/src/SDFSFormatter.h
@@ -76,7 +76,7 @@ private:
 	esp8266::polledTimeout::periodicFastMs timeToYield(5); // Yield every 5ms of runtime
         for (uint32_t i = 0; i < count; i++) {
             if (timeToYield) {
-                delay(0); // WDT feed
+                yield(); // WDT feed
             }
             if (!card->writeData(cache->data)) {
                 DEBUGV("SDFS: Clear FAT/DIR writeData failed");
@@ -383,7 +383,7 @@ public:
             if (!card->erase(firstBlock, lastBlock)) {
                 return false; // Erase fail
             }
-            delay(0); // yield to the OS to avoid WDT
+            yield(); // yield to the OS to avoid WDT
             firstBlock += ERASE_SIZE;
         } while (firstBlock < cardSizeBlocks);
 

--- a/libraries/esp8266/examples/SerialStress/SerialStress.ino
+++ b/libraries/esp8266/examples/SerialStress/SerialStress.ino
@@ -128,7 +128,7 @@ void loop() {
   if ((out_idx += local_written_size) == BUFFER_SIZE) {
     out_idx = 0;
   }
-  delay(0);
+  yield();
 
   DEBUG(logger->printf("----------\n"));
 


### PR DESCRIPTION
Let's unroll the code:
yield() =>
```
if (can_yield()) {
  ets_post(LOOP_TASK_PRIORITY, 0, 0); // esp_schedule();
  esp_yield_within_cont();
}
else {
  panic();
}          
```

delay(0): =>
```
ets_post(LOOP_TASK_PRIORITY, 0, 0); // esp_schedule();
if (can_yield()) {
  esp_yield_within_cont();
}
```
So, in detail, there is a difference. Yield() panics in ISRs (and SYS?), delay(0) posts CONT from ISR and SYS just fine, but doesn't actually yield unless in CONT.
I don't think using delay(0), requiring an extra literal 0 argument passed, is more expressive in SYS or ISRs to express a restart for suspend-yielded CONT.

For compatibility expectations, in AVR Arduino core, delay(0) is basically a no-op, it does not yield.

On the ESP32:
```
void delay(uint32_t ms) {
  vTaskDelay(ms / portTICK_PERIOD_MS);
}
```
This obviously is illegal to call from ISRs.

The take-away, as far as I am concerned, is that for the legal uses, yield() succinctly expresses what delay(0) does, and is slightly more efficient and safer.

In ClientContext.h, the `delay(0)` is probably unintentional, the `esp_schedule()` direct call is used in a few places already, and is functionally identical in this place, while also more expressive and saves resources.