### PR TITLE
Add clear method to IPAddress

### DIFF
--- a/cores/esp8266/IPAddress.cpp
+++ b/cores/esp8266/IPAddress.cpp
@@ -183,6 +183,10 @@ bool IPAddress::isValid(const char* arg) {
 const IPAddress INADDR_ANY; // generic "0.0.0.0" for IPv4 & IPv6
 const IPAddress INADDR_NONE(255,255,255,255);
 
+void IPAddress::clear() {
+    (*this) = INADDR_ANY;
+}
+
 /**************************************/
 
 #if LWIP_IPV6

--- a/cores/esp8266/IPAddress.h
+++ b/cores/esp8266/IPAddress.h
@@ -125,6 +125,8 @@ class IPAddress: public Printable {
         virtual size_t printTo(Print& p) const;
         String toString() const;
 
+        void clear();
+
         /*
                 check if input string(arg) is a valid IPV4 address or not.
                 return true on valid.


### PR DESCRIPTION
Added `clear` method to `IPAddress` class that will set the ip to `INADDR_ANY` (aka `0.0.0.0`).
That's because INADDR_ANY and INADDR_NONE confuse me, and every time I don't remember which is which.
This method will help me (and others?) a lot.