### PR TITLE
Fix typos in tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -124,7 +124,7 @@ Makefile in tests/device/ directory handles compiling, uploading, and executing 
 
 Here are some of the supported targets:
 
-- `virtualenv`: prepares Python virtual environment inside tests/device/libaries/BSTest/virtualenv/. This has to be run once on each computer where tests are to be run. This target will use `pip` to install several Python libraries required by the test runner (see tests/device/libaries/BSTest/requirements.txt).
+- `virtualenv`: prepares Python virtual environment inside tests/device/libraries/BSTest/virtualenv/. This has to be run once on each computer where tests are to be run. This target will use `pip` to install several Python libraries required by the test runner (see tests/device/libraries/BSTest/requirements.txt).
 
 - `test_xxx/test_xxx.ino`: compiles, uploads, and runs the tests defined in `test_xxx/test_xxx.ino` sketch. Some extra options are available, these can be passed as additional arguments to `make`:
     - `NO_BUILD=1`: don't compile the test.

--- a/tests/host/README.txt
+++ b/tests/host/README.txt
@@ -11,7 +11,7 @@ Sketch emulation on host
 
 This environment let compile esp8266/Arduino sketches into native
 environment.  Network (tcp, udp, including ssl and multicast) is linked to
-local host interfaces.  WiFi is trivialy emulated and reported as "just"
+local host interfaces.  WiFi is trivially emulated and reported as "just"
 already connected and usable.
 
 Currently network emulation is a complete rewrite of
@@ -24,7 +24,7 @@ stdin is connected to UART0(RX) and stdout is connected to UART0(TX).
 UART1(TX) writes to stderr.  Reading from stdin happens in non-blocking
 raw mode, that means each character is directly injected into the UART
 FIFO without any buffering in the console.  The command line switch -c
-can be used to stop the emulation from intersepting CTRL-C (SIGINT).
+can be used to stop the emulation from intercepting CTRL-C (SIGINT).
 
 How to compile and run a sketch
 -------------------------------
@@ -102,7 +102,7 @@ Make fun, propose PRs.
 - SDCARD on Host filesystem ? or in an image ?
 - nice curses interface to display/change gpios ?
 - display device emulation (like ssd1306)
-- optionaly use arduino-builder ?
+- optionally use arduino-builder ?
 - store sketch objects and binaries outside from the source directories (done for sketches)
 - compile and use lwIP on host
 - easily debug HTTP classes

--- a/tests/platformio.sh
+++ b/tests/platformio.sh
@@ -39,7 +39,7 @@ function build_sketches_with_platformio()
         local sketchdirname=$(basename $sketchdir)
         local sketchname=$(basename $sketch)
         if [[ "${sketchdirname}.ino" != "$sketchname" ]]; then
-            echo "Skipping $sketch, beacause it is not the main sketch file";
+            echo "Skipping $sketch, because it is not the main sketch file";
             continue
         fi;
         if [[ -f "$sketchdir/.test.skip" ]]; then


### PR DESCRIPTION
This patch fixes some spelling typos found in tests directory.