### PR TITLE
Preserve phase relationship when waveform updated

### DIFF
--- a/cores/esp8266/core_esp8266_waveform.cpp
+++ b/cores/esp8266/core_esp8266_waveform.cpp
@@ -114,13 +114,17 @@ void setTimer1Callback(uint32_t (*fn)()) {
 // waveform smoothly on next low->high transition.  For immediate change, stopWaveform()
 // first, then it will immediately begin.
 int startWaveform(uint8_t pin, uint32_t timeHighUS, uint32_t timeLowUS, uint32_t runTimeUS) {
+  return startWaveformCycles(pin, microsecondsToClockCycles(timeHighUS), microsecondsToClockCycles(timeLowUS), microsecondsToClockCycles(runTimeUS));
+}
+
+int startWaveformCycles(uint8_t pin, uint32_t timeHighCycles, uint32_t timeLowCycles, uint32_t runTimeCycles) {
   if ((pin > 16) || isFlashInterfacePin(pin)) {
     return false;
   }
   Waveform *wave = &waveform[pin];
 
-  wave->expiryCycle = runTimeUS ? GetCycleCount() + microsecondsToClockCycles(runTimeUS) : 0;
-  if (runTimeUS && !wave->expiryCycle) {
+  wave->expiryCycle = runTimeCycles ? GetCycleCount() + runTimeCycles : 0;
+  if (runTimeCycles && !wave->expiryCycle) {
     wave->expiryCycle = 1; // expiryCycle==0 means no timeout, so avoid setting it
   }
 
@@ -130,14 +134,14 @@ int startWaveform(uint8_t pin, uint32_t timeHighUS, uint32_t timeLowUS, uint32_t
     // Need to manually do RSIL here because this is "C" code and can't use the InterruptLock class
     uint32_t _state = xt_rsil(15);
 
-    wave->gotoTimeLowCycles = microsecondsToClockCycles(timeLowUS);
-    wave->gotoTimeHighCycles = microsecondsToClockCycles(timeHighUS);
+    wave->gotoTimeLowCycles = timeLowCycles;
+    wave->gotoTimeHighCycles = timeHighCycles;
 
     // Restore interrupt state
     xt_wsr_ps(_state);
   } else { //  if (!(waveformEnabled & mask))
-    wave->timeHighCycles = microsecondsToClockCycles(timeHighUS);
-    wave->timeLowCycles = microsecondsToClockCycles(timeLowUS);
+    wave->timeHighCycles = timeHighCycles;
+    wave->timeLowCycles = timeLowCycles;
     wave->gotoTimeHighCycles = wave->timeHighCycles;
     wave->gotoTimeLowCycles = wave->timeLowCycles;
     // Actually set the pin high or low in the IRQ service to guarantee times

--- a/cores/esp8266/core_esp8266_waveform.cpp
+++ b/cores/esp8266/core_esp8266_waveform.cpp
@@ -38,7 +38,7 @@
 */
 
 #include <Arduino.h>
-#include "ets_sys.h"
+#include "interrupts.h"
 #include "core_esp8266_waveform.h"
 
 extern "C" {
@@ -130,15 +130,9 @@ int startWaveformCycles(uint8_t pin, uint32_t timeHighCycles, uint32_t timeLowCy
 
   uint32_t mask = 1<<pin;
   if (waveformEnabled & mask) {
-    // Don't interrupt a cycle, so store the new high and low
-    // Need to manually do RSIL here because this is "C" code and can't use the InterruptLock class
-    uint32_t _state = xt_rsil(15);
-
+    esp8266::InterruptLock il; // Make the variable sets atomic
     wave->gotoTimeLowCycles = timeLowCycles;
     wave->gotoTimeHighCycles = timeHighCycles;
-
-    // Restore interrupt state
-    xt_wsr_ps(_state);
   } else { //  if (!(waveformEnabled & mask))
     wave->timeHighCycles = timeHighCycles;
     wave->timeLowCycles = timeLowCycles;

--- a/cores/esp8266/core_esp8266_waveform.cpp
+++ b/cores/esp8266/core_esp8266_waveform.cpp
@@ -288,7 +288,7 @@ static ICACHE_RAM_ATTR void timer1Interrupt() {
             } else {
               SetGPIO(mask);
             }
-            wave->nextServiceCycle = now + wave->timeHighCycles;
+            wave->nextServiceCycle += wave->timeHighCycles;
             nextEventCycles = min_u32(nextEventCycles, wave->timeHighCycles);
           } else {
             if (i == 16) {
@@ -296,7 +296,7 @@ static ICACHE_RAM_ATTR void timer1Interrupt() {
             } else {
               ClearGPIO(mask);
             }
-            wave->nextServiceCycle = now + wave->timeLowCycles;
+            wave->nextServiceCycle += wave->timeLowCycles;
             nextEventCycles = min_u32(nextEventCycles, wave->timeLowCycles);
             // Copy over next full-cycle timings
             wave->timeHighCycles = wave->gotoTimeHighCycles;

--- a/cores/esp8266/core_esp8266_waveform.h
+++ b/cores/esp8266/core_esp8266_waveform.h
@@ -50,6 +50,8 @@ extern "C" {
 // If runtimeUS > 0 then automatically stop it after that many usecs.
 // Returns true or false on success or failure.
 int startWaveform(uint8_t pin, uint32_t timeHighUS, uint32_t timeLowUS, uint32_t runTimeUS);
+// Same as above, but pass in CPU clock cycles instead of microseconds
+int startWaveformCycles(uint8_t pin, uint32_t timeHighCycles, uint32_t timeLowCycles, uint32_t runTimeCycles);
 // Stop a waveform, if any, on the specified pin.
 // Returns true or false on success or failure.
 int stopWaveform(uint8_t pin);

--- a/cores/esp8266/core_esp8266_wiring_pwm.cpp
+++ b/cores/esp8266/core_esp8266_wiring_pwm.cpp
@@ -69,7 +69,7 @@ extern void __analogWrite(uint8_t pin, int val) {
     stopWaveform(pin);
     digitalWrite(pin, LOW);
   } else {
-    if (startWaveform(pin, high, low, 0)) {
+    if (startWaveformCycles(pin, high, low, 0)) {
       analogMap |= (1 << pin);
     }
   }

--- a/cores/esp8266/core_esp8266_wiring_pwm.cpp
+++ b/cores/esp8266/core_esp8266_wiring_pwm.cpp
@@ -25,6 +25,7 @@
 #include "core_esp8266_waveform.h"
 
 extern "C" {
+#include "user_interface.h"
 
 static uint32_t analogMap = 0;
 static int32_t analogScale = PWMRANGE;
@@ -50,7 +51,7 @@ extern void __analogWrite(uint8_t pin, int val) {
   if (pin > 16) {
     return;
   }
-  uint32_t analogPeriod = 1000000L / analogFreq;
+  uint32_t analogPeriod = (1000000L * system_get_cpu_freq()) / analogFreq;
   if (val < 0) {
     val = 0;
   } else if (val > analogScale) {


### PR DESCRIPTION
Preserve the phase relationship as close as possibly by taking an entire
period of the waveform and copying it over to the machine state, instead
of doing it on rising and falling edges.