### PR TITLE
FIX StaticRequestHandler crashes when cache_header is null

### DIFF
--- a/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
@@ -81,7 +81,7 @@ public:
             _isFile = false;
         }
 
-        DEBUGV("StaticRequestHandler: path=%s uri=%s isFile=%d, cache_header=%s\r\n", path, uri, _isFile, cache_header);
+        DEBUGV("StaticRequestHandler: path=%s uri=%s isFile=%d, cache_header=%s\r\n", path, uri, _isFile, cache_header == __null ? "" : cache_header);
         _baseUriLength = _uri.length();
     }
 


### PR DESCRIPTION
In the StaticRequestHandler method, exception 28 (LoadProhibitedCause) occurs when debugging with the DEBUG_ESP_CORE option and if the default parameter null is used for cache_header.

In this commit, the pointer is checked for null before output.