### PR TITLE
WString: mark move ctor as noexcept

### DIFF
--- a/cores/esp8266/WString.cpp
+++ b/cores/esp8266/WString.cpp
@@ -46,12 +46,12 @@ String::String(const __FlashStringHelper *pstr) {
 }
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-String::String(String &&rval) {
+String::String(String &&rval) noexcept {
     init();
     move(rval);
 }
 
-String::String(StringSumHelper &&rval) {
+String::String(StringSumHelper &&rval) noexcept {
     init();
     move(rval);
 }
@@ -224,7 +224,7 @@ String & String::copy(const __FlashStringHelper *pstr, unsigned int length) {
 }
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-void String::move(String &rhs) {
+void String::move(String &rhs) noexcept {
     if (buffer()) {
         if (capacity() >= rhs.len()) {
             memmove_P(wbuffer(), rhs.buffer(), rhs.length() + 1);
@@ -267,13 +267,13 @@ String & String::operator =(const String &rhs) {
 }
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-String & String::operator =(String &&rval) {
+String & String::operator =(String &&rval) noexcept {
     if (this != &rval)
         move(rval);
     return *this;
 }
 
-String & String::operator =(StringSumHelper &&rval) {
+String & String::operator =(StringSumHelper &&rval) noexcept {
     if (this != &rval)
         move(rval);
     return *this;

--- a/cores/esp8266/WString.h
+++ b/cores/esp8266/WString.h
@@ -57,8 +57,8 @@ class String {
         String(const String &str);
         String(const __FlashStringHelper *str);
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-        String(String &&rval);
-        String(StringSumHelper &&rval);
+        String(String &&rval) noexcept;
+        String(StringSumHelper &&rval) noexcept;
 #endif
         explicit String(char c);
         explicit String(unsigned char, unsigned char base = 10);
@@ -96,8 +96,8 @@ class String {
         String & operator =(const char *cstr);
         String & operator = (const __FlashStringHelper *str);
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-        String & operator =(String &&rval);
-        String & operator =(StringSumHelper &&rval);
+        String & operator =(String &&rval) noexcept;
+        String & operator =(StringSumHelper &&rval) noexcept;
 #endif
 
         // concatenate (works w/ built-in types)
@@ -317,7 +317,7 @@ class String {
         String & copy(const char *cstr, unsigned int length);
         String & copy(const __FlashStringHelper *pstr, unsigned int length);
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-        void move(String &rhs);
+        void move(String &rhs) noexcept;
 #endif
 };
 


### PR DESCRIPTION
ref.
- https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-move-noexcept
- https://rules.sonarsource.com/cpp/RSPEC-5018?search=noexecept
- https://clang.llvm.org/extra/clang-tidy/checks/performance-noexcept-move-constructor.html

> Move constructors of all the types used with STL containers, for
example, need to be declared noexcept. Otherwise STL will choose copy
constructors instead. The same is valid for move assignment operations.

With a basic example based on the `master`
```diff
diff --git a/cores/esp8266/WString.cpp b/cores/esp8266/WString.cpp
index 46aad5d5..1c93d8f2 100644
--- a/cores/esp8266/WString.cpp
+++ b/cores/esp8266/WString.cpp
@@ -225,6 +225,7 @@ String & String::copy(const __FlashStringHelper *pstr, unsigned int length) {

 #ifdef __GXX_EXPERIMENTAL_CXX0X__
 void String::move(String &rhs) {
+    Serial.printf("moved! %p -> %p\n", &rhs, this);
     if (buffer()) {
         if (capacity() >= rhs.len()) {
             memmove_P(wbuffer(), rhs.buffer(), rhs.length() + 1);
```

```cpp
#include <Arduino.h>

#include <vector>

void setup() {
    Serial.begin(115200);

    std::vector<String> objects;
    for (int num = 0; num < 10; ++num) {
        objects.emplace_back(num); 
    }
}

void loop() { delay(1000); ESP.restart(); }
```
Since the vector is not using `.reserve(...)`, we need to realloc + move existing vector contents every push when vector needs more capacity. Without the patch, we will never see the `moved!` string from the above.

Core does use `std::vector<String>` in a couple of places as well, it is not just possible user code:
```
git grep 'std::vector<Str'
libraries/ESP8266WebServer/src/Uri.h:        virtual bool canHandle(const String &requestUri, __attribute__((unused)) std::vector<String> &pathArgs) {
libraries/ESP8266WebServer/src/detail/RequestHandler.h:    std::vector<String> pathArgs;
libraries/ESP8266WebServer/src/uri/UriBraces.h:        bool canHandle(const String &requestUri, std::vector<String> &pathArgs) override final {
libraries/ESP8266WebServer/src/uri/UriGlob.h:        bool canHandle(const String &requestUri, __attribute__((unused)) std::vector<String> &pathArgs) override final {
libraries/ESP8266WebServer/src/uri/UriRegex.h:        bool canHandle(const String &requestUri, std::vector<String> &pathArgs) override final {
```
(But, I am not sure what is the implication for the overall Arduino API stuff. Does it need the patch, too, if this is valid?)