### PR TITLE
Fix spelling typos in files under packages dir

### DIFF
--- a/package/README.md
+++ b/package/README.md
@@ -3,7 +3,7 @@
 ## Release model
 
 The release model is linear. That means that there is only one main code branch, and releases are snapshots of that branch at specific points in the sequence of commits.
-The advantage of this model is that the maintenance effort is greately reduced compared to other release models, such as a branched model.
+The advantage of this model is that the maintenance effort is greatly reduced compared to other release models, such as a branched model.
 The disadvantage is that progress is ever only forward, and fixes can't be backported to prior releases. this means there is no such thing as a "stable" release (however, see Sub releases below).
 
 There are 4 types of releases:
@@ -118,7 +118,7 @@ The following points assume work in a direct clone of the repository, and not in
 
 6. Navigate to [Travis CI options](https://travis-ci.org/esp8266/Arduino/settings), enable ´Build pushed branches´ (before tagging in next step)
 
-7. Tag the latest commit on the master branch. In this project, tags have form `X.Y.Z`, e.g. `3.0.0`, or `X.Y.Z-betaN` for release candiate versions. Notice that there's no `v`at the beginning of the tag. Tags must be annotated, not lightweight tags. To create a tag, use git command (assuming that the master branch is checked out):
+7. Tag the latest commit on the master branch. In this project, tags have form `X.Y.Z`, e.g. `3.0.0`, or `X.Y.Z-betaN` for release candidate versions. Notice that there's no `v`at the beginning of the tag. Tags must be annotated, not lightweight tags. To create a tag, use git command (assuming that the master branch is checked out):
 
    ```
    git tag -a -m "Release 3.0.0" 3.0.0

--- a/package/esp8266-arduino-doc.bash
+++ b/package/esp8266-arduino-doc.bash
@@ -43,7 +43,7 @@ echo "documentation template url: "$doc_template_url
 echo "                       url: "$url
 
 # continue?
-read -e -p "Dou you wish to continue (y/n)? " -n 1 decision
+read -e -p "Do you wish to continue (y/n)? " -n 1 decision
 if echo "$decision" | grep -iq "^y" ;then
 	echo "okay"
 else
@@ -59,7 +59,7 @@ rm -fR $destination_path
 mkdir -p $destination_path/src
 mkdir -p $destination_path/$version
 
-# copy doc files to destination soruce dir
+# copy doc files to destination source dir
 cp -R $arduinoESP_src/doc/* $destination_path/src
 
 # download doc template
@@ -68,7 +68,7 @@ rsync -av $doc_src_path/ $destination_path/build/
 
 # create versions.html file
 
-# ... read verions
+# ... read versions
 pushd $arduinoESP_src
 old_versions=$(git ls-tree -d --name-only remotes/origin/gh-pages versions/ | sed -e 's/versions\///g')
 popd


### PR DESCRIPTION
This patch fixes spelling typos found in following files
README.md
esp8266-arduino-doc.bash