### PR TITLE
getCpuFreqMHz(): fix when F_CPU is not defined

### DIFF
--- a/cores/esp8266/Esp.h
+++ b/cores/esp8266/Esp.h
@@ -127,10 +127,7 @@ class EspClass {
             return esp_get_cpu_freq_mhz();
         }
 #else
-        uint8_t getCpuFreqMHz() const
-        {
-            return esp_get_cpu_freq_mhz();
-        }
+        uint8_t getCpuFreqMHz() const;
 #endif
 
         uint32_t getFlashChipId();


### PR DESCRIPTION
The method is declared in Esp.h and implemented in Esp.cpp.
That was broken by #7356.
Currently, F_CPU is always defined.
