### PR TITLE
Add valgrind mocked test to CI

### DIFF
--- a/libraries/ESP8266WiFi/examples/WiFiClient/WiFiClient.ino
+++ b/libraries/ESP8266WiFi/examples/WiFiClient/WiFiClient.ino
@@ -44,6 +44,8 @@ void setup() {
 }
 
 void loop() {
+  static bool wait = false;
+
   Serial.print("connecting to ");
   Serial.print(host);
   Serial.print(':');
@@ -87,5 +89,8 @@ void loop() {
   Serial.println("closing connection");
   client.stop();
 
-  delay(300000); // execute once every 5 minutes, don't flood remote service
+  if (wait) {
+    delay(300000); // execute once every 5 minutes, don't flood remote service
+  }
+  wait = true;
 }

--- a/tests/ci/host_test.sh
+++ b/tests/ci/host_test.sh
@@ -6,5 +6,18 @@ set -ev
 
 cd $TRAVIS_BUILD_DIR/tests/host
 
-make CI
+
+make -j2 ssl
+for i in ../../libraries/ESP8266WiFi/examples/WiFiClient/WiFiClient \
+	../../libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation \
+	../../libraries/ESP8266WebServer/examples/HelloServer/HelloServer \
+	../../libraries/SD/examples/Files/Files \
+	../../libraries/LittleFS/examples/LittleFS_Timestamp/LittleFS_Timestamp \
+	../../libraries/LittleFS/examples/SpeedTest/SpeedTest ; do
+	make -j2 D=1 $i
+	valgrind --leak-check=full --track-origins=yes --error-limit=no --show-leak-kinds=all --error-exitcode=999 bin/$(basename $i)/$(basename $i) -1
+done
+
+make -j2 CI
+
 make clean-objects

--- a/tests/host/common/ArduinoMain.cpp
+++ b/tests/host/common/ArduinoMain.cpp
@@ -42,6 +42,7 @@
 #define MOCK_PORT_SHIFTER 9000
 
 bool user_exit = false;
+bool run_once = false;
 const char* host_interface = nullptr;
 size_t spiffs_kb = 1024;
 size_t littlefs_kb = 1024;
@@ -137,6 +138,7 @@ void help (const char* argv0, int exitcode)
         "\tgeneral:\n"
 		"\t-c             - ignore CTRL-C (send it via Serial)\n"
 		"\t-f             - no throttle (possibly 100%%CPU)\n"
+		"\t-1             - run loop once then exit (for host testing)\n"
 		"\t-v             - verbose\n"
 		, argv0, MOCK_PORT_SHIFTER, argv0, spiffs_kb, littlefs_kb);
 	exit(exitcode);
@@ -152,10 +154,11 @@ static struct option options[] =
 	{ "verbose",        no_argument,        NULL, 'v' },
 	{ "timestamp",      no_argument,        NULL, 'T' },
 	{ "interface",      required_argument,  NULL, 'i' },
-    { "fspath",         required_argument,  NULL, 'P' },
+	{ "fspath",         required_argument,  NULL, 'P' },
 	{ "spiffskb",       required_argument,  NULL, 'S' },
 	{ "littlefskb",     required_argument,  NULL, 'L' },
 	{ "portshifter",    required_argument,  NULL, 's' },
+	{ "once",           no_argument,        NULL, '1' },
 };
 
 void cleanup ()
@@ -209,7 +212,7 @@ int main (int argc, char* const argv [])
 
 	for (;;)
 	{
-		int n = getopt_long(argc, argv, "hlcfbvTi:S:s:L:P:", options, NULL);
+		int n = getopt_long(argc, argv, "hlcfbvTi:S:s:L:P:1", options, NULL);
 		if (n < 0)
 			break;
 		switch (n)
@@ -249,6 +252,9 @@ int main (int argc, char* const argv [])
 			break;
 		case 'T':
 			serial_timestamp = true;
+			break;
+		case '1':
+			run_once = true;
 			break;
 		default:
 			help(argv[0], EXIT_FAILURE);
@@ -300,6 +306,9 @@ int main (int argc, char* const argv [])
 			usleep(1000); // not 100% cpu, ~1000 loops per second
 		loop();
 		check_incoming_udp();
+
+		if (run_once)
+			user_exit = true;
 	}
 	cleanup();
 


### PR DESCRIPTION
Run valgrind on host mock example runs to catch more bugs in CI.  These
tests would have caught the problem in #7464 before users did.

Add a list of some randomly picked examples to run, and add an option to
run the loop exactly once in the host mock routine, so the test will
actually exit under valgrind.