### PR TITLE
Flash size reduction for mime-type

### DIFF
--- a/libraries/ESP8266WebServer/src/detail/mimetable.cpp
+++ b/libraries/ESP8266WebServer/src/detail/mimetable.cpp
@@ -7,8 +7,9 @@ namespace mime
 
 static const char kHtmlSuffix[] PROGMEM = ".html";
 static const char kHtmSuffix[] PROGMEM = ".htm";
-static const char kCssSuffix[] PROGMEM = ".css";
 static const char kTxtSuffix[] PROGMEM = ".txt";
+#ifndef MIMETYPE_MINIMAL
+static const char kCssSuffix[] PROGMEM = ".css";
 static const char kJsSuffix[] PROGMEM = ".js";
 static const char kJsonSuffix[] PROGMEM = ".json";
 static const char kPngSuffix[] PROGMEM = ".png";
@@ -26,13 +27,15 @@ static const char kSfntSuffix[] PROGMEM = ".sfnt";
 static const char kXmlSuffix[] PROGMEM = ".xml";
 static const char kPdfSuffix[] PROGMEM = ".pdf";
 static const char kZipSuffix[] PROGMEM = ".zip";
-static const char kGzSuffix[] PROGMEM = ".gz";
 static const char kAppcacheSuffix[] PROGMEM = ".appcache";
+#endif // MIMETYPE_MINIMAL
+static const char kGzSuffix[] PROGMEM = ".gz";
 static const char kDefaultSuffix[] PROGMEM = "";
 
 static const char kHtml[] PROGMEM = "text/html";
-static const char kCss[] PROGMEM = "text/css";
 static const char kTxt[] PROGMEM = "text/plain";
+#ifndef MIMETYPE_MINIMAL
+static const char kCss[] PROGMEM = "text/css";
 static const char kJs[] PROGMEM = "application/javascript";
 static const char kJson[] PROGMEM = "application/json";
 static const char kPng[] PROGMEM = "image/png";
@@ -50,8 +53,9 @@ static const char kSfnt[] PROGMEM = "application/font-sfnt";
 static const char kXml[] PROGMEM = "text/xml";
 static const char kPdf[] PROGMEM = "application/pdf";
 static const char kZip[] PROGMEM = "application/zip";
-static const char kGz[] PROGMEM = "application/x-gzip";
 static const char kAppcache[] PROGMEM = "text/cache-manifest";
+#endif // MIMETYPE_MINIMAL
+static const char kGz[] PROGMEM = "application/x-gzip";
 static const char kDefault[] PROGMEM = "application/octet-stream";
 
 const Entry mimeTable[maxType] PROGMEM =

