### PR TITLE
Allocate BSSL stack for SigningVerifier

### DIFF
--- a/libraries/ESP8266WiFi/src/BearSSLHelpers.h
+++ b/libraries/ESP8266WiFi/src/BearSSLHelpers.h
@@ -24,6 +24,7 @@
 #define _BEARSSLHELPERS_H
 
 #include <bearssl/bearssl.h>
+#include <StackThunk.h>
 #include <Updater.h>
 
 // Internal opaque structures, not needed by user applications
@@ -157,7 +158,8 @@ class SigningVerifier : public UpdaterVerifyClass {
     virtual bool verify(UpdaterHashClass *hash, const void *signature, uint32_t signatureLen) override;
 
   public:
-    SigningVerifier(PublicKey *pubKey) { _pubKey = pubKey; }
+    SigningVerifier(PublicKey *pubKey) { _pubKey = pubKey; stack_thunk_add_ref(); }
+    ~SigningVerifier() { stack_thunk_del_ref(); }
 
   private:
     PublicKey *_pubKey;


### PR DESCRIPTION
The BearSSL SigningVerifier was moved to the 2nd stack because some uses
required much more stack than available on the normal stack.

Add a reference to the second stack on object creation (which will
allocate it, if there is no BSSL stack already allocated), and delete
that reference on exit.

Fixes #7288