### PR TITLE
MD5 Builder: Rework for unqiue_ptr instead of malloc for internal dynamic buffers.

### DIFF
--- a/cores/esp8266/MD5Builder.cpp
+++ b/cores/esp8266/MD5Builder.cpp
@@ -1,10 +1,11 @@
 #include <Arduino.h>
 #include <MD5Builder.h>
+#include <memory>
 
-uint8_t hex_char_to_byte(uint8_t c){
-    return  (c >= 'a' && c <= 'f') ? (c - ((uint8_t)'a' - 0xa)) :
-            (c >= 'A' && c <= 'F') ? (c - ((uint8_t)'A' - 0xA)) :
-            (c >= '0' &&  c<= '9') ? (c - (uint8_t)'0') : 0;
+uint8_t hex_char_to_byte(uint8_t c) {
+    return (c >= 'a' && c <= 'f') ? (c - ((uint8_t)'a' - 0xa)) :
+           (c >= 'A' && c <= 'F') ? (c - ((uint8_t)'A' - 0xA)) :
+           (c >= '0' && c <= '9') ? (c - (uint8_t)'0') : 0;
 }
 
 void MD5Builder::begin(void){
@@ -18,25 +19,27 @@ void MD5Builder::add(const uint8_t * data, const uint16_t len){
 
 void MD5Builder::addHexString(const char * data){
     uint16_t i, len = strlen(data);
-    uint8_t * tmp = (uint8_t*)malloc(len/2);
-    if(tmp == NULL) {
+    auto tmp = std::unique_ptr<uint8_t[]>{new(std::nothrow) uint8_t[len / 2]};
+
+    if (!tmp) {
         return;
     }
+
     for(i=0; i<len; i+=2) {
         uint8_t high = hex_char_to_byte(data[i]);
         uint8_t low = hex_char_to_byte(data[i+1]);
         tmp[i/2] = (high & 0x0F) << 4 | (low & 0x0F);
     }
-    add(tmp, len/2);
-    free(tmp);
+    add(tmp.get(), len/2);
 }
 
-bool MD5Builder::addStream(Stream & stream, const size_t maxLen){
+bool MD5Builder::addStream(Stream &stream, const size_t maxLen) {
     const int buf_size = 512;
     int maxLengthLeft = maxLen;
-    uint8_t * buf = (uint8_t*) malloc(buf_size);
 
-    if(!buf) {
+    auto buf = std::unique_ptr<uint8_t[]>{new(std::nothrow) uint8_t[buf_size]};
+
+    if (!buf) {
         return false;
     }
 
@@ -45,22 +48,21 @@ bool MD5Builder::addStream(Stream & stream, const size_t maxLen){
 
         // determine number of bytes to read
         int readBytes = bytesAvailable;
-        if(readBytes > maxLengthLeft) {
-            readBytes = maxLengthLeft ;    // read only until max_len
+        if (readBytes > maxLengthLeft){
+            readBytes = maxLengthLeft;    // read only until max_len
         }
-        if(readBytes > buf_size) {
+        if (readBytes > buf_size){
             readBytes = buf_size;    // not read more the buffer can handle
         }
 
         // read data and check if we got something
-        int numBytesRead = stream.readBytes(buf, readBytes);
-        if(numBytesRead< 1) {
-            free(buf); // release the buffer
+        int numBytesRead = stream.readBytes(buf.get(), readBytes);
+        if (numBytesRead < 1) {
             return false;
         }
 
         // Update MD5 with buffer payload
-        MD5Update(&_ctx, buf, numBytesRead);
+        MD5Update(&_ctx, buf.get(), numBytesRead);
 
         yield();      // time for network streams
 
@@ -68,7 +70,7 @@ bool MD5Builder::addStream(Stream & stream, const size_t maxLen){
         maxLengthLeft -= numBytesRead;
         bytesAvailable = stream.available();
     }
-    free(buf);
+
     return true;
 }
 
@@ -76,17 +78,17 @@ void MD5Builder::calculate(void){
     MD5Final(_buf, &_ctx);
 }
 
-void MD5Builder::getBytes(uint8_t * output){
+void MD5Builder::getBytes(uint8_t * output) const {
     memcpy(output, _buf, 16);
 }
 
-void MD5Builder::getChars(char * output){
-    for(uint8_t i = 0; i < 16; i++) {
+void MD5Builder::getChars(char * output) const {
+    for (uint8_t i=0; i<16; i++){
         sprintf(output + (i * 2), "%02x", _buf[i]);
     }
 }
 
-String MD5Builder::toString(void){
+String MD5Builder::toString(void) const {
     char out[33];
     getChars(out);
     return String(out);

--- a/cores/esp8266/MD5Builder.h
+++ b/cores/esp8266/MD5Builder.h
@@ -40,9 +40,9 @@ class MD5Builder {
     void addHexString(const String& data){ addHexString(data.c_str()); }
     bool addStream(Stream & stream, const size_t maxLen);
     void calculate(void);
-    void getBytes(uint8_t * output);
-    void getChars(char * output);
-    String toString(void);
+    void getBytes(uint8_t * output) const;
+    void getChars(char * output) const;
+    String toString(void) const;
 };
 
 


### PR DESCRIPTION
In order to guarantee exception-safety I used `unique_ptr` to `uint8_t[]`, with `std::nothrow` decorator.
I cannot mark the functions as no-except because I don't know if the called functions (especially the Stream implementations) are no-except.
 
I also fixed the const-correctness of const member functions, such as toString() and getters. 

I executed the host tests, I still need to run tests on the ESP8266, but this is the first time that I contribute with you, so I have to study how to setup and run your tests suite on my device.
