### PR TITLE
libraries/SPI: abs -> std::abs and cast fixes

### DIFF
--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -260,7 +260,7 @@ void SPIClass::setFrequency(uint32_t freq) {
                 break;
             } else if(calFreq < (int32_t) freq) {
                 // never go over the requested frequency
-                if(abs(freq - calFreq) < abs(freq - bestFreq)) {
+                if((freq - calFreq) < (freq - bestFreq)) {
                     bestFreq = calFreq;
                     memcpy(&bestReg, &reg, sizeof(bestReg));
                 }

--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -22,7 +22,6 @@
 #define _SPI_H_INCLUDED
 
 #include <Arduino.h>
-#include <stdlib.h>
 
 #define SPI_HAS_TRANSACTION 1
 


### PR DESCRIPTION
Not to complicate comment chain in #6294 further

SPI library code erroneously assumed that <s>abs() is a C function, so include stdlib.h is required.
  what happens instead is Arduino.h shadows `abs()` with it's own macro</s>
`freq - calFreq` or `freq - bestFreq` may produce negative results and require `abs()`
In the referenced PR, when adding `using std::abs;` it confuses GCC by introducing multiple functions named abs(), neither of which have uint32_t argument. As it turns out, `uint32_t() - int32_t()` promotes to `uint32_t`, where old libc abs() silently converted it back to `int`

Fixing casts for `freq` to explicitly make it a signed int when comparing with generated values, both of which are signed.

*edit: noting that abs() isn't a macro and we actually want signedness*