### PR TITLE
Fix the bad address of the the AP if the settings are wrong

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiAP.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiAP.cpp
@@ -170,8 +170,8 @@ bool ESP8266WiFiAPClass::softAP(const char* ssid, const char* passphrase, int ch
         if(ip.ip.addr == 0x00000000) {
             // Invalid config
             DEBUG_WIFI("[AP] IP config Invalid resetting...\n");
-            //192.168.244.1 , 192.168.244.1 , 255.255.255.0
-            ret = softAPConfig(0x01F4A8C0, 0x01F4A8C0, 0x00FFFFFF);
+            //192.168.4.1 , 192.168.4.1 , 255.255.255.0
+            ret = softAPConfig(0x0104A8C0, 0x00F4A8C0, 0x00FFFFFF);
             if(!ret) {
                 DEBUG_WIFI("[AP] softAPConfig failed!\n");
                 ret = false;


### PR DESCRIPTION
Hi,
This should fix the problem seen from time to time on our device. The default IP should be 192.168.4.1 and not 192.168.244.1

This should fix this issue: https://github.com/esp8266/Arduino/issues/5627