### PR TITLE
Fix for MD5 leak bug, issue #7195

### DIFF
--- a/cores/esp8266/MD5Builder.cpp
+++ b/cores/esp8266/MD5Builder.cpp
@@ -55,6 +55,7 @@ bool MD5Builder::addStream(Stream & stream, const size_t maxLen){
         // read data and check if we got something
         int numBytesRead = stream.readBytes(buf, readBytes);
         if(numBytesRead< 1) {
+            free(buf); // release the buffer
             return false;
         }
 


### PR DESCRIPTION
Added the `free` before the return.
I was wondering if a more "C++ish" resource handling could be fine for you (e.g. buffer as unique_ptr).