### PR TITLE
WIP - Add device tests for PWM and Tone test/dev

### DIFF
--- a/tests/pwm/README.md
+++ b/tests/pwm/README.md
@@ -1,0 +1,29 @@
+#PWM Tests
+
+WIP
+
+This directory contains a slave app to be uploaded and run on the ESP8266
+and a series of tests which will perform measurements on the PWM performance
+of the current PR.
+
+It requires:
+* ESP8266
+* Sigrok-CLI (https://sigrok.org/)
+* USB logic analyzer compatible with Sigrok-CLI
+
+##Prepare for testing
+* Configure the IDE for either 80 or 160MHz operation.
+* Build and upload the test.ino file to the ESP8266 and verify basic connectivity (you can blink the LED, etc.).
+* Connect the logic analyzer to the desired output pins
+<insert wiring diagram here>
+* NOTE:  You will need to rebuild and reupload the app if you want to swap between 80 and 160mhz operation.
+
+##Running the tests
+* Ensure the serial monitor is closed in the Arduino IDE, and any LogicView or Sigrok apps are closed
+* Run the test using the commands:  <TBD>
+
+##Checking results
+Test results will be output to CSV files, comma delimited.
+
+##Adding Tests
+TBD.  For now, edit the test script.

--- a/tests/pwm/pwmtestersut.ino
+++ b/tests/pwm/pwmtestersut.ino
@@ -1,0 +1,42 @@
+#include <ESP8266WiFi.h>
+
+const int pin[] = { D0, D1, D2, D3, D4, D5, D6, D7, D8 };
+
+void setup() {
+  WiFi.disconnect(true);
+  WiFi.forceSleepBegin();
+  Serial.begin(115200);
+  Serial.printf("\nPWM tester\n");
+  Serial.printf("z        = Reset ESP8266\n");
+  Serial.printf("d # 0/1  = pinMode(D#, OUTPUT); digitalWrite(D#, h/l)\n");
+  Serial.printf("t # freq = pinMode(D#, OUTPUT); tone(D#, freq)\n");
+  Serial.printf("f freq   = analogWriteFreq(freq)\n");
+  Serial.printf("r range  = analogWriteRange(range)\n");
+  Serial.printf("a # val  = pinMode(D#, OUTPUT); analogWrite(D#, val)\n\n");
+}
+
+void loop() {
+  char buff[32];
+  if (Serial.available() > 0) {
+    memset(buff, 0, 32);
+    Serial.readBytesUntil('\n', buff, 31);
+    int a = 0, b = 0;
+    sscanf(buff, "%*s %d %d", &a, &b);
+    if (buff[0] == 'd') {
+      pinMode(pin[a], OUTPUT);
+      digitalWrite(pin[a], b ? HIGH : LOW);
+    } else if (buff[0] == 't') {
+      pinMode(pin[a], OUTPUT);
+      tone(pin[a], b);
+    } else if (buff[0] == 'f') {
+      analogWriteFreq(a);
+    } else if (buff[0] == 'r') {
+      analogWriteRange(a);
+    } else if (buff[0] == 'a') {
+      pinMode(pin[a], OUTPUT);
+      analogWrite(pin[a], b);
+    } else if (buff[0] == 'z') {
+      ESP.reset();
+    }
+  }
+}

--- a/tests/pwm/tester.ps1
+++ b/tests/pwm/tester.ps1
@@ -1,0 +1,87 @@
+# PWM tester
+
+# Sigrok configuration
+$sigrokcli = 'C:\Program Files (x86)\sigrok\sigrok-cli\sigrok-cli.exe'
+$samplerate = "24mhz"
+$samples = "120000"
+
+# Open and close the COM port as fast as possible
+function writeline([string]$text) {
+	$com = new-Object System.IO.Ports.SerialPort COM6,115200,None,8,One
+	$com.open()
+	$com.WriteLine($text)
+	$com.close()
+}
+
+# Probably smarter way to do this!
+function stddev([int[]]$vals) {
+	$sum = [float]0.0;
+	foreach ($e in $vals) { $sum += $e }
+	$avg = $sum / [float]$vals.length
+	$sum = [float]0.0;
+	foreach ($e in $vals) { $sum += ($e - $avg) * ($e - $avg) }
+	$sum = $sum / [float]$vals.length
+	$rho = [math]::sqrt($sum)
+	return $rho
+}
+
+writeline("z") # Reset the chip
+sleep 5
+writeline("r {0}" -f 1000)
+
+
+$freqs = 25000 # 1000, 5000, 10000, 20000, 30000, 40000
+
+"PWMFREQ,VALUE,CYCLES,PERIODAVGNS,TIMEHIGHAVGNS,PERIODSTDDEVNS,TIMEHIGHSTDDEVNS"
+foreach ($f in $freqs) {
+	#";Testing frequency: {0}`n" -f [string]$f;
+	writeline("f {0}" -f $f)
+	sleep 1
+	for ($i=0; $i -lt 1000; $i=$i+10) {
+		#"Testing PWM: {0}`n" -f [string]$i;
+		writeline("a {0} {1}" -f '8', $i)
+		writeline("a {0} {1}" -f '9', [string](1000-[int]$i))
+		sleep 1
+		(((& $sigrokcli -d fx2lafw -C D5=p -O csv --samples $samples -c samplerate=$samplerate) | Select-Object -Skip 3 ) -replace ' ', '') > run.csv
+		$csv = import-csv -path run.csv -delimiter ','
+		$cnt = $csv.length
+		# Skip any 0s to find first full edge
+		$x = 0;
+		$cyclecnt = 0;
+		$pdttl = 0;
+		$hittl = 0;
+		$pl = New-Object Collections.Generic.List[float]
+		$hl = New-Object Collections.Generic.List[float]
+		while ( $csv[$x].logic -eq 0 ) { $x++ }
+		for ($x=$x; $x -lt $cnt; $x++) {
+			$h = $csv[$x].nanoseconds
+			# Look for low
+			for ($x=$x; ($csv[$x].logic -eq 1) -and ($x -lt $cnt); $x++ ) { }
+			if ($x -lt $cnt) {
+				# Found 1->0 transition, record it
+				$l = $csv[$x].nanoseconds
+				$timehigh = $l - $h
+				# Now look for 0->1 so we can get period
+				for ($x=$x; ($csv[$x].logic -eq 0) -and ($x -lt $cnt); $x++ ) { }
+				if ($x -lt $cnt) {
+					$period = $csv[$x].nanoseconds - $h
+					$pdttl += $period
+					$hittl += $timehigh
+					$pl.Add($period)
+					$hl.Add($timehigh)
+					$cyclecnt++
+					#"Period {0} TimeHigh {1}" -f [string]$period, [string]$timehigh
+				}
+			}
+		}
+		if ($cyclecnt -le 0) {
+			"{0},{1},0,0,0,0,0" -f [string]$f, [string]$i
+		} else {
+			$pdavg = $pdttl / $cyclecnt
+			$hiavg = $hittl / $cyclecnt
+			$ps = stddev($pl)
+			$hs = stddev($hl)
+			"{0},{1},{2},{3},{4},{5},{6}" -f [string]$f, [string]$i, [string]$cyclecnt, [int]$pdavg, [int]$hiavg, [int]$ps, [int]$hs
+		}
+	}
+}


### PR DESCRIPTION
This is a WIP and includes a PowerShell script (yes, I hear the groans
already), but it will be moved to Python soon to allow cross-platform
compatibility.

A new directory under tests is added (because the tests/device are
self-contained and doesn't easily support the needs of this test).

A USB logic analyzer is required to be hooked up to the 8266, and a test
slave script should be uploaded.

The main test script, run on the host, will reset the chip, then run a
series of tests varying some parameter or other and collect individual
waveforms at each test point.

These raw waveforms are the post-processed to determine exact, per-cycle
phase, period, etc. parameters at that test point.

This will be repeated for every test point desired (the checked in
version now starts 2 25MHz analogWrites, one moviing from 0...1000 and
one moving from 1000...0) and calculates the performance.

Eventually this will be part of a makefile with a series of test scripts
running on a more general-purpose host test driver.