### PR TITLE
Add documentation on recovering from deep sleep with WAKE_RF_DISABLED

### DIFF
--- a/doc/faq/readme.rst
+++ b/doc/faq/readme.rst
@@ -136,7 +136,7 @@ For reference:
 
 Time-wait PCB state helps TCP not confusing two consecutive connections with the
 same (s-ip,s-port,d-ip,d-port) when the first is already closed but still
-having duplicate packets lost in internet arriving later during the second. 
+having duplicate packets lost in internet arriving later during the second.
 Artificially clearing them is a workaround to help saving precious heap.
 
 The following lines are compatible with both lwIP versions:
@@ -147,7 +147,7 @@ The following lines are compatible with both lwIP versions:
     struct tcp_pcb;
     extern struct tcp_pcb* tcp_tw_pcbs;
     extern "C" void tcp_abort (struct tcp_pcb* pcb);
-    
+
     void tcpCleanup (void) {
       while (tcp_tw_pcbs)
         tcp_abort(tcp_tw_pcbs);
@@ -168,3 +168,13 @@ This script is also used to manage uncommon options that are currently not
 available in the IDE menu.
 
 `Read more <a05-board-generator.rst>`__.
+
+My WiFi won't reconnect after deep sleep using ``WAKE_RF_DISABLED``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When you implement deep sleep using ``WAKE_RF_DISABLED``, this forces what
+appears to be a bare metal disabling of WiFi functionality, which is not
+restored using ``WiFi.forceSleepWake()`` or ``WiFi.mode(WIFI_STA)``. If you need
+to implement deep sleep with ``WAKE_RF_DISABLED`` and later connect to WiFi, you
+will need to implement an additional (short) deep sleep using
+``WAKE_RF_DEFAULT``.

--- a/doc/faq/readme.rst
+++ b/doc/faq/readme.rst
@@ -178,3 +178,5 @@ restored using ``WiFi.forceSleepWake()`` or ``WiFi.mode(WIFI_STA)``. If you need
 to implement deep sleep with ``WAKE_RF_DISABLED`` and later connect to WiFi, you
 will need to implement an additional (short) deep sleep using
 ``WAKE_RF_DEFAULT``.
+
+Ref.  `#3072 <https://github.com/esp8266/Arduino/issues/3072#issuecomment-288530130>`__

--- a/doc/faq/readme.rst
+++ b/doc/faq/readme.rst
@@ -179,4 +179,4 @@ to implement deep sleep with ``WAKE_RF_DISABLED`` and later connect to WiFi, you
 will need to implement an additional (short) deep sleep using
 ``WAKE_RF_DEFAULT``.
 
-Ref.  `#3072 <https://github.com/esp8266/Arduino/issues/3072#issuecomment-288530130>`__
+Ref.  `#3072 <https://github.com/esp8266/Arduino/issues/3072>`__

--- a/doc/libraries.rst
+++ b/doc/libraries.rst
@@ -41,7 +41,7 @@ SPI
 
 SPI library supports the entire Arduino SPI API including transactions, including setting phase (CPHA). Setting the Clock polarity (CPOL) is not supported, yet (SPI\_MODE2 and SPI\_MODE3 not working).
 
-The usual SPI pins are: 
+The usual SPI pins are:
 
 - ``MOSI`` = GPIO13
 - ``MISO`` = GPIO12
@@ -73,7 +73,7 @@ ESP-specific APIs
 
 Some ESP-specific APIs related to deep sleep, RTC and flash memories are available in the ``ESP`` object.
 
-``ESP.deepSleep(microseconds, mode)`` will put the chip into deep sleep. ``mode`` is one of ``WAKE_RF_DEFAULT``, ``WAKE_RFCAL``, ``WAKE_NO_RFCAL``, ``WAKE_RF_DISABLED``. (GPIO16 needs to be tied to RST to wake from deepSleep.) The chip can sleep for at most ``ESP.deepSleepMax()`` microseconds.
+``ESP.deepSleep(microseconds, mode)`` will put the chip into deep sleep. ``mode`` is one of ``WAKE_RF_DEFAULT``, ``WAKE_RFCAL``, ``WAKE_NO_RFCAL``, ``WAKE_RF_DISABLED``. (GPIO16 needs to be tied to RST to wake from deepSleep.) The chip can sleep for at most ``ESP.deepSleepMax()`` microseconds. If you implement deep sleep with ``WAKE_RF_DISABLED`` and require WiFi functionality on wake up, you will need to implement an additional ``WAKE_RF_DEFAULT`` before WiFi functionality is available.
 
 ``ESP.deepSleepInstant(microseconds, mode)`` works similarly to ``ESP.deepSleep`` but  sleeps instantly without waiting for WiFi to shutdown.
 


### PR DESCRIPTION
This PR adds an extra line of documentation and a new FAQ entry relating to #3072, on how to enable WiFi connectivity after implementing deep sleep with `WAKE_RF_DISABLED`