### PR TITLE
(WIP) mDNS: single instance for all interfaces (udp: +multicast on all interfaces)

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiUdp.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiUdp.cpp
@@ -87,7 +87,7 @@ uint8_t WiFiUDP::begin(uint16_t port)
 
 uint8_t WiFiUDP::beginMulticast(IPAddress multicast, uint16_t port)
 {
-    return beginMulticast(IPAddress(IP4_ADDR_ANY), multicast port);
+    return beginMulticast(IPAddress(IP4_ADDR_ANY), multicast, port);
 }
 
 uint8_t WiFiUDP::beginMulticast(IPAddress interfaceAddr, IPAddress multicast, uint16_t port)
@@ -161,7 +161,7 @@ int WiFiUDP::beginPacket(IPAddress ip, uint16_t port)
 int WiFiUDP::beginPacketMulticast(IPAddress multicastAddress, uint16_t port,
     IPAddress interfaceAddress, int ttl)
 {
-    if (!beginPacket(multicastAddress, port))
+    if (!beginPacket(multicastAddress, port)) {
         return 0;
     }
     _ctx->setMulticastInterface(interfaceAddress);

--- a/libraries/ESP8266WiFi/src/WiFiUdp.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiUdp.cpp
@@ -85,7 +85,7 @@ uint8_t WiFiUDP::begin(uint16_t port)
     return (_ctx->listen(IPAddress(), port)) ? 1 : 0;
 }
 
-uint8_t WiFiUDP::beginMulticast(IPAddress interfaceAddr, IPAddress multicast, uint16_t port)
+uint8_t WiFiUDP::beginMulticast(IPAddress multicast, uint16_t port)
 {
     return beginMulticast(IPAddress(IP4_ADDR_ANY), multicast port);
 }

