### PR TITLE
Remove warnings when buinding NoAssert

### DIFF
--- a/cores/esp8266/Crypto.cpp
+++ b/cores/esp8266/Crypto.cpp
@@ -100,6 +100,7 @@ void *createBearsslHmac(const br_hash_class *hashType, const void *data, const s
 
 String createBearsslHmac(const br_hash_class *hashType, const uint8_t hashTypeNaturalLength, const String &message, const void *hashKey, const size_t hashKeyLength, const size_t hmacLength)
 {
+    (void) hashTypeNaturalLength;
     assert(1 <= hmacLength && hmacLength <= hashTypeNaturalLength);
 
     uint8_t hmac[hmacLength];
@@ -152,6 +153,7 @@ void *createBearsslHmacCT(const br_hash_class *hashType, const void *data, const
 
 String createBearsslHmacCT(const br_hash_class *hashType, const uint8_t hashTypeNaturalLength, const String &message, const void *hashKey, const size_t hashKeyLength, const size_t hmacLength)
 {
+    (void) hashTypeNaturalLength;
     assert(1 <= hmacLength && hmacLength <= hashTypeNaturalLength);
 
     uint8_t hmac[hmacLength];


### PR DESCRIPTION
Parameters that are only used in an assert() statement are unused when
the NoAssert-NDEBUG option is used.  This causes the following unused
parameter warnings while building:

````
/home/earle/Arduino/hardware/esp8266com/esp8266/cores/esp8266/Crypto.cpp: In function 'String {anonymous}::createBearsslHmac(const br_hash_class*, uint8_t, const String&, const void*, size_t, size_t)':
/home/earle/Arduino/hardware/esp8266com/esp8266/cores/esp8266/Crypto.cpp:101:71: warning: unused parameter 'hashTypeNaturalLength' [-Wunused-parameter]
  101 | String createBearsslHmac(const br_hash_class *hashType, const uint8_t hashTypeNaturalLength, const String &message, const void *hashKey, const size_t hashKeyLength, const size_t hmacLength)
      |                                                         ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
/home/earle/Arduino/hardware/esp8266com/esp8266/cores/esp8266/Crypto.cpp: In function 'String {anonymous}::createBearsslHmacCT(const br_hash_class*, uint8_t, const String&, const void*, size_t, size_t)':
/home/earle/Arduino/hardware/esp8266com/esp8266/cores/esp8266/Crypto.cpp:153:73: warning: unused parameter 'hashTypeNaturalLength' [-Wunused-parameter]
  153 | String createBearsslHmacCT(const br_hash_class *hashType, const uint8_t hashTypeNaturalLength, const String &message, const void *hashKey, const size_t hashKeyLength, const size_t hmacLength)
      |                                                           ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
````

Mark them unused in the code to avoid the error.  The assert() still
works.