### PR TITLE
Tone limit 20KHz 

### DIFF
--- a/cores/esp8266/Tone.cpp
+++ b/cores/esp8266/Tone.cpp
@@ -38,9 +38,7 @@ static void _startTone(uint8_t _pin, uint32_t high, uint32_t low, unsigned long 
   high = std::max(high, (uint32_t)100);  // 5KHz maximum tone for Arduino compatibility
   low = std::max(low, (uint32_t)100);    // (100us high + 100us low period = 5KHz)
 
-  duration *= 1000UL;
-  duration -= duration % (high + low);
-  if (startWaveform(_pin, high, low, duration)) {
+  if (startWaveform(_pin, high, low, (uint32_t) duration * 1000)) {
     _toneMap |= 1 << _pin;
   }
 }

--- a/cores/esp8266/Tone.cpp
+++ b/cores/esp8266/Tone.cpp
@@ -35,10 +35,12 @@ static void _startTone(uint8_t _pin, uint32_t high, uint32_t low, unsigned long 
 
   pinMode(_pin, OUTPUT);
 
-  high = std::max(high, (uint32_t)100);
-  low = std::max(low, (uint32_t)100);
+  high = std::max(high, (uint32_t)100);  // 5KHz maximum tone for Arduino compatibility
+  low = std::max(low, (uint32_t)100);    // (100us high + 100us low period = 5KHz)
 
-  if (startWaveform(_pin, high, low, (uint32_t) duration * 1000)) {
+  duration *= 1000UL;
+  duration -= duration % (high + low);
+  if (startWaveform(_pin, high, low, duration)) {
     _toneMap |= 1 << _pin;
   }
 }

--- a/cores/esp8266/Tone.cpp
+++ b/cores/esp8266/Tone.cpp
@@ -35,7 +35,7 @@ static void _startTone(uint8_t _pin, uint32_t high, uint32_t low, unsigned long 
 
   pinMode(_pin, OUTPUT);
 
-  high = std::max(high, (uint32_t)25);  // new 20KHz maximum tone frequency,
+  high = std::max(high, (uint32_t)25);  // 20KHz maximum tone frequency (new),
   low = std::max(low, (uint32_t)25);   // (25us high + 25us low period = 20KHz)
 
   if (startWaveform(_pin, high, low, (uint32_t) duration * 1000)) {

--- a/cores/esp8266/Tone.cpp
+++ b/cores/esp8266/Tone.cpp
@@ -35,7 +35,7 @@ static void _startTone(uint8_t _pin, uint32_t high, uint32_t low, unsigned long 
 
   pinMode(_pin, OUTPUT);
 
-  high = std::max(high, (uint32_t)25);  // 20KHz maximum tone frequency (new),
+  high = std::max(high, (uint32_t)25);  // new 20KHz maximum tone frequency,
   low = std::max(low, (uint32_t)25);   // (25us high + 25us low period = 20KHz)
 
   if (startWaveform(_pin, high, low, (uint32_t) duration * 1000)) {

--- a/cores/esp8266/Tone.cpp
+++ b/cores/esp8266/Tone.cpp
@@ -35,8 +35,8 @@ static void _startTone(uint8_t _pin, uint32_t high, uint32_t low, unsigned long 
 
   pinMode(_pin, OUTPUT);
 
-  high = std::max(high, (uint32_t)100);  // 5KHz maximum tone for Arduino compatibility
-  low = std::max(low, (uint32_t)100);    // (100us high + 100us low period = 5KHz)
+  high = std::max(high, (uint32_t)25);  // new 20KHz maximum tone frequency,
+  low = std::max(low, (uint32_t)25);   // (25us high + 25us low period = 20KHz)
 
   if (startWaveform(_pin, high, low, (uint32_t) duration * 1000)) {
     _toneMap |= 1 << _pin;

--- a/cores/esp8266/core_esp8266_wiring_digital.cpp
+++ b/cores/esp8266/core_esp8266_wiring_digital.cpp
@@ -236,12 +236,9 @@ extern void __attachInterrupt(uint8_t pin, voidFuncPtr userFunc, int mode)
 }
 
 extern void __resetPins() {
-  for (int i = 0; i <= 5; ++i) {
-    pinMode(i, INPUT);
-  }
-  // pins 6-11 are used for the SPI flash interface
-  for (int i = 12; i <= 16; ++i) {
-    pinMode(i, INPUT);
+  for (int i = 0; i <= 16; ++i) {
+    if (!isFlashInterfacePin(i))
+        pinMode(i, INPUT);
   }
 }
 


### PR DESCRIPTION
Add 2 comments since I found out where the 5KHz upper limit on Tone output frequency was, apparently added for compatibility with the Arduino library some time in the past.

If you want the full 20KHz audio frequency range, change the two lines in Tone.cpp at line 38 to:
```cpp
  high = std::max(high, (uint32_t)25);  // new 20KHz maximum Tone frequency
  low = std::max(low, (uint32_t)25);
```