### PR TITLE
Null pointer call from WiFiClient::localIP() to IPAddress

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -367,7 +367,7 @@ uint16_t WiFiClient::remotePort()
 
 IPAddress WiFiClient::localIP()
 {
-    if (!_client)
+    if (!_client || !_client->getLocalAddress())
         return IPAddress(0U);
 
     return IPAddress(_client->getLocalAddress());
@@ -389,7 +389,7 @@ void WiFiClient::stopAll()
 }
 
 
-void WiFiClient::stopAllExcept(WiFiClient* except) 
+void WiFiClient::stopAllExcept(WiFiClient* except)
 {
     for (WiFiClient* it = _s_first; it; it = it->_next) {
         if (it != except) {


### PR DESCRIPTION
Fixes exception 28 in `IPAddress(const ipv4_addr* fw_addr);` with null ip_addr
pointer passed in by `WiFiCient.cpp localIP()`. I assumed that `localIP()`
was called shortly after _pcb became null.