### PR TITLE
Ability to define -DFP_IN_IROM when generating ld script

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -247,9 +247,12 @@ else:
 #
 
 current_vtables = None
+fp_in_irom = ""
 for d in flatten_cppdefines:
     if str(d).startswith("VTABLES_IN_"):
         current_vtables = d
+    if str(d) == "FP_IN_IROM":
+        fp_in_irom = "-DFP_IN_IROM"
 if not current_vtables:
     current_vtables = "VTABLES_IN_FLASH"
     env.Append(CPPDEFINES=[current_vtables])
@@ -260,7 +263,7 @@ app_ld = env.Command(
     join("$BUILD_DIR", "ld", "local.eagle.app.v6.common.ld"),
     join(FRAMEWORK_DIR, "tools", "sdk", "ld", "eagle.app.v6.common.ld.h"),
     env.VerboseAction(
-        "$CC -CC -E -P -D%s $SOURCE -o $TARGET" % current_vtables,
+        "$CC -CC -E -P -D%s %s $SOURCE -o $TARGET" % (current_vtables, fp_in_irom),
         "Generating LD script $TARGET"))
 env.Depends("$BUILD_DIR/$PROGNAME$PROGSUFFIX", app_ld)
 


### PR DESCRIPTION
Follow up of #7180, there was no way to enable the `-DFP_IN_IROM` flag when generating the ld script.
