### PR TITLE
Use development branch of espressif8266 platform in PlatformIO build

### DIFF
--- a/tests/platformio.sh
+++ b/tests/platformio.sh
@@ -7,8 +7,8 @@ source "$TRAVIS_BUILD_DIR"/tests/common.sh
 function install_platformio()
 {
     pip3 install --user -U https://github.com/platformio/platformio/archive/develop.zip
-    platformio platform install "https://github.com/platformio/platform-espressif8266.git#feature/stage"
-    sed -i 's/https:\/\/github\.com\/esp8266\/Arduino\.git/*/' ~/.platformio/platforms/espressif8266/platform.json
+    platformio platform install "https://github.com/platformio/platform-espressif8266.git"
+    python -c "import json; import os; fp=open(os.path.expanduser('~/.platformio/platforms/espressif8266/platform.json'), 'r+'); data=json.load(fp); data['packages']['framework-arduinoespressif8266']['version'] = '*'; fp.seek(0); fp.truncate(); json.dump(data, fp); fp.close()"
     ln -sf $TRAVIS_BUILD_DIR ~/.platformio/packages/framework-arduinoespressif8266
     # Install dependencies:
     # - esp8266/examples/ConfigFile


### PR DESCRIPTION
There is no `stage` branch anymore, CI build should use the development branch instead.