### PR TITLE
Add CI test for eboot build

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -251,9 +251,16 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: '3.x'
+    - name: Cache Linux toolchain
+      id: cache-linux
+      uses: actions/cache@v2
+      with:
+        path: ./tools/dist
+        key: key-linux-toolchain
     - name: Boards.txt diff
       env:
         TRAVIS_BUILD_DIR: ${{ github.workspace }}
         TRAVIS_TAG: ${{ github.ref }}
       run: |
           bash ./tests/ci/build_boards.sh
+          bash ./tests/ci/eboot_test.sh

--- a/bootloaders/eboot/eboot.c
+++ b/bootloaders/eboot/eboot.c
@@ -28,7 +28,7 @@ int print_version(const uint32_t flash_addr)
         return 1;
     }
     char fmt[7];
-    fmt[0] = 'V';
+    fmt[0] = 'v';
     fmt[1] = '%';
     fmt[2] = '0';
     fmt[3] = '8';

--- a/bootloaders/eboot/eboot.c
+++ b/bootloaders/eboot/eboot.c
@@ -28,7 +28,7 @@ int print_version(const uint32_t flash_addr)
         return 1;
     }
     char fmt[7];
-    fmt[0] = 'v';
+    fmt[0] = 'V';
     fmt[1] = '%';
     fmt[2] = '0';
     fmt[3] = '8';

--- a/tests/ci/eboot_test.sh
+++ b/tests/ci/eboot_test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+READELF="$TRAVIS_BUILD_DIR/tools/xtensa-lx106-elf/bin/xtensa-lx106-elf-readelf"
+
+set -ev
+
+cd $TRAVIS_BUILD_DIR/tools
+python3 get.py -q
+
+cd $TRAVIS_BUILD_DIR/bootloaders/eboot
+
+"$READELF" -x .data -x .text eboot.elf > git.txt
+make clean
+make
+"$READELF" -x .data -x .text eboot.elf > build.txt
+diff git.txt build.txt
+if [ $? -ne 0 ]; then
+    echo ERROR:  eboot.elf in repo does not match output from compile.
+    echo ERROR:  Need to rebuild and check in updated eboot from repo.
+    exit 1
+fi

--- a/tests/ci/eboot_test.sh
+++ b/tests/ci/eboot_test.sh
@@ -16,6 +16,6 @@ make
 diff git.txt build.txt
 if [ $? -ne 0 ]; then
     echo ERROR:  eboot.elf in repo does not match output from compile.
-    echo ERROR:  Need to rebuild and check in updated eboot from repo.
+    echo ERROR:  Need to rebuild and check in updated eboot.
     exit 1
 fi


### PR DESCRIPTION
Check that building the eboot.c block generates the same binary as
the verison checked into the repo.  Catches the case where a library
or eboot.c file is changed, but an updated eboot.elf isn't included
in a PR.

Can't do simple binary diff of the ELFs because paths and compile
times will change, so dump the two sections we care about.