--- a/libraries/ESP8266WebServer/src/detail/mimetable.cpp
+++ b/libraries/ESP8266WebServer/src/detail/mimetable.cpp
@@ -5,48 +5,93 @@
 namespace mime
 {
 
-// Table of extension->MIME strings stored in PROGMEM, needs to be global due to GCC section typing rules
-const Entry mimeTable[maxType] PROGMEM = 
+static const char kHtmlSuffix[] PROGMEM = ".html";
+static const char kHtmSuffix[] PROGMEM = ".htm";
+static const char kCssSuffix[] PROGMEM = ".css";
+static const char kTxtSuffix[] PROGMEM = ".txt";
+static const char kJsSuffix[] PROGMEM = ".js";
+static const char kJsonSuffix[] PROGMEM = ".json";
+static const char kPngSuffix[] PROGMEM = ".png";
+static const char kGifSuffix[] PROGMEM = ".gif";
+static const char kJpgSuffix[] PROGMEM = ".jpg";
+static const char kJpegSuffix[] PROGMEM = ".jpeg";
+static const char kIcoSuffix[] PROGMEM = ".ico";
+static const char kSvgSuffix[] PROGMEM = ".svg";
+static const char kTtfSuffix[] PROGMEM = ".ttf";
+static const char kOtfSuffix[] PROGMEM = ".otf";
+static const char kWoffSuffix[] PROGMEM = ".woff";
+static const char kWoff2Suffix[] PROGMEM = ".woff2";
+static const char kEotSuffix[] PROGMEM = ".eot";
+static const char kSfntSuffix[] PROGMEM = ".sfnt";
+static const char kXmlSuffix[] PROGMEM = ".xml";
+static const char kPdfSuffix[] PROGMEM = ".pdf";
+static const char kZipSuffix[] PROGMEM = ".zip";
+static const char kGzSuffix[] PROGMEM = ".gz";
+static const char kAppcacheSuffix[] PROGMEM = ".appcache";
+static const char kDefaultSuffix[] PROGMEM = "";
+
+static const char kHtml[] PROGMEM = "text/html";
+static const char kCss[] PROGMEM = "text/css";
+static const char kTxt[] PROGMEM = "text/plain";
+static const char kJs[] PROGMEM = "application/javascript";
+static const char kJson[] PROGMEM = "application/json";
+static const char kPng[] PROGMEM = "image/png";
+static const char kGif[] PROGMEM = "image/gif";
+static const char kJpg[] PROGMEM = "image/jpeg";
+static const char kJpeg[] PROGMEM = "image/jpeg";
+static const char kIco[] PROGMEM = "image/x-icon";
+static const char kSvg[] PROGMEM = "image/svg+xml";
+static const char kTtf[] PROGMEM = "application/x-font-ttf";
+static const char kOtf[] PROGMEM = "application/x-font-opentype";
+static const char kWoff[] PROGMEM = "application/font-woff";
+static const char kWoff2[] PROGMEM = "application/font-woff2";
+static const char kEot[] PROGMEM = "application/vnd.ms-fontobject";
+static const char kSfnt[] PROGMEM = "application/font-sfnt";
+static const char kXml[] PROGMEM = "text/xml";
+static const char kPdf[] PROGMEM = "application/pdf";
+static const char kZip[] PROGMEM = "application/zip";
+static const char kGz[] PROGMEM = "application/x-gzip";
+static const char kAppcache[] PROGMEM = "text/cache-manifest";
+static const char kDefault[] PROGMEM = "application/octet-stream";
+
+const Entry mimeTable[maxType] PROGMEM =
 {
-    { ".html", "text/html" },
-    { ".htm", "text/html" },
-    { ".css", "text/css" },
-    { ".txt", "text/plain" },
-    { ".js", "application/javascript" },
-    { ".json", "application/json" },
-    { ".png", "image/png" },
-    { ".gif", "image/gif" },
-    { ".jpg", "image/jpeg" },
-    { ".jpeg", "image/jpeg" },
-    { ".ico", "image/x-icon" },
-    { ".svg", "image/svg+xml" },
-    { ".ttf", "application/x-font-ttf" },
-    { ".otf", "application/x-font-opentype" },
-    { ".woff", "application/font-woff" },
-    { ".woff2", "application/font-woff2" },
-    { ".eot", "application/vnd.ms-fontobject" },
-    { ".sfnt", "application/font-sfnt" },
-    { ".xml", "text/xml" },
-    { ".pdf", "application/pdf" },
-    { ".zip", "application/zip" },
-    { ".gz", "application/x-gzip" },
-    { ".appcache", "text/cache-manifest" },
-    { "", "application/octet-stream" } 
+    { kHtmlSuffix, kHtml },
+    { kHtmSuffix, kHtml },
+    { kTxtSuffix, kTxtSuffix },
+#ifndef MIMETYPE_MINIMAL
+    { kCssSuffix, kCss },
+    { kJsSuffix, kJs },
+    { kJsonSuffix, kJson },
+    { kPngSuffix, kPng },
+    { kGifSuffix, kGif },
+    { kJpgSuffix, kJpg },
+    { kJpegSuffix, kJpeg },
+    { kIcoSuffix, kIco },
+    { kSvgSuffix, kSvg },
+    { kTtfSuffix, kTtf },
+    { kOtfSuffix, kOtf },
+    { kWoffSuffix, kWoff },
+    { kWoff2Suffix, kWoff2 },
+    { kEotSuffix, kEot },
+    { kSfntSuffix, kSfnt },
+    { kXmlSuffix, kXml },
+    { kPdfSuffix, kPdf },
+    { kZipSuffix, kZip },
+    { kAppcacheSuffix, kAppcache },
+#endif // MIMETYPE_MINIMAL
+    { kGzSuffix, kGz },
+    { kDefaultSuffix, kDefault }
 };
 
     String getContentType(const String& path) {
-        char buff[sizeof(mimeTable[0].mimeType)];
-        // Check all entries but last one for match, return if found
-        for (size_t i=0; i < sizeof(mimeTable)/sizeof(mimeTable[0])-1; i++) {
-            strcpy_P(buff, mimeTable[i].endsWith);
-            if (path.endsWith(buff)) {
-                strcpy_P(buff, mimeTable[i].mimeType);
-                return String(buff);
+        for (size_t i = 0; i < maxType; i++) {
+            if (path.endsWith(FPSTR(mimeTable[i].endsWith))) {
+                return String(FPSTR(mimeTable[i].mimeType));
             }
         }
         // Fall-through and just return default type
-        strcpy_P(buff, mimeTable[sizeof(mimeTable)/sizeof(mimeTable[0])-1].mimeType);
-        return String(buff);
+        return String(FPSTR(kDefault));
     }
 
 }

--- a/libraries/ESP8266WebServer/src/detail/mimetable.h
+++ b/libraries/ESP8266WebServer/src/detail/mimetable.h
@@ -10,8 +10,9 @@ enum type
 {
   html,
   htm,
-  css,
   txt,
+#ifndef MIMETYPE_MINIMAL    // allow to compile with only the strict minimum of mime-types
+  css,
   js,
   json,
   png,
@@ -29,16 +30,17 @@ enum type
   xml,
   pdf,
   zip,
-  gz,
   appcache,
+#endif // MIMETYPE_MINIMAL
+  gz,
   none,
   maxType
 };
 
 struct Entry
 {
-  const char endsWith[16]; 
-  const char mimeType[32];
+  const char * endsWith; 
+  const char * mimeType;
 };
 
 


### PR DESCRIPTION
Superseded #7311 

The current mime-type array is based on `Entry` structure with fixed size string that waste a lot of Flash space (~400 bytes):
```
struct Entry
{
  const char endsWith[16]; 
  const char mimeType[32];
};
```

I replaced with standard PROGMEM strings.

I also added `#define MIMETYPE_MINIMAL` to reduce the footprint to mime-types that are strictly necessary: `html`, `txt`, `gz`

Overall this saves 1kB for Tasmota.