--- a/libraries/ESP8266WiFi/src/WiFiUdp.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiUdp.cpp
@@ -87,6 +87,11 @@ uint8_t WiFiUDP::begin(uint16_t port)
 
 uint8_t WiFiUDP::beginMulticast(IPAddress interfaceAddr, IPAddress multicast, uint16_t port)
 {
+    return beginMulticast(IPAddress(IP4_ADDR_ANY), multicast port);
+}
+
+uint8_t WiFiUDP::beginMulticast(IPAddress interfaceAddr, IPAddress multicast, uint16_t port)
+{
     if (_ctx) {
         _ctx->unref();
         _ctx = 0;
@@ -156,11 +161,7 @@ int WiFiUDP::beginPacket(IPAddress ip, uint16_t port)
 int WiFiUDP::beginPacketMulticast(IPAddress multicastAddress, uint16_t port,
     IPAddress interfaceAddress, int ttl)
 {
-    if (!_ctx) {
-        _ctx = new UdpContext;
-        _ctx->ref();
-    }
-    if (!_ctx->connect(multicastAddress, port)) {
+    if (!beginPacket(multicastAddress, port))
         return 0;
     }
     _ctx->setMulticastInterface(interfaceAddress);
@@ -174,6 +175,14 @@ int WiFiUDP::endPacket()
         return 0;
 
     return (_ctx->send()) ? 1 : 0;
+}
+
+int WiFiUDP::endPacketOverMulticast()
+{
+    if (!_ctx)
+        return 0;
+
+    return (_ctx->send_multicast_all()) ? 1 : 0;
 }
 
 size_t WiFiUDP::write(uint8_t byte)

--- a/libraries/ESP8266WiFi/src/WiFiUdp.h
+++ b/libraries/ESP8266WiFi/src/WiFiUdp.h
@@ -48,15 +48,18 @@ public:
   void stop() override;
   // join a multicast group and listen on the given port
   uint8_t beginMulticast(IPAddress interfaceAddr, IPAddress multicast, uint16_t port);
+  uint8_t beginMulticast(IPAddress multicast, uint16_t port);
 
   // Sending UDP packets
   
   // Start building up a packet to send to the remote host specific in ip and port
   // Returns 1 if successful, 0 if there was a problem with the supplied IP address or port
   int beginPacket(IPAddress ip, uint16_t port) override;
+
   // Start building up a packet to send to the remote host specific in host and port
   // Returns 1 if successful, 0 if there was a problem resolving the hostname or port
   int beginPacket(const char *host, uint16_t port) override;
+
   // Start building up a packet to send to the multicast address
   // multicastAddress - muticast address to send to
   // interfaceAddress - the local IP address of the interface that should be used
@@ -67,9 +70,14 @@ public:
                                    uint16_t port, 
                                    IPAddress interfaceAddress,
                                    int ttl = 1);
+
   // Finish off this packet and send it
   // Returns 1 if the packet was sent successfully, 0 if there was an error
   int endPacket() override;
+
+  int beginPacketOverMulticast(const IPAddress& ip, uint16_t port) { return beginPacket(ip, port); }
+  int endPacketOverMulticast();
+
   // Write a single byte into the packet
   size_t write(uint8_t) override;
   // Write size bytes from buffer into the packet

--- a/libraries/ESP8266mDNS/src/LEAmDNS.cpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS.cpp
@@ -62,11 +62,10 @@ MDNSResponder::MDNSResponder(void)
         m_pServiceQueries(0),
         m_fnServiceTxtCallback(0),
 #ifdef ENABLE_ESP_MDNS_RESPONDER_PASSIV_MODE
-        m_bPassivModeEnabled(true),
+        m_bPassivModeEnabled(true)
 #else
-        m_bPassivModeEnabled(false),
+        m_bPassivModeEnabled(false)
 #endif
-        m_netif(nullptr)
 {
 }
 
@@ -95,6 +94,7 @@ MDNSResponder::~MDNSResponder(void)
 bool MDNSResponder::begin(const char* p_pcHostname, const IPAddress& p_IPAddress, uint32_t p_u32TTL)
 {
 
+    (void)p_IPAddress;
     (void)p_u32TTL; // ignored
     bool    bResult = false;
 
@@ -102,82 +102,25 @@ bool MDNSResponder::begin(const char* p_pcHostname, const IPAddress& p_IPAddress
     {
         if (_setHostname(p_pcHostname))
         {
-
-            //// select interface
-
-            m_netif = nullptr;
-            IPAddress ipAddress = p_IPAddress;
-
-            if (!ipAddress.isSet())
+            m_GotIPHandler = WiFi.onStationModeGotIP([this](const WiFiEventStationModeGotIP & pEvent)
             {
-
-                IPAddress sta = WiFi.localIP();
-                IPAddress ap = WiFi.softAPIP();
-
-                if (sta.isSet())
+                (void) pEvent;
+                // Ensure that _restart() runs in USER context
+                schedule_function([this]()
                 {
-                    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] STA interface selected\n")));
-                    ipAddress = sta;
-                }
-                else if (ap.isSet())
-                {
-                    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] AP interface selected\n")));
-                    ipAddress = ap;
-                }
-                else
-                {
-                    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] standard interfaces are not up, please specify one in ::begin()\n")));
-                    return false;
-                }
-
-                // continue to ensure interface is UP
-            }
-
-            // check existence of this IP address in the interface list
-            bool found = false;
-            m_netif = nullptr;
-            for (auto a : addrList)
-                if (ipAddress == a.addr())
-                {
-                    if (a.ifUp())
-                    {
-                        found = true;
-                        m_netif = a.interface();
-                        break;
-                    }
-                    DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] found interface for IP '%s' but it is not UP\n"), ipAddress.toString().c_str()););
-                }
-            if (!found)
-            {
-                DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] interface defined by IP '%s' not found\n"), ipAddress.toString().c_str()););
-                return false;
-            }
-
-            //// done selecting the interface
-
-            if (m_netif->num == STATION_IF)
-            {
-
-                m_GotIPHandler = WiFi.onStationModeGotIP([this](const WiFiEventStationModeGotIP & pEvent)
-                {
-                    (void) pEvent;
-                    // Ensure that _restart() runs in USER context
-                    schedule_function([this]()
-                    {
-                        MDNSResponder::_restart();
-                    });
+                    MDNSResponder::_restart();
                 });
+            });
 
-                m_DisconnectedHandler = WiFi.onStationModeDisconnected([this](const WiFiEventStationModeDisconnected & pEvent)
+            m_DisconnectedHandler = WiFi.onStationModeDisconnected([this](const WiFiEventStationModeDisconnected & pEvent)
+            {
+                (void) pEvent;
+                // Ensure that _restart() runs in USER context
+                schedule_function([this]()
                 {
-                    (void) pEvent;
-                    // Ensure that _restart() runs in USER context
-                    schedule_function([this]()
-                    {
-                        MDNSResponder::_restart();
-                    });
+                    MDNSResponder::_restart();
                 });
-            }
+            });
 
             bResult = _restart();
         }

--- a/libraries/ESP8266mDNS/src/LEAmDNS.h
+++ b/libraries/ESP8266mDNS/src/LEAmDNS.h
@@ -1203,7 +1203,6 @@ protected:
     MDNSDynamicServiceTxtCallbackFunc m_fnServiceTxtCallback;
     bool                            m_bPassivModeEnabled;
     stcProbeInformation             m_HostProbeInformation;
-    CONST netif*                    m_netif; // network interface to run on
 
     /** CONTROL **/
     /* MAINTENANCE */
@@ -1258,10 +1257,12 @@ protected:
                         uint16_t p_u16QueryType,
                         stcMDNSServiceQuery::stcAnswer* p_pKnownAnswers = 0);
 
+/*
     const IPAddress _getResponseMulticastInterface() const
     {
-        return IPAddress(m_netif->ip_addr);
+        return IPAddress(IP4_ANY_ADDR);
     }
+*/
 
     uint8_t _replyMaskForHost(const stcMDNS_RRHeader& p_RRHeader,
                               bool* p_pbFullNameMatch = 0) const;

