### PR TITLE
Fix configTime(tz,dst,)

### DIFF
--- a/cores/esp8266/time.cpp
+++ b/cores/esp8266/time.cpp
@@ -175,7 +175,7 @@ void configTime(int timezone_sec, int daylightOffset_sec, const char* server1, c
         tzr->d = 0;
         tzr->s = 0;
         tzr->change = 0;
-        tzr->offset = _timezone;
+        tzr->offset = -_timezone;
     }
 
     // sntp servers


### PR DESCRIPTION
fixes #7319

Timezone sign was incorrectly set