### PR TITLE
Iod update

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1,2014 +1,1092 @@
+#
+# Do not create pull-requests with this abridged file!
+# Do as instructed further down.
+#
+# Abridged boards.txt or boards.local.txt created by: C:\Users\james\Downloads\esp8266\arduino\tools\boards.txt.py --boardsgen --filter favourites.txt
+# The following boards were included:  gen4iod generic esp8285
+#
+#
+# Do not create pull-requests for this file only, CI will not accept them.
+# You *must* edit/modify/run boards.txt.py to regenerate boards.txt.
+# All modified files after running with option "--allgen" must be included in the pull-request.
+#
+
 menu.BoardModel=Model
-menu.UploadSpeed=Upload Speed
-menu.CpuFrequency=CPU Frequency
+menu.ESPModule=Module
+menu.led=Builtin Led
+menu.baud=Upload Speed
+menu.xtal=CPU Frequency
 menu.CrystalFreq=Crystal Frequency
-menu.FlashSize=Flash Size
+menu.eesz=Flash Size
 menu.FlashMode=Flash Mode
 menu.FlashFreq=Flash Frequency
 menu.ResetMethod=Reset Method
-menu.ESPModule=Module
-menu.Debug=Debug port
-menu.DebugLevel=Debug Level
-menu.LwIPVariant=lwIP Variant
+menu.dbg=Debug port
+menu.lvl=Debug Level
+menu.ip=lwIP Variant
+menu.vt=VTables
+menu.exception=Exceptions
+menu.wipe=Erase Flash
+menu.sdk=Espressif FW
+menu.ssl=SSL Support
+
+##############################################################
+gen4iod.name=4D Systems gen4 IoD Range
+gen4iod.build.board=GEN4_IOD
+gen4iod.build.f_cpu=160000000L
+gen4iod.build.variant=generic
+gen4iod.upload.tool=esptool
+gen4iod.upload.maximum_data_size=81920
+gen4iod.upload.wait_for_upload_port=true
+gen4iod.upload.erase_cmd=
+gen4iod.serial.disableDTR=true
+gen4iod.serial.disableRTS=true
+gen4iod.build.mcu=esp8266
+gen4iod.build.core=esp8266
+gen4iod.build.spiffs_pagesize=256
+gen4iod.build.debug_port=
+gen4iod.build.debug_level=
+gen4iod.menu.xtal.80=80 MHz
+gen4iod.menu.xtal.80.build.f_cpu=80000000L
+gen4iod.menu.xtal.160=160 MHz
+gen4iod.menu.xtal.160.build.f_cpu=160000000L
+gen4iod.menu.vt.flash=Flash
+gen4iod.menu.vt.flash.build.vtable_flags=-DVTABLES_IN_FLASH
+gen4iod.menu.vt.heap=Heap
+gen4iod.menu.vt.heap.build.vtable_flags=-DVTABLES_IN_DRAM
+gen4iod.menu.vt.iram=IRAM
+gen4iod.menu.vt.iram.build.vtable_flags=-DVTABLES_IN_IRAM
+gen4iod.menu.exception.legacy=Legacy (new can return nullptr)
+gen4iod.menu.exception.legacy.build.exception_flags=-fno-exceptions
+gen4iod.menu.exception.legacy.build.stdcpp_lib=-lstdc++
+gen4iod.menu.exception.disabled=Disabled (new can abort)
+gen4iod.menu.exception.disabled.build.exception_flags=-fno-exceptions -DNEW_OOM_ABORT
+gen4iod.menu.exception.disabled.build.stdcpp_lib=-lstdc++
+gen4iod.menu.exception.enabled=Enabled
+gen4iod.menu.exception.enabled.build.exception_flags=-fexceptions
+gen4iod.menu.exception.enabled.build.stdcpp_lib=-lstdc++-exc
+gen4iod.menu.ssl.all=All SSL ciphers (most compatible)
+gen4iod.menu.ssl.all.build.sslflags=
+gen4iod.menu.ssl.basic=Basic SSL ciphers (lower ROM use)
+gen4iod.menu.ssl.basic.build.sslflags=-DBEARSSL_SSL_BASIC
+gen4iod.upload.resetmethod=--before default_reset --after hard_reset
+gen4iod.build.flash_mode=dio
+gen4iod.build.flash_flags=-DFLASHMODE_DIO
+gen4iod.build.flash_mode=qio
+gen4iod.build.flash_flags=-DFLASHMODE_QIO
+gen4iod.build.flash_freq=80
+gen4iod.menu.eesz.512K32=512KB (FS:32KB OTA:~230KB)
+gen4iod.menu.eesz.512K32.build.flash_size=512K
+gen4iod.menu.eesz.512K32.build.flash_size_bytes=0x80000
+gen4iod.menu.eesz.512K32.build.flash_ld=eagle.flash.512k32.ld
+gen4iod.menu.eesz.512K32.build.spiffs_pagesize=256
+gen4iod.menu.eesz.512K32.upload.maximum_size=466928
+gen4iod.menu.eesz.512K32.build.rfcal_addr=0x7C000
+gen4iod.menu.eesz.512K32.build.spiffs_start=0x73000
+gen4iod.menu.eesz.512K32.build.spiffs_end=0x7B000
+gen4iod.menu.eesz.512K32.build.spiffs_blocksize=4096
+gen4iod.menu.eesz.512K64=512KB (FS:64KB OTA:~214KB)
+gen4iod.menu.eesz.512K64.build.flash_size=512K
+gen4iod.menu.eesz.512K64.build.flash_size_bytes=0x80000
+gen4iod.menu.eesz.512K64.build.flash_ld=eagle.flash.512k64.ld
+gen4iod.menu.eesz.512K64.build.spiffs_pagesize=256
+gen4iod.menu.eesz.512K64.upload.maximum_size=434160
+gen4iod.menu.eesz.512K64.build.rfcal_addr=0x7C000
+gen4iod.menu.eesz.512K64.build.spiffs_start=0x6B000
+gen4iod.menu.eesz.512K64.build.spiffs_end=0x7B000
+gen4iod.menu.eesz.512K64.build.spiffs_blocksize=4096
+gen4iod.menu.eesz.512K128=512KB (FS:128KB OTA:~182KB)
+gen4iod.menu.eesz.512K128.build.flash_size=512K
+gen4iod.menu.eesz.512K128.build.flash_size_bytes=0x80000
+gen4iod.menu.eesz.512K128.build.flash_ld=eagle.flash.512k128.ld
+gen4iod.menu.eesz.512K128.build.spiffs_pagesize=256
+gen4iod.menu.eesz.512K128.upload.maximum_size=368624
+gen4iod.menu.eesz.512K128.build.rfcal_addr=0x7C000
+gen4iod.menu.eesz.512K128.build.spiffs_start=0x5B000
+gen4iod.menu.eesz.512K128.build.spiffs_end=0x7B000
+gen4iod.menu.eesz.512K128.build.spiffs_blocksize=4096
+gen4iod.menu.eesz.512K=512KB (FS:none OTA:~246KB)
+gen4iod.menu.eesz.512K.build.flash_size=512K
+gen4iod.menu.eesz.512K.build.flash_size_bytes=0x80000
+gen4iod.menu.eesz.512K.build.flash_ld=eagle.flash.512k.ld
+gen4iod.menu.eesz.512K.build.spiffs_pagesize=256
+gen4iod.menu.eesz.512K.upload.maximum_size=499696
+gen4iod.menu.eesz.512K.build.rfcal_addr=0x7C000
+gen4iod.menu.eesz.2M64=2MB (FS:64KB OTA:~992KB)
+gen4iod.menu.eesz.2M64.build.flash_size=2M
+gen4iod.menu.eesz.2M64.build.flash_size_bytes=0x200000
+gen4iod.menu.eesz.2M64.build.flash_ld=eagle.flash.2m64.ld
+gen4iod.menu.eesz.2M64.build.spiffs_pagesize=256
+gen4iod.menu.eesz.2M64.upload.maximum_size=1044464
+gen4iod.menu.eesz.2M64.build.rfcal_addr=0x1FC000
+gen4iod.menu.eesz.2M64.build.spiffs_start=0x1F0000
+gen4iod.menu.eesz.2M64.build.spiffs_end=0x1FB000
+gen4iod.menu.eesz.2M64.build.spiffs_blocksize=4096
+gen4iod.menu.eesz.2M128=2MB (FS:128KB OTA:~960KB)
+gen4iod.menu.eesz.2M128.build.flash_size=2M
+gen4iod.menu.eesz.2M128.build.flash_size_bytes=0x200000
+gen4iod.menu.eesz.2M128.build.flash_ld=eagle.flash.2m128.ld
+gen4iod.menu.eesz.2M128.build.spiffs_pagesize=256
+gen4iod.menu.eesz.2M128.upload.maximum_size=1044464
+gen4iod.menu.eesz.2M128.build.rfcal_addr=0x1FC000
+gen4iod.menu.eesz.2M128.build.spiffs_start=0x1E0000
+gen4iod.menu.eesz.2M128.build.spiffs_end=0x1FB000
+gen4iod.menu.eesz.2M128.build.spiffs_blocksize=4096
+gen4iod.menu.eesz.2M256=2MB (FS:256KB OTA:~896KB)
+gen4iod.menu.eesz.2M256.build.flash_size=2M
+gen4iod.menu.eesz.2M256.build.flash_size_bytes=0x200000
+gen4iod.menu.eesz.2M256.build.flash_ld=eagle.flash.2m256.ld
+gen4iod.menu.eesz.2M256.build.spiffs_pagesize=256
+gen4iod.menu.eesz.2M256.upload.maximum_size=1044464
+gen4iod.menu.eesz.2M256.build.rfcal_addr=0x1FC000
+gen4iod.menu.eesz.2M256.build.spiffs_start=0x1C0000
+gen4iod.menu.eesz.2M256.build.spiffs_end=0x1FB000
+gen4iod.menu.eesz.2M256.build.spiffs_blocksize=4096
+gen4iod.menu.eesz.2M512=2MB (FS:512KB OTA:~768KB)
+gen4iod.menu.eesz.2M512.build.flash_size=2M
+gen4iod.menu.eesz.2M512.build.flash_size_bytes=0x200000
+gen4iod.menu.eesz.2M512.build.flash_ld=eagle.flash.2m512.ld
+gen4iod.menu.eesz.2M512.build.spiffs_pagesize=256
+gen4iod.menu.eesz.2M512.upload.maximum_size=1044464
+gen4iod.menu.eesz.2M512.build.rfcal_addr=0x1FC000
+gen4iod.menu.eesz.2M512.build.spiffs_start=0x180000
+gen4iod.menu.eesz.2M512.build.spiffs_end=0x1FA000
+gen4iod.menu.eesz.2M512.build.spiffs_blocksize=8192
+gen4iod.menu.eesz.2M1M=2MB (FS:1MB OTA:~512KB)
+gen4iod.menu.eesz.2M1M.build.flash_size=2M
+gen4iod.menu.eesz.2M1M.build.flash_size_bytes=0x200000
+gen4iod.menu.eesz.2M1M.build.flash_ld=eagle.flash.2m1m.ld
+gen4iod.menu.eesz.2M1M.build.spiffs_pagesize=256
+gen4iod.menu.eesz.2M1M.upload.maximum_size=1044464
+gen4iod.menu.eesz.2M1M.build.rfcal_addr=0x1FC000
+gen4iod.menu.eesz.2M1M.build.spiffs_start=0x100000
+gen4iod.menu.eesz.2M1M.build.spiffs_end=0x1FA000
+gen4iod.menu.eesz.2M1M.build.spiffs_blocksize=8192
+gen4iod.menu.eesz.2M=2MB (FS:none OTA:~1019KB)
+gen4iod.menu.eesz.2M.build.flash_size=2M
+gen4iod.menu.eesz.2M.build.flash_size_bytes=0x200000
+gen4iod.menu.eesz.2M.build.flash_ld=eagle.flash.2m.ld
+gen4iod.menu.eesz.2M.build.spiffs_pagesize=256
+gen4iod.menu.eesz.2M.upload.maximum_size=1044464
+gen4iod.menu.eesz.2M.build.rfcal_addr=0x1FC000
+gen4iod.menu.ip.lm2f=v2 Lower Memory
+gen4iod.menu.ip.lm2f.build.lwip_include=lwip2/include
+gen4iod.menu.ip.lm2f.build.lwip_lib=-llwip2-536-feat
+gen4iod.menu.ip.lm2f.build.lwip_flags=-DLWIP_OPEN_SRC -DTCP_MSS=536 -DLWIP_FEATURES=1 -DLWIP_IPV6=0
+gen4iod.menu.ip.hb2f=v2 Higher Bandwidth
+gen4iod.menu.ip.hb2f.build.lwip_include=lwip2/include
+gen4iod.menu.ip.hb2f.build.lwip_lib=-llwip2-1460-feat
+gen4iod.menu.ip.hb2f.build.lwip_flags=-DLWIP_OPEN_SRC -DTCP_MSS=1460 -DLWIP_FEATURES=1 -DLWIP_IPV6=0
+gen4iod.menu.ip.lm2n=v2 Lower Memory (no features)
+gen4iod.menu.ip.lm2n.build.lwip_include=lwip2/include
+gen4iod.menu.ip.lm2n.build.lwip_lib=-llwip2-536
+gen4iod.menu.ip.lm2n.build.lwip_flags=-DLWIP_OPEN_SRC -DTCP_MSS=536 -DLWIP_FEATURES=0 -DLWIP_IPV6=0
+gen4iod.menu.ip.hb2n=v2 Higher Bandwidth (no features)
+gen4iod.menu.ip.hb2n.build.lwip_include=lwip2/include
+gen4iod.menu.ip.hb2n.build.lwip_lib=-llwip2-1460
+gen4iod.menu.ip.hb2n.build.lwip_flags=-DLWIP_OPEN_SRC -DTCP_MSS=1460 -DLWIP_FEATURES=0 -DLWIP_IPV6=0
+gen4iod.menu.ip.lm6f=v2 IPv6 Lower Memory
+gen4iod.menu.ip.lm6f.build.lwip_include=lwip2/include
+gen4iod.menu.ip.lm6f.build.lwip_lib=-llwip6-536-feat
+gen4iod.menu.ip.lm6f.build.lwip_flags=-DLWIP_OPEN_SRC -DTCP_MSS=536 -DLWIP_FEATURES=1 -DLWIP_IPV6=1
+gen4iod.menu.ip.hb6f=v2 IPv6 Higher Bandwidth
+gen4iod.menu.ip.hb6f.build.lwip_include=lwip2/include
+gen4iod.menu.ip.hb6f.build.lwip_lib=-llwip6-1460-feat
+gen4iod.menu.ip.hb6f.build.lwip_flags=-DLWIP_OPEN_SRC -DTCP_MSS=1460 -DLWIP_FEATURES=1 -DLWIP_IPV6=1
+gen4iod.menu.ip.hb1=v1.4 Higher Bandwidth
+gen4iod.menu.ip.hb1.build.lwip_lib=-llwip_gcc
+gen4iod.menu.ip.hb1.build.lwip_flags=-DLWIP_OPEN_SRC
+gen4iod.menu.ip.src=v1.4 Compile from source
+gen4iod.menu.ip.src.build.lwip_lib=-llwip_src
+gen4iod.menu.ip.src.build.lwip_flags=-DLWIP_OPEN_SRC
+gen4iod.menu.ip.src.recipe.hooks.sketch.prebuild.1.pattern=make -C "{runtime.platform.path}/tools/sdk/lwip/src" install TOOLS_PATH="{runtime.tools.xtensa-lx106-elf-gcc.path}/bin/xtensa-lx106-elf-"
+gen4iod.menu.dbg.Disabled=Disabled
+gen4iod.menu.dbg.Disabled.build.debug_port=
+gen4iod.menu.dbg.Serial=Serial
+gen4iod.menu.dbg.Serial.build.debug_port=-DDEBUG_ESP_PORT=Serial
+gen4iod.menu.dbg.Serial1=Serial1
+gen4iod.menu.dbg.Serial1.build.debug_port=-DDEBUG_ESP_PORT=Serial1
+gen4iod.menu.lvl.None____=None
+gen4iod.menu.lvl.None____.build.debug_level=
+gen4iod.menu.lvl.SSL=SSL
+gen4iod.menu.lvl.SSL.build.debug_level= -DDEBUG_ESP_SSL
+gen4iod.menu.lvl.TLS_MEM=TLS_MEM
+gen4iod.menu.lvl.TLS_MEM.build.debug_level= -DDEBUG_ESP_TLS_MEM
+gen4iod.menu.lvl.HTTP_CLIENT=HTTP_CLIENT
+gen4iod.menu.lvl.HTTP_CLIENT.build.debug_level= -DDEBUG_ESP_HTTP_CLIENT
+gen4iod.menu.lvl.HTTP_SERVER=HTTP_SERVER
+gen4iod.menu.lvl.HTTP_SERVER.build.debug_level= -DDEBUG_ESP_HTTP_SERVER
+gen4iod.menu.lvl.SSLTLS_MEM=SSL+TLS_MEM
+gen4iod.menu.lvl.SSLTLS_MEM.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_TLS_MEM
+gen4iod.menu.lvl.SSLHTTP_CLIENT=SSL+HTTP_CLIENT
+gen4iod.menu.lvl.SSLHTTP_CLIENT.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_HTTP_CLIENT
+gen4iod.menu.lvl.SSLHTTP_SERVER=SSL+HTTP_SERVER
+gen4iod.menu.lvl.SSLHTTP_SERVER.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_HTTP_SERVER
+gen4iod.menu.lvl.TLS_MEMHTTP_CLIENT=TLS_MEM+HTTP_CLIENT
+gen4iod.menu.lvl.TLS_MEMHTTP_CLIENT.build.debug_level= -DDEBUG_ESP_TLS_MEM -DDEBUG_ESP_HTTP_CLIENT
+gen4iod.menu.lvl.TLS_MEMHTTP_SERVER=TLS_MEM+HTTP_SERVER
+gen4iod.menu.lvl.TLS_MEMHTTP_SERVER.build.debug_level= -DDEBUG_ESP_TLS_MEM -DDEBUG_ESP_HTTP_SERVER
+gen4iod.menu.lvl.HTTP_CLIENTHTTP_SERVER=HTTP_CLIENT+HTTP_SERVER
+gen4iod.menu.lvl.HTTP_CLIENTHTTP_SERVER.build.debug_level= -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_SERVER
+gen4iod.menu.lvl.SSLTLS_MEMHTTP_CLIENT=SSL+TLS_MEM+HTTP_CLIENT
+gen4iod.menu.lvl.SSLTLS_MEMHTTP_CLIENT.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_TLS_MEM -DDEBUG_ESP_HTTP_CLIENT
+gen4iod.menu.lvl.SSLTLS_MEMHTTP_SERVER=SSL+TLS_MEM+HTTP_SERVER
+gen4iod.menu.lvl.SSLTLS_MEMHTTP_SERVER.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_TLS_MEM -DDEBUG_ESP_HTTP_SERVER
+gen4iod.menu.lvl.SSLHTTP_CLIENTHTTP_SERVER=SSL+HTTP_CLIENT+HTTP_SERVER
+gen4iod.menu.lvl.SSLHTTP_CLIENTHTTP_SERVER.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_SERVER
+gen4iod.menu.lvl.TLS_MEMHTTP_CLIENTHTTP_SERVER=TLS_MEM+HTTP_CLIENT+HTTP_SERVER
+gen4iod.menu.lvl.TLS_MEMHTTP_CLIENTHTTP_SERVER.build.debug_level= -DDEBUG_ESP_TLS_MEM -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_SERVER
+gen4iod.menu.lvl.SSLTLS_MEMHTTP_CLIENTHTTP_SERVER=SSL+TLS_MEM+HTTP_CLIENT+HTTP_SERVER
+gen4iod.menu.lvl.SSLTLS_MEMHTTP_CLIENTHTTP_SERVER.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_TLS_MEM -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_SERVER
+gen4iod.menu.lvl.CORE=CORE
+gen4iod.menu.lvl.CORE.build.debug_level= -DDEBUG_ESP_CORE
+gen4iod.menu.lvl.WIFI=WIFI
+gen4iod.menu.lvl.WIFI.build.debug_level= -DDEBUG_ESP_WIFI
+gen4iod.menu.lvl.HTTP_UPDATE=HTTP_UPDATE
+gen4iod.menu.lvl.HTTP_UPDATE.build.debug_level= -DDEBUG_ESP_HTTP_UPDATE
+gen4iod.menu.lvl.UPDATER=UPDATER
+gen4iod.menu.lvl.UPDATER.build.debug_level= -DDEBUG_ESP_UPDATER
+gen4iod.menu.lvl.OTA=OTA
+gen4iod.menu.lvl.OTA.build.debug_level= -DDEBUG_ESP_OTA
+gen4iod.menu.lvl.OOM=OOM
+gen4iod.menu.lvl.OOM.build.debug_level= -DDEBUG_ESP_OOM
+gen4iod.menu.lvl.MDNS=MDNS
+gen4iod.menu.lvl.MDNS.build.debug_level= -DDEBUG_ESP_MDNS
+gen4iod.menu.lvl.COREWIFIHTTP_UPDATEUPDATEROTAOOMMDNS=CORE+WIFI+HTTP_UPDATE+UPDATER+OTA+OOM+MDNS
+gen4iod.menu.lvl.COREWIFIHTTP_UPDATEUPDATEROTAOOMMDNS.build.debug_level= -DDEBUG_ESP_CORE -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_UPDATER -DDEBUG_ESP_OTA -DDEBUG_ESP_OOM -DDEBUG_ESP_MDNS
+gen4iod.menu.lvl.SSLTLS_MEMHTTP_CLIENTHTTP_SERVERCOREWIFIHTTP_UPDATEUPDATEROTAOOMMDNS=SSL+TLS_MEM+HTTP_CLIENT+HTTP_SERVER+CORE+WIFI+HTTP_UPDATE+UPDATER+OTA+OOM+MDNS
+gen4iod.menu.lvl.SSLTLS_MEMHTTP_CLIENTHTTP_SERVERCOREWIFIHTTP_UPDATEUPDATEROTAOOMMDNS.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_TLS_MEM -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_SERVER -DDEBUG_ESP_CORE -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_UPDATER -DDEBUG_ESP_OTA -DDEBUG_ESP_OOM -DDEBUG_ESP_MDNS
+gen4iod.menu.lvl.NoAssert-NDEBUG=NoAssert-NDEBUG
+gen4iod.menu.lvl.NoAssert-NDEBUG.build.debug_level= -DNDEBUG
+gen4iod.menu.wipe.none=Only Sketch
+gen4iod.menu.wipe.none.upload.erase_cmd=
+gen4iod.menu.wipe.sdk=Sketch + WiFi Settings
+gen4iod.menu.wipe.sdk.upload.erase_cmd=erase_region "{build.rfcal_addr}" 0x4000
+gen4iod.menu.wipe.all=All Flash Contents
+gen4iod.menu.wipe.all.upload.erase_cmd=erase_flash
+gen4iod.menu.baud.115200=115200
+gen4iod.menu.baud.115200.upload.speed=115200
+gen4iod.menu.baud.57600=57600
+gen4iod.menu.baud.57600.upload.speed=57600
+gen4iod.menu.baud.230400.linux=230400
+gen4iod.menu.baud.230400.macosx=230400
+gen4iod.menu.baud.230400.upload.speed=230400
+gen4iod.menu.baud.256000.windows=256000
+gen4iod.menu.baud.256000.upload.speed=256000
+gen4iod.menu.baud.460800.linux=460800
+gen4iod.menu.baud.460800.macosx=460800
+gen4iod.menu.baud.460800.upload.speed=460800
+gen4iod.menu.baud.512000.windows=512000
+gen4iod.menu.baud.512000.upload.speed=512000
+gen4iod.menu.baud.921600=921600
+gen4iod.menu.baud.921600.upload.speed=921600
+gen4iod.menu.baud.3000000=3000000
+gen4iod.menu.baud.3000000.upload.speed=3000000
 
 ##############################################################
 generic.name=Generic ESP8266 Module
-
+generic.build.board=ESP8266_GENERIC
 generic.upload.tool=esptool
-generic.upload.speed=115200
-generic.upload.resetmethod=ck
-generic.upload.maximum_size=434160
 generic.upload.maximum_data_size=81920
 generic.upload.wait_for_upload_port=true
+generic.upload.erase_cmd=
 generic.serial.disableDTR=true
 generic.serial.disableRTS=true
-
 generic.build.mcu=esp8266
-generic.build.f_cpu=80000000L
-generic.build.board=ESP8266_ESP01
 generic.build.core=esp8266
 generic.build.variant=generic
-generic.build.flash_mode=qio
 generic.build.spiffs_pagesize=256
 generic.build.debug_port=
 generic.build.debug_level=
-
-generic.menu.CpuFrequency.80=80 MHz
-generic.menu.CpuFrequency.80.build.f_cpu=80000000L
-generic.menu.CpuFrequency.160=160 MHz
-generic.menu.CpuFrequency.160.build.f_cpu=160000000L
-
+generic.menu.xtal.80=80 MHz
+generic.menu.xtal.80.build.f_cpu=80000000L
+generic.menu.xtal.160=160 MHz
+generic.menu.xtal.160.build.f_cpu=160000000L
+generic.menu.vt.flash=Flash
+generic.menu.vt.flash.build.vtable_flags=-DVTABLES_IN_FLASH
+generic.menu.vt.heap=Heap
+generic.menu.vt.heap.build.vtable_flags=-DVTABLES_IN_DRAM
+generic.menu.vt.iram=IRAM
+generic.menu.vt.iram.build.vtable_flags=-DVTABLES_IN_IRAM
+generic.menu.exception.legacy=Legacy (new can return nullptr)
+generic.menu.exception.legacy.build.exception_flags=-fno-exceptions
+generic.menu.exception.legacy.build.stdcpp_lib=-lstdc++
+generic.menu.exception.disabled=Disabled (new can abort)
+generic.menu.exception.disabled.build.exception_flags=-fno-exceptions -DNEW_OOM_ABORT
+generic.menu.exception.disabled.build.stdcpp_lib=-lstdc++
+generic.menu.exception.enabled=Enabled
+generic.menu.exception.enabled.build.exception_flags=-fexceptions
+generic.menu.exception.enabled.build.stdcpp_lib=-lstdc++-exc
+generic.menu.ssl.all=All SSL ciphers (most compatible)
+generic.menu.ssl.all.build.sslflags=
+generic.menu.ssl.basic=Basic SSL ciphers (lower ROM use)
+generic.menu.ssl.basic.build.sslflags=-DBEARSSL_SSL_BASIC
+generic.menu.ResetMethod.nodemcu=dtr (aka nodemcu)
+generic.menu.ResetMethod.nodemcu.upload.resetmethod=--before default_reset --after hard_reset
+generic.menu.ResetMethod.ck=no dtr (aka ck)
+generic.menu.ResetMethod.ck.upload.resetmethod=--before no_reset --after soft_reset
+generic.menu.ResetMethod.nodtr_nosync=no dtr, no_sync
+generic.menu.ResetMethod.nodtr_nosync.upload.resetmethod=--before no_reset_no_sync --after soft_reset
+generic.menu.CrystalFreq.26=26 MHz
+generic.menu.CrystalFreq.40=40 MHz
+generic.menu.CrystalFreq.40.build.extra_flags=-DF_CRYSTAL=40000000 -DESP8266
 generic.menu.FlashFreq.40=40MHz
 generic.menu.FlashFreq.40.build.flash_freq=40
 generic.menu.FlashFreq.80=80MHz
 generic.menu.FlashFreq.80.build.flash_freq=80
-
+generic.menu.FlashFreq.20=20MHz
+generic.menu.FlashFreq.20.build.flash_freq=20
+generic.menu.FlashFreq.26=26MHz
+generic.menu.FlashFreq.26.build.flash_freq=26
+generic.menu.FlashMode.dout=DOUT (compatible)
+generic.menu.FlashMode.dout.build.flash_mode=dout
+generic.menu.FlashMode.dout.build.flash_flags=-DFLASHMODE_DOUT
 generic.menu.FlashMode.dio=DIO
 generic.menu.FlashMode.dio.build.flash_mode=dio
-generic.menu.FlashMode.qio=QIO
-generic.menu.FlashMode.qio.build.flash_mode=qio
-generic.menu.FlashMode.dout=DOUT
-generic.menu.FlashMode.dout.build.flash_mode=dout
+generic.menu.FlashMode.dio.build.flash_flags=-DFLASHMODE_DIO
 generic.menu.FlashMode.qout=QOUT
 generic.menu.FlashMode.qout.build.flash_mode=qout
