### PR TITLE
Turn off IRQ on stopWaveform after Tone timeout

### DIFF
--- a/cores/esp8266/core_esp8266_waveform.cpp
+++ b/cores/esp8266/core_esp8266_waveform.cpp
@@ -182,7 +182,7 @@ int ICACHE_RAM_ATTR stopWaveform(uint8_t pin) {
     timer1_write(microsecondsToClockCycles(10));
   }
   while (waveformToDisable) {
-    /* no-op */ // Can't delay() since stopWaveform may be called from an IRQ
+    /* no-op */ // Can't delay() because stopWaveform may be called from an IRQ
   }
   if (!waveformEnabled && !timer1CB) {
     deinitTimer();

--- a/cores/esp8266/core_esp8266_waveform.cpp
+++ b/cores/esp8266/core_esp8266_waveform.cpp
@@ -176,12 +176,6 @@ int ICACHE_RAM_ATTR stopWaveform(uint8_t pin) {
   if (!timerRunning) {
     return false;
   }
-  // If user sends in a pin >16 but <32, this will always point to a 0 bit
-  // If they send >=32, then the shift will result in 0 and it will also return false
-  uint32_t mask = 1<<pin;
-  if (!(waveformEnabled & mask)) {
-    return false; // It's not running, nothing to do here
-  }
   waveformToDisable |= mask;
   // Ensure timely service....
   if (T1L > microsecondsToClockCycles(10)) {

--- a/cores/esp8266/core_esp8266_waveform.cpp
+++ b/cores/esp8266/core_esp8266_waveform.cpp
@@ -176,13 +176,14 @@ int ICACHE_RAM_ATTR stopWaveform(uint8_t pin) {
   if (!timerRunning) {
     return false;
   }
+  uint32_t mask = 1<<pin;
   waveformToDisable |= mask;
   // Ensure timely service....
   if (T1L > microsecondsToClockCycles(10)) {
     timer1_write(microsecondsToClockCycles(10));
   }
   while (waveformToDisable) {
-    /* no-op */ // Can't delay() because stopWaveform may be called from an IRQ
+    /* no-op */ // Can't delay() since stopWaveform may be called from an IRQ
   }
   if (!waveformEnabled && !timer1CB) {
     deinitTimer();


### PR DESCRIPTION
Fix #7230 (until 3.0 when this whole code will probably change).

Before, a timed out pin would clear its bit in `waveformEnabled`.  The
logic in `stopWaveform`.  If only one tone was running and timed out,
`stopWaveform` would check the `enabled` bitmask and see nothing active
and immediately return w/o cancelling the IRQ.  So, the IRQ would be
called every 1/100th of a second and return immediately when no work to
be done was detected.

Remove the check and always send in a `waveformToDisable` bit.  It's
save to disable an already disabled pin, so no logical consequences will
occur, and the final IRQ disable will be executed when appropriate.