### PR TITLE
Update HTML in CaptivePortal examples for better mobile device viewing ...

### DIFF
--- a/libraries/DNSServer/examples/CaptivePortal/CaptivePortal.ino
+++ b/libraries/DNSServer/examples/CaptivePortal/CaptivePortal.ino
@@ -8,9 +8,11 @@ DNSServer dnsServer;
 ESP8266WebServer webServer(80);
 
 String responseHTML = ""
-                      "<!DOCTYPE html><html><head><title>CaptivePortal</title></head><body>"
-                      "<h1>Hello World!</h1><p>This is a captive portal example. All requests will "
-                      "be redirected here.</p></body></html>";
+                      "<!DOCTYPE html><html lang='en'><head>"
+                      "<meta name='viewport' content='width=device-width'>"
+                      "<title>CaptivePortal</title></head><body>"
+                      "<h1>Hello World!</h1><p>This is a captive portal example."
+                      " All requests will be redirected here.</p></body></html>";
 
 void setup() {
   WiFi.mode(WIFI_AP);

--- a/libraries/DNSServer/examples/CaptivePortalAdvanced/CaptivePortalAdvanced.ino
+++ b/libraries/DNSServer/examples/CaptivePortalAdvanced/CaptivePortalAdvanced.ino
@@ -30,8 +30,8 @@ const char *softAP_password = APPSK;
 const char *myHostname = "esp8266";
 
 /* Don't set this wifi credentials. They are configurated at runtime and stored on EEPROM */
-char ssid[32] = "";
-char password[32] = "";
+char ssid[33] = "";
+char password[65] = "";
 
 // DNS server
 const byte DNS_PORT = 53;
@@ -140,4 +140,3 @@ void loop() {
   //HTTP
   server.handleClient();
 }
-

--- a/libraries/DNSServer/examples/CaptivePortalAdvanced/handleHttp.ino
+++ b/libraries/DNSServer/examples/CaptivePortalAdvanced/handleHttp.ino
@@ -9,7 +9,9 @@ void handleRoot() {
 
   String Page;
   Page += F(
-            "<html><head></head><body>"
+            "<!DOCTYPE html><html lang='en'><head>"
+            "<meta name='viewport' content='width=device-width'>"
+            "<title>CaptivePortal</title></head><body>"
             "<h1>HELLO WORLD!!</h1>");
   if (server.client().localIP() == apIP) {
     Page += String(F("<p>You are connected through the soft AP: ")) + softAP_ssid + F("</p>");
@@ -43,7 +45,9 @@ void handleWifi() {
 
   String Page;
   Page += F(
-            "<html><head></head><body>"
+            "<!DOCTYPE html><html lang='en'><head>"
+            "<meta name='viewport' content='width=device-width'>"
+            "<title>CaptivePortal</title></head><body>"
             "<h1>Wifi config</h1>");
   if (server.client().localIP() == apIP) {
     Page += String(F("<p>You are connected through the soft AP: ")) + softAP_ssid + F("</p>");
@@ -130,4 +134,3 @@ void handleNotFound() {
   server.sendHeader("Expires", "-1");
   server.send(404, "text/plain", message);
 }
-


### PR DESCRIPTION
For example CaptivePortal, update HTML to pass HTML checker.
Added meta viewport element for better mobile device viewing.

For example, CaptivePortalAdvanced, increased size of ssid and password array
to hold maximums 32 and 64 character strings. Added missing HTML elements
to the main splash and wifi config. pages. They should now pass an HTML checker.
Also added meta viewport element for better mobile device viewing.