-
-generic.menu.UploadSpeed.115200=115200
-generic.menu.UploadSpeed.115200.upload.speed=115200
-generic.menu.UploadSpeed.9600=9600
-generic.menu.UploadSpeed.9600.upload.speed=9600
-generic.menu.UploadSpeed.57600=57600
-generic.menu.UploadSpeed.57600.upload.speed=57600
-generic.menu.UploadSpeed.256000.windows=256000
-generic.menu.UploadSpeed.256000.upload.speed=256000
-generic.menu.UploadSpeed.230400.linux=230400
-generic.menu.UploadSpeed.230400.macosx=230400
-generic.menu.UploadSpeed.230400.upload.speed=230400
-generic.menu.UploadSpeed.460800.linux=460800
-generic.menu.UploadSpeed.460800.macosx=460800
-generic.menu.UploadSpeed.460800.upload.speed=460800
-generic.menu.UploadSpeed.512000.windows=512000
-generic.menu.UploadSpeed.512000.upload.speed=512000
-generic.menu.UploadSpeed.921600=921600
-generic.menu.UploadSpeed.921600.upload.speed=921600
-
-generic.menu.FlashSize.512K64=512K (64K SPIFFS)
-generic.menu.FlashSize.512K64.build.flash_size=512K
-generic.menu.FlashSize.512K64.build.flash_ld=eagle.flash.512k64.ld
-generic.menu.FlashSize.512K64.build.spiffs_start=0x6B000
-generic.menu.FlashSize.512K64.build.spiffs_end=0x7B000
-generic.menu.FlashSize.512K64.build.spiffs_blocksize=4096
-generic.menu.FlashSize.512K64.upload.maximum_size=434160
-
-generic.menu.FlashSize.512K128=512K (128K SPIFFS)
-generic.menu.FlashSize.512K128.build.flash_size=512K
-generic.menu.FlashSize.512K128.build.flash_ld=eagle.flash.512k128.ld
-generic.menu.FlashSize.512K128.build.spiffs_start=0x5B000
-generic.menu.FlashSize.512K128.build.spiffs_end=0x7B000
-generic.menu.FlashSize.512K128.build.spiffs_blocksize=4096
-generic.menu.FlashSize.512K128.upload.maximum_size=368624
-
-generic.menu.FlashSize.512K0=512K (no SPIFFS)
-generic.menu.FlashSize.512K0.build.flash_size=512K
-generic.menu.FlashSize.512K0.build.flash_ld=eagle.flash.512k0.ld
-generic.menu.FlashSize.512K0.upload.maximum_size=499696
-
-generic.menu.FlashSize.1M512=1M (512K SPIFFS)
-generic.menu.FlashSize.1M512.build.flash_size=1M
-generic.menu.FlashSize.1M512.build.flash_ld=eagle.flash.1m512.ld
-generic.menu.FlashSize.1M512.build.spiffs_start=0x7B000
-generic.menu.FlashSize.1M512.build.spiffs_end=0xFB000
-generic.menu.FlashSize.1M512.build.spiffs_blocksize=8192
-generic.menu.FlashSize.1M512.upload.maximum_size=499696
-
-generic.menu.FlashSize.1M256=1M (256K SPIFFS)
-generic.menu.FlashSize.1M256.build.flash_size=1M
-generic.menu.FlashSize.1M256.build.flash_ld=eagle.flash.1m256.ld
-generic.menu.FlashSize.1M256.build.spiffs_start=0xBB000
-generic.menu.FlashSize.1M256.build.spiffs_end=0xFB000
-generic.menu.FlashSize.1M256.build.spiffs_blocksize=4096
-generic.menu.FlashSize.1M256.upload.maximum_size=761840
-
-generic.menu.FlashSize.1M192=1M (192K SPIFFS)
-generic.menu.FlashSize.1M192.build.flash_size=1M
-generic.menu.FlashSize.1M192.build.flash_ld=eagle.flash.1m192.ld
-generic.menu.FlashSize.1M192.build.spiffs_start=0xCB000
-generic.menu.FlashSize.1M192.build.spiffs_end=0xFB000
-generic.menu.FlashSize.1M192.build.spiffs_blocksize=4096
-generic.menu.FlashSize.1M192.upload.maximum_size=827376
-
-generic.menu.FlashSize.1M160=1M (160K SPIFFS)
-generic.menu.FlashSize.1M160.build.flash_size=1M
-generic.menu.FlashSize.1M160.build.flash_ld=eagle.flash.1m160.ld
-generic.menu.FlashSize.1M160.build.spiffs_start=0xD3000
-generic.menu.FlashSize.1M160.build.spiffs_end=0xFB000
-generic.menu.FlashSize.1M160.build.spiffs_blocksize=4096
-generic.menu.FlashSize.1M160.upload.maximum_size=860144
-
-generic.menu.FlashSize.1M144=1M (144K SPIFFS)
-generic.menu.FlashSize.1M144.build.flash_size=1M
-generic.menu.FlashSize.1M144.build.flash_ld=eagle.flash.1m144.ld
-generic.menu.FlashSize.1M144.build.spiffs_start=0xD7000
-generic.menu.FlashSize.1M144.build.spiffs_end=0xFB000
-generic.menu.FlashSize.1M144.build.spiffs_blocksize=4096
-generic.menu.FlashSize.1M144.upload.maximum_size=876528
-
-generic.menu.FlashSize.1M128=1M (128K SPIFFS)
-generic.menu.FlashSize.1M128.build.flash_size=1M
-generic.menu.FlashSize.1M128.build.flash_ld=eagle.flash.1m128.ld
-generic.menu.FlashSize.1M128.build.spiffs_start=0xDB000
-generic.menu.FlashSize.1M128.build.spiffs_end=0xFB000
-generic.menu.FlashSize.1M128.build.spiffs_blocksize=4096
-generic.menu.FlashSize.1M128.upload.maximum_size=892912
-
-generic.menu.FlashSize.1M64=1M (64K SPIFFS)
-generic.menu.FlashSize.1M64.build.flash_size=1M
-generic.menu.FlashSize.1M64.build.flash_ld=eagle.flash.1m64.ld
-generic.menu.FlashSize.1M64.build.spiffs_start=0xEB000
-generic.menu.FlashSize.1M64.build.spiffs_end=0xFB000
-generic.menu.FlashSize.1M64.build.spiffs_blocksize=4096
-generic.menu.FlashSize.1M64.upload.maximum_size=958448
-
-generic.menu.FlashSize.2M=2M (1M SPIFFS)
-generic.menu.FlashSize.2M.build.flash_size=2M
-generic.menu.FlashSize.2M.build.flash_ld=eagle.flash.2m.ld
-generic.menu.FlashSize.2M.build.spiffs_start=0x100000
-generic.menu.FlashSize.2M.build.spiffs_end=0x1FB000
-generic.menu.FlashSize.2M.build.spiffs_blocksize=8192
-generic.menu.FlashSize.2M.upload.maximum_size=1044464
-
-generic.menu.FlashSize.4M1M=4M (1M SPIFFS)
-generic.menu.FlashSize.4M1M.build.flash_size=4M
-generic.menu.FlashSize.4M1M.build.flash_ld=eagle.flash.4m1m.ld
-generic.menu.FlashSize.4M1M.build.spiffs_start=0x300000
-generic.menu.FlashSize.4M1M.build.spiffs_end=0x3FB000
-generic.menu.FlashSize.4M1M.build.spiffs_blocksize=8192
-generic.menu.FlashSize.4M1M.build.spiffs_pagesize=256
-generic.menu.FlashSize.4M1M.upload.maximum_size=1044464
-
-generic.menu.FlashSize.4M3M=4M (3M SPIFFS)
-generic.menu.FlashSize.4M3M.build.flash_size=4M
-generic.menu.FlashSize.4M3M.build.flash_ld=eagle.flash.4m.ld
-generic.menu.FlashSize.4M3M.build.spiffs_start=0x100000
-generic.menu.FlashSize.4M3M.build.spiffs_end=0x3FB000
-generic.menu.FlashSize.4M3M.build.spiffs_blocksize=8192
-generic.menu.FlashSize.4M3M.upload.maximum_size=1044464
-
-generic.menu.ResetMethod.ck=ck
-generic.menu.ResetMethod.ck.upload.resetmethod=ck
-generic.menu.ResetMethod.nodemcu=nodemcu
-generic.menu.ResetMethod.nodemcu.upload.resetmethod=nodemcu
-
-generic.menu.Debug.Disabled=Disabled
-generic.menu.Debug.Disabled.build.debug_port=
-generic.menu.Debug.Serial=Serial
-generic.menu.Debug.Serial.build.debug_port=-DDEBUG_ESP_PORT=Serial
-generic.menu.Debug.Serial1=Serial1
-generic.menu.Debug.Serial1.build.debug_port=-DDEBUG_ESP_PORT=Serial1
-
-generic.menu.DebugLevel.None____=None
-generic.menu.DebugLevel.None____.build.debug_level=
-generic.menu.DebugLevel.Core____=Core
-generic.menu.DebugLevel.Core____.build.debug_level=-DDEBUG_ESP_CORE
-generic.menu.DebugLevel.SSL_____=Core + SSL
-generic.menu.DebugLevel.SSL_____.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_SSL
-generic.menu.DebugLevel.SSL_MEM_=Core + SSL + TLS Mem
-generic.menu.DebugLevel.SSL_MEM_.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_SSL -DDEBUG_TLS_MEM
-generic.menu.DebugLevel.WiFic___=Core + WiFi
-generic.menu.DebugLevel.WiFic___.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_WIFI
-generic.menu.DebugLevel.WiFi____=WiFi
-generic.menu.DebugLevel.WiFi____.build.debug_level=-DDEBUG_ESP_WIFI
-generic.menu.DebugLevel.HTTPClient=HTTPClient
-generic.menu.DebugLevel.HTTPClient.build.debug_level=-DDEBUG_ESP_HTTP_CLIENT
-generic.menu.DebugLevel.HTTPClient2=HTTPClient + SSL
-generic.menu.DebugLevel.HTTPClient2.build.debug_level=-DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_SSL
-generic.menu.DebugLevel.HTTPUpdate=HTTPUpdate
-generic.menu.DebugLevel.HTTPUpdate.build.debug_level=-DDEBUG_ESP_HTTP_UPDATE
-generic.menu.DebugLevel.HTTPUpdate2=HTTPClient + HTTPUpdate
-generic.menu.DebugLevel.HTTPUpdate2.build.debug_level=-DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_UPDATE
-generic.menu.DebugLevel.HTTPUpdate3=HTTPClient + HTTPUpdate + Updater
-generic.menu.DebugLevel.HTTPUpdate3.build.debug_level=-DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_UPDATER
-generic.menu.DebugLevel.HTTPServer=HTTPServer
-generic.menu.DebugLevel.HTTPServer.build.debug_level=-DDEBUG_ESP_HTTP_SERVER
-generic.menu.DebugLevel.UPDATER=Updater
-generic.menu.DebugLevel.UPDATER.build.debug_level=-DDEBUG_ESP_UPDATER
-generic.menu.DebugLevel.OTA_____=OTA
-generic.menu.DebugLevel.OTA_____.build.debug_level=-DDEBUG_ESP_OTA
-generic.menu.DebugLevel.OTA2____=OTA + Updater
-generic.menu.DebugLevel.OTA2____.build.debug_level=-DDEBUG_ESP_OTA -DDEBUG_ESP_UPDATER
-generic.menu.DebugLevel.all_____=All
-generic.menu.DebugLevel.all_____.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_SSL -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_SERVER -DDEBUG_ESP_UPDATER -DDEBUG_ESP_OTA -DDEBUG_TLS_MEM
-
-# disabled because espressif's bootloader refuses to write above 4M
-# generic.menu.FlashSize.8M=8M (7M SPIFFS)
-# generic.menu.FlashSize.8M.build.flash_size=1M
-# generic.menu.FlashSize.8M.build.flash_ld=eagle.flash.8m.ld
-# generic.menu.FlashSize.8M.build.spiffs_start=0x100000
-# generic.menu.FlashSize.8M.build.spiffs_end=0x800000
-# generic.menu.FlashSize.8M.build.spiffs_blocksize=8192
-# generic.menu.FlashSize.16M=16M (15M SPIFFS)
-# generic.menu.FlashSize.16M.build.flash_size=1M
-# generic.menu.FlashSize.16M.build.flash_ld=eagle.flash.16m.ld
-# generic.menu.FlashSize.16M.build.spiffs_start=0x100000
-# generic.menu.FlashSize.16M.build.spiffs_end=0x1000000
-# generic.menu.FlashSize.16M.build.spiffs_blocksize=8192
+generic.menu.FlashMode.qout.build.flash_flags=-DFLASHMODE_QOUT
+generic.menu.FlashMode.qio=QIO (fast)
+generic.menu.FlashMode.qio.build.flash_mode=qio
+generic.menu.FlashMode.qio.build.flash_flags=-DFLASHMODE_QIO
+generic.menu.eesz.1M64=1MB (FS:64KB OTA:~470KB)
+generic.menu.eesz.1M64.build.flash_size=1M
+generic.menu.eesz.1M64.build.flash_size_bytes=0x100000
+generic.menu.eesz.1M64.build.flash_ld=eagle.flash.1m64.ld
+generic.menu.eesz.1M64.build.spiffs_pagesize=256
+generic.menu.eesz.1M64.upload.maximum_size=958448
+generic.menu.eesz.1M64.build.rfcal_addr=0xFC000
+generic.menu.eesz.1M64.build.spiffs_start=0xEB000
+generic.menu.eesz.1M64.build.spiffs_end=0xFB000
+generic.menu.eesz.1M64.build.spiffs_blocksize=4096
+generic.menu.eesz.1M128=1MB (FS:128KB OTA:~438KB)
+generic.menu.eesz.1M128.build.flash_size=1M
+generic.menu.eesz.1M128.build.flash_size_bytes=0x100000
+generic.menu.eesz.1M128.build.flash_ld=eagle.flash.1m128.ld
+generic.menu.eesz.1M128.build.spiffs_pagesize=256
+generic.menu.eesz.1M128.upload.maximum_size=892912
+generic.menu.eesz.1M128.build.rfcal_addr=0xFC000
+generic.menu.eesz.1M128.build.spiffs_start=0xDB000
+generic.menu.eesz.1M128.build.spiffs_end=0xFB000
+generic.menu.eesz.1M128.build.spiffs_blocksize=4096
+generic.menu.eesz.1M144=1MB (FS:144KB OTA:~430KB)
+generic.menu.eesz.1M144.build.flash_size=1M
+generic.menu.eesz.1M144.build.flash_size_bytes=0x100000
+generic.menu.eesz.1M144.build.flash_ld=eagle.flash.1m144.ld
+generic.menu.eesz.1M144.build.spiffs_pagesize=256
+generic.menu.eesz.1M144.upload.maximum_size=876528
+generic.menu.eesz.1M144.build.rfcal_addr=0xFC000
+generic.menu.eesz.1M144.build.spiffs_start=0xD7000
+generic.menu.eesz.1M144.build.spiffs_end=0xFB000
+generic.menu.eesz.1M144.build.spiffs_blocksize=4096
+generic.menu.eesz.1M160=1MB (FS:160KB OTA:~422KB)
+generic.menu.eesz.1M160.build.flash_size=1M
+generic.menu.eesz.1M160.build.flash_size_bytes=0x100000
+generic.menu.eesz.1M160.build.flash_ld=eagle.flash.1m160.ld
+generic.menu.eesz.1M160.build.spiffs_pagesize=256
+generic.menu.eesz.1M160.upload.maximum_size=860144
+generic.menu.eesz.1M160.build.rfcal_addr=0xFC000
+generic.menu.eesz.1M160.build.spiffs_start=0xD3000
+generic.menu.eesz.1M160.build.spiffs_end=0xFB000
+generic.menu.eesz.1M160.build.spiffs_blocksize=4096
+generic.menu.eesz.1M192=1MB (FS:192KB OTA:~406KB)
+generic.menu.eesz.1M192.build.flash_size=1M
+generic.menu.eesz.1M192.build.flash_size_bytes=0x100000
+generic.menu.eesz.1M192.build.flash_ld=eagle.flash.1m192.ld
+generic.menu.eesz.1M192.build.spiffs_pagesize=256
+generic.menu.eesz.1M192.upload.maximum_size=827376
+generic.menu.eesz.1M192.build.rfcal_addr=0xFC000
+generic.menu.eesz.1M192.build.spiffs_start=0xCB000
+generic.menu.eesz.1M192.build.spiffs_end=0xFB000
+generic.menu.eesz.1M192.build.spiffs_blocksize=4096
+generic.menu.eesz.1M256=1MB (FS:256KB OTA:~374KB)
+generic.menu.eesz.1M256.build.flash_size=1M
+generic.menu.eesz.1M256.build.flash_size_bytes=0x100000
+generic.menu.eesz.1M256.build.flash_ld=eagle.flash.1m256.ld
+generic.menu.eesz.1M256.build.spiffs_pagesize=256
+generic.menu.eesz.1M256.upload.maximum_size=761840
+generic.menu.eesz.1M256.build.rfcal_addr=0xFC000
+generic.menu.eesz.1M256.build.spiffs_start=0xBB000
+generic.menu.eesz.1M256.build.spiffs_end=0xFB000
+generic.menu.eesz.1M256.build.spiffs_blocksize=4096
+generic.menu.eesz.1M512=1MB (FS:512KB OTA:~246KB)
+generic.menu.eesz.1M512.build.flash_size=1M
+generic.menu.eesz.1M512.build.flash_size_bytes=0x100000
+generic.menu.eesz.1M512.build.flash_ld=eagle.flash.1m512.ld
+generic.menu.eesz.1M512.build.spiffs_pagesize=256
+generic.menu.eesz.1M512.upload.maximum_size=499696
+generic.menu.eesz.1M512.build.rfcal_addr=0xFC000
+generic.menu.eesz.1M512.build.spiffs_start=0x7B000
+generic.menu.eesz.1M512.build.spiffs_end=0xFB000
+generic.menu.eesz.1M512.build.spiffs_blocksize=8192
+generic.menu.eesz.1M=1MB (FS:none OTA:~502KB)
+generic.menu.eesz.1M.build.flash_size=1M
+generic.menu.eesz.1M.build.flash_size_bytes=0x100000
+generic.menu.eesz.1M.build.flash_ld=eagle.flash.1m.ld
+generic.menu.eesz.1M.build.spiffs_pagesize=256
+generic.menu.eesz.1M.upload.maximum_size=1023984
+generic.menu.eesz.1M.build.rfcal_addr=0xFC000
+generic.menu.eesz.2M64=2MB (FS:64KB OTA:~992KB)
+generic.menu.eesz.2M64.build.flash_size=2M
+generic.menu.eesz.2M64.build.flash_size_bytes=0x200000
+generic.menu.eesz.2M64.build.flash_ld=eagle.flash.2m64.ld
+generic.menu.eesz.2M64.build.spiffs_pagesize=256
+generic.menu.eesz.2M64.upload.maximum_size=1044464
+generic.menu.eesz.2M64.build.rfcal_addr=0x1FC000
+generic.menu.eesz.2M64.build.spiffs_start=0x1F0000
+generic.menu.eesz.2M64.build.spiffs_end=0x1FB000
+generic.menu.eesz.2M64.build.spiffs_blocksize=4096
+generic.menu.eesz.2M128=2MB (FS:128KB OTA:~960KB)
+generic.menu.eesz.2M128.build.flash_size=2M
+generic.menu.eesz.2M128.build.flash_size_bytes=0x200000
+generic.menu.eesz.2M128.build.flash_ld=eagle.flash.2m128.ld
+generic.menu.eesz.2M128.build.spiffs_pagesize=256
+generic.menu.eesz.2M128.upload.maximum_size=1044464
+generic.menu.eesz.2M128.build.rfcal_addr=0x1FC000
+generic.menu.eesz.2M128.build.spiffs_start=0x1E0000
+generic.menu.eesz.2M128.build.spiffs_end=0x1FB000
+generic.menu.eesz.2M128.build.spiffs_blocksize=4096
+generic.menu.eesz.2M256=2MB (FS:256KB OTA:~896KB)
+generic.menu.eesz.2M256.build.flash_size=2M
+generic.menu.eesz.2M256.build.flash_size_bytes=0x200000
+generic.menu.eesz.2M256.build.flash_ld=eagle.flash.2m256.ld
+generic.menu.eesz.2M256.build.spiffs_pagesize=256
+generic.menu.eesz.2M256.upload.maximum_size=1044464
+generic.menu.eesz.2M256.build.rfcal_addr=0x1FC000
+generic.menu.eesz.2M256.build.spiffs_start=0x1C0000
+generic.menu.eesz.2M256.build.spiffs_end=0x1FB000
+generic.menu.eesz.2M256.build.spiffs_blocksize=4096
+generic.menu.eesz.2M512=2MB (FS:512KB OTA:~768KB)
+generic.menu.eesz.2M512.build.flash_size=2M
+generic.menu.eesz.2M512.build.flash_size_bytes=0x200000
+generic.menu.eesz.2M512.build.flash_ld=eagle.flash.2m512.ld
+generic.menu.eesz.2M512.build.spiffs_pagesize=256
+generic.menu.eesz.2M512.upload.maximum_size=1044464
+generic.menu.eesz.2M512.build.rfcal_addr=0x1FC000
+generic.menu.eesz.2M512.build.spiffs_start=0x180000
+generic.menu.eesz.2M512.build.spiffs_end=0x1FA000
+generic.menu.eesz.2M512.build.spiffs_blocksize=8192
+generic.menu.eesz.2M1M=2MB (FS:1MB OTA:~512KB)
+generic.menu.eesz.2M1M.build.flash_size=2M
+generic.menu.eesz.2M1M.build.flash_size_bytes=0x200000
+generic.menu.eesz.2M1M.build.flash_ld=eagle.flash.2m1m.ld
+generic.menu.eesz.2M1M.build.spiffs_pagesize=256
+generic.menu.eesz.2M1M.upload.maximum_size=1044464
+generic.menu.eesz.2M1M.build.rfcal_addr=0x1FC000
+generic.menu.eesz.2M1M.build.spiffs_start=0x100000
+generic.menu.eesz.2M1M.build.spiffs_end=0x1FA000
+generic.menu.eesz.2M1M.build.spiffs_blocksize=8192
+generic.menu.eesz.2M=2MB (FS:none OTA:~1019KB)
+generic.menu.eesz.2M.build.flash_size=2M
+generic.menu.eesz.2M.build.flash_size_bytes=0x200000
+generic.menu.eesz.2M.build.flash_ld=eagle.flash.2m.ld
+generic.menu.eesz.2M.build.spiffs_pagesize=256
+generic.menu.eesz.2M.upload.maximum_size=1044464
+generic.menu.eesz.2M.build.rfcal_addr=0x1FC000
+generic.menu.eesz.4M2M=4MB (FS:2MB OTA:~1019KB)
+generic.menu.eesz.4M2M.build.flash_size=4M
+generic.menu.eesz.4M2M.build.flash_size_bytes=0x400000
+generic.menu.eesz.4M2M.build.flash_ld=eagle.flash.4m2m.ld
+generic.menu.eesz.4M2M.build.spiffs_pagesize=256
+generic.menu.eesz.4M2M.upload.maximum_size=1044464
+generic.menu.eesz.4M2M.build.rfcal_addr=0x3FC000
+generic.menu.eesz.4M2M.build.spiffs_start=0x200000
+generic.menu.eesz.4M2M.build.spiffs_end=0x3FA000
+generic.menu.eesz.4M2M.build.spiffs_blocksize=8192
+generic.menu.eesz.4M3M=4MB (FS:3MB OTA:~512KB)
+generic.menu.eesz.4M3M.build.flash_size=4M
+generic.menu.eesz.4M3M.build.flash_size_bytes=0x400000
+generic.menu.eesz.4M3M.build.flash_ld=eagle.flash.4m3m.ld
+generic.menu.eesz.4M3M.build.spiffs_pagesize=256
+generic.menu.eesz.4M3M.upload.maximum_size=1044464
+generic.menu.eesz.4M3M.build.rfcal_addr=0x3FC000
+generic.menu.eesz.4M3M.build.spiffs_start=0x100000
+generic.menu.eesz.4M3M.build.spiffs_end=0x3FA000
+generic.menu.eesz.4M3M.build.spiffs_blocksize=8192
+generic.menu.eesz.4M1M=4MB (FS:1MB OTA:~1019KB)
+generic.menu.eesz.4M1M.build.flash_size=4M
+generic.menu.eesz.4M1M.build.flash_size_bytes=0x400000
+generic.menu.eesz.4M1M.build.flash_ld=eagle.flash.4m1m.ld
+generic.menu.eesz.4M1M.build.spiffs_pagesize=256
+generic.menu.eesz.4M1M.upload.maximum_size=1044464
+generic.menu.eesz.4M1M.build.rfcal_addr=0x3FC000
+generic.menu.eesz.4M1M.build.spiffs_start=0x300000
+generic.menu.eesz.4M1M.build.spiffs_end=0x3FA000
+generic.menu.eesz.4M1M.build.spiffs_blocksize=8192
+generic.menu.eesz.4M=4MB (FS:none OTA:~1019KB)
+generic.menu.eesz.4M.build.flash_size=4M
+generic.menu.eesz.4M.build.flash_size_bytes=0x400000
+generic.menu.eesz.4M.build.flash_ld=eagle.flash.4m.ld
+generic.menu.eesz.4M.build.spiffs_pagesize=256
+generic.menu.eesz.4M.upload.maximum_size=1044464
+generic.menu.eesz.4M.build.rfcal_addr=0x3FC000
+generic.menu.eesz.8M6M=8MB (FS:6MB OTA:~1019KB)
+generic.menu.eesz.8M6M.build.flash_size=8M
+generic.menu.eesz.8M6M.build.flash_size_bytes=0x800000
+generic.menu.eesz.8M6M.build.flash_ld=eagle.flash.8m6m.ld
+generic.menu.eesz.8M6M.build.spiffs_pagesize=256
+generic.menu.eesz.8M6M.upload.maximum_size=1044464
+generic.menu.eesz.8M6M.build.rfcal_addr=0x7FC000
+generic.menu.eesz.8M6M.build.spiffs_start=0x200000
+generic.menu.eesz.8M6M.build.spiffs_end=0x7FA000
+generic.menu.eesz.8M6M.build.spiffs_blocksize=8192
+generic.menu.eesz.8M7M=8MB (FS:7MB OTA:~512KB)
+generic.menu.eesz.8M7M.build.flash_size=8M
+generic.menu.eesz.8M7M.build.flash_size_bytes=0x800000
+generic.menu.eesz.8M7M.build.flash_ld=eagle.flash.8m7m.ld
+generic.menu.eesz.8M7M.build.spiffs_pagesize=256
+generic.menu.eesz.8M7M.upload.maximum_size=1044464
+generic.menu.eesz.8M7M.build.rfcal_addr=0x7FC000
+generic.menu.eesz.8M7M.build.spiffs_start=0x100000
+generic.menu.eesz.8M7M.build.spiffs_end=0x7FA000
+generic.menu.eesz.8M7M.build.spiffs_blocksize=8192
+generic.menu.eesz.16M14M=16MB (FS:14MB OTA:~1019KB)
+generic.menu.eesz.16M14M.build.flash_size=16M
+generic.menu.eesz.16M14M.build.flash_size_bytes=0x1000000
+generic.menu.eesz.16M14M.build.flash_ld=eagle.flash.16m14m.ld
+generic.menu.eesz.16M14M.build.spiffs_pagesize=256
+generic.menu.eesz.16M14M.upload.maximum_size=1044464
+generic.menu.eesz.16M14M.build.rfcal_addr=0xFFC000
+generic.menu.eesz.16M14M.build.spiffs_start=0x200000
+generic.menu.eesz.16M14M.build.spiffs_end=0xFFA000
+generic.menu.eesz.16M14M.build.spiffs_blocksize=8192
+generic.menu.eesz.16M15M=16MB (FS:15MB OTA:~512KB)
+generic.menu.eesz.16M15M.build.flash_size=16M
+generic.menu.eesz.16M15M.build.flash_size_bytes=0x1000000
+generic.menu.eesz.16M15M.build.flash_ld=eagle.flash.16m15m.ld
+generic.menu.eesz.16M15M.build.spiffs_pagesize=256
+generic.menu.eesz.16M15M.upload.maximum_size=1044464
+generic.menu.eesz.16M15M.build.rfcal_addr=0xFFC000
+generic.menu.eesz.16M15M.build.spiffs_start=0x100000
+generic.menu.eesz.16M15M.build.spiffs_end=0xFFA000
+generic.menu.eesz.16M15M.build.spiffs_blocksize=8192
+generic.menu.eesz.512K32=512KB (FS:32KB OTA:~230KB)
+generic.menu.eesz.512K32.build.flash_size=512K
+generic.menu.eesz.512K32.build.flash_size_bytes=0x80000
+generic.menu.eesz.512K32.build.flash_ld=eagle.flash.512k32.ld
+generic.menu.eesz.512K32.build.spiffs_pagesize=256
+generic.menu.eesz.512K32.upload.maximum_size=466928
+generic.menu.eesz.512K32.build.rfcal_addr=0x7C000
+generic.menu.eesz.512K32.build.spiffs_start=0x73000
+generic.menu.eesz.512K32.build.spiffs_end=0x7B000
+generic.menu.eesz.512K32.build.spiffs_blocksize=4096
+generic.menu.eesz.512K64=512KB (FS:64KB OTA:~214KB)
+generic.menu.eesz.512K64.build.flash_size=512K
+generic.menu.eesz.512K64.build.flash_size_bytes=0x80000
+generic.menu.eesz.512K64.build.flash_ld=eagle.flash.512k64.ld
+generic.menu.eesz.512K64.build.spiffs_pagesize=256
+generic.menu.eesz.512K64.upload.maximum_size=434160
+generic.menu.eesz.512K64.build.rfcal_addr=0x7C000
+generic.menu.eesz.512K64.build.spiffs_start=0x6B000
+generic.menu.eesz.512K64.build.spiffs_end=0x7B000
+generic.menu.eesz.512K64.build.spiffs_blocksize=4096
+generic.menu.eesz.512K128=512KB (FS:128KB OTA:~182KB)
+generic.menu.eesz.512K128.build.flash_size=512K
+generic.menu.eesz.512K128.build.flash_size_bytes=0x80000
+generic.menu.eesz.512K128.build.flash_ld=eagle.flash.512k128.ld
+generic.menu.eesz.512K128.build.spiffs_pagesize=256
+generic.menu.eesz.512K128.upload.maximum_size=368624
+generic.menu.eesz.512K128.build.rfcal_addr=0x7C000
+generic.menu.eesz.512K128.build.spiffs_start=0x5B000
+generic.menu.eesz.512K128.build.spiffs_end=0x7B000
+generic.menu.eesz.512K128.build.spiffs_blocksize=4096
+generic.menu.eesz.512K=512KB (FS:none OTA:~246KB)
+generic.menu.eesz.512K.build.flash_size=512K
+generic.menu.eesz.512K.build.flash_size_bytes=0x80000
+generic.menu.eesz.512K.build.flash_ld=eagle.flash.512k.ld
+generic.menu.eesz.512K.build.spiffs_pagesize=256
+generic.menu.eesz.512K.upload.maximum_size=499696
+generic.menu.eesz.512K.build.rfcal_addr=0x7C000
+generic.menu.led.2=2
+generic.menu.led.2.build.led=-DLED_BUILTIN=2
+generic.menu.led.0=0
+generic.menu.led.0.build.led=-DLED_BUILTIN=0
+generic.menu.led.1=1
+generic.menu.led.1.build.led=-DLED_BUILTIN=1
+generic.menu.led.3=3
+generic.menu.led.3.build.led=-DLED_BUILTIN=3
+generic.menu.led.4=4
+generic.menu.led.4.build.led=-DLED_BUILTIN=4
+generic.menu.led.5=5
+generic.menu.led.5.build.led=-DLED_BUILTIN=5
+generic.menu.led.6=6
+generic.menu.led.6.build.led=-DLED_BUILTIN=6
+generic.menu.led.7=7
+generic.menu.led.7.build.led=-DLED_BUILTIN=7
+generic.menu.led.8=8
+generic.menu.led.8.build.led=-DLED_BUILTIN=8
+generic.menu.led.9=9
+generic.menu.led.9.build.led=-DLED_BUILTIN=9
+generic.menu.led.10=10
+generic.menu.led.10.build.led=-DLED_BUILTIN=10
+generic.menu.led.11=11
+generic.menu.led.11.build.led=-DLED_BUILTIN=11
+generic.menu.led.12=12
+generic.menu.led.12.build.led=-DLED_BUILTIN=12
+generic.menu.led.13=13
+generic.menu.led.13.build.led=-DLED_BUILTIN=13
+generic.menu.led.14=14
+generic.menu.led.14.build.led=-DLED_BUILTIN=14
+generic.menu.led.15=15
+generic.menu.led.15.build.led=-DLED_BUILTIN=15
+generic.menu.led.16=16
+generic.menu.led.16.build.led=-DLED_BUILTIN=16
+generic.menu.sdk.nonosdk_190703=nonos-sdk 2.2.1+100 (190703)
+generic.menu.sdk.nonosdk_190703.build.sdk=NONOSDK22x_190703
+generic.menu.sdk.nonosdk_191122=nonos-sdk 2.2.1+119 (191122)
+generic.menu.sdk.nonosdk_191122.build.sdk=NONOSDK22x_191122
+generic.menu.sdk.nonosdk_191105=nonos-sdk 2.2.1+113 (191105)
+generic.menu.sdk.nonosdk_191105.build.sdk=NONOSDK22x_191105
+generic.menu.sdk.nonosdk_191024=nonos-sdk 2.2.1+111 (191024)
+generic.menu.sdk.nonosdk_191024.build.sdk=NONOSDK22x_191024
+generic.menu.sdk.nonosdk221=nonos-sdk 2.2.1 (legacy)
+generic.menu.sdk.nonosdk221.build.sdk=NONOSDK221
+generic.menu.sdk.nonosdk3v0=nonos-sdk pre-3 (180626 known issues)
+generic.menu.sdk.nonosdk3v0.build.sdk=NONOSDK3V0
+generic.menu.ip.lm2f=v2 Lower Memory
+generic.menu.ip.lm2f.build.lwip_include=lwip2/include
+generic.menu.ip.lm2f.build.lwip_lib=-llwip2-536-feat
+generic.menu.ip.lm2f.build.lwip_flags=-DLWIP_OPEN_SRC -DTCP_MSS=536 -DLWIP_FEATURES=1 -DLWIP_IPV6=0
+generic.menu.ip.hb2f=v2 Higher Bandwidth
+generic.menu.ip.hb2f.build.lwip_include=lwip2/include
+generic.menu.ip.hb2f.build.lwip_lib=-llwip2-1460-feat
+generic.menu.ip.hb2f.build.lwip_flags=-DLWIP_OPEN_SRC -DTCP_MSS=1460 -DLWIP_FEATURES=1 -DLWIP_IPV6=0
+generic.menu.ip.lm2n=v2 Lower Memory (no features)
+generic.menu.ip.lm2n.build.lwip_include=lwip2/include
+generic.menu.ip.lm2n.build.lwip_lib=-llwip2-536
+generic.menu.ip.lm2n.build.lwip_flags=-DLWIP_OPEN_SRC -DTCP_MSS=536 -DLWIP_FEATURES=0 -DLWIP_IPV6=0
+generic.menu.ip.hb2n=v2 Higher Bandwidth (no features)
+generic.menu.ip.hb2n.build.lwip_include=lwip2/include
+generic.menu.ip.hb2n.build.lwip_lib=-llwip2-1460
+generic.menu.ip.hb2n.build.lwip_flags=-DLWIP_OPEN_SRC -DTCP_MSS=1460 -DLWIP_FEATURES=0 -DLWIP_IPV6=0
+generic.menu.ip.lm6f=v2 IPv6 Lower Memory
+generic.menu.ip.lm6f.build.lwip_include=lwip2/include
+generic.menu.ip.lm6f.build.lwip_lib=-llwip6-536-feat
+generic.menu.ip.lm6f.build.lwip_flags=-DLWIP_OPEN_SRC -DTCP_MSS=536 -DLWIP_FEATURES=1 -DLWIP_IPV6=1
+generic.menu.ip.hb6f=v2 IPv6 Higher Bandwidth
+generic.menu.ip.hb6f.build.lwip_include=lwip2/include
+generic.menu.ip.hb6f.build.lwip_lib=-llwip6-1460-feat
+generic.menu.ip.hb6f.build.lwip_flags=-DLWIP_OPEN_SRC -DTCP_MSS=1460 -DLWIP_FEATURES=1 -DLWIP_IPV6=1
+generic.menu.ip.hb1=v1.4 Higher Bandwidth
+generic.menu.ip.hb1.build.lwip_lib=-llwip_gcc
+generic.menu.ip.hb1.build.lwip_flags=-DLWIP_OPEN_SRC
+generic.menu.ip.src=v1.4 Compile from source
+generic.menu.ip.src.build.lwip_lib=-llwip_src
+generic.menu.ip.src.build.lwip_flags=-DLWIP_OPEN_SRC
+generic.menu.ip.src.recipe.hooks.sketch.prebuild.1.pattern=make -C "{runtime.platform.path}/tools/sdk/lwip/src" install TOOLS_PATH="{runtime.tools.xtensa-lx106-elf-gcc.path}/bin/xtensa-lx106-elf-"
+generic.menu.dbg.Disabled=Disabled
+generic.menu.dbg.Disabled.build.debug_port=
+generic.menu.dbg.Serial=Serial
+generic.menu.dbg.Serial.build.debug_port=-DDEBUG_ESP_PORT=Serial
+generic.menu.dbg.Serial1=Serial1
+generic.menu.dbg.Serial1.build.debug_port=-DDEBUG_ESP_PORT=Serial1
+generic.menu.lvl.None____=None
+generic.menu.lvl.None____.build.debug_level=
+generic.menu.lvl.SSL=SSL
+generic.menu.lvl.SSL.build.debug_level= -DDEBUG_ESP_SSL
+generic.menu.lvl.TLS_MEM=TLS_MEM
+generic.menu.lvl.TLS_MEM.build.debug_level= -DDEBUG_ESP_TLS_MEM
+generic.menu.lvl.HTTP_CLIENT=HTTP_CLIENT
+generic.menu.lvl.HTTP_CLIENT.build.debug_level= -DDEBUG_ESP_HTTP_CLIENT
+generic.menu.lvl.HTTP_SERVER=HTTP_SERVER
+generic.menu.lvl.HTTP_SERVER.build.debug_level= -DDEBUG_ESP_HTTP_SERVER
+generic.menu.lvl.SSLTLS_MEM=SSL+TLS_MEM
+generic.menu.lvl.SSLTLS_MEM.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_TLS_MEM
+generic.menu.lvl.SSLHTTP_CLIENT=SSL+HTTP_CLIENT
+generic.menu.lvl.SSLHTTP_CLIENT.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_HTTP_CLIENT
+generic.menu.lvl.SSLHTTP_SERVER=SSL+HTTP_SERVER
+generic.menu.lvl.SSLHTTP_SERVER.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_HTTP_SERVER
+generic.menu.lvl.TLS_MEMHTTP_CLIENT=TLS_MEM+HTTP_CLIENT
+generic.menu.lvl.TLS_MEMHTTP_CLIENT.build.debug_level= -DDEBUG_ESP_TLS_MEM -DDEBUG_ESP_HTTP_CLIENT
+generic.menu.lvl.TLS_MEMHTTP_SERVER=TLS_MEM+HTTP_SERVER
+generic.menu.lvl.TLS_MEMHTTP_SERVER.build.debug_level= -DDEBUG_ESP_TLS_MEM -DDEBUG_ESP_HTTP_SERVER
+generic.menu.lvl.HTTP_CLIENTHTTP_SERVER=HTTP_CLIENT+HTTP_SERVER
+generic.menu.lvl.HTTP_CLIENTHTTP_SERVER.build.debug_level= -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_SERVER
+generic.menu.lvl.SSLTLS_MEMHTTP_CLIENT=SSL+TLS_MEM+HTTP_CLIENT
+generic.menu.lvl.SSLTLS_MEMHTTP_CLIENT.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_TLS_MEM -DDEBUG_ESP_HTTP_CLIENT
+generic.menu.lvl.SSLTLS_MEMHTTP_SERVER=SSL+TLS_MEM+HTTP_SERVER
+generic.menu.lvl.SSLTLS_MEMHTTP_SERVER.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_TLS_MEM -DDEBUG_ESP_HTTP_SERVER
+generic.menu.lvl.SSLHTTP_CLIENTHTTP_SERVER=SSL+HTTP_CLIENT+HTTP_SERVER
+generic.menu.lvl.SSLHTTP_CLIENTHTTP_SERVER.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_SERVER
+generic.menu.lvl.TLS_MEMHTTP_CLIENTHTTP_SERVER=TLS_MEM+HTTP_CLIENT+HTTP_SERVER
+generic.menu.lvl.TLS_MEMHTTP_CLIENTHTTP_SERVER.build.debug_level= -DDEBUG_ESP_TLS_MEM -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_SERVER
+generic.menu.lvl.SSLTLS_MEMHTTP_CLIENTHTTP_SERVER=SSL+TLS_MEM+HTTP_CLIENT+HTTP_SERVER
+generic.menu.lvl.SSLTLS_MEMHTTP_CLIENTHTTP_SERVER.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_TLS_MEM -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_SERVER
+generic.menu.lvl.CORE=CORE
+generic.menu.lvl.CORE.build.debug_level= -DDEBUG_ESP_CORE
+generic.menu.lvl.WIFI=WIFI
+generic.menu.lvl.WIFI.build.debug_level= -DDEBUG_ESP_WIFI
+generic.menu.lvl.HTTP_UPDATE=HTTP_UPDATE
+generic.menu.lvl.HTTP_UPDATE.build.debug_level= -DDEBUG_ESP_HTTP_UPDATE
+generic.menu.lvl.UPDATER=UPDATER
+generic.menu.lvl.UPDATER.build.debug_level= -DDEBUG_ESP_UPDATER
+generic.menu.lvl.OTA=OTA
+generic.menu.lvl.OTA.build.debug_level= -DDEBUG_ESP_OTA
+generic.menu.lvl.OOM=OOM
+generic.menu.lvl.OOM.build.debug_level= -DDEBUG_ESP_OOM
+generic.menu.lvl.MDNS=MDNS
+generic.menu.lvl.MDNS.build.debug_level= -DDEBUG_ESP_MDNS
+generic.menu.lvl.COREWIFIHTTP_UPDATEUPDATEROTAOOMMDNS=CORE+WIFI+HTTP_UPDATE+UPDATER+OTA+OOM+MDNS
+generic.menu.lvl.COREWIFIHTTP_UPDATEUPDATEROTAOOMMDNS.build.debug_level= -DDEBUG_ESP_CORE -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_UPDATER -DDEBUG_ESP_OTA -DDEBUG_ESP_OOM -DDEBUG_ESP_MDNS
+generic.menu.lvl.SSLTLS_MEMHTTP_CLIENTHTTP_SERVERCOREWIFIHTTP_UPDATEUPDATEROTAOOMMDNS=SSL+TLS_MEM+HTTP_CLIENT+HTTP_SERVER+CORE+WIFI+HTTP_UPDATE+UPDATER+OTA+OOM+MDNS
+generic.menu.lvl.SSLTLS_MEMHTTP_CLIENTHTTP_SERVERCOREWIFIHTTP_UPDATEUPDATEROTAOOMMDNS.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_TLS_MEM -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_SERVER -DDEBUG_ESP_CORE -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_UPDATER -DDEBUG_ESP_OTA -DDEBUG_ESP_OOM -DDEBUG_ESP_MDNS
+generic.menu.lvl.NoAssert-NDEBUG=NoAssert-NDEBUG
+generic.menu.lvl.NoAssert-NDEBUG.build.debug_level= -DNDEBUG
+generic.menu.wipe.none=Only Sketch
+generic.menu.wipe.none.upload.erase_cmd=
+generic.menu.wipe.sdk=Sketch + WiFi Settings
+generic.menu.wipe.sdk.upload.erase_cmd=erase_region "{build.rfcal_addr}" 0x4000
+generic.menu.wipe.all=All Flash Contents
+generic.menu.wipe.all.upload.erase_cmd=erase_flash
+generic.menu.baud.115200=115200
+generic.menu.baud.115200.upload.speed=115200
+generic.menu.baud.57600=57600
+generic.menu.baud.57600.upload.speed=57600
+generic.menu.baud.230400.linux=230400
+generic.menu.baud.230400.macosx=230400
+generic.menu.baud.230400.upload.speed=230400
+generic.menu.baud.256000.windows=256000
+generic.menu.baud.256000.upload.speed=256000
+generic.menu.baud.460800.linux=460800
+generic.menu.baud.460800.macosx=460800
+generic.menu.baud.460800.upload.speed=460800
+generic.menu.baud.512000.windows=512000
+generic.menu.baud.512000.upload.speed=512000
+generic.menu.baud.921600=921600
+generic.menu.baud.921600.upload.speed=921600
+generic.menu.baud.3000000=3000000
+generic.menu.baud.3000000.upload.speed=3000000
 
 ##############################################################
