### PR TITLE
Keep client certs when server authentication set

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
@@ -96,11 +96,8 @@ void WiFiClientSecure::_clearAuthenticationSettings() {
   _use_fingerprint = false;
   _use_self_signed = false;
   _knownkey = nullptr;
-  _sk = nullptr;
   _ta = nullptr;
   _axtls_ta = nullptr;
-  _axtls_chain = nullptr;
-  _axtls_sk = nullptr;
 }
 
 


### PR DESCRIPTION
WiFiClientSecure.setInsecure() was clearing the secret key (but not the
_chain public client cert) incorrectly.  The other server authentication
modes also had the same effect.

The only way for it to work would be if the app first set the server
authentication method and then the client keys.  There's no good reason
for this.

Adjust the connection to only clear the server id methods and leave the
client ID untouched.

Fixes #7455