### PR TITLE
Move floating point from libgcc out of IRAM

### DIFF
--- a/tools/sdk/ld/eagle.app.v6.common.ld.h
+++ b/tools/sdk/ld/eagle.app.v6.common.ld.h
@@ -151,6 +151,14 @@ SECTIONS
 
     *libc.a:(.literal .text .literal.* .text.*)
     *libm.a:(.literal .text .literal.* .text.*)
+#ifdef FP_IN_IROM
+    *libgcc.a:*f2.o(.literal .text)
+    *libgcc.a:*f3.o(.literal .text)
+    *libgcc.a:*fsi.o(.literal .text)
+    *libgcc.a:*fdi.o(.literal .text)
+    *libgcc.a:*ifs.o(.literal .text)
+    *libgcc.a:*idf.o(.literal .text)
+#endif
     *libgcc.a:_umoddi3.o(.literal .text)
     *libgcc.a:_udivdi3.o(.literal .text)
     *libstdc++.a:( .literal .text .literal.* .text.*)


### PR DESCRIPTION
In Tasmota I realized the following floating point function are in precious IRAM:

```
                0x0000000040107184                __divsf3
                0x0000000040107240                __eqsf2
                0x0000000040107240                __nesf2
                0x0000000040107268                __gtsf2
                0x0000000040107288                __lesf2
                0x00000000401072d4                __gesf2
                0x00000000401072f4                __ltsf2
                0x0000000040107340                __unordsf2
                0x0000000040107364                __fixsfsi
                0x00000000401073a4                __nedf2
                0x00000000401073a4                __eqdf2
                0x00000000401073d4                __gtdf2
                0x00000000401073f8                __ledf2
                0x000000004010745c                __gedf2
                0x0000000040107480                __ltdf2
                0x00000000401074e4                __unorddf2
```

This PR adds a `#define FP_IN_IROM` to move floating point function out of IRAM to IROM.

- `*f2.o`,`*f3.o` : `float` and `double` functions
- `*fsi.o`: fp to int
- `*fdi.o`: fp to long
- `*ifs.o`: int to fp
- `*ids.o`: long to fp

In Tasmota, the only functions from `libgcc` remaining in IRAM are: `__modsi3` (integer modulus) and `__ashrdi3` (bit shifting).