-# ESP8285 chip has built-in 1MB flash
-
 esp8285.name=Generic ESP8285 Module
-
+esp8285.build.board=ESP8266_ESP01
+esp8285.build.variant=esp8285
 esp8285.upload.tool=esptool
-esp8285.upload.speed=115200
-esp8285.upload.resetmethod=ck
-esp8285.upload.maximum_size=434160
 esp8285.upload.maximum_data_size=81920
 esp8285.upload.wait_for_upload_port=true
+esp8285.upload.erase_cmd=
 esp8285.serial.disableDTR=true
 esp8285.serial.disableRTS=true
-
 esp8285.build.mcu=esp8266
-esp8285.build.f_cpu=80000000L
-esp8285.build.board=ESP8266_ESP01
 esp8285.build.core=esp8266
-esp8285.build.variant=generic
-esp8285.build.flash_mode=dout
-esp8285.build.flash_freq=40
 esp8285.build.spiffs_pagesize=256
 esp8285.build.debug_port=
 esp8285.build.debug_level=
+esp8285.menu.xtal.80=80 MHz
+esp8285.menu.xtal.80.build.f_cpu=80000000L
+esp8285.menu.xtal.160=160 MHz
+esp8285.menu.xtal.160.build.f_cpu=160000000L
+esp8285.menu.vt.flash=Flash
+esp8285.menu.vt.flash.build.vtable_flags=-DVTABLES_IN_FLASH
+esp8285.menu.vt.heap=Heap
+esp8285.menu.vt.heap.build.vtable_flags=-DVTABLES_IN_DRAM
+esp8285.menu.vt.iram=IRAM
+esp8285.menu.vt.iram.build.vtable_flags=-DVTABLES_IN_IRAM
+esp8285.menu.exception.legacy=Legacy (new can return nullptr)
+esp8285.menu.exception.legacy.build.exception_flags=-fno-exceptions
+esp8285.menu.exception.legacy.build.stdcpp_lib=-lstdc++
+esp8285.menu.exception.disabled=Disabled (new can abort)
+esp8285.menu.exception.disabled.build.exception_flags=-fno-exceptions -DNEW_OOM_ABORT
+esp8285.menu.exception.disabled.build.stdcpp_lib=-lstdc++
+esp8285.menu.exception.enabled=Enabled
+esp8285.menu.exception.enabled.build.exception_flags=-fexceptions
+esp8285.menu.exception.enabled.build.stdcpp_lib=-lstdc++-exc
+esp8285.menu.ssl.all=All SSL ciphers (most compatible)
+esp8285.menu.ssl.all.build.sslflags=
+esp8285.menu.ssl.basic=Basic SSL ciphers (lower ROM use)
+esp8285.menu.ssl.basic.build.sslflags=-DBEARSSL_SSL_BASIC
+esp8285.menu.ResetMethod.nodemcu=dtr (aka nodemcu)
+esp8285.menu.ResetMethod.nodemcu.upload.resetmethod=--before default_reset --after hard_reset
+esp8285.menu.ResetMethod.ck=no dtr (aka ck)
+esp8285.menu.ResetMethod.ck.upload.resetmethod=--before no_reset --after soft_reset
+esp8285.menu.ResetMethod.nodtr_nosync=no dtr, no_sync
+esp8285.menu.ResetMethod.nodtr_nosync.upload.resetmethod=--before no_reset_no_sync --after soft_reset
+esp8285.menu.CrystalFreq.26=26 MHz
+esp8285.menu.CrystalFreq.40=40 MHz
+esp8285.menu.CrystalFreq.40.build.extra_flags=-DF_CRYSTAL=40000000 -DESP8266
+esp8285.build.flash_mode=dout
+esp8285.build.flash_flags=-DFLASHMODE_DOUT
+esp8285.build.flash_freq=40
+esp8285.menu.eesz.1M64=1MB (FS:64KB OTA:~470KB)
+esp8285.menu.eesz.1M64.build.flash_size=1M
+esp8285.menu.eesz.1M64.build.flash_size_bytes=0x100000
+esp8285.menu.eesz.1M64.build.flash_ld=eagle.flash.1m64.ld
+esp8285.menu.eesz.1M64.build.spiffs_pagesize=256
+esp8285.menu.eesz.1M64.upload.maximum_size=958448
+esp8285.menu.eesz.1M64.build.rfcal_addr=0xFC000
+esp8285.menu.eesz.1M64.build.spiffs_start=0xEB000
+esp8285.menu.eesz.1M64.build.spiffs_end=0xFB000
+esp8285.menu.eesz.1M64.build.spiffs_blocksize=4096
+esp8285.menu.eesz.1M128=1MB (FS:128KB OTA:~438KB)
+esp8285.menu.eesz.1M128.build.flash_size=1M
+esp8285.menu.eesz.1M128.build.flash_size_bytes=0x100000
+esp8285.menu.eesz.1M128.build.flash_ld=eagle.flash.1m128.ld
+esp8285.menu.eesz.1M128.build.spiffs_pagesize=256
+esp8285.menu.eesz.1M128.upload.maximum_size=892912
+esp8285.menu.eesz.1M128.build.rfcal_addr=0xFC000
+esp8285.menu.eesz.1M128.build.spiffs_start=0xDB000
+esp8285.menu.eesz.1M128.build.spiffs_end=0xFB000
+esp8285.menu.eesz.1M128.build.spiffs_blocksize=4096
+esp8285.menu.eesz.1M144=1MB (FS:144KB OTA:~430KB)
+esp8285.menu.eesz.1M144.build.flash_size=1M
+esp8285.menu.eesz.1M144.build.flash_size_bytes=0x100000
+esp8285.menu.eesz.1M144.build.flash_ld=eagle.flash.1m144.ld
+esp8285.menu.eesz.1M144.build.spiffs_pagesize=256
+esp8285.menu.eesz.1M144.upload.maximum_size=876528
+esp8285.menu.eesz.1M144.build.rfcal_addr=0xFC000
+esp8285.menu.eesz.1M144.build.spiffs_start=0xD7000
+esp8285.menu.eesz.1M144.build.spiffs_end=0xFB000
+esp8285.menu.eesz.1M144.build.spiffs_blocksize=4096
+esp8285.menu.eesz.1M160=1MB (FS:160KB OTA:~422KB)
+esp8285.menu.eesz.1M160.build.flash_size=1M
+esp8285.menu.eesz.1M160.build.flash_size_bytes=0x100000
+esp8285.menu.eesz.1M160.build.flash_ld=eagle.flash.1m160.ld
+esp8285.menu.eesz.1M160.build.spiffs_pagesize=256
+esp8285.menu.eesz.1M160.upload.maximum_size=860144
+esp8285.menu.eesz.1M160.build.rfcal_addr=0xFC000
+esp8285.menu.eesz.1M160.build.spiffs_start=0xD3000
+esp8285.menu.eesz.1M160.build.spiffs_end=0xFB000
+esp8285.menu.eesz.1M160.build.spiffs_blocksize=4096
+esp8285.menu.eesz.1M192=1MB (FS:192KB OTA:~406KB)
+esp8285.menu.eesz.1M192.build.flash_size=1M
+esp8285.menu.eesz.1M192.build.flash_size_bytes=0x100000
+esp8285.menu.eesz.1M192.build.flash_ld=eagle.flash.1m192.ld
+esp8285.menu.eesz.1M192.build.spiffs_pagesize=256
+esp8285.menu.eesz.1M192.upload.maximum_size=827376
+esp8285.menu.eesz.1M192.build.rfcal_addr=0xFC000
+esp8285.menu.eesz.1M192.build.spiffs_start=0xCB000
+esp8285.menu.eesz.1M192.build.spiffs_end=0xFB000
+esp8285.menu.eesz.1M192.build.spiffs_blocksize=4096
+esp8285.menu.eesz.1M256=1MB (FS:256KB OTA:~374KB)
+esp8285.menu.eesz.1M256.build.flash_size=1M
+esp8285.menu.eesz.1M256.build.flash_size_bytes=0x100000
+esp8285.menu.eesz.1M256.build.flash_ld=eagle.flash.1m256.ld
+esp8285.menu.eesz.1M256.build.spiffs_pagesize=256
+esp8285.menu.eesz.1M256.upload.maximum_size=761840
+esp8285.menu.eesz.1M256.build.rfcal_addr=0xFC000
+esp8285.menu.eesz.1M256.build.spiffs_start=0xBB000
+esp8285.menu.eesz.1M256.build.spiffs_end=0xFB000
+esp8285.menu.eesz.1M256.build.spiffs_blocksize=4096
+esp8285.menu.eesz.1M512=1MB (FS:512KB OTA:~246KB)
+esp8285.menu.eesz.1M512.build.flash_size=1M
+esp8285.menu.eesz.1M512.build.flash_size_bytes=0x100000
+esp8285.menu.eesz.1M512.build.flash_ld=eagle.flash.1m512.ld
+esp8285.menu.eesz.1M512.build.spiffs_pagesize=256
+esp8285.menu.eesz.1M512.upload.maximum_size=499696
+esp8285.menu.eesz.1M512.build.rfcal_addr=0xFC000
+esp8285.menu.eesz.1M512.build.spiffs_start=0x7B000
+esp8285.menu.eesz.1M512.build.spiffs_end=0xFB000
+esp8285.menu.eesz.1M512.build.spiffs_blocksize=8192
+esp8285.menu.eesz.1M=1MB (FS:none OTA:~502KB)
+esp8285.menu.eesz.1M.build.flash_size=1M
+esp8285.menu.eesz.1M.build.flash_size_bytes=0x100000
+esp8285.menu.eesz.1M.build.flash_ld=eagle.flash.1m.ld
+esp8285.menu.eesz.1M.build.spiffs_pagesize=256
+esp8285.menu.eesz.1M.upload.maximum_size=1023984
+esp8285.menu.eesz.1M.build.rfcal_addr=0xFC000
+esp8285.menu.eesz.2M64=2MB (FS:64KB OTA:~992KB)
+esp8285.menu.eesz.2M64.build.flash_size=2M
+esp8285.menu.eesz.2M64.build.flash_size_bytes=0x200000
+esp8285.menu.eesz.2M64.build.flash_ld=eagle.flash.2m64.ld
+esp8285.menu.eesz.2M64.build.spiffs_pagesize=256
+esp8285.menu.eesz.2M64.upload.maximum_size=1044464
+esp8285.menu.eesz.2M64.build.rfcal_addr=0x1FC000
+esp8285.menu.eesz.2M64.build.spiffs_start=0x1F0000
+esp8285.menu.eesz.2M64.build.spiffs_end=0x1FB000
+esp8285.menu.eesz.2M64.build.spiffs_blocksize=4096
+esp8285.menu.eesz.2M128=2MB (FS:128KB OTA:~960KB)
+esp8285.menu.eesz.2M128.build.flash_size=2M
+esp8285.menu.eesz.2M128.build.flash_size_bytes=0x200000
+esp8285.menu.eesz.2M128.build.flash_ld=eagle.flash.2m128.ld
+esp8285.menu.eesz.2M128.build.spiffs_pagesize=256
+esp8285.menu.eesz.2M128.upload.maximum_size=1044464
+esp8285.menu.eesz.2M128.build.rfcal_addr=0x1FC000
+esp8285.menu.eesz.2M128.build.spiffs_start=0x1E0000
+esp8285.menu.eesz.2M128.build.spiffs_end=0x1FB000
+esp8285.menu.eesz.2M128.build.spiffs_blocksize=4096
+esp8285.menu.eesz.2M256=2MB (FS:256KB OTA:~896KB)
+esp8285.menu.eesz.2M256.build.flash_size=2M
+esp8285.menu.eesz.2M256.build.flash_size_bytes=0x200000
+esp8285.menu.eesz.2M256.build.flash_ld=eagle.flash.2m256.ld
+esp8285.menu.eesz.2M256.build.spiffs_pagesize=256
+esp8285.menu.eesz.2M256.upload.maximum_size=1044464
+esp8285.menu.eesz.2M256.build.rfcal_addr=0x1FC000
+esp8285.menu.eesz.2M256.build.spiffs_start=0x1C0000
+esp8285.menu.eesz.2M256.build.spiffs_end=0x1FB000
+esp8285.menu.eesz.2M256.build.spiffs_blocksize=4096
+esp8285.menu.eesz.2M512=2MB (FS:512KB OTA:~768KB)
+esp8285.menu.eesz.2M512.build.flash_size=2M
+esp8285.menu.eesz.2M512.build.flash_size_bytes=0x200000
+esp8285.menu.eesz.2M512.build.flash_ld=eagle.flash.2m512.ld
+esp8285.menu.eesz.2M512.build.spiffs_pagesize=256
+esp8285.menu.eesz.2M512.upload.maximum_size=1044464
+esp8285.menu.eesz.2M512.build.rfcal_addr=0x1FC000
+esp8285.menu.eesz.2M512.build.spiffs_start=0x180000
+esp8285.menu.eesz.2M512.build.spiffs_end=0x1FA000
+esp8285.menu.eesz.2M512.build.spiffs_blocksize=8192
+esp8285.menu.eesz.2M1M=2MB (FS:1MB OTA:~512KB)
+esp8285.menu.eesz.2M1M.build.flash_size=2M
+esp8285.menu.eesz.2M1M.build.flash_size_bytes=0x200000
+esp8285.menu.eesz.2M1M.build.flash_ld=eagle.flash.2m1m.ld
+esp8285.menu.eesz.2M1M.build.spiffs_pagesize=256
+esp8285.menu.eesz.2M1M.upload.maximum_size=1044464
+esp8285.menu.eesz.2M1M.build.rfcal_addr=0x1FC000
+esp8285.menu.eesz.2M1M.build.spiffs_start=0x100000
+esp8285.menu.eesz.2M1M.build.spiffs_end=0x1FA000
+esp8285.menu.eesz.2M1M.build.spiffs_blocksize=8192
+esp8285.menu.eesz.2M=2MB (FS:none OTA:~1019KB)
+esp8285.menu.eesz.2M.build.flash_size=2M
+esp8285.menu.eesz.2M.build.flash_size_bytes=0x200000
+esp8285.menu.eesz.2M.build.flash_ld=eagle.flash.2m.ld
+esp8285.menu.eesz.2M.build.spiffs_pagesize=256
+esp8285.menu.eesz.2M.upload.maximum_size=1044464
+esp8285.menu.eesz.2M.build.rfcal_addr=0x1FC000
+esp8285.menu.led.2=2
+esp8285.menu.led.2.build.led=-DLED_BUILTIN=2
+esp8285.menu.led.0=0
+esp8285.menu.led.0.build.led=-DLED_BUILTIN=0
+esp8285.menu.led.1=1
+esp8285.menu.led.1.build.led=-DLED_BUILTIN=1
+esp8285.menu.led.3=3
+esp8285.menu.led.3.build.led=-DLED_BUILTIN=3
+esp8285.menu.led.4=4
+esp8285.menu.led.4.build.led=-DLED_BUILTIN=4
+esp8285.menu.led.5=5
+esp8285.menu.led.5.build.led=-DLED_BUILTIN=5
+esp8285.menu.led.6=6
+esp8285.menu.led.6.build.led=-DLED_BUILTIN=6
+esp8285.menu.led.7=7
+esp8285.menu.led.7.build.led=-DLED_BUILTIN=7
+esp8285.menu.led.8=8
+esp8285.menu.led.8.build.led=-DLED_BUILTIN=8
+esp8285.menu.led.9=9
+esp8285.menu.led.9.build.led=-DLED_BUILTIN=9
+esp8285.menu.led.10=10
+esp8285.menu.led.10.build.led=-DLED_BUILTIN=10
+esp8285.menu.led.11=11
+esp8285.menu.led.11.build.led=-DLED_BUILTIN=11
+esp8285.menu.led.12=12
+esp8285.menu.led.12.build.led=-DLED_BUILTIN=12
+esp8285.menu.led.13=13
+esp8285.menu.led.13.build.led=-DLED_BUILTIN=13
+esp8285.menu.led.14=14
+esp8285.menu.led.14.build.led=-DLED_BUILTIN=14
+esp8285.menu.led.15=15
+esp8285.menu.led.15.build.led=-DLED_BUILTIN=15
+esp8285.menu.led.16=16
+esp8285.menu.led.16.build.led=-DLED_BUILTIN=16
+esp8285.menu.ip.lm2f=v2 Lower Memory
+esp8285.menu.ip.lm2f.build.lwip_include=lwip2/include
+esp8285.menu.ip.lm2f.build.lwip_lib=-llwip2-536-feat
+esp8285.menu.ip.lm2f.build.lwip_flags=-DLWIP_OPEN_SRC -DTCP_MSS=536 -DLWIP_FEATURES=1 -DLWIP_IPV6=0
+esp8285.menu.ip.hb2f=v2 Higher Bandwidth
+esp8285.menu.ip.hb2f.build.lwip_include=lwip2/include
+esp8285.menu.ip.hb2f.build.lwip_lib=-llwip2-1460-feat
+esp8285.menu.ip.hb2f.build.lwip_flags=-DLWIP_OPEN_SRC -DTCP_MSS=1460 -DLWIP_FEATURES=1 -DLWIP_IPV6=0
+esp8285.menu.ip.lm2n=v2 Lower Memory (no features)
+esp8285.menu.ip.lm2n.build.lwip_include=lwip2/include
+esp8285.menu.ip.lm2n.build.lwip_lib=-llwip2-536
+esp8285.menu.ip.lm2n.build.lwip_flags=-DLWIP_OPEN_SRC -DTCP_MSS=536 -DLWIP_FEATURES=0 -DLWIP_IPV6=0
+esp8285.menu.ip.hb2n=v2 Higher Bandwidth (no features)
+esp8285.menu.ip.hb2n.build.lwip_include=lwip2/include
+esp8285.menu.ip.hb2n.build.lwip_lib=-llwip2-1460
+esp8285.menu.ip.hb2n.build.lwip_flags=-DLWIP_OPEN_SRC -DTCP_MSS=1460 -DLWIP_FEATURES=0 -DLWIP_IPV6=0
+esp8285.menu.ip.lm6f=v2 IPv6 Lower Memory
+esp8285.menu.ip.lm6f.build.lwip_include=lwip2/include
+esp8285.menu.ip.lm6f.build.lwip_lib=-llwip6-536-feat
+esp8285.menu.ip.lm6f.build.lwip_flags=-DLWIP_OPEN_SRC -DTCP_MSS=536 -DLWIP_FEATURES=1 -DLWIP_IPV6=1
+esp8285.menu.ip.hb6f=v2 IPv6 Higher Bandwidth
+esp8285.menu.ip.hb6f.build.lwip_include=lwip2/include
+esp8285.menu.ip.hb6f.build.lwip_lib=-llwip6-1460-feat
+esp8285.menu.ip.hb6f.build.lwip_flags=-DLWIP_OPEN_SRC -DTCP_MSS=1460 -DLWIP_FEATURES=1 -DLWIP_IPV6=1
+esp8285.menu.ip.hb1=v1.4 Higher Bandwidth
+esp8285.menu.ip.hb1.build.lwip_lib=-llwip_gcc
+esp8285.menu.ip.hb1.build.lwip_flags=-DLWIP_OPEN_SRC
+esp8285.menu.ip.src=v1.4 Compile from source
+esp8285.menu.ip.src.build.lwip_lib=-llwip_src
+esp8285.menu.ip.src.build.lwip_flags=-DLWIP_OPEN_SRC
+esp8285.menu.ip.src.recipe.hooks.sketch.prebuild.1.pattern=make -C "{runtime.platform.path}/tools/sdk/lwip/src" install TOOLS_PATH="{runtime.tools.xtensa-lx106-elf-gcc.path}/bin/xtensa-lx106-elf-"
+esp8285.menu.dbg.Disabled=Disabled
+esp8285.menu.dbg.Disabled.build.debug_port=
+esp8285.menu.dbg.Serial=Serial
+esp8285.menu.dbg.Serial.build.debug_port=-DDEBUG_ESP_PORT=Serial
+esp8285.menu.dbg.Serial1=Serial1
+esp8285.menu.dbg.Serial1.build.debug_port=-DDEBUG_ESP_PORT=Serial1
+esp8285.menu.lvl.None____=None
+esp8285.menu.lvl.None____.build.debug_level=
+esp8285.menu.lvl.SSL=SSL
+esp8285.menu.lvl.SSL.build.debug_level= -DDEBUG_ESP_SSL
+esp8285.menu.lvl.TLS_MEM=TLS_MEM
+esp8285.menu.lvl.TLS_MEM.build.debug_level= -DDEBUG_ESP_TLS_MEM
+esp8285.menu.lvl.HTTP_CLIENT=HTTP_CLIENT
+esp8285.menu.lvl.HTTP_CLIENT.build.debug_level= -DDEBUG_ESP_HTTP_CLIENT
+esp8285.menu.lvl.HTTP_SERVER=HTTP_SERVER
+esp8285.menu.lvl.HTTP_SERVER.build.debug_level= -DDEBUG_ESP_HTTP_SERVER
+esp8285.menu.lvl.SSLTLS_MEM=SSL+TLS_MEM
+esp8285.menu.lvl.SSLTLS_MEM.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_TLS_MEM
+esp8285.menu.lvl.SSLHTTP_CLIENT=SSL+HTTP_CLIENT
+esp8285.menu.lvl.SSLHTTP_CLIENT.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_HTTP_CLIENT
+esp8285.menu.lvl.SSLHTTP_SERVER=SSL+HTTP_SERVER
+esp8285.menu.lvl.SSLHTTP_SERVER.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_HTTP_SERVER
+esp8285.menu.lvl.TLS_MEMHTTP_CLIENT=TLS_MEM+HTTP_CLIENT
+esp8285.menu.lvl.TLS_MEMHTTP_CLIENT.build.debug_level= -DDEBUG_ESP_TLS_MEM -DDEBUG_ESP_HTTP_CLIENT
+esp8285.menu.lvl.TLS_MEMHTTP_SERVER=TLS_MEM+HTTP_SERVER
+esp8285.menu.lvl.TLS_MEMHTTP_SERVER.build.debug_level= -DDEBUG_ESP_TLS_MEM -DDEBUG_ESP_HTTP_SERVER
+esp8285.menu.lvl.HTTP_CLIENTHTTP_SERVER=HTTP_CLIENT+HTTP_SERVER
+esp8285.menu.lvl.HTTP_CLIENTHTTP_SERVER.build.debug_level= -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_SERVER
+esp8285.menu.lvl.SSLTLS_MEMHTTP_CLIENT=SSL+TLS_MEM+HTTP_CLIENT
+esp8285.menu.lvl.SSLTLS_MEMHTTP_CLIENT.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_TLS_MEM -DDEBUG_ESP_HTTP_CLIENT
+esp8285.menu.lvl.SSLTLS_MEMHTTP_SERVER=SSL+TLS_MEM+HTTP_SERVER
+esp8285.menu.lvl.SSLTLS_MEMHTTP_SERVER.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_TLS_MEM -DDEBUG_ESP_HTTP_SERVER
+esp8285.menu.lvl.SSLHTTP_CLIENTHTTP_SERVER=SSL+HTTP_CLIENT+HTTP_SERVER
+esp8285.menu.lvl.SSLHTTP_CLIENTHTTP_SERVER.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_SERVER
+esp8285.menu.lvl.TLS_MEMHTTP_CLIENTHTTP_SERVER=TLS_MEM+HTTP_CLIENT+HTTP_SERVER
+esp8285.menu.lvl.TLS_MEMHTTP_CLIENTHTTP_SERVER.build.debug_level= -DDEBUG_ESP_TLS_MEM -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_SERVER
+esp8285.menu.lvl.SSLTLS_MEMHTTP_CLIENTHTTP_SERVER=SSL+TLS_MEM+HTTP_CLIENT+HTTP_SERVER
+esp8285.menu.lvl.SSLTLS_MEMHTTP_CLIENTHTTP_SERVER.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_TLS_MEM -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_SERVER
+esp8285.menu.lvl.CORE=CORE
+esp8285.menu.lvl.CORE.build.debug_level= -DDEBUG_ESP_CORE
+esp8285.menu.lvl.WIFI=WIFI
+esp8285.menu.lvl.WIFI.build.debug_level= -DDEBUG_ESP_WIFI
+esp8285.menu.lvl.HTTP_UPDATE=HTTP_UPDATE
+esp8285.menu.lvl.HTTP_UPDATE.build.debug_level= -DDEBUG_ESP_HTTP_UPDATE
+esp8285.menu.lvl.UPDATER=UPDATER
+esp8285.menu.lvl.UPDATER.build.debug_level= -DDEBUG_ESP_UPDATER
+esp8285.menu.lvl.OTA=OTA
+esp8285.menu.lvl.OTA.build.debug_level= -DDEBUG_ESP_OTA
+esp8285.menu.lvl.OOM=OOM
+esp8285.menu.lvl.OOM.build.debug_level= -DDEBUG_ESP_OOM
+esp8285.menu.lvl.MDNS=MDNS
+esp8285.menu.lvl.MDNS.build.debug_level= -DDEBUG_ESP_MDNS
+esp8285.menu.lvl.COREWIFIHTTP_UPDATEUPDATEROTAOOMMDNS=CORE+WIFI+HTTP_UPDATE+UPDATER+OTA+OOM+MDNS
+esp8285.menu.lvl.COREWIFIHTTP_UPDATEUPDATEROTAOOMMDNS.build.debug_level= -DDEBUG_ESP_CORE -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_UPDATER -DDEBUG_ESP_OTA -DDEBUG_ESP_OOM -DDEBUG_ESP_MDNS
+esp8285.menu.lvl.SSLTLS_MEMHTTP_CLIENTHTTP_SERVERCOREWIFIHTTP_UPDATEUPDATEROTAOOMMDNS=SSL+TLS_MEM+HTTP_CLIENT+HTTP_SERVER+CORE+WIFI+HTTP_UPDATE+UPDATER+OTA+OOM+MDNS
+esp8285.menu.lvl.SSLTLS_MEMHTTP_CLIENTHTTP_SERVERCOREWIFIHTTP_UPDATEUPDATEROTAOOMMDNS.build.debug_level= -DDEBUG_ESP_SSL -DDEBUG_ESP_TLS_MEM -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_SERVER -DDEBUG_ESP_CORE -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_UPDATER -DDEBUG_ESP_OTA -DDEBUG_ESP_OOM -DDEBUG_ESP_MDNS
+esp8285.menu.lvl.NoAssert-NDEBUG=NoAssert-NDEBUG
+esp8285.menu.lvl.NoAssert-NDEBUG.build.debug_level= -DNDEBUG
+esp8285.menu.wipe.none=Only Sketch
+esp8285.menu.wipe.none.upload.erase_cmd=
+esp8285.menu.wipe.sdk=Sketch + WiFi Settings
+esp8285.menu.wipe.sdk.upload.erase_cmd=erase_region "{build.rfcal_addr}" 0x4000
+esp8285.menu.wipe.all=All Flash Contents
+esp8285.menu.wipe.all.upload.erase_cmd=erase_flash
+esp8285.menu.baud.115200=115200
+esp8285.menu.baud.115200.upload.speed=115200
+esp8285.menu.baud.57600=57600
+esp8285.menu.baud.57600.upload.speed=57600
+esp8285.menu.baud.230400.linux=230400
+esp8285.menu.baud.230400.macosx=230400
+esp8285.menu.baud.230400.upload.speed=230400
+esp8285.menu.baud.256000.windows=256000
+esp8285.menu.baud.256000.upload.speed=256000
+esp8285.menu.baud.460800.linux=460800
+esp8285.menu.baud.460800.macosx=460800
+esp8285.menu.baud.460800.upload.speed=460800
+esp8285.menu.baud.512000.windows=512000
+esp8285.menu.baud.512000.upload.speed=512000
+esp8285.menu.baud.921600=921600
+esp8285.menu.baud.921600.upload.speed=921600
+esp8285.menu.baud.3000000=3000000
+esp8285.menu.baud.3000000.upload.speed=3000000
 
