### PR TITLE
Ability to set connect timeout in WifiMulti->run

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp
@@ -46,7 +46,7 @@ bool ESP8266WiFiMulti::existsAP(const char* ssid, const char *passphrase) {
     return APlistExists(ssid, passphrase);
 }
 
-wl_status_t ESP8266WiFiMulti::run(void) {
+wl_status_t ESP8266WiFiMulti::run(uint32_t connectTimeout) {
 
     wl_status_t status = WiFi.status();
     if(status == WL_DISCONNECTED || status == WL_NO_SSID_AVAIL || status == WL_IDLE_STATUS || status == WL_CONNECT_FAILED) {
@@ -132,8 +132,6 @@ wl_status_t ESP8266WiFiMulti::run(void) {
 
                 WiFi.begin(bestNetwork.ssid, bestNetwork.passphrase, bestChannel, bestBSSID);
                 status = WiFi.status();
-
-                static const uint32_t connectTimeout = 5000; //5s timeout
                 
                 auto startTime = millis();
                 // wait for connection, fail, or timeout

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp
@@ -46,7 +46,7 @@ bool ESP8266WiFiMulti::existsAP(const char* ssid, const char *passphrase) {
     return APlistExists(ssid, passphrase);
 }
 
-wl_status_t ESP8266WiFiMulti::run(uint32_t connectTimeout) {
+wl_status_t ESP8266WiFiMulti::run(uint32_t connectTimeoutMs) {
 
     wl_status_t status = WiFi.status();
     if(status == WL_DISCONNECTED || status == WL_NO_SSID_AVAIL || status == WL_IDLE_STATUS || status == WL_CONNECT_FAILED) {
@@ -135,7 +135,7 @@ wl_status_t ESP8266WiFiMulti::run(uint32_t connectTimeout) {
                 
                 auto startTime = millis();
                 // wait for connection, fail, or timeout
-                while(status != WL_CONNECTED && status != WL_NO_SSID_AVAIL && status != WL_CONNECT_FAILED && (millis() - startTime) <= connectTimeout) {
+                while(status != WL_CONNECTED && status != WL_NO_SSID_AVAIL && status != WL_CONNECT_FAILED && (millis() - startTime) <= connectTimeoutMs) {
                     delay(10);
                     status = WiFi.status();
                 }

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.h
@@ -55,7 +55,7 @@ class ESP8266WiFiMulti {
         bool addAP(const char* ssid, const char *passphrase = NULL);
         bool existsAP(const char* ssid, const char *passphrase = NULL);
 
-        wl_status_t run(uint32_t connectTimeout=5000);
+        wl_status_t run(uint32_t connectTimeoutMs=5000);
 
         void cleanAPlist(void);
 

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.h
@@ -55,7 +55,7 @@ class ESP8266WiFiMulti {
         bool addAP(const char* ssid, const char *passphrase = NULL);
         bool existsAP(const char* ssid, const char *passphrase = NULL);
 
-        wl_status_t run(void);
+        wl_status_t run(uint32_t connectTimeout=5000);
 
         void cleanAPlist(void);
 


### PR DESCRIPTION
WifiMulti->run has a built in timeout when connecting set to 5s. In some cases this is not enough time to set up the connection.

I noticed that my ESP-boards quite often failed to connect to my wifi if my repeater mode AP was selected as the strongest SSID. Don't know the reason for the slow connection setup, but my other devices connect without issue.

For Esp32, the 5s timeout was added some time ago based on this project (https://github.com/espressif/arduino-esp32/pull/1220/files). They implemented it a bit different where the timeout could be altered and with a default set to 5s.

I made a PR that changes the API to the same as for Esp32.