### PR TITLE
I2C pin assignment fix

### DIFF
--- a/variants/modwifi/pins_arduino.h
+++ b/variants/modwifi/pins_arduino.h
@@ -27,7 +27,7 @@
 #define Pins_Arduino_h
 
 #define PIN_WIRE_SDA (2)
-#define PIN_WIRE_SCL (4)
+#define PIN_WIRE_SCL (14)
 
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;


### PR DESCRIPTION
There was a typo in I2C pin assignment, SCL was set to GPIO #4 instead of GPIO #14, The schematic can be seen here: https://github.com/OLIMEX/ESP8266/blob/master/HARDWARE/MOD-WIFI-ESP8266-DEV/MOD-WiFi-ESP8266-DEV%20revision%20B1/MOD-WiFi-ESP8266-DEV_Rev_B1.pdf