-esp8285.menu.CpuFrequency.80=80 MHz
-esp8285.menu.CpuFrequency.80.build.f_cpu=80000000L
-esp8285.menu.CpuFrequency.160=160 MHz
-esp8285.menu.CpuFrequency.160.build.f_cpu=160000000L
-
-esp8285.menu.UploadSpeed.115200=115200
-esp8285.menu.UploadSpeed.115200.upload.speed=115200
-esp8285.menu.UploadSpeed.9600=9600
-esp8285.menu.UploadSpeed.9600.upload.speed=9600
-esp8285.menu.UploadSpeed.57600=57600
-esp8285.menu.UploadSpeed.57600.upload.speed=57600
-esp8285.menu.UploadSpeed.256000.windows=256000
-esp8285.menu.UploadSpeed.256000.upload.speed=256000
-esp8285.menu.UploadSpeed.230400.linux=230400
-esp8285.menu.UploadSpeed.230400.macosx=230400
-esp8285.menu.UploadSpeed.230400.upload.speed=230400
-esp8285.menu.UploadSpeed.460800.linux=460800
-esp8285.menu.UploadSpeed.460800.macosx=460800
-esp8285.menu.UploadSpeed.460800.upload.speed=460800
-esp8285.menu.UploadSpeed.512000.windows=512000
-esp8285.menu.UploadSpeed.512000.upload.speed=512000
-esp8285.menu.UploadSpeed.921600=921600
-esp8285.menu.UploadSpeed.921600.upload.speed=921600
-
-esp8285.menu.FlashSize.1M512=1M (512K SPIFFS)
-esp8285.menu.FlashSize.1M512.build.flash_size=1M
-esp8285.menu.FlashSize.1M512.build.flash_ld=eagle.flash.1m512.ld
-esp8285.menu.FlashSize.1M512.build.spiffs_start=0x7B000
-esp8285.menu.FlashSize.1M512.build.spiffs_end=0xFB000
-esp8285.menu.FlashSize.1M512.build.spiffs_blocksize=8192
-esp8285.menu.FlashSize.1M512.upload.maximum_size=499696
-
-esp8285.menu.FlashSize.1M256=1M (256K SPIFFS)
-esp8285.menu.FlashSize.1M256.build.flash_size=1M
-esp8285.menu.FlashSize.1M256.build.flash_ld=eagle.flash.1m256.ld
-esp8285.menu.FlashSize.1M256.build.spiffs_start=0xBB000
-esp8285.menu.FlashSize.1M256.build.spiffs_end=0xFB000
-esp8285.menu.FlashSize.1M256.build.spiffs_blocksize=4096
-esp8285.menu.FlashSize.1M256.upload.maximum_size=761840
-
-esp8285.menu.FlashSize.1M192=1M (192K SPIFFS)
-esp8285.menu.FlashSize.1M192.build.flash_size=1M
-esp8285.menu.FlashSize.1M192.build.flash_ld=eagle.flash.1m192.ld
-esp8285.menu.FlashSize.1M192.build.spiffs_start=0xCB000
-esp8285.menu.FlashSize.1M192.build.spiffs_end=0xFB000
-esp8285.menu.FlashSize.1M192.build.spiffs_blocksize=4096
-esp8285.menu.FlashSize.1M192.upload.maximum_size=827376
-
-esp8285.menu.FlashSize.1M160=1M (160K SPIFFS)
-esp8285.menu.FlashSize.1M160.build.flash_size=1M
-esp8285.menu.FlashSize.1M160.build.flash_ld=eagle.flash.1m160.ld
-esp8285.menu.FlashSize.1M160.build.spiffs_start=0xD3000
-esp8285.menu.FlashSize.1M160.build.spiffs_end=0xFB000
-esp8285.menu.FlashSize.1M160.build.spiffs_blocksize=4096
-esp8285.menu.FlashSize.1M160.upload.maximum_size=860144
-
-esp8285.menu.FlashSize.1M144=1M (144K SPIFFS)
-esp8285.menu.FlashSize.1M144.build.flash_size=1M
-esp8285.menu.FlashSize.1M144.build.flash_ld=eagle.flash.1m144.ld
-esp8285.menu.FlashSize.1M144.build.spiffs_start=0xD7000
-esp8285.menu.FlashSize.1M144.build.spiffs_end=0xFB000
-esp8285.menu.FlashSize.1M144.build.spiffs_blocksize=4096
-esp8285.menu.FlashSize.1M144.upload.maximum_size=876528
-
-esp8285.menu.FlashSize.1M128=1M (128K SPIFFS)
-esp8285.menu.FlashSize.1M128.build.flash_size=1M
-esp8285.menu.FlashSize.1M128.build.flash_ld=eagle.flash.1m128.ld
-esp8285.menu.FlashSize.1M128.build.spiffs_start=0xDB000
-esp8285.menu.FlashSize.1M128.build.spiffs_end=0xFB000
-esp8285.menu.FlashSize.1M128.build.spiffs_blocksize=4096
-esp8285.menu.FlashSize.1M128.upload.maximum_size=892912
-
-esp8285.menu.FlashSize.1M64=1M (64K SPIFFS)
-esp8285.menu.FlashSize.1M64.build.flash_size=1M
-esp8285.menu.FlashSize.1M64.build.flash_ld=eagle.flash.1m64.ld
-esp8285.menu.FlashSize.1M64.build.spiffs_start=0xEB000
-esp8285.menu.FlashSize.1M64.build.spiffs_end=0xFB000
-esp8285.menu.FlashSize.1M64.build.spiffs_blocksize=4096
-esp8285.menu.FlashSize.1M64.upload.maximum_size=958448
-
-
-##############################################################
-
-espduino.name=ESPDuino (ESP-13 Module)
-
-espduino.upload.tool=esptool
-espduino.upload.speed=115200
-espduino.upload.resetmethod=ck
-espduino.upload.maximum_size=1044464
-espduino.upload.maximum_data_size=81920
-espduino.upload.wait_for_upload_port=true
-espduino.serial.disableDTR=true
-espduino.serial.disableRTS=true
-
-espduino.build.mcu=esp8266
-espduino.build.f_cpu=80000000L
-espduino.build.board=ESP8266_ESP13
-espduino.build.core=esp8266
-espduino.build.variant=ESPDuino
-espduino.build.flash_mode=dio
-espduino.build.flash_size=4M
-espduino.build.flash_freq=40
-espduino.build.debug_port=
-espduino.build.debug_level=
-
-espduino.menu.CpuFrequency.80=80 MHz
-espduino.menu.CpuFrequency.80.build.f_cpu=80000000L
-espduino.menu.CpuFrequency.160=160 MHz
-espduino.menu.CpuFrequency.160.build.f_cpu=160000000L
-
-espduino.menu.UploadSpeed.115200=115200
-espduino.menu.UploadSpeed.115200.upload.speed=115200
-espduino.menu.UploadSpeed.9600=9600
-espduino.menu.UploadSpeed.9600.upload.speed=9600
-espduino.menu.UploadSpeed.57600=57600
-espduino.menu.UploadSpeed.57600.upload.speed=57600
-espduino.menu.UploadSpeed.256000.windows=256000
-espduino.menu.UploadSpeed.256000.upload.speed=256000
-espduino.menu.UploadSpeed.230400.linux=230400
-espduino.menu.UploadSpeed.230400.macosx=230400
-espduino.menu.UploadSpeed.230400.macosx=230400
-espduino.menu.UploadSpeed.230400.upload.speed=230400
-espduino.menu.UploadSpeed.460800.linux=460800
-espduino.menu.UploadSpeed.460800.macosx=460800
-espduino.menu.UploadSpeed.460800.upload.speed=460800
-espduino.menu.UploadSpeed.512000.windows=512000
-espduino.menu.UploadSpeed.512000.upload.speed=512000
-espduino.menu.UploadSpeed.921600=921600
-espduino.menu.UploadSpeed.921600.upload.speed=921600
-
-espduino.menu.FlashSize.4M3M=4M (3M SPIFFS)
-espduino.menu.FlashSize.4M3M.build.flash_size=4M
-espduino.menu.FlashSize.4M3M.build.flash_ld=eagle.flash.4m.ld
-espduino.menu.FlashSize.4M3M.build.spiffs_start=0x100000
-espduino.menu.FlashSize.4M3M.build.spiffs_end=0x3FB000
-espduino.menu.FlashSize.4M3M.build.spiffs_blocksize=8192
-espduino.menu.FlashSize.4M3M.build.spiffs_pagesize=256
-
-espduino.menu.FlashSize.4M1M=4M (1M SPIFFS)
-espduino.menu.FlashSize.4M1M.build.flash_size=4M
-espduino.menu.FlashSize.4M1M.build.flash_ld=eagle.flash.4m1m.ld
-espduino.menu.FlashSize.4M1M.build.spiffs_start=0x300000
-espduino.menu.FlashSize.4M1M.build.spiffs_end=0x3FB000
-espduino.menu.FlashSize.4M1M.build.spiffs_blocksize=8192
-espduino.menu.FlashSize.4M1M.build.spiffs_pagesize=256
-##############################################################
-huzzah.name=Adafruit HUZZAH ESP8266
-
-huzzah.upload.tool=esptool
-huzzah.upload.speed=115200
-huzzah.upload.resetmethod=nodemcu
-huzzah.upload.maximum_size=1044464
-huzzah.upload.maximum_data_size=81920
-huzzah.upload.wait_for_upload_port=true
-huzzah.serial.disableDTR=true
-huzzah.serial.disableRTS=true
-
-huzzah.build.mcu=esp8266
-huzzah.build.f_cpu=80000000L
-huzzah.build.board=ESP8266_ESP12
-huzzah.build.core=esp8266
-huzzah.build.variant=adafruit
-huzzah.build.flash_mode=qio
-huzzah.build.flash_size=4M
-huzzah.build.flash_freq=40
-huzzah.build.debug_port=
-huzzah.build.debug_level=
-
-huzzah.menu.CpuFrequency.80=80 MHz
-huzzah.menu.CpuFrequency.80.build.f_cpu=80000000L
-huzzah.menu.CpuFrequency.160=160 MHz
-huzzah.menu.CpuFrequency.160.build.f_cpu=160000000L
-
-huzzah.menu.UploadSpeed.115200=115200
-huzzah.menu.UploadSpeed.115200.upload.speed=115200
-huzzah.menu.UploadSpeed.9600=9600
-huzzah.menu.UploadSpeed.9600.upload.speed=9600
-huzzah.menu.UploadSpeed.57600=57600
-huzzah.menu.UploadSpeed.57600.upload.speed=57600
-huzzah.menu.UploadSpeed.256000=256000
-huzzah.menu.UploadSpeed.256000.upload.speed=256000
-huzzah.menu.UploadSpeed.921600=921600
-huzzah.menu.UploadSpeed.921600.upload.speed=921600
-
-huzzah.menu.FlashSize.4M3M=4M (3M SPIFFS)
-huzzah.menu.FlashSize.4M3M.build.flash_size=4M
-huzzah.menu.FlashSize.4M3M.build.flash_ld=eagle.flash.4m.ld
-huzzah.menu.FlashSize.4M3M.build.spiffs_start=0x100000
-huzzah.menu.FlashSize.4M3M.build.spiffs_end=0x3FB000
-huzzah.menu.FlashSize.4M3M.build.spiffs_blocksize=8192
-huzzah.menu.FlashSize.4M3M.build.spiffs_pagesize=256
-
-huzzah.menu.FlashSize.4M1M=4M (1M SPIFFS)
-huzzah.menu.FlashSize.4M1M.build.flash_size=4M
-huzzah.menu.FlashSize.4M1M.build.flash_ld=eagle.flash.4m1m.ld
-huzzah.menu.FlashSize.4M1M.build.spiffs_start=0x300000
-huzzah.menu.FlashSize.4M1M.build.spiffs_end=0x3FB000
-huzzah.menu.FlashSize.4M1M.build.spiffs_blocksize=8192
-huzzah.menu.FlashSize.4M1M.build.spiffs_pagesize=256
-
-##############################################################
-espresso_lite_v1.name=ESPresso Lite 1.0
-espresso_lite_v1.upload.tool=esptool
-espresso_lite_v1.upload.speed=115200
-espresso_lite_v1.upload.maximum_size=1044464
-espresso_lite_v1.upload.maximum_data_size=81920
-espresso_lite_v1.upload.wait_for_upload_port=true
-
-espresso_lite_v1.build.mcu=esp8266
-espresso_lite_v1.build.f_cpu=80000000L
-espresso_lite_v1.build.board=ESP8266_ESPRESSO_LITE_V1
-espresso_lite_v1.build.core=esp8266
-espresso_lite_v1.build.variant=espresso_lite_v1
-espresso_lite_v1.build.flash_mode=dio
-espresso_lite_v1.build.flash_size=4M
-espresso_lite_v1.build.flash_freq=40
-
-espresso_lite_v1.menu.CpuFrequency.80=80 MHz
-espresso_lite_v1.menu.CpuFrequency.80.build.f_cpu=80000000L
-espresso_lite_v1.menu.CpuFrequency.160=160 MHz
-espresso_lite_v1.menu.CpuFrequency.160.build.f_cpu=160000000L
-
-espresso_lite_v1.menu.UploadSpeed.115200=115200
-espresso_lite_v1.menu.UploadSpeed.115200.upload.speed=115200
-espresso_lite_v1.menu.UploadSpeed.57600=57600
-espresso_lite_v1.menu.UploadSpeed.57600.upload.speed=57600
-espresso_lite_v1.menu.UploadSpeed.256000.windows=256000
-espresso_lite_v1.menu.UploadSpeed.256000.upload.speed=256000
-espresso_lite_v1.menu.UploadSpeed.230400.linux=230400
-espresso_lite_v1.menu.UploadSpeed.230400.macosx=230400
-espresso_lite_v1.menu.UploadSpeed.230400.macosx=230400
-espresso_lite_v1.menu.UploadSpeed.230400.upload.speed=230400
-espresso_lite_v1.menu.UploadSpeed.460800.linux=460800
-espresso_lite_v1.menu.UploadSpeed.460800.macosx=460800
-espresso_lite_v1.menu.UploadSpeed.460800.upload.speed=460800
-espresso_lite_v1.menu.UploadSpeed.512000.windows=512000
-espresso_lite_v1.menu.UploadSpeed.512000.upload.speed=512000
-espresso_lite_v1.menu.UploadSpeed.921600=921600
-espresso_lite_v1.menu.UploadSpeed.921600.upload.speed=921600
-
-espresso_lite_v1.menu.FlashSize.4M3M=4M (3M SPIFFS)
-espresso_lite_v1.menu.FlashSize.4M3M.build.flash_size=4M
-espresso_lite_v1.menu.FlashSize.4M3M.build.flash_ld=eagle.flash.4m.ld
-espresso_lite_v1.menu.FlashSize.4M3M.build.spiffs_start=0x100000
-espresso_lite_v1.menu.FlashSize.4M3M.build.spiffs_end=0x3FB000
-espresso_lite_v1.menu.FlashSize.4M3M.build.spiffs_blocksize=8192
-espresso_lite_v1.menu.FlashSize.4M3M.upload.maximum_size=1044464
-
-espresso_lite_v1.menu.FlashSize.4M1M=4M (1M SPIFFS)
-espresso_lite_v1.menu.FlashSize.4M1M.build.flash_size=4M
-espresso_lite_v1.menu.FlashSize.4M1M.build.flash_ld=eagle.flash.4m1m.ld
-espresso_lite_v1.menu.FlashSize.4M1M.build.spiffs_start=0x300000
-espresso_lite_v1.menu.FlashSize.4M1M.build.spiffs_end=0x3FB000
-espresso_lite_v1.menu.FlashSize.4M1M.build.spiffs_blocksize=8192
-espresso_lite_v1.menu.FlashSize.4M1M.build.spiffs_pagesize=256
-espresso_lite_v1.menu.FlashSize.4M1M.upload.maximum_size=1044464
-
-espresso_lite_v1.menu.ResetMethod.nodemcu=nodemcu
-espresso_lite_v1.menu.ResetMethod.nodemcu.upload.resetmethod=nodemcu
-espresso_lite_v1.menu.ResetMethod.ck=ck
-espresso_lite_v1.menu.ResetMethod.ck.upload.resetmethod=ck
-
-espresso_lite_v1.menu.Debug.Disabled=Disabled
-espresso_lite_v1.menu.Debug.Disabled.build.debug_port=
-espresso_lite_v1.menu.Debug.Serial=Serial
-espresso_lite_v1.menu.Debug.Serial.build.debug_port=-DDEBUG_ESP_PORT=Serial
-espresso_lite_v1.menu.Debug.Serial1=Serial1
-espresso_lite_v1.menu.Debug.Serial1.build.debug_port=-DDEBUG_ESP_PORT=Serial1
-
-espresso_lite_v1.menu.DebugLevel.None____=None
-espresso_lite_v1.menu.DebugLevel.None____.build.debug_level=
-espresso_lite_v1.menu.DebugLevel.Core____=Core
-espresso_lite_v1.menu.DebugLevel.Core____.build.debug_level=-DDEBUG_ESP_CORE
-espresso_lite_v1.menu.DebugLevel.SSL_____=Core + SSL
-espresso_lite_v1.menu.DebugLevel.SSL_____.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_SSL
-espresso_lite_v1.menu.DebugLevel.SSL_MEM_=Core + SSL + TLS Mem
-espresso_lite_v1.menu.DebugLevel.SSL_MEM_.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_SSL -DDEBUG_TLS_MEM
-espresso_lite_v1.menu.DebugLevel.WiFic___=Core + WiFi
-espresso_lite_v1.menu.DebugLevel.WiFic___.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_WIFI
-espresso_lite_v1.menu.DebugLevel.WiFi____=WiFi
-espresso_lite_v1.menu.DebugLevel.WiFi____.build.debug_level=-DDEBUG_ESP_WIFI
-espresso_lite_v1.menu.DebugLevel.HTTPClient=HTTPClient
-espresso_lite_v1.menu.DebugLevel.HTTPClient.build.debug_level=-DDEBUG_ESP_HTTP_CLIENT
-espresso_lite_v1.menu.DebugLevel.HTTPClient2=HTTPClient + SSL
-espresso_lite_v1.menu.DebugLevel.HTTPClient2.build.debug_level=-DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_SSL
-espresso_lite_v1.menu.DebugLevel.HTTPUpdate=HTTPUpdate
-espresso_lite_v1.menu.DebugLevel.HTTPUpdate.build.debug_level=-DDEBUG_ESP_HTTP_UPDATE
-espresso_lite_v1.menu.DebugLevel.HTTPUpdate2=HTTPClient + HTTPUpdate
-espresso_lite_v1.menu.DebugLevel.HTTPUpdate2.build.debug_level=-DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_UPDATE
-espresso_lite_v1.menu.DebugLevel.HTTPUpdate3=HTTPClient + HTTPUpdate + Updater
-espresso_lite_v1.menu.DebugLevel.HTTPUpdate3.build.debug_level=-DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_UPDATER
-espresso_lite_v1.menu.DebugLevel.HTTPServer=HTTPServer
-espresso_lite_v1.menu.DebugLevel.HTTPServer.build.debug_level=-DDEBUG_ESP_HTTP_SERVER
-espresso_lite_v1.menu.DebugLevel.UPDATER=Updater
-espresso_lite_v1.menu.DebugLevel.UPDATER.build.debug_level=-DDEBUG_ESP_UPDATER
-espresso_lite_v1.menu.DebugLevel.OTA_____=OTA
-espresso_lite_v1.menu.DebugLevel.OTA_____.build.debug_level=-DDEBUG_ESP_OTA
-espresso_lite_v1.menu.DebugLevel.OTA2____=OTA + Updater
-espresso_lite_v1.menu.DebugLevel.OTA2____.build.debug_level=-DDEBUG_ESP_OTA -DDEBUG_ESP_UPDATER
-espresso_lite_v1.menu.DebugLevel.all_____=All
-espresso_lite_v1.menu.DebugLevel.all_____.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_SSL -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_SERVER -DDEBUG_ESP_UPDATER -DDEBUG_ESP_OTA -DDEBUG_TLS_MEM
-
-espresso_lite_v1.build.debug_port=
-espresso_lite_v1.build.debug_level=
-
-##############################################################
-espresso_lite_v2.name=ESPresso Lite 2.0
-espresso_lite_v2.upload.tool=esptool
-espresso_lite_v2.upload.speed=115200
-espresso_lite_v2.upload.maximum_size=1044464
-espresso_lite_v2.upload.maximum_data_size=81920
-espresso_lite_v2.upload.wait_for_upload_port=true
-
-espresso_lite_v2.build.mcu=esp8266
-espresso_lite_v2.build.f_cpu=80000000L
-espresso_lite_v2.build.board=ESP8266_ESPRESSO_LITE_V2
-espresso_lite_v2.build.core=esp8266
-espresso_lite_v2.build.variant=espresso_lite_v2
-espresso_lite_v2.build.flash_mode=dio
-espresso_lite_v2.build.flash_size=4M
-espresso_lite_v2.build.flash_freq=40
-
-espresso_lite_v2.menu.CpuFrequency.80=80 MHz
-espresso_lite_v2.menu.CpuFrequency.80.build.f_cpu=80000000L
-espresso_lite_v2.menu.CpuFrequency.160=160 MHz
-espresso_lite_v2.menu.CpuFrequency.160.build.f_cpu=160000000L
-
-espresso_lite_v2.menu.UploadSpeed.115200=115200
-espresso_lite_v2.menu.UploadSpeed.115200.upload.speed=115200
-espresso_lite_v2.menu.UploadSpeed.57600=57600
-espresso_lite_v2.menu.UploadSpeed.57600.upload.speed=57600
-espresso_lite_v2.menu.UploadSpeed.256000.windows=256000
-espresso_lite_v2.menu.UploadSpeed.256000.upload.speed=256000
-espresso_lite_v2.menu.UploadSpeed.230400.linux=230400
-espresso_lite_v2.menu.UploadSpeed.230400.macosx=230400
-espresso_lite_v2.menu.UploadSpeed.230400.macosx=230400
-espresso_lite_v2.menu.UploadSpeed.230400.upload.speed=230400
-espresso_lite_v2.menu.UploadSpeed.460800.linux=460800
-espresso_lite_v2.menu.UploadSpeed.460800.macosx=460800
-espresso_lite_v2.menu.UploadSpeed.460800.upload.speed=460800
-espresso_lite_v2.menu.UploadSpeed.512000.windows=512000
-espresso_lite_v2.menu.UploadSpeed.512000.upload.speed=512000
-espresso_lite_v2.menu.UploadSpeed.921600=921600
-espresso_lite_v2.menu.UploadSpeed.921600.upload.speed=921600
-
-espresso_lite_v2.menu.FlashSize.4M3M=4M (3M SPIFFS)
-espresso_lite_v2.menu.FlashSize.4M3M.build.flash_size=4M
-espresso_lite_v2.menu.FlashSize.4M3M.build.flash_ld=eagle.flash.4m.ld
-espresso_lite_v2.menu.FlashSize.4M3M.build.spiffs_start=0x100000
-espresso_lite_v2.menu.FlashSize.4M3M.build.spiffs_end=0x3FB000
-espresso_lite_v2.menu.FlashSize.4M3M.build.spiffs_blocksize=8192
-espresso_lite_v2.menu.FlashSize.4M3M.upload.maximum_size=1044464
-
-espresso_lite_v2.menu.FlashSize.4M1M=4M (1M SPIFFS)
-espresso_lite_v2.menu.FlashSize.4M1M.build.flash_size=4M
-espresso_lite_v2.menu.FlashSize.4M1M.build.flash_ld=eagle.flash.4m1m.ld
-espresso_lite_v2.menu.FlashSize.4M1M.build.spiffs_start=0x300000
-espresso_lite_v2.menu.FlashSize.4M1M.build.spiffs_end=0x3FB000
-espresso_lite_v2.menu.FlashSize.4M1M.build.spiffs_blocksize=8192
-espresso_lite_v2.menu.FlashSize.4M1M.build.spiffs_pagesize=256
-espresso_lite_v2.menu.FlashSize.4M1M.upload.maximum_size=1044464
-
-espresso_lite_v2.menu.ResetMethod.ck=ck
-espresso_lite_v2.menu.ResetMethod.ck.upload.resetmethod=ck
-espresso_lite_v2.menu.ResetMethod.nodemcu=nodemcu
-espresso_lite_v2.menu.ResetMethod.nodemcu.upload.resetmethod=nodemcu
-
-espresso_lite_v2.menu.Debug.Disabled=Disabled
-espresso_lite_v2.menu.Debug.Disabled.build.debug_port=
-espresso_lite_v2.menu.Debug.Serial=Serial
-espresso_lite_v2.menu.Debug.Serial.build.debug_port=-DDEBUG_ESP_PORT=Serial
-espresso_lite_v2.menu.Debug.Serial1=Serial1
-espresso_lite_v2.menu.Debug.Serial1.build.debug_port=-DDEBUG_ESP_PORT=Serial1
-
-espresso_lite_v2.menu.DebugLevel.None____=None
-espresso_lite_v2.menu.DebugLevel.None____.build.debug_level=
-espresso_lite_v2.menu.DebugLevel.Core____=Core
-espresso_lite_v2.menu.DebugLevel.Core____.build.debug_level=-DDEBUG_ESP_CORE
-espresso_lite_v2.menu.DebugLevel.SSL_____=Core + SSL
-espresso_lite_v2.menu.DebugLevel.SSL_____.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_SSL
-espresso_lite_v2.menu.DebugLevel.SSL_MEM_=Core + SSL + TLS Mem
-espresso_lite_v2.menu.DebugLevel.SSL_MEM_.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_SSL -DDEBUG_TLS_MEM
-espresso_lite_v2.menu.DebugLevel.WiFic___=Core + WiFi
-espresso_lite_v2.menu.DebugLevel.WiFic___.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_WIFI
-espresso_lite_v2.menu.DebugLevel.WiFi____=WiFi
-espresso_lite_v2.menu.DebugLevel.WiFi____.build.debug_level=-DDEBUG_ESP_WIFI
-espresso_lite_v2.menu.DebugLevel.HTTPClient=HTTPClient
-espresso_lite_v2.menu.DebugLevel.HTTPClient.build.debug_level=-DDEBUG_ESP_HTTP_CLIENT
-espresso_lite_v2.menu.DebugLevel.HTTPClient2=HTTPClient + SSL
-espresso_lite_v2.menu.DebugLevel.HTTPClient2.build.debug_level=-DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_SSL
-espresso_lite_v2.menu.DebugLevel.HTTPUpdate=HTTPUpdate
-espresso_lite_v2.menu.DebugLevel.HTTPUpdate.build.debug_level=-DDEBUG_ESP_HTTP_UPDATE
-espresso_lite_v2.menu.DebugLevel.HTTPUpdate2=HTTPClient + HTTPUpdate
-espresso_lite_v2.menu.DebugLevel.HTTPUpdate2.build.debug_level=-DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_UPDATE
-espresso_lite_v2.menu.DebugLevel.HTTPUpdate3=HTTPClient + HTTPUpdate + Updater
-espresso_lite_v2.menu.DebugLevel.HTTPUpdate3.build.debug_level=-DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_UPDATER
-espresso_lite_v2.menu.DebugLevel.HTTPServer=HTTPServer
-espresso_lite_v2.menu.DebugLevel.HTTPServer.build.debug_level=-DDEBUG_ESP_HTTP_SERVER
-espresso_lite_v2.menu.DebugLevel.UPDATER=Updater
-espresso_lite_v2.menu.DebugLevel.UPDATER.build.debug_level=-DDEBUG_ESP_UPDATER
-espresso_lite_v2.menu.DebugLevel.OTA_____=OTA
-espresso_lite_v2.menu.DebugLevel.OTA_____.build.debug_level=-DDEBUG_ESP_OTA
-espresso_lite_v2.menu.DebugLevel.OTA2____=OTA + Updater
-espresso_lite_v2.menu.DebugLevel.OTA2____.build.debug_level=-DDEBUG_ESP_OTA -DDEBUG_ESP_UPDATER
-espresso_lite_v2.menu.DebugLevel.all_____=All
-espresso_lite_v2.menu.DebugLevel.all_____.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_SSL -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_SERVER -DDEBUG_ESP_UPDATER -DDEBUG_ESP_OTA -DDEBUG_TLS_MEM
-
-espresso_lite_v2.build.debug_port=
-espresso_lite_v2.build.debug_level=
-
-##############################################################
-phoenix_v1.name=Phoenix 1.0
-phoenix_v1.upload.tool=esptool
-phoenix_v1.upload.speed=115200
-phoenix_v1.upload.maximum_size=1044464
-phoenix_v1.upload.maximum_data_size=81920
-phoenix_v1.upload.wait_for_upload_port=true
-
-phoenix_v1.build.mcu=esp8266
-phoenix_v1.build.f_cpu=80000000L
-phoenix_v1.build.board=ESP8266_PHOENIX_V1
-phoenix_v1.build.core=esp8266
-phoenix_v1.build.variant=phoenix_v1
-phoenix_v1.build.flash_mode=dio
-phoenix_v1.build.flash_size=4M
-phoenix_v1.build.flash_freq=40
-
-phoenix_v1.menu.CpuFrequency.80=80 MHz
-phoenix_v1.menu.CpuFrequency.80.build.f_cpu=80000000L
-phoenix_v1.menu.CpuFrequency.160=160 MHz
-phoenix_v1.menu.CpuFrequency.160.build.f_cpu=160000000L
-
-phoenix_v1.menu.UploadSpeed.115200=115200
-phoenix_v1.menu.UploadSpeed.115200.upload.speed=115200
-phoenix_v1.menu.UploadSpeed.57600=57600
-phoenix_v1.menu.UploadSpeed.57600.upload.speed=57600
-phoenix_v1.menu.UploadSpeed.256000.windows=256000
-phoenix_v1.menu.UploadSpeed.256000.upload.speed=256000
-phoenix_v1.menu.UploadSpeed.230400.linux=230400
-phoenix_v1.menu.UploadSpeed.230400.macosx=230400
-phoenix_v1.menu.UploadSpeed.230400.macosx=230400
-phoenix_v1.menu.UploadSpeed.230400.upload.speed=230400
-phoenix_v1.menu.UploadSpeed.460800.linux=460800
-phoenix_v1.menu.UploadSpeed.460800.macosx=460800
-phoenix_v1.menu.UploadSpeed.460800.upload.speed=460800
-phoenix_v1.menu.UploadSpeed.512000.windows=512000
-phoenix_v1.menu.UploadSpeed.512000.upload.speed=512000
-phoenix_v1.menu.UploadSpeed.921600=921600
-phoenix_v1.menu.UploadSpeed.921600.upload.speed=921600
-
-phoenix_v1.menu.FlashSize.4M3M=4M (3M SPIFFS)
-phoenix_v1.menu.FlashSize.4M3M.build.flash_size=4M
-phoenix_v1.menu.FlashSize.4M3M.build.flash_ld=eagle.flash.4m.ld
-phoenix_v1.menu.FlashSize.4M3M.build.spiffs_start=0x100000
-phoenix_v1.menu.FlashSize.4M3M.build.spiffs_end=0x3FB000
-phoenix_v1.menu.FlashSize.4M3M.build.spiffs_blocksize=8192
-phoenix_v1.menu.FlashSize.4M3M.upload.maximum_size=1044464
-
-phoenix_v1.menu.FlashSize.4M1M=4M (1M SPIFFS)
-phoenix_v1.menu.FlashSize.4M1M.build.flash_size=4M
-phoenix_v1.menu.FlashSize.4M1M.build.flash_ld=eagle.flash.4m1m.ld
-phoenix_v1.menu.FlashSize.4M1M.build.spiffs_start=0x300000
-phoenix_v1.menu.FlashSize.4M1M.build.spiffs_end=0x3FB000
-phoenix_v1.menu.FlashSize.4M1M.build.spiffs_blocksize=8192
-phoenix_v1.menu.FlashSize.4M1M.build.spiffs_pagesize=256
-phoenix_v1.menu.FlashSize.4M1M.upload.maximum_size=1044464
-
-phoenix_v1.menu.ResetMethod.nodemcu=nodemcu
-phoenix_v1.menu.ResetMethod.nodemcu.upload.resetmethod=nodemcu
-phoenix_v1.menu.ResetMethod.ck=ck
-phoenix_v1.menu.ResetMethod.ck.upload.resetmethod=ck
-
-phoenix_v1.menu.Debug.Disabled=Disabled
-phoenix_v1.menu.Debug.Disabled.build.debug_port=
-phoenix_v1.menu.Debug.Serial=Serial
-phoenix_v1.menu.Debug.Serial.build.debug_port=-DDEBUG_ESP_PORT=Serial
-phoenix_v1.menu.Debug.Serial1=Serial1
-phoenix_v1.menu.Debug.Serial1.build.debug_port=-DDEBUG_ESP_PORT=Serial1
-
-phoenix_v1.menu.DebugLevel.None____=None
-phoenix_v1.menu.DebugLevel.None____.build.debug_level=
-phoenix_v1.menu.DebugLevel.Core____=Core
-phoenix_v1.menu.DebugLevel.Core____.build.debug_level=-DDEBUG_ESP_CORE
-phoenix_v1.menu.DebugLevel.SSL_____=Core + SSL
-phoenix_v1.menu.DebugLevel.SSL_____.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_SSL
-phoenix_v1.menu.DebugLevel.SSL_MEM_=Core + SSL + TLS Mem
-phoenix_v1.menu.DebugLevel.SSL_MEM_.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_SSL -DDEBUG_TLS_MEM
-phoenix_v1.menu.DebugLevel.WiFic___=Core + WiFi
-phoenix_v1.menu.DebugLevel.WiFic___.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_WIFI
-phoenix_v1.menu.DebugLevel.WiFi____=WiFi
-phoenix_v1.menu.DebugLevel.WiFi____.build.debug_level=-DDEBUG_ESP_WIFI
-phoenix_v1.menu.DebugLevel.HTTPClient=HTTPClient
-phoenix_v1.menu.DebugLevel.HTTPClient.build.debug_level=-DDEBUG_ESP_HTTP_CLIENT
-phoenix_v1.menu.DebugLevel.HTTPClient2=HTTPClient + SSL
-phoenix_v1.menu.DebugLevel.HTTPClient2.build.debug_level=-DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_SSL
-phoenix_v1.menu.DebugLevel.HTTPUpdate=HTTPUpdate
-phoenix_v1.menu.DebugLevel.HTTPUpdate.build.debug_level=-DDEBUG_ESP_HTTP_UPDATE
-phoenix_v1.menu.DebugLevel.HTTPUpdate2=HTTPClient + HTTPUpdate
-phoenix_v1.menu.DebugLevel.HTTPUpdate2.build.debug_level=-DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_UPDATE
-phoenix_v1.menu.DebugLevel.HTTPUpdate3=HTTPClient + HTTPUpdate + Updater
-phoenix_v1.menu.DebugLevel.HTTPUpdate3.build.debug_level=-DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_UPDATER
-phoenix_v1.menu.DebugLevel.HTTPServer=HTTPServer
-phoenix_v1.menu.DebugLevel.HTTPServer.build.debug_level=-DDEBUG_ESP_HTTP_SERVER
-phoenix_v1.menu.DebugLevel.UPDATER=Updater
-phoenix_v1.menu.DebugLevel.UPDATER.build.debug_level=-DDEBUG_ESP_UPDATER
-phoenix_v1.menu.DebugLevel.OTA_____=OTA
-phoenix_v1.menu.DebugLevel.OTA_____.build.debug_level=-DDEBUG_ESP_OTA
-phoenix_v1.menu.DebugLevel.OTA2____=OTA + Updater
-phoenix_v1.menu.DebugLevel.OTA2____.build.debug_level=-DDEBUG_ESP_OTA -DDEBUG_ESP_UPDATER
-phoenix_v1.menu.DebugLevel.all_____=All
-phoenix_v1.menu.DebugLevel.all_____.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_SSL -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_SERVER -DDEBUG_ESP_UPDATER -DDEBUG_ESP_OTA -DDEBUG_TLS_MEM
-
-phoenix_v1.build.debug_port=
-phoenix_v1.build.debug_level=
-
-##############################################################
-phoenix_v2.name=Phoenix 2.0
-phoenix_v2.upload.tool=esptool
-phoenix_v2.upload.speed=115200
-phoenix_v2.upload.maximum_size=1044464
-phoenix_v2.upload.maximum_data_size=81920
-phoenix_v2.upload.wait_for_upload_port=true
-
-phoenix_v2.build.mcu=esp8266
-phoenix_v2.build.f_cpu=80000000L
-phoenix_v2.build.board=ESP8266_PHOENIX_V2
-phoenix_v2.build.core=esp8266
-phoenix_v2.build.variant=phoenix_v2
-phoenix_v2.build.flash_mode=dio
-phoenix_v2.build.flash_size=4M
-phoenix_v2.build.flash_freq=40
-
-phoenix_v2.menu.CpuFrequency.80=80 MHz
-phoenix_v2.menu.CpuFrequency.80.build.f_cpu=80000000L
-phoenix_v2.menu.CpuFrequency.160=160 MHz
-phoenix_v2.menu.CpuFrequency.160.build.f_cpu=160000000L
-
-phoenix_v2.menu.UploadSpeed.115200=115200
-phoenix_v2.menu.UploadSpeed.115200.upload.speed=115200
-phoenix_v2.menu.UploadSpeed.57600=57600
-phoenix_v2.menu.UploadSpeed.57600.upload.speed=57600
-phoenix_v2.menu.UploadSpeed.256000.windows=256000
-phoenix_v2.menu.UploadSpeed.256000.upload.speed=256000
-phoenix_v2.menu.UploadSpeed.230400.linux=230400
-phoenix_v2.menu.UploadSpeed.230400.macosx=230400
-phoenix_v2.menu.UploadSpeed.230400.macosx=230400
-phoenix_v2.menu.UploadSpeed.230400.upload.speed=230400
-phoenix_v2.menu.UploadSpeed.460800.linux=460800
-phoenix_v2.menu.UploadSpeed.460800.macosx=460800
-phoenix_v2.menu.UploadSpeed.460800.upload.speed=460800
-phoenix_v2.menu.UploadSpeed.512000.windows=512000
-phoenix_v2.menu.UploadSpeed.512000.upload.speed=512000
-phoenix_v2.menu.UploadSpeed.921600=921600
-phoenix_v2.menu.UploadSpeed.921600.upload.speed=921600
-
-phoenix_v2.menu.FlashSize.4M3M=4M (3M SPIFFS)
-phoenix_v2.menu.FlashSize.4M3M.build.flash_size=4M
-phoenix_v2.menu.FlashSize.4M3M.build.flash_ld=eagle.flash.4m.ld
-phoenix_v2.menu.FlashSize.4M3M.build.spiffs_start=0x100000
-phoenix_v2.menu.FlashSize.4M3M.build.spiffs_end=0x3FB000
-phoenix_v2.menu.FlashSize.4M3M.build.spiffs_blocksize=8192
-phoenix_v2.menu.FlashSize.4M3M.upload.maximum_size=1044464
-
-phoenix_v2.menu.FlashSize.4M1M=4M (1M SPIFFS)
-phoenix_v2.menu.FlashSize.4M1M.build.flash_size=4M
-phoenix_v2.menu.FlashSize.4M1M.build.flash_ld=eagle.flash.4m1m.ld
-phoenix_v2.menu.FlashSize.4M1M.build.spiffs_start=0x300000
-phoenix_v2.menu.FlashSize.4M1M.build.spiffs_end=0x3FB000
-phoenix_v2.menu.FlashSize.4M1M.build.spiffs_blocksize=8192
-phoenix_v2.menu.FlashSize.4M1M.build.spiffs_pagesize=256
-phoenix_v2.menu.FlashSize.4M1M.upload.maximum_size=1044464
-
-phoenix_v2.menu.ResetMethod.ck=ck
-phoenix_v2.menu.ResetMethod.ck.upload.resetmethod=ck
-phoenix_v2.menu.ResetMethod.nodemcu=nodemcu
-phoenix_v2.menu.ResetMethod.nodemcu.upload.resetmethod=nodemcu
-
-phoenix_v2.menu.Debug.Disabled=Disabled
-phoenix_v2.menu.Debug.Disabled.build.debug_port=
-phoenix_v2.menu.Debug.Serial=Serial
-phoenix_v2.menu.Debug.Serial.build.debug_port=-DDEBUG_ESP_PORT=Serial
-phoenix_v2.menu.Debug.Serial1=Serial1
-phoenix_v2.menu.Debug.Serial1.build.debug_port=-DDEBUG_ESP_PORT=Serial1
-
-phoenix_v2.menu.DebugLevel.None____=None
-phoenix_v2.menu.DebugLevel.None____.build.debug_level=
-phoenix_v2.menu.DebugLevel.Core____=Core
-phoenix_v2.menu.DebugLevel.Core____.build.debug_level=-DDEBUG_ESP_CORE
-phoenix_v2.menu.DebugLevel.SSL_____=Core + SSL
-phoenix_v2.menu.DebugLevel.SSL_____.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_SSL
-phoenix_v2.menu.DebugLevel.SSL_MEM_=Core + SSL + TLS Mem
-phoenix_v2.menu.DebugLevel.SSL_MEM_.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_SSL -DDEBUG_TLS_MEM
-phoenix_v2.menu.DebugLevel.WiFic___=Core + WiFi
-phoenix_v2.menu.DebugLevel.WiFic___.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_WIFI
-phoenix_v2.menu.DebugLevel.WiFi____=WiFi
-phoenix_v2.menu.DebugLevel.WiFi____.build.debug_level=-DDEBUG_ESP_WIFI
-phoenix_v2.menu.DebugLevel.HTTPClient=HTTPClient
-phoenix_v2.menu.DebugLevel.HTTPClient.build.debug_level=-DDEBUG_ESP_HTTP_CLIENT
-phoenix_v2.menu.DebugLevel.HTTPClient2=HTTPClient + SSL
-phoenix_v2.menu.DebugLevel.HTTPClient2.build.debug_level=-DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_SSL
-phoenix_v2.menu.DebugLevel.HTTPUpdate=HTTPUpdate
-phoenix_v2.menu.DebugLevel.HTTPUpdate.build.debug_level=-DDEBUG_ESP_HTTP_UPDATE
-phoenix_v2.menu.DebugLevel.HTTPUpdate2=HTTPClient + HTTPUpdate
-phoenix_v2.menu.DebugLevel.HTTPUpdate2.build.debug_level=-DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_UPDATE
-phoenix_v2.menu.DebugLevel.HTTPUpdate3=HTTPClient + HTTPUpdate + Updater
-phoenix_v2.menu.DebugLevel.HTTPUpdate3.build.debug_level=-DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_UPDATER
-phoenix_v2.menu.DebugLevel.HTTPServer=HTTPServer
-phoenix_v2.menu.DebugLevel.HTTPServer.build.debug_level=-DDEBUG_ESP_HTTP_SERVER
-phoenix_v2.menu.DebugLevel.UPDATER=Updater
-phoenix_v2.menu.DebugLevel.UPDATER.build.debug_level=-DDEBUG_ESP_UPDATER
-phoenix_v2.menu.DebugLevel.OTA_____=OTA
-phoenix_v2.menu.DebugLevel.OTA_____.build.debug_level=-DDEBUG_ESP_OTA
-phoenix_v2.menu.DebugLevel.OTA2____=OTA + Updater
-phoenix_v2.menu.DebugLevel.OTA2____.build.debug_level=-DDEBUG_ESP_OTA -DDEBUG_ESP_UPDATER
-phoenix_v2.menu.DebugLevel.all_____=All
-phoenix_v2.menu.DebugLevel.all_____.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_SSL -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_SERVER -DDEBUG_ESP_UPDATER -DDEBUG_ESP_OTA -DDEBUG_TLS_MEM
-
-phoenix_v2.build.debug_port=
-phoenix_v2.build.debug_level=
-
-##############################################################
-nodemcu.name=NodeMCU 0.9 (ESP-12 Module)
-
-nodemcu.upload.tool=esptool
-nodemcu.upload.speed=115200
-nodemcu.upload.resetmethod=nodemcu
-nodemcu.upload.maximum_size=1044464
-nodemcu.upload.maximum_data_size=81920
-nodemcu.upload.wait_for_upload_port=true
-nodemcu.serial.disableDTR=true
-nodemcu.serial.disableRTS=true
-
-nodemcu.build.mcu=esp8266
-nodemcu.build.f_cpu=80000000L
-nodemcu.build.board=ESP8266_NODEMCU
-nodemcu.build.core=esp8266
-nodemcu.build.variant=nodemcu
-nodemcu.build.flash_mode=qio
-nodemcu.build.flash_size=4M
-nodemcu.build.flash_freq=40
-nodemcu.build.debug_port=
-nodemcu.build.debug_level=
-
-nodemcu.menu.CpuFrequency.80=80 MHz
-nodemcu.menu.CpuFrequency.80.build.f_cpu=80000000L
-nodemcu.menu.CpuFrequency.160=160 MHz
-nodemcu.menu.CpuFrequency.160.build.f_cpu=160000000L
-
-nodemcu.menu.UploadSpeed.115200=115200
-nodemcu.menu.UploadSpeed.115200.upload.speed=115200
-nodemcu.menu.UploadSpeed.9600=9600
-nodemcu.menu.UploadSpeed.9600.upload.speed=9600
-nodemcu.menu.UploadSpeed.57600=57600
-nodemcu.menu.UploadSpeed.57600.upload.speed=57600
-nodemcu.menu.UploadSpeed.256000.windows=256000
-nodemcu.menu.UploadSpeed.256000.upload.speed=256000
-nodemcu.menu.UploadSpeed.230400.linux=230400
-nodemcu.menu.UploadSpeed.230400.macosx=230400
-nodemcu.menu.UploadSpeed.230400.macosx=230400
-nodemcu.menu.UploadSpeed.230400.upload.speed=230400
-nodemcu.menu.UploadSpeed.460800.linux=460800
-nodemcu.menu.UploadSpeed.460800.macosx=460800
-nodemcu.menu.UploadSpeed.460800.upload.speed=460800
-nodemcu.menu.UploadSpeed.512000.windows=512000
-nodemcu.menu.UploadSpeed.512000.upload.speed=512000
-nodemcu.menu.UploadSpeed.921600=921600
-nodemcu.menu.UploadSpeed.921600.upload.speed=921600
-
-nodemcu.menu.FlashSize.4M3M=4M (3M SPIFFS)
-nodemcu.menu.FlashSize.4M3M.build.flash_size=4M
-nodemcu.menu.FlashSize.4M3M.build.flash_ld=eagle.flash.4m.ld
-nodemcu.menu.FlashSize.4M3M.build.spiffs_start=0x100000
-nodemcu.menu.FlashSize.4M3M.build.spiffs_end=0x3FB000
-nodemcu.menu.FlashSize.4M3M.build.spiffs_blocksize=8192
-nodemcu.menu.FlashSize.4M3M.build.spiffs_pagesize=256
-
-nodemcu.menu.FlashSize.4M1M=4M (1M SPIFFS)
-nodemcu.menu.FlashSize.4M1M.build.flash_size=4M
-nodemcu.menu.FlashSize.4M1M.build.flash_ld=eagle.flash.4m1m.ld
-nodemcu.menu.FlashSize.4M1M.build.spiffs_start=0x300000
-nodemcu.menu.FlashSize.4M1M.build.spiffs_end=0x3FB000
-nodemcu.menu.FlashSize.4M1M.build.spiffs_blocksize=8192
-nodemcu.menu.FlashSize.4M1M.build.spiffs_pagesize=256
-
-##############################################################
-nodemcuv2.name=NodeMCU 1.0 (ESP-12E Module)
-
-nodemcuv2.upload.tool=esptool
-nodemcuv2.upload.speed=115200
-nodemcuv2.upload.resetmethod=nodemcu
-nodemcuv2.upload.maximum_size=1044464
-nodemcuv2.upload.maximum_data_size=81920
-nodemcuv2.upload.wait_for_upload_port=true
-nodemcuv2.serial.disableDTR=true
-nodemcuv2.serial.disableRTS=true
-
-nodemcuv2.build.mcu=esp8266
-nodemcuv2.build.f_cpu=80000000L
-nodemcuv2.build.board=ESP8266_NODEMCU
-nodemcuv2.build.core=esp8266
-nodemcuv2.build.variant=nodemcu
-nodemcuv2.build.flash_mode=dio
-nodemcuv2.build.flash_size=4M
-nodemcuv2.build.flash_freq=40
-nodemcuv2.build.debug_port=
-nodemcuv2.build.debug_level=
-
-nodemcuv2.menu.CpuFrequency.80=80 MHz
-nodemcuv2.menu.CpuFrequency.80.build.f_cpu=80000000L
-nodemcuv2.menu.CpuFrequency.160=160 MHz
-nodemcuv2.menu.CpuFrequency.160.build.f_cpu=160000000L
-
-nodemcuv2.menu.UploadSpeed.115200=115200
-nodemcuv2.menu.UploadSpeed.115200.upload.speed=115200
-nodemcuv2.menu.UploadSpeed.9600=9600
-nodemcuv2.menu.UploadSpeed.9600.upload.speed=9600
-nodemcuv2.menu.UploadSpeed.57600=57600
-nodemcuv2.menu.UploadSpeed.57600.upload.speed=57600
-nodemcuv2.menu.UploadSpeed.256000.windows=256000
-nodemcuv2.menu.UploadSpeed.256000.upload.speed=256000
-nodemcuv2.menu.UploadSpeed.230400.linux=230400
-nodemcuv2.menu.UploadSpeed.230400.macosx=230400
-nodemcuv2.menu.UploadSpeed.230400.macosx=230400
-nodemcuv2.menu.UploadSpeed.230400.upload.speed=230400
-nodemcuv2.menu.UploadSpeed.460800.linux=460800
-nodemcuv2.menu.UploadSpeed.460800.macosx=460800
-nodemcuv2.menu.UploadSpeed.460800.upload.speed=460800
-nodemcuv2.menu.UploadSpeed.512000.windows=512000
-nodemcuv2.menu.UploadSpeed.512000.upload.speed=512000
-nodemcuv2.menu.UploadSpeed.921600=921600
-nodemcuv2.menu.UploadSpeed.921600.upload.speed=921600
-
-nodemcuv2.menu.FlashSize.4M3M=4M (3M SPIFFS)
-nodemcuv2.menu.FlashSize.4M3M.build.flash_size=4M
-nodemcuv2.menu.FlashSize.4M3M.build.flash_ld=eagle.flash.4m.ld
-nodemcuv2.menu.FlashSize.4M3M.build.spiffs_start=0x100000
-nodemcuv2.menu.FlashSize.4M3M.build.spiffs_end=0x3FB000
-nodemcuv2.menu.FlashSize.4M3M.build.spiffs_blocksize=8192
-nodemcuv2.menu.FlashSize.4M3M.build.spiffs_pagesize=256
-
-nodemcuv2.menu.FlashSize.4M1M=4M (1M SPIFFS)
-nodemcuv2.menu.FlashSize.4M1M.build.flash_size=4M
-nodemcuv2.menu.FlashSize.4M1M.build.flash_ld=eagle.flash.4m1m.ld
-nodemcuv2.menu.FlashSize.4M1M.build.spiffs_start=0x300000
-nodemcuv2.menu.FlashSize.4M1M.build.spiffs_end=0x3FB000
-nodemcuv2.menu.FlashSize.4M1M.build.spiffs_blocksize=8192
-nodemcuv2.menu.FlashSize.4M1M.build.spiffs_pagesize=256
-
-
-##############################################################
-modwifi.name=Olimex MOD-WIFI-ESP8266(-DEV)
-
-modwifi.upload.tool=esptool
-modwifi.upload.speed=115200
-modwifi.upload.resetmethod=ck
-modwifi.upload.maximum_size=1044464
-modwifi.upload.maximum_data_size=81920
-modwifi.upload.wait_for_upload_port=true
-modwifi.serial.disableDTR=true
-modwifi.serial.disableRTS=true
-
-modwifi.build.mcu=esp8266
-modwifi.build.f_cpu=80000000L
-modwifi.build.board=MOD_WIFI_ESP8266
-modwifi.build.core=esp8266
-modwifi.build.variant=generic
-# Winbond W25Q16 flash
-modwifi.build.flash_mode=qio
-modwifi.build.flash_size=2M
-modwifi.build.flash_freq=40
-modwifi.build.flash_ld=eagle.flash.2m.ld
-modwifi.build.spiffs_start=0x100000
-modwifi.build.spiffs_end=0x1FB000
-modwifi.build.spiffs_pagesize=256
-modwifi.build.spiffs_blocksize=8192
-modwifi.build.debug_port=
-modwifi.build.debug_level=
-
-modwifi.menu.CpuFrequency.80=80 MHz
-modwifi.menu.CpuFrequency.80.build.f_cpu=80000000L
-modwifi.menu.CpuFrequency.160=160 MHz
-modwifi.menu.CpuFrequency.160.build.f_cpu=160000000L
-
-modwifi.menu.UploadSpeed.115200=115200
-modwifi.menu.UploadSpeed.115200.upload.speed=115200
-modwifi.menu.UploadSpeed.9600=9600
-modwifi.menu.UploadSpeed.9600.upload.speed=9600
-modwifi.menu.UploadSpeed.57600=57600
-modwifi.menu.UploadSpeed.57600.upload.speed=57600
-modwifi.menu.UploadSpeed.256000.windows=256000
-modwifi.menu.UploadSpeed.256000.upload.speed=256000
-modwifi.menu.UploadSpeed.230400.linux=230400
-modwifi.menu.UploadSpeed.230400.macosx=230400
-modwifi.menu.UploadSpeed.230400.macosx=230400
-modwifi.menu.UploadSpeed.230400.upload.speed=230400
-modwifi.menu.UploadSpeed.460800.linux=460800
-modwifi.menu.UploadSpeed.460800.macosx=460800
-modwifi.menu.UploadSpeed.460800.upload.speed=460800
-modwifi.menu.UploadSpeed.512000.windows=512000
-modwifi.menu.UploadSpeed.512000.upload.speed=512000
-modwifi.menu.UploadSpeed.921600=921600
-modwifi.menu.UploadSpeed.921600.upload.speed=921600
-
-##############################################################
-thing.name=SparkFun ESP8266 Thing
-
-thing.upload.tool=esptool
-thing.upload.speed=921600
-thing.upload.resetmethod=ck
-thing.upload.maximum_size=434160
-thing.upload.maximum_data_size=81920
-thing.upload.wait_for_upload_port=true
-thing.serial.disableDTR=true
-thing.serial.disableRTS=true
-
-thing.build.mcu=esp8266
-thing.build.f_cpu=80000000L
-thing.build.board=ESP8266_THING
-thing.build.core=esp8266
-thing.build.variant=thing
-thing.build.flash_mode=qio
-# flash chip: AT25SF041 (512 kbyte, 4Mbit)
-thing.build.flash_size=512K
-thing.build.flash_ld=eagle.flash.512k64.ld
-thing.build.flash_freq=40
-thing.build.spiffs_start=0x6B000
-thing.build.spiffs_end=0x7B000
-thing.build.spiffs_blocksize=4096
-thing.build.spiffs_pagesize=256
-thing.build.debug_port=
-thing.build.debug_level=
-
-thing.menu.CpuFrequency.80=80 MHz
-thing.menu.CpuFrequency.80.build.f_cpu=80000000L
-thing.menu.CpuFrequency.160=160 MHz
-thing.menu.CpuFrequency.160.build.f_cpu=160000000L
-
-thing.menu.UploadSpeed.115200=115200
-thing.menu.UploadSpeed.115200.upload.speed=115200
-thing.menu.UploadSpeed.9600=9600
-thing.menu.UploadSpeed.9600.upload.speed=9600
-thing.menu.UploadSpeed.57600=57600
-thing.menu.UploadSpeed.57600.upload.speed=57600
-thing.menu.UploadSpeed.256000.windows=256000
-thing.menu.UploadSpeed.256000.upload.speed=256000
-thing.menu.UploadSpeed.230400.linux=230400
-thing.menu.UploadSpeed.230400.macosx=230400
-thing.menu.UploadSpeed.230400.upload.speed=230400
-thing.menu.UploadSpeed.460800.linux=460800
-thing.menu.UploadSpeed.460800.macosx=460800
-thing.menu.UploadSpeed.460800.upload.speed=460800
-thing.menu.UploadSpeed.512000.windows=512000
-thing.menu.UploadSpeed.512000.upload.speed=512000
-thing.menu.UploadSpeed.921600=921600
-thing.menu.UploadSpeed.921600.upload.speed=921600
-
-##############################################################
-thingdev.name=SparkFun ESP8266 Thing Dev
-
-thingdev.upload.tool=esptool
-thingdev.upload.speed=921600
-thingdev.upload.resetmethod=nodemcu
-thingdev.upload.maximum_size=434160
-thingdev.upload.maximum_data_size=81920
-thingdev.upload.wait_for_upload_port=true
-thingdev.serial.disableDTR=true
-thingdev.serial.disableRTS=true
-
-thingdev.build.mcu=esp8266
-thingdev.build.f_cpu=80000000L
-thingdev.build.board=ESP8266_THING_DEV
-thingdev.build.core=esp8266
-thingdev.build.variant=thing
-thingdev.build.flash_mode=dio
-# flash chip: AT25SF041 (512 kbyte, 4Mbit)
-thingdev.build.flash_size=512K
-thingdev.build.flash_ld=eagle.flash.512k64.ld
-thingdev.build.flash_freq=40
-thingdev.build.debug_port=
-thingdev.build.debug_level=
-
-thingdev.menu.CpuFrequency.80=80 MHz
-thingdev.menu.CpuFrequency.80.build.f_cpu=80000000L
-thingdev.menu.CpuFrequency.160=160 MHz
-thingdev.menu.CpuFrequency.160.build.f_cpu=160000000L
-
-thingdev.menu.UploadSpeed.115200=115200
-thingdev.menu.UploadSpeed.115200.upload.speed=115200
-thingdev.menu.UploadSpeed.9600=9600
-thingdev.menu.UploadSpeed.9600.upload.speed=9600
-thingdev.menu.UploadSpeed.57600=57600
-thingdev.menu.UploadSpeed.57600.upload.speed=57600
-thingdev.menu.UploadSpeed.256000.windows=256000
-thingdev.menu.UploadSpeed.256000.upload.speed=256000
-thingdev.menu.UploadSpeed.230400.linux=230400
-thingdev.menu.UploadSpeed.230400.macosx=230400
-thingdev.menu.UploadSpeed.230400.upload.speed=230400
-thingdev.menu.UploadSpeed.460800.linux=460800
-thingdev.menu.UploadSpeed.460800.macosx=460800
-thingdev.menu.UploadSpeed.460800.upload.speed=460800
-thingdev.menu.UploadSpeed.512000.windows=512000
-thingdev.menu.UploadSpeed.512000.upload.speed=512000
-thingdev.menu.UploadSpeed.921600=921600
-thingdev.menu.UploadSpeed.921600.upload.speed=921600
-
-##############################################################
-esp210.name=SweetPea ESP-210
-
-esp210.upload.tool=esptool
-esp210.upload.speed=115200
-esp210.upload.resetmethod=ck
-esp210.upload.maximum_size=1044464
-esp210.upload.maximum_data_size=81920
-esp210.upload.wait_for_upload_port=true
-esp210.serial.disableDTR=true
-esp210.serial.disableRTS=true
-
-esp210.build.mcu=esp8266
-esp210.build.f_cpu=80000000L
-esp210.build.board=ESP8266_ESP210
-esp210.build.core=esp8266
-esp210.build.variant=generic
-esp210.build.flash_mode=qio
-esp210.build.flash_size=4M
-esp210.build.flash_freq=40
-esp210.build.debug_port=
-esp210.build.debug_level=
-
-esp210.menu.CpuFrequency.80=80 MHz
-esp210.menu.CpuFrequency.80.build.f_cpu=80000000L
-esp210.menu.CpuFrequency.160=160 MHz
-esp210.menu.CpuFrequency.160.build.f_cpu=160000000L
-
-esp210.menu.UploadSpeed.57600=57600
-esp210.menu.UploadSpeed.57600.upload.speed=57600
-esp210.menu.UploadSpeed.115200=115200
-esp210.menu.UploadSpeed.115200.upload.speed=115200
-esp210.menu.UploadSpeed.256000.windows=256000
-esp210.menu.UploadSpeed.256000.upload.speed=256000
-esp210.menu.UploadSpeed.230400.linux=230400
-esp210.menu.UploadSpeed.230400.macosx=230400
-esp210.menu.UploadSpeed.230400.macosx=230400
-esp210.menu.UploadSpeed.230400.upload.speed=230400
-esp210.menu.UploadSpeed.460800.linux=460800
-esp210.menu.UploadSpeed.460800.macosx=460800
-esp210.menu.UploadSpeed.460800.upload.speed=460800
-esp210.menu.UploadSpeed.512000.windows=512000
-esp210.menu.UploadSpeed.512000.upload.speed=512000
-esp210.menu.UploadSpeed.921600=921600
-esp210.menu.UploadSpeed.921600.upload.speed=921600
-
-esp210.menu.FlashSize.4M3M=4M (3M SPIFFS)
-esp210.menu.FlashSize.4M3M.build.flash_size=4M
-esp210.menu.FlashSize.4M3M.build.flash_ld=eagle.flash.4m.ld
-esp210.menu.FlashSize.4M3M.build.spiffs_start=0x100000
-esp210.menu.FlashSize.4M3M.build.spiffs_end=0x3FB000
-esp210.menu.FlashSize.4M3M.build.spiffs_blocksize=8192
-esp210.menu.FlashSize.4M3M.build.spiffs_pagesize=256
-
-esp210.menu.FlashSize.4M1M=4M (1M SPIFFS)
-esp210.menu.FlashSize.4M1M.build.flash_size=4M
-esp210.menu.FlashSize.4M1M.build.flash_ld=eagle.flash.4m1m.ld
-esp210.menu.FlashSize.4M1M.build.spiffs_start=0x300000
-esp210.menu.FlashSize.4M1M.build.spiffs_end=0x3FB000
-esp210.menu.FlashSize.4M1M.build.spiffs_blocksize=8192
-esp210.menu.FlashSize.4M1M.build.spiffs_pagesize=256
-
-##############################################################
-# wifio.name=Wifio
-#
-# wifio.upload.tool=esptool
-# wifio.upload.speed=115200
-# wifio.upload.resetmethod=wifio
-# wifio.upload.maximum_size=524288
-# wifio.upload.wait_for_upload_port=true
-#
-# wifio.build.mcu=esp8266
-# wifio.build.f_cpu=80000000L
-# wifio.build.board=ESP8266_WIFIO
-# wifio.build.core=esp8266
-# wifio.build.variant=wifio
-# wifio.build.flash_mode=qio
-# wifio.build.flash_size=512K
-# wifio.build.flash_freq=40
-# wifio.build.flash_ld=eagle.flash.512k64.ld
-# wifio.build.spiffs_start=0x6B000
-# wifio.build.spiffs_end=0x7B000
-#
-# wifio.menu.CpuFrequency.80=80MHz
-# wifio.menu.CpuFrequency.80.build.f_cpu=80000000L
-# wifio.menu.CpuFrequency.160=160MHz
-# wifio.menu.CpuFrequency.160.build.f_cpu=160000000L
-#
-# wifio.upload.tool=esptool
-#
-
-##############################################################
-d1_mini.name=WeMos D1 R2 & mini
-
-d1_mini.upload.tool=esptool
-d1_mini.upload.speed=460800
-d1_mini.upload.resetmethod=nodemcu
-d1_mini.upload.maximum_size=1044464
-d1_mini.upload.maximum_data_size=81920
-d1_mini.upload.wait_for_upload_port=true
-d1_mini.serial.disableDTR=true
-d1_mini.serial.disableRTS=true
-
-d1_mini.build.mcu=esp8266
-d1_mini.build.f_cpu=80000000L
-d1_mini.build.board=ESP8266_WEMOS_D1MINI
-d1_mini.build.core=esp8266
-d1_mini.build.variant=d1_mini
-d1_mini.build.flash_mode=dio
-d1_mini.build.flash_size=4M
-d1_mini.build.flash_freq=40
-d1_mini.build.debug_port=
-d1_mini.build.debug_level=
-
-d1_mini.menu.CpuFrequency.80=80 MHz
-d1_mini.menu.CpuFrequency.80.build.f_cpu=80000000L
-d1_mini.menu.CpuFrequency.160=160 MHz
-d1_mini.menu.CpuFrequency.160.build.f_cpu=160000000L
-
-d1_mini.menu.UploadSpeed.921600=921600
-d1_mini.menu.UploadSpeed.921600.upload.speed=921600
-d1_mini.menu.UploadSpeed.115200=115200
-d1_mini.menu.UploadSpeed.115200.upload.speed=115200
-d1_mini.menu.UploadSpeed.9600=9600
-d1_mini.menu.UploadSpeed.9600.upload.speed=9600
-d1_mini.menu.UploadSpeed.57600=57600
-d1_mini.menu.UploadSpeed.57600.upload.speed=57600
-d1_mini.menu.UploadSpeed.256000.windows=256000
-d1_mini.menu.UploadSpeed.256000.upload.speed=256000
-d1_mini.menu.UploadSpeed.230400.linux=230400
-d1_mini.menu.UploadSpeed.230400.macosx=230400
-d1_mini.menu.UploadSpeed.230400.macosx=230400
-d1_mini.menu.UploadSpeed.230400.upload.speed=230400
-d1_mini.menu.UploadSpeed.460800.linux=460800
-d1_mini.menu.UploadSpeed.460800.macosx=460800
-d1_mini.menu.UploadSpeed.460800.upload.speed=460800
-d1_mini.menu.UploadSpeed.512000.windows=512000
-d1_mini.menu.UploadSpeed.512000.upload.speed=512000
-
-
-d1_mini.menu.FlashSize.4M3M=4M (3M SPIFFS)
-d1_mini.menu.FlashSize.4M3M.build.flash_size=4M
-d1_mini.menu.FlashSize.4M3M.build.flash_ld=eagle.flash.4m.ld
-d1_mini.menu.FlashSize.4M3M.build.spiffs_start=0x100000
-d1_mini.menu.FlashSize.4M3M.build.spiffs_end=0x3FB000
-d1_mini.menu.FlashSize.4M3M.build.spiffs_blocksize=8192
-d1_mini.menu.FlashSize.4M3M.build.spiffs_pagesize=256
-
-d1_mini.menu.FlashSize.4M1M=4M (1M SPIFFS)
-d1_mini.menu.FlashSize.4M1M.build.flash_size=4M
-d1_mini.menu.FlashSize.4M1M.build.flash_ld=eagle.flash.4m1m.ld
-d1_mini.menu.FlashSize.4M1M.build.spiffs_start=0x300000
-d1_mini.menu.FlashSize.4M1M.build.spiffs_end=0x3FB000
-d1_mini.menu.FlashSize.4M1M.build.spiffs_blocksize=8192
-d1_mini.menu.FlashSize.4M1M.build.spiffs_pagesize=256
-
-##############################################################
-d1.name=WeMos D1(Retired)
-
-d1.upload.tool=esptool
-d1.upload.speed=460800
-d1.upload.resetmethod=nodemcu
-d1.upload.maximum_size=1044464
-d1.upload.maximum_data_size=81920
-d1.upload.wait_for_upload_port=true
-d1.serial.disableDTR=true
-d1.serial.disableRTS=true
-
-d1.build.mcu=esp8266
-d1.build.f_cpu=80000000L
-d1.build.board=ESP8266_WEMOS_D1MINI
-d1.build.core=esp8266
-d1.build.variant=d1
-d1.build.flash_mode=dio
-d1.build.flash_size=4M
-d1.build.flash_freq=40
-d1.build.debug_port=
-d1.build.debug_level=
-
-d1.menu.CpuFrequency.80=80 MHz
-d1.menu.CpuFrequency.80.build.f_cpu=80000000L
-d1.menu.CpuFrequency.160=160 MHz
-d1.menu.CpuFrequency.160.build.f_cpu=160000000L
-
-d1.menu.UploadSpeed.921600=921600
-d1.menu.UploadSpeed.921600.upload.speed=921600
-d1.menu.UploadSpeed.115200=115200
-d1.menu.UploadSpeed.115200.upload.speed=115200
-d1.menu.UploadSpeed.9600=9600
-d1.menu.UploadSpeed.9600.upload.speed=9600
-d1.menu.UploadSpeed.57600=57600
-d1.menu.UploadSpeed.57600.upload.speed=57600
-d1.menu.UploadSpeed.256000.windows=256000
-d1.menu.UploadSpeed.256000.upload.speed=256000
-d1.menu.UploadSpeed.230400.linux=230400
-d1.menu.UploadSpeed.230400.macosx=230400
-d1.menu.UploadSpeed.230400.macosx=230400
-d1.menu.UploadSpeed.230400.upload.speed=230400
-d1.menu.UploadSpeed.460800.linux=460800
-d1.menu.UploadSpeed.460800.macosx=460800
-d1.menu.UploadSpeed.460800.upload.speed=460800
-d1.menu.UploadSpeed.512000.windows=512000
-d1.menu.UploadSpeed.512000.upload.speed=512000
-
-
-d1.menu.FlashSize.4M3M=4M (3M SPIFFS)
-d1.menu.FlashSize.4M3M.build.flash_size=4M
-d1.menu.FlashSize.4M3M.build.flash_ld=eagle.flash.4m.ld
-d1.menu.FlashSize.4M3M.build.spiffs_start=0x100000
-d1.menu.FlashSize.4M3M.build.spiffs_end=0x3FB000
-d1.menu.FlashSize.4M3M.build.spiffs_blocksize=8192
-d1.menu.FlashSize.4M3M.build.spiffs_pagesize=256
-
-d1.menu.FlashSize.4M1M=4M (1M SPIFFS)
-d1.menu.FlashSize.4M1M.build.flash_size=4M
-d1.menu.FlashSize.4M1M.build.flash_ld=eagle.flash.4m1m.ld
-d1.menu.FlashSize.4M1M.build.spiffs_start=0x300000
-d1.menu.FlashSize.4M1M.build.spiffs_end=0x3FB000
-d1.menu.FlashSize.4M1M.build.spiffs_blocksize=8192
-d1.menu.FlashSize.4M1M.build.spiffs_pagesize=256
-
-
-##############################################################
-
-espino.name=ESPino (ESP-12 Module)
-
-espino.upload.tool=esptool
-espino.upload.speed=115200
-espino.upload.resetmethod=ck
-espino.upload.maximum_size=1044464
-espino.upload.maximum_data_size=81920
-espino.upload.wait_for_upload_port=true
-espino.serial.disableDTR=true
-espino.serial.disableRTS=true
-
-espino.build.mcu=esp8266
-espino.build.f_cpu=80000000L
-espino.build.board=ESP8266_ESP12
-espino.build.core=esp8266
-espino.build.variant=espino
-espino.build.flash_mode=qio
-espino.build.flash_size=4M
-espino.build.flash_freq=40
-espino.build.spiffs_pagesize=256
-espino.build.debug_port=
-espino.build.debug_level=
-
-espino.menu.CpuFrequency.80=80 MHz
-espino.menu.CpuFrequency.80.build.f_cpu=80000000L
-espino.menu.CpuFrequency.160=160 MHz
-espino.menu.CpuFrequency.160.build.f_cpu=160000000L
-
-espino.menu.FlashMode.dio=DIO
-espino.menu.FlashMode.dio.build.flash_mode=dio
-espino.menu.FlashMode.qio=QIO
-espino.menu.FlashMode.qio.build.flash_mode=qio
-
-espino.menu.UploadSpeed.115200=115200
-espino.menu.UploadSpeed.115200.upload.speed=115200
-espino.menu.UploadSpeed.9600=9600
-espino.menu.UploadSpeed.9600.upload.speed=9600
-espino.menu.UploadSpeed.57600=57600
-espino.menu.UploadSpeed.57600.upload.speed=57600
-espino.menu.UploadSpeed.256000.windows=256000
-espino.menu.UploadSpeed.256000.upload.speed=256000
-espino.menu.UploadSpeed.230400.linux=230400
-espino.menu.UploadSpeed.230400.macosx=230400
-espino.menu.UploadSpeed.230400.upload.speed=230400
-espino.menu.UploadSpeed.460800.linux=460800
-espino.menu.UploadSpeed.460800.macosx=460800
-espino.menu.UploadSpeed.460800.upload.speed=460800
-espino.menu.UploadSpeed.512000.windows=512000
-espino.menu.UploadSpeed.512000.upload.speed=512000
-espino.menu.UploadSpeed.921600=921600
-espino.menu.UploadSpeed.921600.upload.speed=921600
-
-espino.menu.FlashSize.4M1M=4M (1M SPIFFS)
-espino.menu.FlashSize.4M1M.build.flash_size=4M
-espino.menu.FlashSize.4M1M.build.flash_ld=eagle.flash.4m1m.ld
-espino.menu.FlashSize.4M1M.build.spiffs_start=0x300000
-espino.menu.FlashSize.4M1M.build.spiffs_end=0x3FB000
-espino.menu.FlashSize.4M1M.build.spiffs_blocksize=8192
-espino.menu.FlashSize.4M1M.build.spiffs_pagesize=256
-espino.menu.FlashSize.4M1M.upload.maximum_size=1044464
-
-espino.menu.FlashSize.4M3M=4M (3M SPIFFS)
-espino.menu.FlashSize.4M3M.build.flash_size=4M
-espino.menu.FlashSize.4M3M.build.flash_ld=eagle.flash.4m.ld
-espino.menu.FlashSize.4M3M.build.spiffs_start=0x100000
-espino.menu.FlashSize.4M3M.build.spiffs_end=0x3FB000
-espino.menu.FlashSize.4M3M.build.spiffs_blocksize=8192
-espino.menu.FlashSize.4M3M.upload.maximum_size=1044464
-
-espino.menu.ResetMethod.ck=ck
-espino.menu.ResetMethod.ck.upload.resetmethod=ck
-espino.menu.ResetMethod.nodemcu=nodemcu
-espino.menu.ResetMethod.nodemcu.upload.resetmethod=nodemcu
-
-##############################################################
-espinotee.name=ThaiEasyElec's ESPino
-
-espinotee.upload.tool=esptool
-espinotee.upload.speed=115200
-espinotee.upload.resetmethod=nodemcu
-espinotee.upload.maximum_size=1044464
-espinotee.upload.maximum_data_size=81920
-espinotee.upload.wait_for_upload_port=true
-espinotee.serial.disableDTR=true
-espinotee.serial.disableRTS=true
-
-espinotee.build.mcu=esp8266
-espinotee.build.f_cpu=80000000L
-espinotee.build.board=ESP8266_ESP13
-espinotee.build.core=esp8266
-espinotee.build.variant=espinotee
-espinotee.build.flash_mode=qio
-espinotee.build.flash_size=4M
-espinotee.build.flash_freq=40
-espinotee.build.debug_port=
-espinotee.build.debug_level=
-
-espinotee.menu.CpuFrequency.80=80 MHz
-espinotee.menu.CpuFrequency.80.build.f_cpu=80000000L
-espinotee.menu.CpuFrequency.160=160 MHz
-espinotee.menu.CpuFrequency.160.build.f_cpu=160000000L
-
-espinotee.menu.UploadSpeed.115200=115200
-espinotee.menu.UploadSpeed.115200.upload.speed=115200
-espinotee.menu.UploadSpeed.9600=9600
-espinotee.menu.UploadSpeed.9600.upload.speed=9600
-espinotee.menu.UploadSpeed.57600=57600
-espinotee.menu.UploadSpeed.57600.upload.speed=57600
-espinotee.menu.UploadSpeed.256000.windows=256000
-espinotee.menu.UploadSpeed.256000.upload.speed=256000
-espinotee.menu.UploadSpeed.230400.linux=230400
-espinotee.menu.UploadSpeed.230400.macosx=230400
-espinotee.menu.UploadSpeed.230400.macosx=230400
-espinotee.menu.UploadSpeed.230400.upload.speed=230400
-espinotee.menu.UploadSpeed.460800.linux=460800
-espinotee.menu.UploadSpeed.460800.macosx=460800
-espinotee.menu.UploadSpeed.460800.upload.speed=460800
-espinotee.menu.UploadSpeed.512000.windows=512000
-espinotee.menu.UploadSpeed.512000.upload.speed=512000
-espinotee.menu.UploadSpeed.921600=921600
-espinotee.menu.UploadSpeed.921600.upload.speed=921600
-
-espinotee.menu.FlashSize.4M3M=4M (3M SPIFFS)
-espinotee.menu.FlashSize.4M3M.build.flash_size=4M
-espinotee.menu.FlashSize.4M3M.build.flash_ld=eagle.flash.4m.ld
-espinotee.menu.FlashSize.4M3M.build.spiffs_start=0x100000
-espinotee.menu.FlashSize.4M3M.build.spiffs_end=0x3FB000
-espinotee.menu.FlashSize.4M3M.build.spiffs_blocksize=8192
-espinotee.menu.FlashSize.4M3M.build.spiffs_pagesize=256
-
-espinotee.menu.FlashSize.4M1M=4M (1M SPIFFS)
-espinotee.menu.FlashSize.4M1M.build.flash_size=4M
-espinotee.menu.FlashSize.4M1M.build.flash_ld=eagle.flash.4m1m.ld
-espinotee.menu.FlashSize.4M1M.build.spiffs_start=0x300000
-espinotee.menu.FlashSize.4M1M.build.spiffs_end=0x3FB000
-espinotee.menu.FlashSize.4M1M.build.spiffs_blocksize=8192
-espinotee.menu.FlashSize.4M1M.build.spiffs_pagesize=256
-
-##############################################################
-wifinfo.name=WifInfo
-
-wifinfo.upload.tool=esptool
-wifinfo.upload.speed=115200
-wifinfo.upload.resetmethod=nodemcu
-wifinfo.upload.maximum_size=434160
-wifinfo.upload.maximum_data_size=81920
-wifinfo.upload.wait_for_upload_port=true
-wifinfo.serial.disableDTR=true
-wifinfo.serial.disableRTS=true
-
-wifinfo.build.mcu=esp8266
-wifinfo.build.core=esp8266
-wifinfo.build.variant=wifinfo
-wifinfo.build.board=WIFINFO
-wifinfo.build.spiffs_pagesize=256
-wifinfo.build.debug_port=Serial1
-wifinfo.build.debug_level=Wifinfo
-
-wifinfo.menu.Debug.Disabled=Disabled
-wifinfo.menu.Debug.Disabled.build.debug_port=
-wifinfo.menu.Debug.Serial=Serial
-wifinfo.menu.Debug.Serial.build.debug_port=-DDEBUG_ESP_PORT=Serial
-wifinfo.menu.Debug.Serial1=Serial1
-wifinfo.menu.Debug.Serial1.build.debug_port=-DDEBUG_ESP_PORT=Serial1
-
-wifinfo.menu.DebugLevel.None=None
-wifinfo.menu.DebugLevel.None.build.debug_level=
-wifinfo.menu.DebugLevel.Wifinfo=Wifinfo
-wifinfo.menu.DebugLevel.Wifinfo.build.debug_level=-DDEBUG_ESP_WIFINFO
-
-#wifinfo.menu.ESPModule.ESP07512=ESP07 (1M/512K SPIFFS)
-#wifinfo.menu.ESPModule.ESP07512.build.board=ESP8266_ESP07
-#wifinfo.menu.ESPModule.ESP07512.build.flash_size=1M
-#wifinfo.menu.ESPModule.ESP07512.build.flash_ld=eagle.flash.1m512.ld
-#wifinfo.menu.ESPModule.ESP07512.build.spiffs_start=0x7B000
-#wifinfo.menu.ESPModule.ESP07512.build.spiffs_end=0xFB000
-#wifinfo.menu.ESPModule.ESP07512.build.spiffs_blocksize=8192
-#wifinfo.menu.ESPModule.ESP07512.upload.maximum_size=499696
-
-#wifinfo.menu.ESPModule.ESP07256=ESP07 (1M/256K SPIFFS)
-#wifinfo.menu.ESPModule.ESP07256.build.board=ESP8266_ESP07
-#wifinfo.menu.ESPModule.ESP07256.build.flash_size=1M
-#wifinfo.menu.ESPModule.ESP07256.build.flash_ld=eagle.flash.1m256.ld
-#wifinfo.menu.ESPModule.ESP07256.build.spiffs_start=0xBB000
-#wifinfo.menu.ESPModule.ESP07256.build.spiffs_end=0xFB000
-##wifinfo.menu.ESPModule.ESP07256.build.spiffs_blocksize=4096
-#wifinfo.menu.ESPModule.ESP07256.upload.maximum_size=761840
-
-wifinfo.menu.ESPModule.ESP07192=ESP07 (1M/192K SPIFFS)
-wifinfo.menu.ESPModule.ESP07192.build.board=ESP8266_ESP07
-wifinfo.menu.ESPModule.ESP07192.build.flash_size=1M
-wifinfo.menu.ESPModule.ESP07192.build.flash_ld=eagle.flash.1m192.ld
-wifinfo.menu.ESPModule.ESP07192.build.spiffs_start=0xCB000
-wifinfo.menu.ESPModule.ESP07192.build.spiffs_end=0xFB000
-wifinfo.menu.ESPModule.ESP07192.build.spiffs_blocksize=4096
-wifinfo.menu.ESPModule.ESP07192.upload.maximum_size=827376
-
-#wifinfo.menu.ESPModule.ESP07160=ESP07 (1M/160K SPIFFS)
-#wifinfo.menu.ESPModule.ESP07160.build.board=ESP8266_ESP07
-#wifinfo.menu.ESPModule.ESP07160.build.flash_size=1M
-#wifinfo.menu.ESPModule.ESP07160.build.flash_ld=eagle.flash.1m160.ld
-#wifinfo.menu.ESPModule.ESP07160.build.spiffs_start=0xD3000
-#wifinfo.menu.ESPModule.ESP07160.build.spiffs_end=0xFB000
-#wifinfo.menu.ESPModule.ESP07160.build.spiffs_blocksize=4096
-#wifinfo.menu.ESPModule.ESP07160.upload.maximum_size=860144
-#
-#wifinfo.menu.ESPModule.ESP07144=ESP07 (1M/144K SPIFFS)
-#wifinfo.menu.ESPModule.ESP07144.build.board=ESP8266_ESP07
-#wifinfo.menu.ESPModule.ESP07144.build.flash_size=1M
-#wifinfo.menu.ESPModule.ESP07144.build.flash_ld=eagle.flash.1m144.ld
-#wifinfo.menu.ESPModule.ESP07144.build.spiffs_start=0xD7000
-#wifinfo.menu.ESPModule.ESP07144.build.spiffs_end=0xFB000
-#wifinfo.menu.ESPModule.ESP07144.build.spiffs_blocksize=4096
-#wifinfo.menu.ESPModule.ESP07144.upload.maximum_size=876528
-#
-#wifinfo.menu.ESPModule.ESP07=ESP07 (1M/64K SPIFFS)
-#wifinfo.menu.ESPModule.ESP07.build.board=ESP8266_ESP07
-#wifinfo.menu.ESPModule.ESP07.build.flash_size=1M
-#wifinfo.menu.ESPModule.ESP07.build.flash_ld=eagle.flash.1m64.ld
-#wifinfo.menu.ESPModule.ESP07.build.spiffs_start=0xEB000
-#wifinfo.menu.ESPModule.ESP07.build.spiffs_end=0xFB000
-#wifinfo.menu.ESPModule.ESP07.build.spiffs_blocksize=4096
-#wifinfo.menu.ESPModule.ESP07.upload.maximum_size=958448
-
-wifinfo.menu.ESPModule.ESP12=ESP12 (4M/1M SPIFFS)
-wifinfo.menu.ESPModule.ESP12.build.board=ESP8266_ESP12
-wifinfo.menu.ESPModule.ESP12.build.flash_size=4M
-wifinfo.menu.ESPModule.ESP12.build.flash_ld=eagle.flash.4m1m.ld
-wifinfo.menu.ESPModule.ESP12.build.spiffs_start=0x300000
-wifinfo.menu.ESPModule.ESP12.build.spiffs_end=0x3FB000
-wifinfo.menu.ESPModule.ESP12.build.spiffs_blocksize=8192
-wifinfo.menu.ESPModule.ESP12.build.spiffs_pagesize=256
-wifinfo.menu.ESPModule.ESP12.upload.maximum_size=1044464
-
-wifinfo.menu.CpuFrequency.160=160 MHz
-wifinfo.menu.CpuFrequency.160.build.f_cpu=160000000L
-wifinfo.menu.CpuFrequency.80=80 MHz
-wifinfo.menu.CpuFrequency.80.build.f_cpu=80000000L
-
-wifinfo.menu.FlashFreq.40=40MHz
-wifinfo.menu.FlashFreq.40.build.flash_freq=40
-wifinfo.menu.FlashFreq.80=80MHz
-wifinfo.menu.FlashFreq.80.build.flash_freq=80
-
-wifinfo.menu.FlashMode.qio=QIO
-wifinfo.menu.FlashMode.qio.build.flash_mode=qio
-wifinfo.menu.FlashMode.dio=DIO
-wifinfo.menu.FlashMode.dio.build.flash_mode=dio
-
-wifinfo.menu.UploadSpeed.115200=115200
-wifinfo.menu.UploadSpeed.115200.upload.speed=115200
-wifinfo.menu.UploadSpeed.9600=9600
-wifinfo.menu.UploadSpeed.9600.upload.speed=9600
-wifinfo.menu.UploadSpeed.57600=57600
-wifinfo.menu.UploadSpeed.57600.upload.speed=57600
-wifinfo.menu.UploadSpeed.256000.windows=256000
-wifinfo.menu.UploadSpeed.256000.upload.speed=256000
-wifinfo.menu.UploadSpeed.230400.linux=230400
-wifinfo.menu.UploadSpeed.230400.macosx=230400
-wifinfo.menu.UploadSpeed.230400.upload.speed=230400
-wifinfo.menu.UploadSpeed.460800.linux=460800
-wifinfo.menu.UploadSpeed.460800.macosx=460800
-wifinfo.menu.UploadSpeed.460800.upload.speed=460800
-wifinfo.menu.UploadSpeed.512000.windows=512000
-wifinfo.menu.UploadSpeed.512000.upload.speed=512000
-wifinfo.menu.UploadSpeed.921600=921600
-wifinfo.menu.UploadSpeed.921600.upload.speed=921600
-
-
-##############################################################
-coredev.name=Core Development Module
-
-coredev.upload.tool=esptool
-coredev.upload.speed=115200
-coredev.upload.resetmethod=ck
-coredev.upload.maximum_size=434160
-coredev.upload.maximum_data_size=81920
-coredev.upload.wait_for_upload_port=true
-coredev.serial.disableDTR=true
-coredev.serial.disableRTS=true
-
-coredev.build.mcu=esp8266
-coredev.build.f_cpu=80000000L
-coredev.build.board=ESP8266_ESP01
-coredev.build.core=esp8266
-coredev.build.variant=generic
-coredev.build.flash_mode=qio
-coredev.build.spiffs_pagesize=256
-coredev.build.debug_port=
-coredev.build.debug_level=
-coredev.build.lwip_lib=-llwip
-coredev.build.lwip_flags=
-
-
-coredev.menu.LwIPVariant.Espressif=Espressif (xcc)
-coredev.menu.LwIPVariant.Espressif.build.lwip_lib=-llwip
-coredev.menu.LwIPVariant.Espressif.build.lwip_flags=-DLWIP_MAYBE_XCC
-coredev.menu.LwIPVariant.Prebuilt=Prebuilt Source (gcc)
-coredev.menu.LwIPVariant.Prebuilt.build.lwip_lib=-llwip_gcc
-coredev.menu.LwIPVariant.Prebuilt.build.lwip_flags=-DLWIP_OPEN_SRC
-coredev.menu.LwIPVariant.OpenSource=Open Source (gcc)
-coredev.menu.LwIPVariant.OpenSource.build.lwip_lib=-llwip_src
-coredev.menu.LwIPVariant.OpenSource.build.lwip_flags=-DLWIP_OPEN_SRC
-coredev.menu.LwIPVariant.OpenSource.recipe.hooks.sketch.prebuild.1.pattern=make -C "{runtime.platform.path}/tools/sdk/lwip/src" install TOOLS_PATH="{runtime.tools.xtensa-lx106-elf-gcc.path}/bin/xtensa-lx106-elf-"
-
-coredev.menu.CpuFrequency.80=80 MHz
-coredev.menu.CpuFrequency.80.build.f_cpu=80000000L
-coredev.menu.CpuFrequency.160=160 MHz
-coredev.menu.CpuFrequency.160.build.f_cpu=160000000L
-
-coredev.menu.FlashFreq.40=40MHz
-coredev.menu.FlashFreq.40.build.flash_freq=40
-coredev.menu.FlashFreq.80=80MHz
-coredev.menu.FlashFreq.80.build.flash_freq=80
-
-coredev.menu.FlashMode.dio=DIO
-coredev.menu.FlashMode.dio.build.flash_mode=dio
-coredev.menu.FlashMode.qio=QIO
-coredev.menu.FlashMode.qio.build.flash_mode=qio
-coredev.menu.FlashMode.dout=DOUT
-coredev.menu.FlashMode.dout.build.flash_mode=dout
-coredev.menu.FlashMode.qout=QOUT
-coredev.menu.FlashMode.qout.build.flash_mode=qout
-
-coredev.menu.UploadSpeed.115200=115200
-coredev.menu.UploadSpeed.115200.upload.speed=115200
-coredev.menu.UploadSpeed.9600=9600
-coredev.menu.UploadSpeed.9600.upload.speed=9600
-coredev.menu.UploadSpeed.57600=57600
-coredev.menu.UploadSpeed.57600.upload.speed=57600
-coredev.menu.UploadSpeed.256000.windows=256000
-coredev.menu.UploadSpeed.256000.upload.speed=256000
-coredev.menu.UploadSpeed.230400.linux=230400
-coredev.menu.UploadSpeed.230400.macosx=230400
-coredev.menu.UploadSpeed.230400.upload.speed=230400
-coredev.menu.UploadSpeed.460800.linux=460800
-coredev.menu.UploadSpeed.460800.macosx=460800
-coredev.menu.UploadSpeed.460800.upload.speed=460800
-coredev.menu.UploadSpeed.512000.windows=512000
-coredev.menu.UploadSpeed.512000.upload.speed=512000
-coredev.menu.UploadSpeed.921600=921600
-coredev.menu.UploadSpeed.921600.upload.speed=921600
-
-coredev.menu.FlashSize.512K64=512K (64K SPIFFS)
-coredev.menu.FlashSize.512K64.build.flash_size=512K
-coredev.menu.FlashSize.512K64.build.flash_ld=eagle.flash.512k64.ld
-coredev.menu.FlashSize.512K64.build.spiffs_start=0x6B000
-coredev.menu.FlashSize.512K64.build.spiffs_end=0x7B000
-coredev.menu.FlashSize.512K64.build.spiffs_blocksize=4096
-coredev.menu.FlashSize.512K64.upload.maximum_size=434160
-
-coredev.menu.FlashSize.512K128=512K (128K SPIFFS)
-coredev.menu.FlashSize.512K128.build.flash_size=512K
-coredev.menu.FlashSize.512K128.build.flash_ld=eagle.flash.512k128.ld
-coredev.menu.FlashSize.512K128.build.spiffs_start=0x5B000
-coredev.menu.FlashSize.512K128.build.spiffs_end=0x7B000
-coredev.menu.FlashSize.512K128.build.spiffs_blocksize=4096
-coredev.menu.FlashSize.512K128.upload.maximum_size=368624
-
-coredev.menu.FlashSize.512K0=512K (no SPIFFS)
-coredev.menu.FlashSize.512K0.build.flash_size=512K
-coredev.menu.FlashSize.512K0.build.flash_ld=eagle.flash.512k0.ld
-coredev.menu.FlashSize.512K0.upload.maximum_size=499696
-
-coredev.menu.FlashSize.1M512=1M (512K SPIFFS)
-coredev.menu.FlashSize.1M512.build.flash_size=1M
-coredev.menu.FlashSize.1M512.build.flash_ld=eagle.flash.1m512.ld
-coredev.menu.FlashSize.1M512.build.spiffs_start=0x7B000
-coredev.menu.FlashSize.1M512.build.spiffs_end=0xFB000
-coredev.menu.FlashSize.1M512.build.spiffs_blocksize=8192
-coredev.menu.FlashSize.1M512.upload.maximum_size=499696
-
-coredev.menu.FlashSize.1M256=1M (256K SPIFFS)
-coredev.menu.FlashSize.1M256.build.flash_size=1M
-coredev.menu.FlashSize.1M256.build.flash_ld=eagle.flash.1m256.ld
-coredev.menu.FlashSize.1M256.build.spiffs_start=0xBB000
-coredev.menu.FlashSize.1M256.build.spiffs_end=0xFB000
-coredev.menu.FlashSize.1M256.build.spiffs_blocksize=4096
-coredev.menu.FlashSize.1M256.upload.maximum_size=761840
-
-coredev.menu.FlashSize.1M192=1M (192K SPIFFS)
-coredev.menu.FlashSize.1M192.build.flash_size=1M
-coredev.menu.FlashSize.1M192.build.flash_ld=eagle.flash.1m192.ld
-coredev.menu.FlashSize.1M192.build.spiffs_start=0xCB000
-coredev.menu.FlashSize.1M192.build.spiffs_end=0xFB000
-coredev.menu.FlashSize.1M192.build.spiffs_blocksize=4096
-coredev.menu.FlashSize.1M192.upload.maximum_size=827376
-
-coredev.menu.FlashSize.1M160=1M (160K SPIFFS)
-coredev.menu.FlashSize.1M160.build.flash_size=1M
-coredev.menu.FlashSize.1M160.build.flash_ld=eagle.flash.1m160.ld
-coredev.menu.FlashSize.1M160.build.spiffs_start=0xD3000
-coredev.menu.FlashSize.1M160.build.spiffs_end=0xFB000
-coredev.menu.FlashSize.1M160.build.spiffs_blocksize=4096
-coredev.menu.FlashSize.1M160.upload.maximum_size=860144
-
-coredev.menu.FlashSize.1M144=1M (144K SPIFFS)
-coredev.menu.FlashSize.1M144.build.flash_size=1M
-coredev.menu.FlashSize.1M144.build.flash_ld=eagle.flash.1m144.ld
-coredev.menu.FlashSize.1M144.build.spiffs_start=0xD7000
-coredev.menu.FlashSize.1M144.build.spiffs_end=0xFB000
-coredev.menu.FlashSize.1M144.build.spiffs_blocksize=4096
-coredev.menu.FlashSize.1M144.upload.maximum_size=876528
-
-coredev.menu.FlashSize.1M128=1M (128K SPIFFS)
-coredev.menu.FlashSize.1M128.build.flash_size=1M
-coredev.menu.FlashSize.1M128.build.flash_ld=eagle.flash.1m128.ld
-coredev.menu.FlashSize.1M128.build.spiffs_start=0xDB000
-coredev.menu.FlashSize.1M128.build.spiffs_end=0xFB000
-coredev.menu.FlashSize.1M128.build.spiffs_blocksize=4096
-coredev.menu.FlashSize.1M128.upload.maximum_size=892912
-
-coredev.menu.FlashSize.1M64=1M (64K SPIFFS)
-coredev.menu.FlashSize.1M64.build.flash_size=1M
-coredev.menu.FlashSize.1M64.build.flash_ld=eagle.flash.1m64.ld
-coredev.menu.FlashSize.1M64.build.spiffs_start=0xEB000
-coredev.menu.FlashSize.1M64.build.spiffs_end=0xFB000
-coredev.menu.FlashSize.1M64.build.spiffs_blocksize=4096
-coredev.menu.FlashSize.1M64.upload.maximum_size=958448
-
-coredev.menu.FlashSize.2M=2M (1M SPIFFS)
-coredev.menu.FlashSize.2M.build.flash_size=2M
-coredev.menu.FlashSize.2M.build.flash_ld=eagle.flash.2m.ld
-coredev.menu.FlashSize.2M.build.spiffs_start=0x100000
-coredev.menu.FlashSize.2M.build.spiffs_end=0x1FB000
-coredev.menu.FlashSize.2M.build.spiffs_blocksize=8192
-coredev.menu.FlashSize.2M.upload.maximum_size=1044464
-
-coredev.menu.FlashSize.4M1M=4M (1M SPIFFS)
-coredev.menu.FlashSize.4M1M.build.flash_size=4M
-coredev.menu.FlashSize.4M1M.build.flash_ld=eagle.flash.4m1m.ld
-coredev.menu.FlashSize.4M1M.build.spiffs_start=0x300000
-coredev.menu.FlashSize.4M1M.build.spiffs_end=0x3FB000
-coredev.menu.FlashSize.4M1M.build.spiffs_blocksize=8192
-coredev.menu.FlashSize.4M1M.build.spiffs_pagesize=256
-coredev.menu.FlashSize.4M1M.upload.maximum_size=1044464
-
-coredev.menu.FlashSize.4M3M=4M (3M SPIFFS)
-coredev.menu.FlashSize.4M3M.build.flash_size=4M
-coredev.menu.FlashSize.4M3M.build.flash_ld=eagle.flash.4m.ld
-coredev.menu.FlashSize.4M3M.build.spiffs_start=0x100000
-coredev.menu.FlashSize.4M3M.build.spiffs_end=0x3FB000
-coredev.menu.FlashSize.4M3M.build.spiffs_pagesize=256
-coredev.menu.FlashSize.4M3M.build.spiffs_blocksize=8192
-coredev.menu.FlashSize.4M3M.upload.maximum_size=1044464
-
-coredev.menu.FlashSize.8M7M=8M (7M SPIFFS)
-coredev.menu.FlashSize.8M7M.build.flash_size=8M
-coredev.menu.FlashSize.8M7M.build.flash_ld=eagle.flash.8m.ld
-coredev.menu.FlashSize.8M7M.build.spiffs_start=0x100000
-coredev.menu.FlashSize.8M7M.build.spiffs_end=0x7FB000
-coredev.menu.FlashSize.8M7M.build.spiffs_pagesize=256
-coredev.menu.FlashSize.8M7M.build.spiffs_blocksize=8192
-coredev.menu.FlashSize.8M7M.upload.maximum_size=1044464
-
-coredev.menu.FlashSize.16M15M=16M (15M SPIFFS)
-coredev.menu.FlashSize.16M15M.build.flash_size=16M
-coredev.menu.FlashSize.16M15M.build.flash_ld=eagle.flash.16m.ld
-coredev.menu.FlashSize.16M15M.build.spiffs_start=0x100000
-coredev.menu.FlashSize.16M15M.build.spiffs_end=0x17FB000
-coredev.menu.FlashSize.16M15M.build.spiffs_pagesize=256
-coredev.menu.FlashSize.16M15M.build.spiffs_blocksize=8192
-coredev.menu.FlashSize.16M15M.upload.maximum_size=1044464
-
-coredev.menu.ResetMethod.ck=ck
-coredev.menu.ResetMethod.ck.upload.resetmethod=ck
-coredev.menu.ResetMethod.nodemcu=nodemcu
-coredev.menu.ResetMethod.nodemcu.upload.resetmethod=nodemcu
-
-coredev.menu.Debug.Disabled=Disabled
-coredev.menu.Debug.Disabled.build.debug_port=
-coredev.menu.Debug.Serial=Serial
-coredev.menu.Debug.Serial.build.debug_port=-DDEBUG_ESP_PORT=Serial
-coredev.menu.Debug.Serial1=Serial1
-coredev.menu.Debug.Serial1.build.debug_port=-DDEBUG_ESP_PORT=Serial1
-
-coredev.menu.DebugLevel.None____=None
-coredev.menu.DebugLevel.None____.build.debug_level=
-coredev.menu.DebugLevel.Core____=Core
-coredev.menu.DebugLevel.Core____.build.debug_level=-DDEBUG_ESP_CORE
-coredev.menu.DebugLevel.SSL_____=Core + SSL
-coredev.menu.DebugLevel.SSL_____.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_SSL
-coredev.menu.DebugLevel.SSL_MEM_=Core + SSL + TLS Mem
-coredev.menu.DebugLevel.SSL_MEM_.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_SSL -DDEBUG_TLS_MEM
-coredev.menu.DebugLevel.WiFic___=Core + WiFi
-coredev.menu.DebugLevel.WiFic___.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_WIFI
-coredev.menu.DebugLevel.WiFi____=WiFi
-coredev.menu.DebugLevel.WiFi____.build.debug_level=-DDEBUG_ESP_WIFI
-coredev.menu.DebugLevel.HTTPClient=HTTPClient
-coredev.menu.DebugLevel.HTTPClient.build.debug_level=-DDEBUG_ESP_HTTP_CLIENT
-coredev.menu.DebugLevel.HTTPClient2=HTTPClient + SSL
-coredev.menu.DebugLevel.HTTPClient2.build.debug_level=-DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_SSL
-coredev.menu.DebugLevel.HTTPUpdate=HTTPUpdate
-coredev.menu.DebugLevel.HTTPUpdate.build.debug_level=-DDEBUG_ESP_HTTP_UPDATE
-coredev.menu.DebugLevel.HTTPUpdate2=HTTPClient + HTTPUpdate
-coredev.menu.DebugLevel.HTTPUpdate2.build.debug_level=-DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_UPDATE
-coredev.menu.DebugLevel.HTTPUpdate3=HTTPClient + HTTPUpdate + Updater
-coredev.menu.DebugLevel.HTTPUpdate3.build.debug_level=-DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_UPDATER
-coredev.menu.DebugLevel.HTTPServer=HTTPServer
-coredev.menu.DebugLevel.HTTPServer.build.debug_level=-DDEBUG_ESP_HTTP_SERVER
-coredev.menu.DebugLevel.UPDATER=Updater
-coredev.menu.DebugLevel.UPDATER.build.debug_level=-DDEBUG_ESP_UPDATER
-coredev.menu.DebugLevel.OTA_____=OTA
-coredev.menu.DebugLevel.OTA_____.build.debug_level=-DDEBUG_ESP_OTA
-coredev.menu.DebugLevel.OTA2____=OTA + Updater
-coredev.menu.DebugLevel.OTA2____.build.debug_level=-DDEBUG_ESP_OTA -DDEBUG_ESP_UPDATER
-coredev.menu.DebugLevel.all_____=All
-coredev.menu.DebugLevel.all_____.build.debug_level=-DDEBUG_ESP_CORE -DDEBUG_ESP_SSL -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_SERVER -DDEBUG_ESP_UPDATER -DDEBUG_ESP_OTA -DDEBUG_TLS_MEM
-
-############ Arduino boards with Esp8266 ############
-
-arduino-esp8266.name=Arduino
-
-arduino-esp8266.upload.tool=esptool
-arduino-esp8266.upload.speed=9600
-arduino-esp8266.upload.resetmethod=ck
-arduino-esp8266.upload.maximum_size=1044464
-arduino-esp8266.upload.maximum_data_size=81920
-arduino-esp8266.upload.wait_for_upload_port=true
-arduino-esp8266.serial.disableDTR=true
-arduino-esp8266.serial.disableRTS=true
-
-arduino-esp8266.build.mcu=esp8266
-arduino-esp8266.build.f_cpu=80000000L
-#arduino-esp8266.build.f_crystal=40000000
-arduino-esp8266.build.core=esp8266
-arduino-esp8266.build.flash_mode=qio
-arduino-esp8266.build.flash_size=4M
-arduino-esp8266.build.flash_freq=40
-arduino-esp8266.build.debug_port=
-arduino-esp8266.build.debug_level=
-arduino-esp8266.build.board=ESP8266_ARDUINO
-
-arduino-esp8266.menu.BoardModel.starottodeved=Star OTTO
-arduino-esp8266.menu.BoardModel.starottodeved.build.board=ESP8266_ARDUINO_STAR_OTTO
-arduino-esp8266.menu.BoardModel.starottodeved.build.variant=arduino_uart
-arduino-esp8266.menu.BoardModel.starottodeved.build.extra_flags=-DF_CRYSTAL=40000000
-
-arduino-esp8266.menu.BoardModel.primo=Primo
-arduino-esp8266.menu.BoardModel.primo.build.board=ESP8266_ARDUINO_PRIMO
-arduino-esp8266.menu.BoardModel.primo.build.variant=arduino_spi
-arduino-esp8266.menu.BoardModel.primo.build.extra_flags=-DF_CRYSTAL=40000000
-
-arduino-esp8266.menu.BoardModel.unowifideved=Uno WiFi
-arduino-esp8266.menu.BoardModel.unowifideved.build.board=ESP8266_ARDUINO_UNOWIFI
-arduino-esp8266.menu.BoardModel.unowifideved.build.variant=arduino_uart
-arduino-esp8266.menu.BoardModel.unowifideved.build.extra_flags=-DF_CRYSTAL=40000000
-
-arduino-esp8266.menu.UploadSpeed.9600=9600
-arduino-esp8266.menu.UploadSpeed.9600.upload.speed=9600
-arduino-esp8266.menu.UploadSpeed.19200=19200
-arduino-esp8266.menu.UploadSpeed.19200.upload.speed=19200
-arduino-esp8266.menu.UploadSpeed.57600=57600
-arduino-esp8266.menu.UploadSpeed.57600.upload.speed=57600
-arduino-esp8266.menu.UploadSpeed.115200=115200
-arduino-esp8266.menu.UploadSpeed.115200.upload.speed=115200
-arduino-esp8266.menu.UploadSpeed.230400=230400
-arduino-esp8266.menu.UploadSpeed.230400.upload.speed=230400
-arduino-esp8266.menu.UploadSpeed.460800=460800
-arduino-esp8266.menu.UploadSpeed.460800.upload.speed=460800
-
-arduino-esp8266.menu.FlashSize.4M1M=4M (1M SPIFFS)
-arduino-esp8266.menu.FlashSize.4M1M.build.flash_size=4M
-arduino-esp8266.menu.FlashSize.4M1M.build.flash_ld=eagle.flash.4m1m.ld
-arduino-esp8266.menu.FlashSize.4M1M.build.spiffs_start=0x300000
-arduino-esp8266.menu.FlashSize.4M1M.build.spiffs_end=0x3FB000
-arduino-esp8266.menu.FlashSize.4M1M.build.spiffs_blocksize=8192
-arduino-esp8266.menu.FlashSize.4M1M.build.spiffs_pagesize=256
-
-arduino-esp8266.menu.FlashSize.4M3M=4M (3M SPIFFS)
-arduino-esp8266.menu.FlashSize.4M3M.build.flash_size=4M
-arduino-esp8266.menu.FlashSize.4M3M.build.flash_ld=eagle.flash.4m.ld
-arduino-esp8266.menu.FlashSize.4M3M.build.spiffs_start=0x100000
-arduino-esp8266.menu.FlashSize.4M3M.build.spiffs_end=0x3FB000
-arduino-esp8266.menu.FlashSize.4M3M.build.spiffs_blocksize=8192
-arduino-esp8266.menu.FlashSize.4M3M.build.spiffs_pagesize=256
-
-##############################################################
-
-gen4iod.name=4D Systems gen4 IoD Range
-
-gen4iod.upload.tool=esptool
-gen4iod.upload.speed=921600
-gen4iod.upload.resetmethod=nodemcu
-gen4iod.upload.maximum_size=434160
-gen4iod.upload.maximum_data_size=81920
-gen4iod.upload.wait_for_upload_port=true
-gen4iod.serial.disableDTR=true
-gen4iod.serial.disableRTS=true
-
-gen4iod.build.mcu=esp8266
-gen4iod.build.f_cpu=160000000L
-gen4iod.build.board=GEN4_IOD
-gen4iod.build.core=esp8266
-gen4iod.build.variant=generic
-gen4iod.build.flash_mode=qio
-# flash chip: AT25SF041 (512 kbyte, 4Mbit)
-gen4iod.build.flash_size=512K
-gen4iod.build.flash_ld=eagle.flash.512k0.ld
-gen4iod.build.flash_freq=80
-gen4iod.build.debug_port=
-gen4iod.build.debug_level=
-
-gen4iod.menu.CpuFrequency.160=160 MHz
-gen4iod.menu.CpuFrequency.160.build.f_cpu=160000000L
-gen4iod.menu.CpuFrequency.80=80 MHz
-gen4iod.menu.CpuFrequency.80.build.f_cpu=80000000L
-
-gen4iod.menu.UploadSpeed.115200=115200
-gen4iod.menu.UploadSpeed.115200.upload.speed=115200
-gen4iod.menu.UploadSpeed.9600=9600
-gen4iod.menu.UploadSpeed.9600.upload.speed=9600
-gen4iod.menu.UploadSpeed.57600=57600
-gen4iod.menu.UploadSpeed.57600.upload.speed=57600
-gen4iod.menu.UploadSpeed.256000.windows=256000
-gen4iod.menu.UploadSpeed.256000.upload.speed=256000
-gen4iod.menu.UploadSpeed.230400.linux=230400
-gen4iod.menu.UploadSpeed.230400.macosx=230400
-gen4iod.menu.UploadSpeed.230400.upload.speed=230400
-gen4iod.menu.UploadSpeed.460800.linux=460800
-gen4iod.menu.UploadSpeed.460800.macosx=460800
-gen4iod.menu.UploadSpeed.460800.upload.speed=460800
-gen4iod.menu.UploadSpeed.512000.windows=512000
-gen4iod.menu.UploadSpeed.512000.upload.speed=512000
-gen4iod.menu.UploadSpeed.921600=921600
-gen4iod.menu.UploadSpeed.921600.upload.speed=921600

