### PR TITLE
FIX MIME-Type for txt-suffix

### DIFF
--- a/libraries/ESP8266WebServer/src/detail/mimetable.cpp
+++ b/libraries/ESP8266WebServer/src/detail/mimetable.cpp
@@ -62,7 +62,7 @@ const Entry mimeTable[maxType] PROGMEM =
 {
     { kHtmlSuffix, kHtml },
     { kHtmSuffix, kHtml },
-    { kTxtSuffix, kTxtSuffix },
+    { kTxtSuffix, kTxt },
 #ifndef MIMETYPE_MINIMAL
     { kCssSuffix, kCss },
     { kJsSuffix, kJs },


### PR DESCRIPTION
In addition to #7312 the MIME type for txt files is to be corrected.

Currently the MimeType for txt files is the file extension ".txt". 
In the commit the variable with text/plain is used again.