### PR TITLE
For UMM_CRITICAL_METRICS fixed time_stats initializer. 

### DIFF
--- a/cores/esp8266/heap.cpp
+++ b/cores/esp8266/heap.cpp
@@ -20,7 +20,7 @@ extern "C" {
 #undef realloc
 #undef free
 
-#elif defined(DEBUG_ESP_OOM)
+#elif defined(DEBUG_ESP_OOM) || defined(UMM_INTEGRITY_CHECK)
 #define UMM_MALLOC(s)           umm_malloc(s)
 #define UMM_CALLOC(n,s)         umm_calloc(n,s)
 #define UMM_REALLOC_FL(p,s,f,l) umm_realloc(p,s)

--- a/cores/esp8266/umm_malloc/umm_local.c
+++ b/cores/esp8266/umm_malloc/umm_local.c
@@ -15,7 +15,7 @@ UMM_TIME_STATS time_stats = {
 #ifdef UMM_INFO
     {0xFFFFFFFF, 0U, 0U, 0U},
 #endif
-#ifdef UMM_POISON_CHECK
+#if defined(UMM_POISON_CHECK) || defined(UMM_POISON_CHECK_LITE)
     {0xFFFFFFFF, 0U, 0U, 0U},
 #endif
 #ifdef UMM_INTEGRITY_CHECK

--- a/cores/esp8266/umm_malloc/umm_malloc.cpp
+++ b/cores/esp8266/umm_malloc/umm_malloc.cpp
@@ -647,9 +647,21 @@ void *umm_realloc( void *ptr, size_t size ) {
 
   DBGLOG_DEBUG( "realloc blocks %d blockSize %d nextBlockSize %d prevBlockSize %d\n", blocks, blockSize, nextBlockSize, prevBlockSize );
 
-//C This has changed need to review and see if UMM_REALLOC_MINIMIZE_COPY really
-//C is that any more. or is it equivalent or close enough to my defrag
-//C - mjh
+//C With each upstream update this section should be reevaluated.
+/*C
+ *
+ * The `#if defined(UMM_REALLOC_MINIMIZE_COPY)` section tracks the content of
+ * the upstream with some local macros added. Back when I made my 1st update to
+ * umm_malloc PR, I found the upstream had been refactored and removed the
+ * defragmenting properties that were originally present. It took some looking
+ * to see the logic, it didn't have any comments to make it stand out.
+ *
+ * I added the `#elif defined(UMM_REALLOC_DEFRAG)` to recreate and preserve the
+ * defragmenting functionality that was lost. This is the default build option
+ * we have set in `umm_malloc_cfg.h`. I have not done any structured testing to
+ * confirm; however, I think this to be the best option when considering the
+ * amount of reallocates that can occur with the Strings library.
+ */
 #if defined(UMM_REALLOC_MINIMIZE_COPY)
   /*
    * Ok, now that we're here we know how many blocks we want and the current

--- a/cores/esp8266/umm_malloc/umm_poison.c
+++ b/cores/esp8266/umm_malloc/umm_poison.c
@@ -69,7 +69,7 @@ static bool check_poison( const void *ptr, size_t poison_size,
  * blocks.
  */
 static bool check_poison_block( umm_block *pblock ) {
-  int ok = true;
+  bool ok = true;
 
   if (pblock->header.used.next & UMM_FREELIST_MASK) {
     DBGLOG_ERROR( "check_poison_block is called for free block 0x%lx\n", (unsigned long)pblock);


### PR DESCRIPTION
Corrected missed edit in check_poison_block() change variable ok from int to bool.

Updated time_stats (used by UMM_CRITICAL_METRICS) initializer to
include UMM_POINSON_CHECK_LITE.

Update maintenance comment block for UMM_REALLOC_...