### PR TITLE
Reduce codesize of setOutputPower

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -369,16 +369,17 @@ WiFiPhyMode_t ESP8266WiFiGenericClass::getPhyMode() {
  */
 void ESP8266WiFiGenericClass::setOutputPower(float dBm) {
 
-    if(dBm > 20.5f) {
-        dBm = 20.5f;
-    } else if(dBm < 0.0f) {
-        dBm = 0.0f;
+    int i_dBm = int(dBm * 4.0f);
+
+    // i_dBm 82 == 20.5 dBm
+    if(i_dBm > 82) {
+        i_dBm = 82;
+    } else if(i_dBm < 0) {
+        i_dBm = 0;
     }
 
-    uint8_t val = (dBm*4.0f);
-    system_phy_set_max_tpw(val);
+    system_phy_set_max_tpw((uint8_t) i_dBm);
 }
-
 
 /**
  * store WiFi config in SDK flash area


### PR DESCRIPTION
The logic can be simplified by using integer logic without a functional
change. Reduces code size by 40% (78 bytes -> 46 bytes) and silences
a Warith-conversion warning.