### PR TITLE
lwip/def.h: Simplify network byte order functions

### DIFF
--- a/tools/sdk/lwip2/include/lwip/def.h
+++ b/tools/sdk/lwip2/include/lwip/def.h
@@ -92,26 +92,16 @@ extern "C" {
 #define PP_HTONL(x)   ((u32_t)(x))
 #define PP_NTOHL(x)   ((u32_t)(x))
 #else /* BYTE_ORDER != BIG_ENDIAN */
-#ifndef lwip_htons
-u16_t lwip_htons(u16_t x);
-#endif
-#define lwip_ntohs(x) lwip_htons(x)
-
-#ifndef lwip_htonl
-u32_t lwip_htonl(u32_t x);
-#endif
-#define lwip_ntohl(x) lwip_htonl(x)
-
-/* These macros should be calculated by the preprocessor and are used
-   with compile-time constants only (so that there is no little-endian
-   overhead at runtime). */
-#define PP_HTONS(x) ((u16_t)((((x) & (u16_t)0x00ffU) << 8) | (((x) & (u16_t)0xff00U) >> 8)))
-#define PP_NTOHS(x) PP_HTONS(x)
-#define PP_HTONL(x) ((((x) & (u32_t)0x000000ffUL) << 24) | \
-                     (((x) & (u32_t)0x0000ff00UL) <<  8) | \
-                     (((x) & (u32_t)0x00ff0000UL) >>  8) | \
-                     (((x) & (u32_t)0xff000000UL) >> 24))
-#define PP_NTOHL(x) PP_HTONL(x)
+/* In fact, `__builtin_bswap16/32/64()` act as compile-time constants
+   if their argument is also compile-time one. */
+#define lwip_htons(x) ((u16_t)__builtin_bswap16(x))
+#define lwip_ntohs(x) ((u16_t)__builtin_bswap16(x))
+#define lwip_htonl(x) ((u32_t)__builtin_bswap32(x))
+#define lwip_ntohl(x) ((u32_t)__builtin_bswap32(x))
+#define PP_HTONS(x)   ((u16_t)__builtin_bswap16(x))
+#define PP_NTOHS(x)   ((u16_t)__builtin_bswap16(x))
+#define PP_HTONL(x)   ((u32_t)__builtin_bswap32(x))
+#define PP_NTOHL(x)   ((u32_t)__builtin_bswap32(x))
 #endif /* BYTE_ORDER == BIG_ENDIAN */
 
 /* Provide usual function names as macros for users, but this can be turned off */


### PR DESCRIPTION
GCC built-in byte order functions

- __builtin_bswap16()
- __builtin_bswap32()
- __builtin_bswap64()

are just like as:
```
#define ALWAYS_INLINE static __inline__ __attribute__((always_inline))

/* merely example, sub-optimal implementation */
uint32_t ALWAYS_INLINE __inlined_bswapsi2(uint32_t u) {
    return ((u & 0xFF000000) >> 24)
         | ((u & 0x00FF0000) >>  8)
         | ((u & 0x0000FF00) <<  8)
         | ((u & 0x000000FF) << 24);
}
uint64_t ALWAYS_INLINE __inlined_bswapdi2(uint64_t u) {
    return ((u & 0xFF00000000000000ULL) >> 56)
         | ((u & 0x00FF000000000000ULL) >> 40)
         | ((u & 0x0000FF0000000000ULL) >> 24)
         | ((u & 0x000000FF00000000ULL) >>  8)
         | ((u & 0x00000000FF000000ULL) <<  8)
         | ((u & 0x0000000000FF0000ULL) << 24)
         | ((u & 0x000000000000FF00ULL) << 40)
         | ((u & 0x00000000000000FFULL) << 56);
}

/* seems to be as below */
uint16_t ALWAYS_INLINE __builtin_bswap16(uint16_t x) {
    return (x >> 8) | (x << 8);
}
uint32_t ALWAYS_INLINE __builtin_bswap32(uint32_t x) {
    extern uint32_t bswapsi2(uint32_t x);
    return __builtin_constant_p(x) ? __inlined_bswapsi2(x) : bswapsi2(x);
}
uint64_t ALWAYS_INLINE __builtin_bswap64(uint64_t x) {
    extern uint64_t bswapdi2(uint64_t x);
    return __builtin_constant_p(x) ? __inlined_bswapdi2(x) : bswapdi2(x);
}
```
```
/* placed to libgcc2.c */
uint32_t __attribute__((noinline)) bswapsi2(uint32_t u) {
    return __inlined_bswapsi2(u);
}
uint64_t __attribute__((noinline)) bswapdi2(uint64_t u) {
    return __inlined_bswapdi2(u);
}
```