--- a/libraries/ESP8266mDNS/src/LEAmDNS.h
+++ b/libraries/ESP8266mDNS/src/LEAmDNS.h
@@ -1257,12 +1257,10 @@ protected:
                         uint16_t p_u16QueryType,
                         stcMDNSServiceQuery::stcAnswer* p_pKnownAnswers = 0);
 
-/*
     const IPAddress _getResponseMulticastInterface() const
     {
-        return IPAddress(IP4_ANY_ADDR);
+        return IPAddress(IP4_ADDR_ANY);
     }
-*/
 
     uint8_t _replyMaskForHost(const stcMDNS_RRHeader& p_RRHeader,
                               bool* p_pbFullNameMatch = 0) const;

--- a/libraries/ESP8266mDNS/src/LEAmDNS_Control.cpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS_Control.cpp
@@ -84,9 +84,7 @@ bool MDNSResponder::_process(bool p_bUserContext)
     }
     else
     {
-        bResult = (m_netif != nullptr) &&
-                  (m_netif->flags & NETIF_FLAG_UP) &&  // network interface is up and running
-                  _updateProbeStatus() &&              // Probing
+        bResult = _updateProbeStatus() &&              // Probing
                   _checkServiceQueryCache();           // Service query cache check
     }
     return bResult;
@@ -98,9 +96,7 @@ bool MDNSResponder::_process(bool p_bUserContext)
 bool MDNSResponder::_restart(void)
 {
 
-    return ((m_netif != nullptr) &&
-            (m_netif->flags & NETIF_FLAG_UP) &&  // network interface is up and running
-            (_resetProbeStatus(true)) &&         // Stop and restart probing
+    return ((_resetProbeStatus(true)) &&         // Stop and restart probing
             (_allocUDPContext()));               // Restart UDP
 }
 

--- a/libraries/ESP8266mDNS/src/LEAmDNS_Helpers.cpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS_Helpers.cpp
@@ -221,12 +221,12 @@ bool MDNSResponder::_allocUDPContext(void)
     //TODO: set multicast address (lwip_joingroup() is IPv4 only at the time of writing)
     multicast_addr.addr = DNS_MQUERY_IPV6_GROUP_INIT;
 #endif
-    if (ERR_OK == igmp_joingroup(ip_2_ip4(&m_netif->ip_addr), ip_2_ip4(&multicast_addr)))
+    if (ERR_OK == igmp_joingroup(IP4_ADDR_ANY, ip_2_ip4(&multicast_addr)))
     {
         m_pUDPContext = new UdpContext;
         m_pUDPContext->ref();
 
-        if (m_pUDPContext->listen(&m_netif->ip_addr, DNS_MQUERY_PORT))
+        if (m_pUDPContext->listen(IP4_ADDR_ANY, DNS_MQUERY_PORT))
         {
             m_pUDPContext->setMulticastTTL(MDNS_MULTICAST_TTL);
             m_pUDPContext->onRx(std::bind(&MDNSResponder::_callProcess, this));

--- a/libraries/ESP8266mDNS/src/LEAmDNS_Helpers.cpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS_Helpers.cpp
@@ -221,7 +221,7 @@ bool MDNSResponder::_allocUDPContext(void)
     //TODO: set multicast address (lwip_joingroup() is IPv4 only at the time of writing)
     multicast_addr.addr = DNS_MQUERY_IPV6_GROUP_INIT;
 #endif
-    if (ERR_OK == igmp_joingroup(IP4_ADDR_ANY, ip_2_ip4(&multicast_addr)))
+    if (ERR_OK == igmp_joingroup(IP4_ADDR_ANY4, ip_2_ip4(&multicast_addr)))
     {
         m_pUDPContext = new UdpContext;
         m_pUDPContext->ref();

--- a/libraries/ESP8266mDNS/src/LEAmDNS_Transfer.cpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS_Transfer.cpp
@@ -133,7 +133,7 @@ bool MDNSResponder::_sendMDNSMessage_Multicast(MDNSResponder::stcMDNSSendParamet
 #endif
     DEBUG_EX_INFO(DEBUG_OUTPUT.printf_P(PSTR("[MDNSResponder] _sendMDNSMessage_Multicast: Will send to '%s'.\n"), toMulticastAddress.toString().c_str()););
     bResult = ((_prepareMDNSMessage(p_rSendParameter, fromIPAddress)) &&
-               (m_pUDPContext->send(toMulticastAddress, DNS_MQUERY_PORT)));
+               (m_pUDPContext->send_multicast_all(toMulticastAddress, DNS_MQUERY_PORT)));
 
     DEBUG_EX_ERR(if (!bResult)
 {


### PR DESCRIPTION
- added `UdpContext::send_multicast_all()` to send a multicast packet on all interfaces
- LEAmDNS adapted to use this change

Notes:
- throwing as WIP:
  - due to lack of time for extensive testing right now
  - some may test as hotfix for multiple interfaces single instance (@BbIKTOP ?)
  - lwIP1.4 will not build
- so far tested **only** with one interface and LEAmDNS example mDNSClock (working)
- new API may evolve
- new API doc will be added
- Arduino API unchanged