### PR TITLE
Avoid float-double-conversion

### DIFF
--- a/cores/esp8266/Stream.cpp
+++ b/cores/esp8266/Stream.cpp
@@ -173,7 +173,7 @@ float Stream::parseFloat(char skipChar) {
     boolean isFraction = false;
     long value = 0;
     int c;
-    float fraction = 1.0;
+    float fraction = 1.0f;
 
     c = peekNextDigit();
     // ignore non numeric leading characters
@@ -190,7 +190,7 @@ float Stream::parseFloat(char skipChar) {
         else if(c >= '0' && c <= '9') {      // is c a digit?
             value = value * 10 + c - '0';
             if(isFraction)
-                fraction *= 0.1;
+                fraction *= 0.1f;
         }
         read();  // consume the character we got with peek
         c = timedPeek();

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -369,10 +369,10 @@ WiFiPhyMode_t ESP8266WiFiGenericClass::getPhyMode() {
  */
 void ESP8266WiFiGenericClass::setOutputPower(float dBm) {
 
-    if(dBm > 20.5) {
-        dBm = 20.5;
-    } else if(dBm < 0) {
-        dBm = 0;
+    if(dBm > 20.5f) {
+        dBm = 20.5f;
+    } else if(dBm < 0.0f) {
+        dBm = 0.0f;
     }
 
     uint8_t val = (dBm*4.0f);


### PR DESCRIPTION
Converting floats to doubles is very expensive on esp8266, so prefer
calculations or comparisons as float. This saves 10% (20 bytes) of the
String::parseFloat() code size and probably quite a bit of runtime
overhead.