### PR TITLE
CI: on host: force 64 bit mode like `make -j2 CI` implicitly does

### DIFF
--- a/tests/ci/host_test.sh
+++ b/tests/ci/host_test.sh
@@ -7,14 +7,14 @@ set -ev
 cd $TRAVIS_BUILD_DIR/tests/host
 
 
-make -j2 ssl
+make -j2 FORCE32=0 ssl
 for i in ../../libraries/ESP8266WiFi/examples/WiFiClient/WiFiClient \
 	../../libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation \
 	../../libraries/ESP8266WebServer/examples/HelloServer/HelloServer \
 	../../libraries/SD/examples/Files/Files \
 	../../libraries/LittleFS/examples/LittleFS_Timestamp/LittleFS_Timestamp \
 	../../libraries/LittleFS/examples/SpeedTest/SpeedTest ; do
-	make -j2 D=1 $i
+	make -j2 D=1 FORCE32=0 $i
 	valgrind --leak-check=full --track-origins=yes --error-limit=no --show-leak-kinds=all --error-exitcode=999 bin/$(basename $i)/$(basename $i) -1
 done
 


### PR DESCRIPTION
It allows to run CI tests on computers having gcc-multilib installed