### PR TITLE
Document ESP.getMaxFreeBlockSize() != max malloc size

### DIFF
--- a/doc/libraries.rst
+++ b/doc/libraries.rst
@@ -87,7 +87,7 @@ Some ESP-specific APIs related to deep sleep, RTC and flash memories are availab
 
 ``ESP.getHeapFragmentation()`` returns the fragmentation metric (0% is clean, more than ~50% is not harmless)
 
-``ESP.getMaxFreeBlockSize()`` returns the maximum allocatable ram block regarding heap fragmentation
+``ESP.getMaxFreeBlockSize()`` returns the largest contiguous free RAM block in the heap, useful for checking heap fragmentation.  **NOTE:** Maximum ``malloc()``able block will be smaller due to memory manager overheads.
 
 ``ESP.getChipId()`` returns the ESP8266 chip ID as a 32-bit integer.
 


### PR DESCRIPTION
Fixes #7322.  Because of UMM internals, the largest `malloc()`able block
will be smaller than the largest contiguous free RAM block.  Note in the docs.