--- a/boards.txt
+++ b/boards.txt
@@ -1962,3 +1962,53 @@ arduino-esp8266.menu.FlashSize.4M3M.build.spiffs_start=0x100000
 arduino-esp8266.menu.FlashSize.4M3M.build.spiffs_end=0x3FB000
 arduino-esp8266.menu.FlashSize.4M3M.build.spiffs_blocksize=8192
 arduino-esp8266.menu.FlashSize.4M3M.build.spiffs_pagesize=256
+
+##############################################################
+
+gen4iod.name=4D Systems gen4 IoD Range
+
+gen4iod.upload.tool=esptool
+gen4iod.upload.speed=921600
+gen4iod.upload.resetmethod=nodemcu
+gen4iod.upload.maximum_size=434160
+gen4iod.upload.maximum_data_size=81920
+gen4iod.upload.wait_for_upload_port=true
+gen4iod.serial.disableDTR=true
+gen4iod.serial.disableRTS=true
+
+gen4iod.build.mcu=esp8266
+gen4iod.build.f_cpu=160000000L
+gen4iod.build.board=GEN4_IOD
+gen4iod.build.core=esp8266
+gen4iod.build.variant=generic
+gen4iod.build.flash_mode=qio
+# flash chip: AT25SF041 (512 kbyte, 4Mbit)
+gen4iod.build.flash_size=512K
+gen4iod.build.flash_ld=eagle.flash.512k0.ld
+gen4iod.build.flash_freq=80
+gen4iod.build.debug_port=
+gen4iod.build.debug_level=
+
+gen4iod.menu.CpuFrequency.160=160 MHz
+gen4iod.menu.CpuFrequency.160.build.f_cpu=160000000L
+gen4iod.menu.CpuFrequency.80=80 MHz
+gen4iod.menu.CpuFrequency.80.build.f_cpu=80000000L
+
+gen4iod.menu.UploadSpeed.115200=115200
+gen4iod.menu.UploadSpeed.115200.upload.speed=115200
+gen4iod.menu.UploadSpeed.9600=9600
+gen4iod.menu.UploadSpeed.9600.upload.speed=9600
+gen4iod.menu.UploadSpeed.57600=57600
+gen4iod.menu.UploadSpeed.57600.upload.speed=57600
+gen4iod.menu.UploadSpeed.256000.windows=256000
+gen4iod.menu.UploadSpeed.256000.upload.speed=256000
+gen4iod.menu.UploadSpeed.230400.linux=230400
+gen4iod.menu.UploadSpeed.230400.macosx=230400
+gen4iod.menu.UploadSpeed.230400.upload.speed=230400
+gen4iod.menu.UploadSpeed.460800.linux=460800
+gen4iod.menu.UploadSpeed.460800.macosx=460800
+gen4iod.menu.UploadSpeed.460800.upload.speed=460800
+gen4iod.menu.UploadSpeed.512000.windows=512000
+gen4iod.menu.UploadSpeed.512000.upload.speed=512000
+gen4iod.menu.UploadSpeed.921600=921600
+gen4iod.menu.UploadSpeed.921600.upload.speed=921600

