### PR TITLE
WiFiSever - Arduino API available() and accept()

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiServer.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiServer.cpp
@@ -115,7 +115,7 @@ bool WiFiServer::hasClient() {
     return false;
 }
 
-WiFiClient WiFiServer::available(byte* status) {
+WiFiClient WiFiServer::accept(byte* status) {
     (void) status;
     if (_unclaimed) {
         WiFiClient result(_unclaimed);
@@ -133,6 +133,24 @@ WiFiClient WiFiServer::available(byte* status) {
 
     optimistic_yield(1000);
     return WiFiClient();
+}
+
+WiFiClient WiFiServer::available() {
+  for (uint8_t i = 0; i < MAX_MONITORED_CLIENTS; i++) {
+    WiFiClient& client = connectedClients[i];
+    if (client && client.status() == CLOSED) {
+      client = WiFiClient();
+    }
+    if (!client) {
+      client = accept();
+    }
+  }
+  for (uint8_t i = 0; i < MAX_MONITORED_CLIENTS; i++) {
+    WiFiClient& client = connectedClients[i];
+    if (client.available())
+      return client;
+  }
+  return WiFiClient();
 }
 
 uint8_t WiFiServer::status()  {

--- a/libraries/ESP8266WiFi/src/WiFiServer.h
+++ b/libraries/ESP8266WiFi/src/WiFiServer.h
@@ -65,6 +65,10 @@ extern "C" {
 class ClientContext;
 class WiFiClient;
 
+#ifndef MAX_MONITORED_CLIENTS
+#define MAX_MONITORED_CLIENTS 5
+#endif
+
 class WiFiServer : public Server {
   // Secure server needs access to all the private entries here
 protected:
@@ -74,13 +78,17 @@ protected:
 
   ClientContext* _unclaimed;
   ClientContext* _discarded;
+
+  WiFiClient connectedClients[MAX_MONITORED_CLIENTS];
+
   enum { _ndDefault, _ndFalse, _ndTrue } _noDelay = _ndDefault;
 
 public:
   WiFiServer(const IPAddress& addr, uint16_t port);
   WiFiServer(uint16_t port);
   virtual ~WiFiServer() {}
-  WiFiClient available(uint8_t* status = NULL);
+  WiFiClient accept(uint8_t* status = NULL);
+  WiFiClient available();
   bool hasClient();
   void begin();
   void begin(uint16_t port);


### PR DESCRIPTION
According to documentation, the `server.available()` should return first client with data available. 
https://www.arduino.cc/en/Reference/WiFiServerAvailable (esp8266 doc points there). 

ESP8266WiFi library now does what a new EthernetServer.accept() method does: https://www.arduino.cc/en/Reference/EthernetServerAccept. It was added to Ethernet library by Paul Stoffregen in 2018 for Ethernet 2.0. I added it to UIPEthernet in February and I have it in my WiFiEspAT library too.

This PR shows a draft of a possible implementation of `available()`.  (This quick implementation could let some client wait to long.)

My opinion is that it is strange to have a function like this available(). My explanation how they defined it like this, is that the networking libraries by Arduino are always remote APIs for a firmware and there it doesn't look so strange.
