### PR TITLE
Initialize _ledPin

### DIFF
--- a/cores/esp8266/Updater.cpp
+++ b/cores/esp8266/Updater.cpp
@@ -38,6 +38,7 @@ UpdaterClass::UpdaterClass()
 , _hash(nullptr)
 , _verify(nullptr)
 , _progress_callback(nullptr)
+, _ledPin(-1)
 {
 #if ARDUINO_SIGNING
   installSignature(&esp8266::updaterSigningHash, &esp8266::updaterSigningVerifier);

--- a/cores/esp8266/Updater.cpp
+++ b/cores/esp8266/Updater.cpp
@@ -35,10 +35,10 @@ UpdaterClass::UpdaterClass()
 , _startAddress(0)
 , _currentAddress(0)
 , _command(U_FLASH)
+, _ledPin(-1)
 , _hash(nullptr)
 , _verify(nullptr)
 , _progress_callback(nullptr)
-, _ledPin(-1)
 {
 #if ARDUINO_SIGNING
   installSignature(&esp8266::updaterSigningHash, &esp8266::updaterSigningVerifier);


### PR DESCRIPTION
_ledPin should be initialized to -1 in the constructor to avoid setting a random pin when calling Updater::end without having called Updater::begin before. This happens, for example, in the Homie software