### PR TITLE
WString: c_str() returns null pointer after move

### DIFF
--- a/cores/esp8266/WString.cpp
+++ b/cores/esp8266/WString.cpp
@@ -45,7 +45,6 @@ String::String(const __FlashStringHelper *pstr) {
     *this = pstr; // see operator =
 }
 
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
 String::String(String &&rval) noexcept {
     init();
     move(rval);
@@ -55,7 +54,6 @@ String::String(StringSumHelper &&rval) noexcept {
     init();
     move(rval);
 }
-#endif
 
 String::String(char c) {
     init();
@@ -223,36 +221,11 @@ String & String::copy(const __FlashStringHelper *pstr, unsigned int length) {
     return *this;
 }
 
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
 void String::move(String &rhs) noexcept {
-    if (buffer()) {
-        if (capacity() >= rhs.len()) {
-            memmove_P(wbuffer(), rhs.buffer(), rhs.length() + 1);
-            setLen(rhs.len());
-            rhs.invalidate();
-            return;
-        } else {
-            if (!isSSO()) {
-                free(wbuffer());
-                setBuffer(nullptr);
-            }
-        }
-    }
-    if (rhs.isSSO()) {
-        setSSO(true);
-        memmove_P(sso.buff, rhs.sso.buff, sizeof(sso.buff));
-    } else {
-        setSSO(false);
-        setBuffer(rhs.wbuffer());
-    }
-    setCapacity(rhs.capacity());
-    setLen(rhs.len());
-    rhs.setSSO(false);
-    rhs.setCapacity(0);
-    rhs.setLen(0);
-    rhs.setBuffer(nullptr);
+    invalidate();
+    sso = rhs.sso;
+    rhs.init();
 }
-#endif
 
 String & String::operator =(const String &rhs) {
     if (this == &rhs)
@@ -266,7 +239,6 @@ String & String::operator =(const String &rhs) {
     return *this;
 }
 
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
 String & String::operator =(String &&rval) noexcept {
     if (this != &rval)
         move(rval);
@@ -278,7 +250,6 @@ String & String::operator =(StringSumHelper &&rval) noexcept {
         move(rval);
     return *this;
 }
-#endif
 
 String & String::operator =(const char *cstr) {
     if (cstr)

--- a/cores/esp8266/WString.h
+++ b/cores/esp8266/WString.h
@@ -53,13 +53,14 @@ class String {
         // if the initial value is null or invalid, or if memory allocation
         // fails, the string will be marked as invalid (i.e. "if (s)" will
         // be false).
-        String(const char *cstr = nullptr);
+        String() {
+            init();
+        }
+        String(const char *cstr);
         String(const String &str);
         String(const __FlashStringHelper *str);
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
         String(String &&rval) noexcept;
         String(StringSumHelper &&rval) noexcept;
-#endif
         explicit String(char c);
         explicit String(unsigned char, unsigned char base = 10);
         explicit String(int, unsigned char base = 10);
@@ -95,10 +96,8 @@ class String {
         String & operator =(const String &rhs);
         String & operator =(const char *cstr);
         String & operator = (const __FlashStringHelper *str);
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
         String & operator =(String &&rval) noexcept;
         String & operator =(StringSumHelper &&rval) noexcept;
-#endif
 
         // concatenate (works w/ built-in types)
 
@@ -316,9 +315,7 @@ class String {
         // copy and move
         String & copy(const char *cstr, unsigned int length);
         String & copy(const __FlashStringHelper *pstr, unsigned int length);
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
         void move(String &rhs) noexcept;
-#endif
 };
 
 class StringSumHelper: public String {

--- a/tests/host/core/test_string.cpp
+++ b/tests/host/core/test_string.cpp
@@ -23,12 +23,13 @@ TEST_CASE("String::move", "[core][String]")
 {
     const char buffer[] = "this string goes over the sso limit";
 
-    String copy;
-    String origin(buffer);
+    String target;
+    String source(buffer);
 
-    copy = std::move(origin);
-    REQUIRE(origin.c_str() != nullptr);
-    REQUIRE(copy == buffer);
+    target = std::move(source);
+    REQUIRE(source.c_str() != nullptr);
+    REQUIRE(!source.length());
+    REQUIRE(target == buffer);
 }
 
 TEST_CASE("String::trim", "[core][String]")

--- a/tests/host/core/test_string.cpp
+++ b/tests/host/core/test_string.cpp
@@ -19,6 +19,18 @@
 #include <limits.h>
 #include <StreamString.h>
 
+TEST_CASE("String::move", "[core][String]")
+{
+    const char buffer[] = "this string goes over the sso limit";
+
+    String copy;
+    String origin(buffer);
+
+    copy = std::move(origin);
+    REQUIRE(origin.c_str() != nullptr);
+    REQUIRE(copy == buffer);
+}
+
 TEST_CASE("String::trim", "[core][String]")
 {
     String str;


### PR DESCRIPTION
target = std::move(source) does not reset source's buffer pointer back to the sso
#7553 fixes this behaviour

Added as a separate test, perhaps it could go into the existing SSO

*edit:* failing, as intended:
https://github.com/esp8266/Arduino/pull/7611/checks?check_run_id=1166504473#step:4:2364
```
-------------------------------------------------------------------------------
core/test_string.cpp:22
...............................................................................

core/test_string.cpp:30: FAILED:
  REQUIRE( origin.c_str() != nullptr )
with expansion:
  {null string} != nullptr
```