--- a/doc/boards.md
+++ b/doc/boards.md
@@ -306,9 +306,11 @@ We will update an English description soon.
 
 ## gen4-IoD Range by 4D Systems
 gen4-IoD Range of ESP8266 powered Display Modules by 4D Systems.
+
 2.4", 2.8" and 3.2" TFT LCD with uSD card socket and Resistive Touch. Chip Antenna + uFL Connector.
   
 Datasheet and associated downloads can be found on the 4D Systems product page.
+
 The gen4-IoD range can be programmed using the Arduino IDE and also the 4D Systems Workshop4 IDE, which incorporates many additional graphics benefits. GFX4d library is available, along with a number of demo applications.
   
 - Product page: http://www.4dsystems.com.au/product/gen4-IoD

--- a/doc/boards.md
+++ b/doc/boards.md
@@ -33,6 +33,7 @@ title: Supported Hardware
   * [WeMos D1](#wemos-d1)
   * [WeMos D1 mini](#wemos-d1-mini)
   * [ESPino by ThaiEasyElec](#espinotee)
+	* [gen4-IoD Range by 4D Systems](#gen4iod)
 
 ## Adafruit HUZZAH ESP8266 (ESP-12)
 
@@ -303,6 +304,14 @@ We will update an English description soon.
 - Dimensions: http://thaieasyelec.com/downloads/ETEE052/ETEE052_ESPino_Dimension.pdf
 - Pinouts: http://thaieasyelec.com/downloads/ETEE052/ETEE052_ESPino_User_Manual_TH_v1_0_20160204.pdf (Please see pg. 8)
 
+## gen4-IoD Range by 4D Systems
+gen4-IoD Range of ESP8266 powered Display Modules by 4D Systems.
+2.4", 2.8" and 3.2" TFT LCD with uSD card socket and Resistive Touch. Chip Antenna + uFL Connector.
+  
+Datasheet and associated downloads can be found on the 4D Systems product page.
+The gen4-IoD range can be programmed using the Arduino IDE and also the 4D Systems Workshop4 IDE, which incorporates many additional graphics benefits. GFX4d library is available, along with a number of demo applications.
+  
+- Product page: http://www.4dsystems.com.au/product/gen4-IoD
 
 
 

--- a/doc/boards.md
+++ b/doc/boards.md
@@ -33,7 +33,7 @@ title: Supported Hardware
   * [WeMos D1](#wemos-d1)
   * [WeMos D1 mini](#wemos-d1-mini)
   * [ESPino by ThaiEasyElec](#espinotee)
-	* [gen4-IoD Range by 4D Systems](#gen4iod)
+  * [gen4-IoD Range by 4D Systems](#gen4iod)
 
 ## Adafruit HUZZAH ESP8266 (ESP-12)
 

--- a/doc/boards.rst
+++ b/doc/boards.rst
@@ -1,0 +1,481 @@
+Boards
+======
+
+Generic ESP8266 Module
+----------------------
+
+These modules come in different form factors and pinouts. See the page at ESP8266 community wiki for more info: `ESP8266 Module Family <http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family>`__.
+
+Usually these modules have no bootstapping resistors on board, insufficient decoupling capacitors, no voltage regulator, no reset circuit, and no USB-serial adapter. This makes using them somewhat tricky, compared to development boards which add these features.
+
+In order to use these modules, make sure to observe the following:
+
+-  **Provide sufficient power to the module.** For stable use of the ESP8266 a power supply with 3.3V and >= 250mA is required. Using the power available from USB to Serial adapter is not recommended, these adapters typically do not supply enough current to run ESP8266 reliably in every situation. An external supply or regulator alongwith filtering capacitors is preferred.
+
+-  **Connect bootstapping resistors** to GPIO0, GPIO2, GPIO15 according to the schematics below.
+
+-  **Put ESP8266 into bootloader mode** before uploading code.
+
+Serial Adapter
+--------------
+
+There are many different USB to Serial adapters / boards. To be able to put ESP8266 into bootloader mode using serial handshaking lines, you need the adapter which breaks out RTS and DTR outputs. CTS and DSR are not useful for upload (they are inputs). Make sure the adapter can work with 3.3V IO voltage: it should have a jumper or a switch to select between 5V and 3.3V, or be marked as 3.3V only.
+
+Adapters based around the following ICs should work:
+
+-  FT232RL
+-  CP2102
+-  CH340G
+
+PL2303-based adapters are known not to work on Mac OS X. See https://github.com/igrr/esptool-ck/issues/9 for more info.
+
+Minimal Hardware Setup for Bootloading and Usage
+------------------------------------------------
+
++-----------------+------------+------------------+
+| PIN             | Resistor   | Serial Adapter   |
++=================+============+==================+
+| VCC             |            | VCC (3.3V)       |
++-----------------+------------+------------------+
+| GND             |            | GND              |
++-----------------+------------+------------------+
+| TX or GPIO2\*   |            | RX               |
++-----------------+------------+------------------+
+| RX              |            | TX               |
++-----------------+------------+------------------+
+| GPIO0           | PullUp     | DTR              |
++-----------------+------------+------------------+
+| Reset\*         | PullUp     | RTS              |
++-----------------+------------+------------------+
+| GPIO15\*        | PullDown   |                  |
++-----------------+------------+------------------+
+| CH\_PD          | PullUp     |                  |
++-----------------+------------+------------------+
+
+-  Note
+-  GPIO15 is also named MTDO
+-  Reset is also named RSBT or REST (adding PullUp improves the
+   stability of the module)
+-  GPIO2 is alternative TX for the boot loader mode
+-  **Directly connecting a pin to VCC or GND is not a substitute for a
+   PullUp or PullDown resistor, doing this can break upload management
+   and the serial console, instability has also been noted in some
+   cases.**
+
+ESP to Serial
+-------------
+
+.. figure:: ESP_to_serial.png
+   :alt: ESP to Serial
+
+   ESP to Serial
+
+Minimal Hardware Setup for Bootloading only
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+ESPxx Hardware
+
++---------------+------------+------------------+
+| PIN           | Resistor   | Serial Adapter   |
++===============+============+==================+
+| VCC           |            | VCC (3.3V)       |
++---------------+------------+------------------+
+| GND           |            | GND              |
++---------------+------------+------------------+
+| TX or GPIO2   |            | RX               |
++---------------+------------+------------------+
+| RX            |            | TX               |
++---------------+------------+------------------+
+| GPIO0         |            | GND              |
++---------------+------------+------------------+
+| Reset         |            | RTS\*            |
++---------------+------------+------------------+
+| GPIO15        | PullDown   |                  |
++---------------+------------+------------------+
+| CH\_PD        | PullUp     |                  |
++---------------+------------+------------------+
+
+-  Note
+-  if no RTS is used a manual power toggle is needed
+
+Minimal Hardware Setup for Running only
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+ESPxx Hardware
+
++----------+------------+----------------+
+| PIN      | Resistor   | Power supply   |
++==========+============+================+
+| VCC      |            | VCC (3.3V)     |
++----------+------------+----------------+
+| GND      |            | GND            |
++----------+------------+----------------+
+| GPIO0    | PullUp     |                |
++----------+------------+----------------+
+| GPIO15   | PullDown   |                |
++----------+------------+----------------+
+| CH\_PD   | PullUp     |                |
++----------+------------+----------------+
+
+Minimal
+-------
+
+.. figure:: ESP_min.png
+   :alt: ESP min
+
+   ESP min
+
+Improved Stability
+------------------
+
+.. figure:: ESP_improved_stability.png
+   :alt: ESP improved stability
+
+   ESP improved stability
+
+Boot Messages and Modes
+-----------------------
+
+The ESP module checks at every boot the Pins 0, 2 and 15. based on them its boots in different modes:
+
++----------+---------+---------+------------------------------------+
+| GPIO15   | GPIO0   | GPIO2   | Mode                               |
++==========+=========+=========+====================================+
+| 0V       | 0V      | 3.3V    | Uart Bootloader                    |
++----------+---------+---------+------------------------------------+
+| 0V       | 3.3V    | 3.3V    | Boot sketch (SPI flash)            |
++----------+---------+---------+------------------------------------+
+| 3.3V     | x       | x       | SDIO mode (not used for Arduino)   |
++----------+---------+---------+------------------------------------+
+
+at startup the ESP prints out the current boot mode example:
+
+::
+
+    rst cause:2, boot mode:(3,6)
+
+note: - GPIO2 is used as TX output and the internal Pullup is enabled on boot.
+
+rst cause
+~~~~~~~~~
+
++----------+------------------+
+| Number   | Description      |
++==========+==================+
+| 0        | unknown          |
++----------+------------------+
+| 1        | normal boot      |
++----------+------------------+
+| 2        | reset pin        |
++----------+------------------+
+| 3        | software reset   |
++----------+------------------+
+| 4        | watchdog reset   |
++----------+------------------+
+
+boot mode
+~~~~~~~~~
+
+the first value respects the pin setup of the Pins 0, 2 and 15.
+
++----------+----------+---------+---------+-------------+
+| Number   | GPIO15   | GPIO0   | GPIO2   | Mode        |
++==========+==========+=========+=========+=============+
+| 0        | 0V       | 0V      | 0V      | Not valid   |
++----------+----------+---------+---------+-------------+
+| 1        | 0V       | 0V      | 3.3V    | Uart        |
++----------+----------+---------+---------+-------------+
+| 2        | 0V       | 3.3V    | 0V      | Not valid   |
++----------+----------+---------+---------+-------------+
+| 3        | 0V       | 3.3V    | 3.3V    | Flash       |
++----------+----------+---------+---------+-------------+
+| 4        | 3.3V     | 0V      | 0V      | SDIO        |
++----------+----------+---------+---------+-------------+
+| 5        | 3.3V     | 0V      | 3.3V    | SDIO        |
++----------+----------+---------+---------+-------------+
+| 6        | 3.3V     | 3.3V    | 0V      | SDIO        |
++----------+----------+---------+---------+-------------+
+| 7        | 3.3V     | 3.3V    | 3.3V    | SDIO        |
++----------+----------+---------+---------+-------------+
+
+note: - number = ((GPIO15 << 2) \| (GPIO0 << 1) \| GPIO2);
+
+Generic ESP8285 Module
+----------------------
+
+ESP8285 (`datasheet <http://www.espressif.com/sites/default/files/0a-esp8285_datasheet_en_v1.0_20160422.pdf>`__) is a multi-chip package which contains ESP8266 and 1MB flash. All points related to bootstrapping resistors and recommended circuits listed above apply to ESP8285 as well.
+
+Note that since ESP8285 has SPI flash memory internally connected in DOUT mode, pins 9 and 10 may be used as GPIO / I2C / PWM pins.
+
+ESPDuino (ESP-13 Module)
+------------------------
+
+*TODO*
+
+Adafruit Feather HUZZAH ESP8266
+-------------------------------
+
+The Adafruit Feather HUZZAH ESP8266 is an Arduino-compatible Wi-Fi development board powered by Ai-Thinker's ESP-12S, clocked at 80 MHz at 3.3V logic. A high-quality SiLabs CP2104 USB-Serial chip is included so that you can upload code at a blistering 921600 baud for fast development time. It also has auto-reset so no noodling with pins and reset button pressings. A 3.7V Lithium polymer battery connector is included, making it ideal for portable projects. The Adafruit Feather HUZZAH ESP8266 will automatically recharge a connected battery when USB power is available.
+
+Product page: https://www.adafruit.com/product/2821
+
+Invent One
+----------
+
+The Invent One is an Arduino-compatible Wi-Fi development board powered by Ai-Thinker's ESP-12F, clocked at 80 MHz at 3.3V logic. It has an onboard ADC (PCF8591) so that you can have multiple analog inputs to work with. More information can be found here: https://blog.inventone.ng
+
+Product page: https://inventone.ng
+
+XinaBox CW01
+------------
+
+The XinaBox CW01(ESP8266) is an Arduino-compatible Wi-Fi development board powered by an ESP-12F, clocked at 80 MHz at 3.3V logic. The CW01 has an onboard RGB LED and 3 xBUS connection ports.
+
+Product page: https://xinabox.cc/products/CW01
+
+ESPresso Lite 1.0
+-----------------
+
+ESPresso Lite 1.0 (beta version) is an Arduino-compatible Wi-Fi development board powered by Espressif System's own ESP8266 WROOM-02 module. It has breadboard-friendly breakout pins with in-built LED, two reset/flash buttons and a user programmable button . The operating voltage is 3.3VDC, regulated with 800mA maximum current. Special distinctive features include on-board I2C pads that allow direct connection to OLED LCD and sensor boards.
+
+ESPresso Lite 2.0
+-----------------
+
+ESPresso Lite 2.0 is an Arduino-compatible Wi-Fi development board based on an earlier V1 (beta version). Re-designed together with Cytron Technologies, the newly-revised ESPresso Lite V2.0 features the auto-load/auto-program function, eliminating the previous need to reset the board manually before flashing a new program. It also feature two user programmable side buttons and a reset button. The special distinctive features of on-board pads for I2C sensor and actuator is retained.
+
+Phoenix 1.0
+-----------
+
+Product page: http://www.espert.co
+
+Phoenix 2.0
+-----------
+
+Product page: http://www.espert.co
+
+NodeMCU 0.9 (ESP-12 Module)
+---------------------------
+
+Pin mapping
+~~~~~~~~~~~
+
+Pin numbers written on the board itself do not correspond to ESP8266 GPIO pin numbers. Constants are defined to make using this board easier:
+
+.. code:: c++
+
+    static const uint8_t D0   = 16;
+    static const uint8_t D1   = 5;
+    static const uint8_t D2   = 4;
+    static const uint8_t D3   = 0;
+    static const uint8_t D4   = 2;
+    static const uint8_t D5   = 14;
+    static const uint8_t D6   = 12;
+    static const uint8_t D7   = 13;
+    static const uint8_t D8   = 15;
+    static const uint8_t D9   = 3;
+    static const uint8_t D10  = 1;
+
+If you want to use NodeMCU pin 5, use D5 for pin number, and it will be translated to 'real' GPIO pin 14.
+
+NodeMCU 1.0 (ESP-12E Module)
+----------------------------
+
+This module is sold under many names for around $6.50 on AliExpress and it's one of the cheapest, fully integrated ESP8266 solutions.
+
+It's an open hardware design with an ESP-12E core and 4 MB of SPI flash.
+
+According to the manufacturer, "with a micro USB cable, you can connect NodeMCU devkit to your laptop and flash it without any trouble". This is more or less true: the board comes with a CP2102 onboard USB to serial adapter which just works, well, the majority of the time. Sometimes flashing fails and you have to reset the board by holding down FLASH +
+RST, then releasing FLASH, then releasing RST. This forces the CP2102 device to power cycle and to be re-numbered by Linux.
+
+The board also features a NCP1117 voltage regulator, a blue LED on GPIO16 and a 220k/100k Ohm voltage divider on the ADC input pin.
+The ESP-12E usually has a led connected on GPIO2.
+
+Full pinout and PDF schematics can be found `here <https://github.com/nodemcu/nodemcu-devkit-v1.0>`__
+
+Olimex MOD-WIFI-ESP8266(-DEV)
+-----------------------------
+
+This board comes with 2 MB of SPI flash and optional accessories (e.g. evaluation board ESP8266-EVB or BAT-BOX for batteries).
+
+The basic module has three solder jumpers that allow you to switch the operating mode between SDIO, UART and FLASH.
+
+The board is shipped for FLASH operation mode, with jumpers TD0JP=0, IO0JP=1, IO2JP=1.
+
+Since jumper IO0JP is tied to GPIO0, which is PIN 21, you'll have to ground it before programming with a USB to serial adapter and reset the board by power cycling it.
+
+UART pins for programming and serial I/O are GPIO1 (TXD, pin 3) and GPIO3 (RXD, pin 4).
+
+You can find the board schematics `here <https://github.com/OLIMEX/ESP8266/blob/master/HARDWARE/MOD-WIFI-ESP8266-DEV/MOD-WIFI-ESP8266-DEV_schematic.pdf>`__
+
+SparkFun ESP8266 Thing
+----------------------
+
+Product page: https://www.sparkfun.com/products/13231
+
+SparkFun ESP8266 Thing Dev
+--------------------------
+
+Product page: https://www.sparkfun.com/products/13711
+
+SparkFun Blynk Board
+--------------------
+
+Product page: https://www.sparkfun.com/products/13794
+
+SweetPea ESP-210
+----------------
+
+*TODO*
+
+LOLIN(WEMOS) D1 R2 & mini
+-------------------------
+
+Product page: https://www.wemos.cc/
+
+LOLIN(WEMOS) D1 mini Pro
+------------------------
+
+Product page: https://www.wemos.cc/
+
+LOLIN(WEMOS) D1 mini Lite
+-------------------------
+
+Parameters in Arduino IDE:
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Card: "WEMOS D1 Mini Lite"
+- Flash Size: "1M (512K FS)"
+- CPU Frequency: "80 Mhz"
+
+Power:
+~~~~~~
+
+- 5V pin : 4.7V 500mA output when the board is powered by USB ; 3.5V-6V input
+- 3V3 pin : 3.3V 500mA regulated output
+- Digital pins : 3.3V 30mA.
+
+links:
+~~~~~~
+
+- Product page: https://www.wemos.cc/
+- Board schematic: https://wiki.wemos.cc/_media/products:d1:sch_d1_mini_lite_v1.0.0.pdf
+- ESP8285 datasheet: https://www.espressif.com/sites/default/files/0a-esp8285_datasheet_en_v1.0_20160422.pdf
+- Voltage regulator datasheet: http://pdf-datasheet.datasheet.netdna-cdn.com/pdf-down/M/E/6/ME6211-Microne.pdf
+
+WeMos D1 R1
+-----------
+
+Product page: https://www.wemos.cc/
+
+ESPino (ESP-12 Module)
+----------------------
+
+ESPino integrates the ESP-12 module with a 3.3v regulator, CP2104 USB-Serial bridge and a micro USB connector for easy programming. It is designed for fitting in a breadboard and has an RGB Led and two buttons for easy prototyping.
+
+For more information about the hardware, pinout diagram and programming procedures, please see the `datasheet <https://github.com/makerlabmx/ESPino-tools/raw/master/Docs/ESPino-Datasheet-EN.pdf>`__.
+
+Product page: http://www.espino.io/en
+
+ThaiEasyElec's ESPino
+---------------------
+
+ESPino by ThaiEasyElec using WROOM-02 module from Espressif Systems with 4 MB Flash.
+
+We will update an English description soon. - Product page:
+http://thaieasyelec.com/products/wireless-modules/wifi-modules/espino-wifi-development-board-detail.html
+- Schematics:
+www.thaieasyelec.com/downloads/ETEE052/ETEE052\_ESPino\_Schematic.pdf -
+Dimensions:
+http://thaieasyelec.com/downloads/ETEE052/ETEE052\_ESPino\_Dimension.pdf
+- Pinouts:
+http://thaieasyelec.com/downloads/ETEE052/ETEE052\_ESPino\_User\_Manual\_TH\_v1\_0\_20160204.pdf (Please see pg. 8)
+
+WifInfo
+-------
+
+WifInfo integrates the ESP-12 or ESP-07+Ext antenna module with a 3.3v regulator and the hardware to be able to measure French telemetry issue from ERDF powering meter serial output. It has a USB connector for powering, an RGB WS2812 Led, 4 pins I2C connector to fit OLED or sensor, and two buttons + FTDI connector and auto reset feature.
+
+For more information, please see WifInfo related `blog <http://hallard.me/category/wifinfo/>`__ entries, `github <https://github.com/hallard/WifInfo>`__ and `community <https://community.hallard.me/category/16/wifinfo>`__ forum.
+
+Arduino
+-------
+
+*TODO*
+
+4D Systems gen4 IoD Range
+-------------------------
+
+gen4-IoD Range of ESP8266 powered Display Modules by 4D Systems.
+
+2.4", 2.8" and 3.2" TFT LCD with uSD card socket and Resistive Touch. Chip Antenna + uFL Connector.
+
+Datasheet and associated downloads can be found on the 4D Systems product page.
+
+The gen4-IoD range can be programmed using the Arduino IDE and also the 4D Systems Workshop4 IDE, which incorporates many additional graphics benefits. GFX4d library is available, along with a number of demo applications.
+
+- Product page: https://4dsystems.com.au/products/iot-display-modules
+
+Digistump Oak
+-------------
+
+The Oak requires an `Serial Adapter`_ for a serial connection or flashing; its micro USB port is only for power.
+
+To make a serial connection, wire the adapter's **TX to P3**, **RX to P4**, and **GND** to **GND**.  Supply 3.3v from the serial adapter if not already powered via USB.
+
+To put the board into bootloader mode, configure a serial connection as above, connect **P2 to GND**, then re-apply power.  Once flashing is complete, remove the connection from P2 to GND, then re-apply power to boot into normal mode.
+
+WiFiduino
+---------
+
+Product page: https://wifiduino.com/esp8266
+
+Amperka WiFi Slot
+-----------------
+
+Product page: http://wiki.amperka.ru/wifi-slot
+
+Seeed Wio Link
+--------------
+
+Wio Link is designed to simplify your IoT development. It is an ESP8266 based open-source Wi-Fi development board to create IoT applications by virtualizing plug-n-play modules to RESTful APIs with mobile APPs. Wio Link is also compatible with the Arduino IDE.
+
+Please DO NOTICE that you MUST pull up pin 15 to enable the power for Grove ports, the board is designed like this for the purpose of peripherals power management.
+
+Product page: https://www.seeedstudio.com/Wio-Link-p-2604.html
+
+ESPectro Core
+-------------
+
+ESPectro Core is ESP8266 development board as the culmination of our 3+ year experience in exploring and developing products with ESP8266 MCU.
+
+Initially designed for kids in mind, everybody should be able to use it. Yet it's still hacker-friendly as we break out all ESP8266 ESP-12F pins.
+
+More details at https://shop.makestro.com/product/espectrocore/
+
+Schirmilabs Eduino WiFi
+-----------------------
+
+Eduino WiFi is an Arduino-compatible DIY WiFi development board using an ESP-12 module
+
+Product page: https://schirmilabs.de/?page_id=165
+
+ITEAD Sonoff
+------------
+
+ESP8266 based devices from ITEAD: Sonoff SV, Sonoff TH, Sonoff Basic, and Sonoff S20
+
+These are not development boards. The development process is inconvenient with these devices. When flashing firmware you will need a Serial Adapter to connect it to your computer.
+
+ | Most of these devices, during normal operation, are connected to *wall power (AKA Mains Electricity)*. **NEVER** try to flash these devices when connected to *wall power*. **ALWAYS** have them disconnected from *wall power* when connecting them to your computer. Your life may depend on it!
+
+When flashing you will need to hold down the push button connected to the GPIO0 pin, while powering up with a safe 3.3 Volt source. Some USB Serial Adapters may supply enough power to handle flashing; however, it many may not supply enough power to handle the activities when the device reboots.
+
+More product details at the bottom of https://www.itead.cc/wiki/Product/
+
+DOIT ESP-Mx DevKit (ESP8285)
+----------------------------
+
+DOIT ESP-Mx DevKit - This is a development board by DOIT, with a DOIT ESP-Mx module (`datasheet <https://github.com/SmartArduino/SZDOITWiKi/wiki/ESP8285---ESP-M2>`__) using a ESP8285 Chip. With the DOIT ESP-Mx module, GPIO pins 9 and 10 are not available. The DOIT ESP-Mx DevKit board has a red power LED and a blue LED connected to GPIO16 and is active low to turn on. It uses a CH340C, USB to Serial converter chip. 
+ESP8285 (`datasheet <http://www.espressif.com/sites/default/files/0a-esp8285_datasheet_en_v1.0_20160422.pdf>`__) is a multi-chip package which contains ESP8266 and 1MB flash. 
+
+

--- a/package/package_esp8266com_index.template.json
+++ b/package/package_esp8266com_index.template.json
@@ -1,247 +1,381 @@
 {
-  "packages": [
-    {
-      "name": "esp8266",
-      "maintainer": "ESP8266 Community",
-      "websiteURL": "https://github.com/esp8266/Arduino",
-      "email": "ivan@esp8266.com",
-      "help": {
-        "online": "http://esp8266.com/arduino"
-      },
-      "platforms": [
-        {
-          "name": "esp8266",
-          "architecture": "esp8266",
-          "version": "",
-          "category": "ESP8266",
-          "url": "",
-          "archiveFileName": "",
-          "checksum": "",
-          "size": "",
-          "help": {
-            "online": ""
-          },
-          "boards": [
+   "packages": [
+      {
+         "name": "esp8266",
+         "maintainer": "ESP8266 Community",
+         "websiteURL": "https://github.com/esp8266/Arduino",
+         "email": "ivan@esp8266.com",
+         "help": {
+            "online": "https://esp8266.com/arduino"
+         },
+         "platforms": [
             {
-              "name": "Generic ESP8266 Module"
-            },
-            {
-              "name": "Olimex MOD-WIFI-ESP8266(-DEV)"
-            },
-            {
-              "name": "NodeMCU 0.9 (ESP-12 Module)"
-            },
-            {
-              "name": "NodeMCU 1.0 (ESP-12E Module)"
-            },
-            {
-              "name": "Adafruit HUZZAH ESP8266 (ESP-12)"
-            },
-            {
-              "name": "ESPresso Lite 1.0"
-            },
-            {
-              "name": "ESPresso Lite 2.0"
-            },
-            {
-              "name": "Phoenix 1.0"
-            },
-            {
-              "name": "Phoenix 2.0"
-            },                        
-            {
-              "name": "SparkFun Thing"
-            },
-            {
-              "name": "SweetPea ESP-210"
-            },
-            {
-              "name": "WeMos D1"
-            },
-            {
-              "name": "WeMos D1 mini"
-            },
-            {
-              "name": "ESPino (ESP-12 Module)"
-            },
-            {
-              "name": "ESPino (WROOM-02 Module)"
-            },
-            {
-              "name": "WifInfo"
-            },
-            {
-              "name": "ESPDuino"
-            },
-            {
-              "name": "4D Systems gen4 IoD Range"
+               "category": "ESP8266",
+               "name": "esp8266",
+               "url": "",
+               "version": "",
+               "architecture": "esp8266",
+               "archiveFileName": "",
+               "boards": [
+                  {
+                     "name": "Generic ESP8266 Module"
+                  },
+                  {
+                     "name": "Generic ESP8285 Module"
+                  },
+                  {
+                     "name": "ESPDuino (ESP-13 Module)"
+                  },
+                  {
+                     "name": "Adafruit Feather HUZZAH ESP8266"
+                  },
+                  {
+                     "name": "Invent One"
+                  },
+                  {
+                     "name": "XinaBox CW01"
+                  },
+                  {
+                     "name": "ESPresso Lite 1.0"
+                  },
+                  {
+                     "name": "ESPresso Lite 2.0"
+                  },
+                  {
+                     "name": "Phoenix 1.0"
+                  },
+                  {
+                     "name": "Phoenix 2.0"
+                  },
+                  {
+                     "name": "NodeMCU 0.9 (ESP-12 Module)"
+                  },
+                  {
+                     "name": "NodeMCU 1.0 (ESP-12E Module)"
+                  },
+                  {
+                     "name": "Olimex MOD-WIFI-ESP8266(-DEV)"
+                  },
+                  {
+                     "name": "SparkFun ESP8266 Thing"
+                  },
+                  {
+                     "name": "SparkFun ESP8266 Thing Dev"
+                  },
+                  {
+                     "name": "SparkFun Blynk Board"
+                  },
+                  {
+                     "name": "SweetPea ESP-210"
+                  },
+                  {
+                     "name": "LOLIN(WEMOS) D1 R2 & mini"
+                  },
+                  {
+                     "name": "LOLIN(WEMOS) D1 mini Pro"
+                  },
+                  {
+                     "name": "LOLIN(WEMOS) D1 mini Lite"
+                  },
+                  {
+                     "name": "WeMos D1 R1"
+                  },
+                  {
+                     "name": "ESPino (ESP-12 Module)"
+                  },
+                  {
+                     "name": "ThaiEasyElec's ESPino"
+                  },
+                  {
+                     "name": "WifInfo"
+                  },
+                  {
+                     "name": "Arduino"
+                  },
+                  {
+                     "name": "4D Systems gen4 IoD Range"
+                  },
+                  {
+                     "name": "Digistump Oak"
+                  },
+                  {
+                     "name": "WiFiduino"
+                  },
+                  {
+                     "name": "Amperka WiFi Slot"
+                  },
+                  {
+                     "name": "Seeed Wio Link"
+                  },
+                  {
+                     "name": "ESPectro Core"
+                  },
+                  {
+                     "name": "Schirmilabs Eduino WiFi"
+                  },
+                  {
+                     "name": "ITEAD Sonoff"
+                  },
+                  {
+                     "name": "DOIT ESP-Mx DevKit (ESP8285)"
+                  }
+               ],
+               "toolsDependencies": [
+                  {
+                     "packager": "esp8266",
+                     "version": "2.5.0-4-b40a506",
+                     "name": "xtensa-lx106-elf-gcc"
+                  },
+                  {
+                     "packager": "esp8266",
+                     "version": "2.5.0-4-b40a506",
+                     "name": "mkspiffs"
+                  },
+                  {
+                     "packager": "esp8266",
+                     "version": "2.5.0-4-fe5bb56",
+                     "name": "mklittlefs"
+                  },
+                  {
+                     "packager": "esp8266",
+                     "version": "3.7.2-post1",
+                     "name": "python3"
+                  }
+               ],
+               "help": {
+                  "online": ""
+               }
             }
-          ],
-          "toolsDependencies": [
+         ],
+         "tools": [
             {
-              "packager": "esp8266",
-              "name": "esptool",
-              "version": "0.4.9"
+               "version": "3.7.2-post1",
+               "name": "python3",
+               "systems": [
+                  {
+                     "host": "x86_64-mingw32",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/python3-3.7.2.post1-embed-win32v2a.zip",
+                     "archiveFileName": "python3-3.7.2.post1-embed-win32v2a.zip",
+                     "checksum": "SHA-256:f57cb2daf86176d2929e7c58990c2ac32554e3219d454dcac10e464ddda35bf2",
+                     "size": "6428926"
+                  },
+                  {
+                     "host": "i686-mingw32",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/python3-3.7.2.post1-embed-win32v2a.zip",
+                     "archiveFileName": "python3-3.7.2.post1-embed-win32va2.zip",
+                     "checksum": "SHA-256:f57cb2daf86176d2929e7c58990c2ac32554e3219d454dcac10e464ddda35bf2",
+                     "size": "6428926"
+                  },
+                  {
+                     "host": "aarch64-linux-gnu",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/python3-via-env.tar.gz",
+                     "archiveFileName": "python3-via-env.tar.gz",
+                     "checksum": "SHA-256:c9237bfe0f62842d7187a39495baa4a7e3ab8b87c0b433614294b023cf0bc0f3",
+                     "size": "292"
+                  },
+                  {
+                     "host": "arm-linux-gnueabihf",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/python3-via-env.tar.gz",
+                     "archiveFileName": "python3-via-env.tar.gz",
+                     "checksum": "SHA-256:c9237bfe0f62842d7187a39495baa4a7e3ab8b87c0b433614294b023cf0bc0f3",
+                     "size": "292"
+                  },
+                  {
+                     "host": "i686-pc-linux-gnu",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/python3-via-env.tar.gz",
+                     "archiveFileName": "python3-via-env.tar.gz",
+                     "checksum": "SHA-256:c9237bfe0f62842d7187a39495baa4a7e3ab8b87c0b433614294b023cf0bc0f3",
+                     "size": "292"
+                  },
+                  {
+                     "host": "x86_64-apple-darwin",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/python3-macosx-portable.tar.gz",
+                     "archiveFileName": "python3-macosx-portable.tar.gz",
+                     "checksum": "SHA-256:01a5bf1fa264c6f04cfaadf4c6e9f6caaacb6833ef40104dfbe953fcdb9bca1c",
+                     "size": "25494144"
+                  },
+                  {
+                     "host": "x86_64-pc-linux-gnu",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/python3-via-env.tar.gz",
+                     "archiveFileName": "python3-via-env.tar.gz",
+                     "checksum": "SHA-256:c9237bfe0f62842d7187a39495baa4a7e3ab8b87c0b433614294b023cf0bc0f3",
+                     "size": "292"
+                  }
+               ]
             },
             {
-              "packager": "esp8266",
-              "name": "xtensa-lx106-elf-gcc",
-              "version": "1.20.0-26-gb404fb9-2"
+               "version": "2.5.0-4-b40a506",
+               "name": "xtensa-lx106-elf-gcc",
+               "systems": [
+                  {
+                     "host": "aarch64-linux-gnu",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/aarch64-linux-gnu.xtensa-lx106-elf-b40a506.1563313032.tar.gz",
+                     "archiveFileName": "aarch64-linux-gnu.xtensa-lx106-elf-b40a506.1563313032.tar.gz",
+                     "checksum": "SHA-256:88c5e9a813bd01c97fe2a07a7280e0685cf18a937ad3ea756d33f8bfbbcbfec3",
+                     "size": "40983153"
+                  },
+                  {
+                     "host": "arm-linux-gnueabihf",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/arm-linux-gnueabihf.xtensa-lx106-elf-b40a506.1563313032.tar.gz",
+                     "archiveFileName": "arm-linux-gnueabihf.xtensa-lx106-elf-b40a506.1563313032.tar.gz",
+                     "checksum": "SHA-256:244d958e2532e5e1195aa6c8bb38e6fcf1601d88b67631a371d93c818a5a5b65",
+                     "size": "37027468"
+                  },
+                  {
+                     "host": "i686-pc-linux-gnu",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/i686-linux-gnu.xtensa-lx106-elf-b40a506.1563313032.tar.gz",
+                     "archiveFileName": "i686-linux-gnu.xtensa-lx106-elf-b40a506.1563313032.tar.gz",
+                     "checksum": "SHA-256:7c84fa929231d2467060b82ba51599cfb227dea1ac58964c74d46800ac33ba47",
+                     "size": "42926131"
+                  },
+                  {
+                     "host": "i686-mingw32",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/i686-w64-mingw32.xtensa-lx106-elf-b40a506.1563313032.zip",
+                     "archiveFileName": "i686-w64-mingw32.xtensa-lx106-elf-b40a506.1563313032.zip",
+                     "checksum": "SHA-256:694680c2215a65364748ca876c701479580c017757cd8ed6c3df0d48c2f7bd79",
+                     "size": "44955630"
+                  },
+                  {
+                     "host": "x86_64-apple-darwin",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/x86_64-apple-darwin14.xtensa-lx106-elf-b40a506.1563313032.tar.gz",
+                     "archiveFileName": "x86_64-apple-darwin14.xtensa-lx106-elf-b40a506.1563313032.tar.gz",
+                     "checksum": "SHA-256:ddf7a7ea4d53469918671ea662cf529dae5b255f06054db17621b34c71710641",
+                     "size": "44393288"
+                  },
+                  {
+                     "host": "x86_64-pc-linux-gnu",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/x86_64-linux-gnu.xtensa-lx106-elf-b40a506.1563313032.tar.gz",
+                     "archiveFileName": "x86_64-linux-gnu.xtensa-lx106-elf-b40a506.1563313032.tar.gz",
+                     "checksum": "SHA-256:90e04da49be288f36097d231e2f46ac46204a7640507011358f8f72c04700080",
+                     "size": "43790957"
+                  },
+                  {
+                     "host": "x86_64-mingw32",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/x86_64-w64-mingw32.xtensa-lx106-elf-b40a506.1563313032.zip",
+                     "archiveFileName": "x86_64-w64-mingw32.xtensa-lx106-elf-b40a506.1563313032.zip",
+                     "checksum": "SHA-256:01c31cd521b058e0805b9d1f3728798a42b1a217a7a34debcda3fcba23414b0e",
+                     "size": "48656678"
+                  }
+               ]
             },
             {
-              "packager": "esp8266",
-              "name": "mkspiffs",
-              "version": "0.1.2"
+               "version": "2.5.0-4-b40a506",
+               "name": "mkspiffs",
+               "systems": [
+                  {
+                     "host": "aarch64-linux-gnu",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/aarch64-linux-gnu.mkspiffs-7fefeac.1563313032.tar.gz",
+                     "archiveFileName": "aarch64-linux-gnu.mkspiffs-7fefeac.1563313032.tar.gz",
+                     "checksum": "SHA-256:49cc1938d5df2bec3eec0b3bf2c84ab887c379b04973a67705c80cf1dec523b3",
+                     "size": "51017"
+                  },
+                  {
+                     "host": "arm-linux-gnueabihf",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/arm-linux-gnueabihf.mkspiffs-7fefeac.1563313032.tar.gz",
+                     "archiveFileName": "arm-linux-gnueabihf.mkspiffs-7fefeac.1563313032.tar.gz",
+                     "checksum": "SHA-256:084518fe5452bc2a33c346e3f0825a7c42e36bdb41ee3320f767a248452813be",
+                     "size": "44050"
+                  },
+                  {
+                     "host": "i686-pc-linux-gnu",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/i686-linux-gnu.mkspiffs-7fefeac.1563313032.tar.gz",
+                     "archiveFileName": "i686-linux-gnu.mkspiffs-7fefeac.1563313032.tar.gz",
+                     "checksum": "SHA-256:d121a44416db8c9772372978f5accd13fe5a926fd17faf55a8dce23744dfc88c",
+                     "size": "54278"
+                  },
+                  {
+                     "host": "i686-mingw32",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/i686-w64-mingw32.mkspiffs-7fefeac.1563313032.zip",
+                     "archiveFileName": "i686-w64-mingw32.mkspiffs-7fefeac.1563313032.zip",
+                     "checksum": "SHA-256:3e0fd9212027cba06e362ae6921f48d252834996d81e1ade41d5b5c54735837a",
+                     "size": "337874"
+                  },
+                  {
+                     "host": "x86_64-apple-darwin",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/x86_64-apple-darwin14.mkspiffs-7fefeac.1563313032.tar.gz",
+                     "archiveFileName": "x86_64-apple-darwin14.mkspiffs-7fefeac.1563313032.tar.gz",
+                     "checksum": "SHA-256:efa480b351be563d35bd6a9bee809cd860f49efd26df711500df02b61460e19c",
+                     "size": "368555"
+                  },
+                  {
+                     "host": "x86_64-pc-linux-gnu",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/x86_64-linux-gnu.mkspiffs-7fefeac.1563313032.tar.gz",
+                     "archiveFileName": "x86_64-linux-gnu.mkspiffs-7fefeac.1563313032.tar.gz",
+                     "checksum": "SHA-256:238f9936f5b39f747602becfe90fae0ed6b31e63ea1fa6f5da062fcb33e0aae9",
+                     "size": "52429"
+                  },
+                  {
+                     "host": "x86_64-mingw32",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/x86_64-w64-mingw32.mkspiffs-7fefeac.1563313032.zip",
+                     "archiveFileName": "x86_64-w64-mingw32.mkspiffs-7fefeac.1563313032.zip",
+                     "checksum": "SHA-256:1c71a7ce71bd39fb83bfab138388adca8c1f9b798e09efd9932aa99d26c04c9b",
+                     "size": "350035"
+                  }
+               ]
+            },
+            {
+               "version": "2.5.0-4-fe5bb56",
+               "name": "mklittlefs",
+               "systems": [
+                  {
+                     "host": "aarch64-linux-gnu",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/aarch64-linux-gnu.mklittlefs-fe5bb56.1578453304.tar.gz",
+                     "archiveFileName": "aarch64-linux-gnu.mklittlefs-fe5bb56.1578453304.tar.gz",
+                     "checksum": "SHA-256:ac50bae3b580053ba98a181ae3700fafd2b2f8a37ed9c16bc22a5d7c1659388e",
+                     "size": "44433"
+                  },
+                  {
+                     "host": "arm-linux-gnueabihf",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/arm-linux-gnueabihf.mklittlefs-fe5bb56.1578453304.tar.gz",
+                     "archiveFileName": "arm-linux-gnueabihf.mklittlefs-fe5bb56.1578453304.tar.gz",
+                     "checksum": "SHA-256:092555612e7e229fbe622df75db70560896c3aea8d0ac2e5fa16d92dc16857cf",
+                     "size": "36917"
+                  },
+                  {
+                     "host": "i686-pc-linux-gnu",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/i686-linux-gnu.mklittlefs-fe5bb56.1578453304.tar.gz",
+                     "archiveFileName": "i686-linux-gnu.mklittlefs-fe5bb56.1578453304.tar.gz",
+                     "checksum": "SHA-256:060e2525223269d2a5d01055542ff36837f0b19598d78cb02d58563aeda441cd",
+                     "size": "47833"
+                  },
+                  {
+                     "host": "i686-pc-linux-gnu",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/i686-linux-gnu.mklittlefs-7f77f2b.1563313032.tar.gz",
+                     "archiveFileName": "i686-linux-gnu.mklittlefs-7f77f2b.1563313032.tar.gz",
+                     "checksum": "SHA-256:022c96df4d110f957d43f6d23e9c5e8b699a66d8ab041056dd5da7411a8ade42",
+                     "size": "47544"
+                  },
+                  {
+                     "host": "i686-mingw32",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/i686-w64-mingw32.mklittlefs-fe5bb56.1578453304.zip",
+                     "archiveFileName": "i686-w64-mingw32.mklittlefs-fe5bb56.1578453304.zip",
+                     "checksum": "SHA-256:2e570bed4ec59a9ecc73290e16c31ed53ee15e3abd8c82cb038b2148596d112e",
+                     "size": "332329"
+                  },
+                  {
+                     "host": "x86_64-apple-darwin",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/x86_64-apple-darwin14.mklittlefs-fe5bb56.1578453304.tar.gz",
+                     "archiveFileName": "x86_64-apple-darwin14.mklittlefs-fe5bb56.1578453304.tar.gz",
+                     "checksum": "SHA-256:fcb57ff58eceac79e988cc26a9e009a11ebda68d4ae97e44fed8e7c6d98a35b5",
+                     "size": "362389"
+                  },
+                  {
+                     "host": "x86_64-pc-linux-gnu",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/x86_64-linux-gnu.mklittlefs-fe5bb56.1578453304.tar.gz",
+                     "archiveFileName": "x86_64-linux-gnu.mklittlefs-fe5bb56.1578453304.tar.gz",
+                     "checksum": "SHA-256:5ef79d76e8e76f8287dc70d10c33f020d4cf5320354571adf666665eeef2e2de",
+                     "size": "46580"
+                  },
+                  {
+                     "host": "x86_64-mingw32",
+                     "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/x86_64-w64-mingw32.mklittlefs-fe5bb56.1578453304.zip",
+                     "archiveFileName": "x86_64-w64-mingw32.mklittlefs-fe5bb56.1578453304.zip",
+                     "checksum": "SHA-256:a460f410a22a59e23d7f862b8d08d6b7dfbc93aa558f8161a3d640d4df2ab86f",
+                     "size": "344792"
+                  }
+               ]
             }
-          ]
-        }
-      ],
-      "tools": [
-        {
-          "name": "esptool",
-          "version": "0.4.9",
-          "systems": [
-            {
-              "host": "i686-mingw32",
-              "url": "https://github.com/igrr/esptool-ck/releases/download/0.4.9/esptool-0.4.9-win32.zip",
-              "archiveFileName": "esptool-0.4.9-win32.zip",
-              "checksum": "SHA-256:9c4162cedf05fcb09fd829bfb90e34ae12458365980d79525a072ff5ca44751c",
-              "size": "32436"
-            },
-            {
-              "host": "x86_64-apple-darwin",
-              "url": "https://github.com/igrr/esptool-ck/releases/download/0.4.9/esptool-0.4.9-osx.tar.gz",
-              "archiveFileName": "esptool-0.4.9-osx.tar.gz",
-              "checksum": "SHA-256:57938b473765723a7e6602d55973017b7719bda69bdcff4250b24fcbf7a399f5",
-              "size": "29310"
-            },
-            {
-              "host": "i386-apple-darwin",
-              "url": "https://github.com/igrr/esptool-ck/releases/download/0.4.9/esptool-0.4.9-osx.tar.gz",
-              "archiveFileName": "esptool-0.4.9-osx.tar.gz",
-              "checksum": "SHA-256:57938b473765723a7e6602d55973017b7719bda69bdcff4250b24fcbf7a399f5",
-              "size": "29310"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/igrr/esptool-ck/releases/download/0.4.9/esptool-0.4.9-linux64.tar.gz",
-              "archiveFileName": "esptool-0.4.9-linux64.tar.gz",
-              "checksum": "SHA-256:fab9d1be8a648bea6728ad5c9d18ce972508187700cf90baf1897ac9cdf4db15",
-              "size": "15564"
-            },
-            {
-              "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/igrr/esptool-ck/releases/download/0.4.9/esptool-0.4.9-linux32.tar.gz",
-              "archiveFileName": "esptool-0.4.9-linux32.tar.gz",
-              "checksum": "SHA-256:bc4444d73d59be74608be5e1431353a0a9ae9e308e99c76a271d68a6ae145b7b",
-              "size": "15984"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/igrr/esptool-ck/releases/download/0.4.9/esptool-0.4.9-linux-armhf.tar.gz",
-              "archiveFileName": "esptool-0.4.9-linux-armhf.tar.gz",
-              "checksum": "SHA-256:d0364492599d90b8305125f8212de5be05397e4efde2fc7d0ed3676bb7018164",
-              "size": "13763"
-            }
-          ]
-        },
-        {
-          "name": "xtensa-lx106-elf-gcc",
-          "version": "1.20.0-26-gb404fb9-2",
-          "systems": [
-            {
-              "host": "i686-mingw32",
-              "url": "https://github.com/esp8266/Arduino/releases/download/2.3.0/win32-xtensa-lx106-elf-gb404fb9-2.tar.gz",
-              "archiveFileName": "win32-xtensa-lx106-elf-gb404fb9-2.tar.gz",
-              "checksum": "SHA-256:10476b9c11a7a90f40883413ddfb409f505b20692e316c4e597c4c175b4be09c",
-              "size": "153527527"
-            },
-            {
-              "host": "x86_64-apple-darwin",
-              "url": "https://github.com/esp8266/Arduino/releases/download/2.3.0/osx-xtensa-lx106-elf-gb404fb9-2.tar.gz",
-              "archiveFileName": "osx-xtensa-lx106-elf-gb404fb9-2.tar.gz",
-              "checksum": "SHA-256:0cf150193997bd1355e0f49d3d49711730035257bc1aee1eaaad619e56b9e4e6",
-              "size": "35385382"
-            },
-            {
-              "host": "i386-apple-darwin",
-              "url": "https://github.com/esp8266/Arduino/releases/download/2.3.0/osx-xtensa-lx106-elf-gb404fb9-2.tar.gz",
-              "archiveFileName": "osx-xtensa-lx106-elf-gb404fb9-2.tar.gz",
-              "checksum": "SHA-256:0cf150193997bd1355e0f49d3d49711730035257bc1aee1eaaad619e56b9e4e6",
-              "size": "35385382"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/esp8266/Arduino/releases/download/2.3.0/linux64-xtensa-lx106-elf-gb404fb9.tgz",
-              "archiveFileName": "linux64-xtensa-lx106-elf-gb404fb9.tar.gz",
-              "checksum": "SHA-256:46f057fbd8b320889a26167daf325038912096d09940b2a95489db92431473b7",
-              "size": "30262903"
-            },
-            {
-              "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/esp8266/Arduino/releases/download/2.3.0/linux32-xtensa-lx106-elf.tar.gz",
-              "archiveFileName": "linux32-xtensa-lx106-elf.tar.gz",
-              "checksum": "SHA-256:b24817819f0078fb05895a640e806e0aca9aa96b47b80d2390ac8e2d9ddc955a",
-              "size": "32734156"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/esp8266/Arduino/releases/download/2.3.0/linuxarm-xtensa-lx106-elf-g46f160f-2.tar.gz",
-              "archiveFileName": "linuxarm-xtensa-lx106-elf-g46f160f-2.tar.gz",
-              "checksum": "SHA-256:f693946288f2ffa17288ef75ae16fa08573993f2b0a2a5e6bc35a68dc6087443",
-              "size": "34938475"
-            }
-          ]
-        },
-        {
-          "name": "mkspiffs",
-          "version": "0.1.2",
-          "systems": [
-            {
-              "host": "i686-mingw32",
-              "url": "https://github.com/igrr/mkspiffs/releases/download/0.1.2/mkspiffs-0.1.2-windows.zip",
-              "archiveFileName": "mkspiffs-0.1.2-windows.zip",
-              "checksum": "SHA-256:0a29119b8458b61a877408f7995e4944623a712e0d313a2c2f76af9ab55cc9f2",
-              "size": "230802"
-            },
-            {
-              "host": "x86_64-apple-darwin",
-              "url": "https://github.com/igrr/mkspiffs/releases/download/0.1.2/mkspiffs-0.1.2-osx.tar.gz",
-              "archiveFileName": "mkspiffs-0.1.2-osx.tar.gz",
-              "checksum": "SHA-256:df656fae21a41c1269ea50cb53752dcaf6a4e1437255f3a9fb50b4025549b58e",
-              "size": "115091"
-            },
-            {
-              "host": "i386-apple-darwin",
-              "url": "https://github.com/igrr/mkspiffs/releases/download/0.1.2/mkspiffs-0.1.2-osx.tar.gz",
-              "archiveFileName": "mkspiffs-0.1.2-osx.tar.gz",
-              "checksum": "SHA-256:df656fae21a41c1269ea50cb53752dcaf6a4e1437255f3a9fb50b4025549b58e",
-              "size": "115091"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/igrr/mkspiffs/releases/download/0.1.2/mkspiffs-0.1.2-linux64.tar.gz",
-              "archiveFileName": "mkspiffs-0.1.2-linux64.tar.gz",
-              "checksum": "SHA-256:1a1dd81b51daf74c382db71b42251757ca4136e8762107e69feaa8617bac315f",
-              "size": "46281"
-            },
-            {
-              "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/igrr/mkspiffs/releases/download/0.1.2/mkspiffs-0.1.2-linux32.tar.gz",
-              "archiveFileName": "mkspiffs-0.1.2-linux32.tar.gz",
-              "checksum": "SHA-256:e990d545dfcae308aabaac5fa9e1db734cc2b08167969e7eedac88bd0839667c",
-              "size": "45272"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/igrr/mkspiffs/releases/download/0.1.2/mkspiffs-0.1.2-linux-armhf.tar.gz",
-              "archiveFileName": "mkspiffs-0.1.2-linux-armhf.tar.gz",
-              "checksum": "SHA-256:5a8836932cd24325d69054cebdd46359eba02919ffaa87b130c54acfecc13f46",
-              "size": "41685"
-            }
-          ]
-        }
-      ]
-    }
-  ]
+         ]
+      }
+   ]
 }

--- a/package/package_esp8266com_index.template.json
+++ b/package/package_esp8266com_index.template.json
@@ -70,8 +70,11 @@
             {
               "name": "WifInfo"
             },
-			{
+            {
               "name": "ESPDuino"
+            },
+            {
+              "name": "4D Systems gen4 IoD Range"
             }
           ],
           "toolsDependencies": [


### PR DESCRIPTION
Modification to boards.txt to add the 2M Flash option and QIO option to the gen4-IoD Range. Previously only 512KB, but these will now be produced with 2M Flash instead.