### PR TITLE
Fix spelling typo under doc/faq

### DIFF
--- a/doc/faq/a01-espcomm_sync-failed.rst
+++ b/doc/faq/a01-espcomm_sync-failed.rst
@@ -313,14 +313,14 @@ example at 921600 baud, but with two reset retries.
 
    Reset Method: nodemcu, reset retries
 
-If you are interested how noodemcu reset method is implemented, then
+If you are interested how nodemcu reset method is implemented, then
 check circuit below. As indicated it does not pull to ground RTS and DTR
 lines once you open Serial Monitor in Arduino IDE.
 
 .. figure:: pictures/a01-nodemcu-reset-implementation.png
-   :alt: Implementation of noodemcu reset
+   :alt: Implementation of nodemcu reset
 
-   Implementation of noodemcu reset
+   Implementation of nodemcu reset
 
 It consists of two transistors and resistors that you can locate on
 NodeMCU board on right. On left you can see complete circuit and the

--- a/doc/faq/a02-my-esp-crashes.rst
+++ b/doc/faq/a02-my-esp-crashes.rst
@@ -187,7 +187,7 @@ If you don't have any code for troubleshooting, use the example below:
       Serial.println();
       Serial.println("Let's provoke the s/w wdt firing...");
       //
-      // provoke an OOM, will be recorded as the last occured one
+      // provoke an OOM, will be recorded as the last occurred one
       char* out_of_memory_failure = (char*)malloc(1000000);
       //
       // wait for s/w wdt in infinite loop below
@@ -310,11 +310,11 @@ Memory, memory, memory
    * If you use std libs like std::vector, make sure to call its ::reserve() method before filling it. This allows allocating only once, which reduces mem fragmentation, and makes sure that there are no empty unused slots left over in the container at the end.
 
 Stack
-   The amount of stack in the ESP is tiny at only 4KB. For normal developement in large systems, it 
+   The amount of stack in the ESP is tiny at only 4KB. For normal development in large systems, it 
    is good practice to use and abuse the stack, because it is faster for allocation/deallocation, the scope of the object is well defined, and deallocation automatically happens in reverse order as allocation, which means no mem fragmentation. However, with the tiny amount of stack available in the ESP, that practice is not really viable, at least not for big objects.
    * Large objects that have internally managed memory, such as String, std::string, std::vector, etc, are ok on the stack, because they internally allocate their buffers on the heap.
    * Large arrays on the stack, such as uint8_t buffer[2048] should be avoided on the stack and be dynamically allocated (consider smart pointers).
-   * Objects that have large data members, such as large arrays, should be avoided on the stack, and be dynamicaly allocated (consider smart pointers).
+   * Objects that have large data members, such as large arrays, should be avoided on the stack, and be dynamically allocated (consider smart pointers).
 
 
 If at the Wall, Enter an Issue Report

--- a/doc/faq/a05-board-generator.rst
+++ b/doc/faq/a05-board-generator.rst
@@ -129,7 +129,7 @@ Additional Notes:
 
 1. The boards.txt file will always contain the generic and esp8285 boards.
 
-2. If boards.txt file exist and no backup copy named boards.txt.orig exist, the current boards.txt will be renamed to boards.txt.orig. Otherwise, the existing boards.txt is over-writen when you generate a new boards.txt file. Similar behavior for when generating a new boards.local.txt.
+2. If boards.txt file exist and no backup copy named boards.txt.orig exist, the current boards.txt will be renamed to boards.txt.orig. Otherwise, the existing boards.txt is over-written when you generate a new boards.txt file. Similar behavior for when generating a new boards.local.txt.
 
 3. The boards in the boards.txt file will be in the order they were listed in your favorites file, specified by option ``--filter <file>``.
 

--- a/doc/faq/readme.rst
+++ b/doc/faq/readme.rst
@@ -55,7 +55,7 @@ How can I get some extra KBs in flash ?
 About WPS
 ~~~~~~~~~
 
-From release 2.4.2 and ahead, not using WPS will give an exra ~4.5KB in
+From release 2.4.2 and ahead, not using WPS will give an extra ~4.5KB in
 heap.
 
 In release 2.4.2 only, WPS is disabled by default and the board generator is


### PR DESCRIPTION
This patch fixes some spelling typo found in doc/faq.