### PR TITLE
Grammar fixes

### DIFF
--- a/doc/esp8266wifi/station-examples.rst
+++ b/doc/esp8266wifi/station-examples.rst
@@ -3,9 +3,9 @@
 Station
 -------
 
-Example of connecting to an access point has been shown in chapter `Quick Start <readme.rst#quick-start>`__. In case connection is lost, ESP8266 will automatically reconnect to the last used access point, once it is again available.
+Example of connecting to an access point has been shown in chapter `Quick Start <readme.rst#quick-start>`__. In case connection is lost, ESP8266 will automatically reconnect to the last used access point, once it is available again.
 
-Can we provide more robust connection to Wi-Fi than that?
+Can we provide a more robust connection to Wi-Fi than that?
 
 Table of Contents
 -----------------
@@ -19,7 +19,7 @@ Table of Contents
 Introduction
 ~~~~~~~~~~~~
 
-Following the example in `Quick Start <readme.rst#quick-start>`__, we would like to go one step further and made ESP connect to next available access point if current connection is lost. This functionality is provided with 'ESP8266WiFiMulti' class and demonstrated in sketch below.
+Following the example in `Quick Start <readme.rst#quick-start>`__, we would like to go one step further and make the ESP connect to the next available access point if the current connection is lost. This functionality is provided with the 'ESP8266WiFiMulti' class and demonstrated in the sketch below.
 
 .. code:: cpp
 
@@ -66,7 +66,7 @@ Following the example in `Quick Start <readme.rst#quick-start>`__, we would like
 Prepare Access Points
 ~~~~~~~~~~~~~~~~~~~~~
 
-To try this sketch in action you need two (or more) access points. In lines below replace ``primary-network-name`` and ``pass-to-primary-network`` with name and password to your primary network. Do the same for secondary network.
+To try this sketch in action you need two (or more) access points. In the lines below replace ``primary-network-name`` and ``pass-to-primary-network`` with the name and password to your primary network. Do the same for the secondary network.
 
 .. code:: cpp
 
@@ -83,7 +83,7 @@ You may add more networks if you have more access points.
 Try it Out
 ~~~~~~~~~~
 
-Now upload updated sketch to ESP module and open serial monitor. Module will first scan for available networks. Then it will select and connect to the network with stronger signal. In case connection is lost, module will connect to next one available.
+Now upload the updated sketch to the ESP module and open a serial monitor. The module will first scan for available networks. Then it will select and connect to the network with a stronger signal. In case the connection is lost, the module will connect to the next one available.
 
 This process may look something like:
 
@@ -93,14 +93,14 @@ This process may look something like:
     Looking for WiFi ....... connected to sensor-net-2
     Looking for WiFi .... connected to sensor-net-1
 
-In above example ESP connected first to ``sensor-net-1``. Then I have switched ``sensor-net-1`` off. ESP discovered that connection is lost and started searching for another configured network. That happened to be ``sensor-net-2`` so ESP connected to it. Then I have switched ``sensor-net-1`` back on and shut down ``sensor-net-2``. ESP reconnected automatically to ``sensor-net-1``.
+In the above example the ESP connects first to ``sensor-net-1``. Then, after I have switched ``sensor-net-1`` off. The ESP discovers that the connection is lost and starts searching for another configured network. That happened to be ``sensor-net-2`` so the ESP connected to it. Then after I have switched ``sensor-net-1`` back on and shut down ``sensor-net-2``. The ESP reconnected automatically to ``sensor-net-1``.
 
-Function ``monitorWiFi()`` is in place to show when connection is lost by displaying ``Looking for WiFi``. Dots ``....`` are displayed during process of searching for another configured access point. Then a message like ``connected to sensor-net-2`` is shown when connection is established.
+Function ``monitorWiFi()`` is in place to show when connection is lost by displaying ``Looking for WiFi``. Dots ``....`` are displayed during the process of searching for another configured access point. Then a message like ``connected to sensor-net-2`` is shown when a connection is established.
 
 Can we Make it Simpler?
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Please note that you may simplify this sketch by removing function ``monitorWiFi()`` and putting inside ``loop()`` only ``wifiMulti.run()``. ESP will still reconnect between configured access points if required. Now you won't be able to see it on serial monitor unless you add ``Serial.setDebugOutput(true)`` as described in point `Enable Wi-Fi Diagnostic <readme.rst#enable-wi-fi-diagnostic>`__.
+Please note that you may simplify this sketch by removing the function ``monitorWiFi()`` and putting inside ``loop()`` only ``wifiMulti.run()``. ESP will still reconnect between configured access points if required. Now you won't be able to see it on serial monitor unless you add ``Serial.setDebugOutput(true)`` as described in point `Enable Wi-Fi Diagnostic <readme.rst#enable-wi-fi-diagnostic>`__.
 
 Updated sketch for such scenario will look as follows:
 
@@ -127,9 +127,9 @@ Updated sketch for such scenario will look as follows:
       wifiMulti.run();
     }
 
-That's it! This is really all the code you need to make ESP automatically reconnecting between available networks.
+That's it! This is really all the code you need to make ESP automatically reconnect between available networks.
 
-After uploading sketch and opening the serial monitor, the messages will look as below.
+After uploading the sketch and opening the serial monitor, the messages will look as below.
 
 *Initial connection to sensor-net-1 on power up:*
 
@@ -198,8 +198,8 @@ After uploading sketch and opening the serial monitor, the messages will look as
 Conclusion
 ~~~~~~~~~~
 
-I believe the minimalist sketch with ``ESP8266WiFiMulti`` class is a cool example what ESP8266 can do for us behind the scenes with just couple lines of code.
+I believe the minimalist sketch with ``ESP8266WiFiMulti`` class is a cool example of what the ESP8266 can do for us behind the scenes with just couple lines of code.
 
-As shown in above example, reconnecting between access points takes time and is not seamless. Therefore, in practical applications, you will likely need to monitor connection status to decide e.g. if you can send the data to external system or should wait until connection is back.
+As shown in the above example, reconnecting between access points takes time and is not seamless. Therefore, in practical applications, you will likely need to monitor connection status to decide e.g. if you can send the data to an external system or should wait until the connection is back.
 
-For detailed review of functions provided to manage station mode please refer to the `Station Class <station-class.rst>`__ documentation.
+For a detailed review of functions provided to manage station mode please refer to the `Station Class <station-class.rst>`__ documentation.


### PR DESCRIPTION
Added a bunch of missing "the"s and "a"s mostly. Didn't change any of the coding examples or the meaning of this example. Great example though, thanks.