### PR TITLE
Fix Error in hostByName with low timeout

### DIFF
--- a/cores/esp8266/IPAddress.cpp
+++ b/cores/esp8266/IPAddress.cpp
@@ -32,7 +32,7 @@ IPAddress::IPAddress() {
 }
 
 bool IPAddress::isSet () const {
-    return !ip_addr_isany(&_ip);
+    return !ip_addr_isany(&_ip) && ((*this) != IPADDR_NONE);
 }
 
 IPAddress::IPAddress(uint8_t first_octet, uint8_t second_octet, uint8_t third_octet, uint8_t fourth_octet) {


### PR DESCRIPTION
Before, `aResult` was set to `INADDR_NONE`, so `255.255.255.255` (broadcast). When timeout was too low and callback didn't fire, the `aResult.isSet()` line returned always true and that's not the correct behaviour.
Even thought I'm not a native speaker, `INADDR_ANY` and `INADDR_NONE` are confusing me.
Whenever I think about it, I always associate `INADDR_NONE` with 0.0.0.0 and `INADDR_ANY` with `255.255.255.255`, but it's the other way.
Also lwIP has the same scheme.
I would like to ask if we can add a `clear` method to `IPAddress` like did to `String` class (maybe in another PR) to resolve any doubts.