### PR TITLE
Update path of gdb

### DIFF
--- a/doc/gdb.rst
+++ b/doc/gdb.rst
@@ -100,7 +100,7 @@ Linux
 
 .. code:: bash
 
-    ~/.arduino15/packages/esp8266/hardware/xtensa-lx106-elf/bin/xtensa-lx106-elf-gdb
+    ~/.arduino15/packages/esp8266/tools/xtensa-lx106-elf-gcc/2.5.0-4-b40a506/bin/xtensa-lx106-elf-gdb
 
 Windows (Using Board Manager version)
 


### PR DESCRIPTION
Used this nice tutorial several times, but each time had to use find to find gdb since it's not in hardware but in tools and also in a version-numbered folder