### PR TITLE
Fix typo in platform.txt causing device test fails

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -37,7 +37,7 @@ build.exception_flags=-fno-exceptions
 build.stdcpp_lib=-lstdc++
 build.stdcpp_level=-std=gnu++17
 
-build.stacksmash=
+build.stacksmash_flags=
 
 build.float=-u _printf_float -u _scanf_float
 build.led=


### PR DESCRIPTION
When stacksmash protection was added, the variable used by the compile
lines and the boards.txt.py generator is "build_stacksmash_flags".
Unfortunately, the default variable name  in the platform.txt is
"build_stacksmash" w/o the "_flags."