### PR TITLE
Remove stray axtls refs, deprecated compat funcs

### DIFF
--- a/doc/esp8266wifi/bearssl-client-secure-class.rst
+++ b/doc/esp8266wifi/bearssl-client-secure-class.rst
@@ -120,14 +120,14 @@ BearSSL::WiFiClientSecure Class
 Validating X509 Certificates (Am I talking to the server I think I'm talking to?)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Prior to connecting to a server, the `BearSSL::WiFiClientSecure` needs to be told how to verify the identity of the other machine.  **By default BearSSL will not validate any connections and will refuse to connect to any server.**  This is a significant difference from the earlier `axTLS::WiFiClientSecure` in that the deprecated axTLS client would connect to any server and would only attempt to validate the identity of the remote server if asked to, after connection.
+Prior to connecting to a server, the `BearSSL::WiFiClientSecure` needs to be told how to verify the identity of the other machine.  **By default BearSSL will not validate any connections and will refuse to connect to any server.**
 
 There are multiple modes to tell BearSSL how to verify the identity of the remote server.  See the `BearSSL_Validation` example for real uses of the following methods:
 
 setInsecure()
 ^^^^^^^^^^^^^
 
-Don't verify any X509 certificates.  There is no guarantee that the server connected to is the one you think it is in this case, but this call will mimic the behavior of the deprecated axTLS code.
+Don't verify any X509 certificates.  There is no guarantee that the server connected to is the one you think it is in this case.
 
 setKnownKey(const BearSSL::PublicKey \*pk)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -198,7 +198,7 @@ If you are connecting to a server repeatedly in a fixed time period (usually 30 
 Errors
 ~~~~~~
 
-BearSSL can fail in many more unique and interesting ways then the deprecated axTLS.  Use these calls to get more information when something fails.  
+BearSSL can fail in many more unique and interesting ways.  Use these calls to get more information when something fails.  
 
 getLastSSLError(char \*dest = NULL, size_t len = 0)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -218,4 +218,4 @@ Takes an array (in PROGMEM is valid) or a std::vector of 16-bit BearSSL cipher i
 setCiphersLessSecure()
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Helper function which essentially limits BearSSL to ciphers that were supported by the deprecated axTLS.  These may be less secure than the ones BearSSL would natively choose, but they may be helpful and faster if your server depended on specific axTLS crypto options.
+Helper function which essentially limits BearSSL to less secure ciphers than it would natively choose, but they may be helpful and faster if your server depended on specific crypto options.

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
@@ -97,7 +97,6 @@ void WiFiClientSecure::_clearAuthenticationSettings() {
   _use_self_signed = false;
   _knownkey = nullptr;
   _ta = nullptr;
-  _axtls_ta = nullptr;
 }
 
 
@@ -106,8 +105,6 @@ WiFiClientSecure::WiFiClientSecure() : WiFiClient() {
   _clearAuthenticationSettings();
   _certStore = nullptr; // Don't want to remove cert store on a clear, should be long lived
   _sk = nullptr;
-  _axtls_chain = nullptr;
-  _axtls_sk = nullptr;
   stack_thunk_add_ref();
 }
 
@@ -124,10 +121,6 @@ WiFiClientSecure::~WiFiClientSecure() {
   _cipher_list = nullptr; // std::shared will free if last reference
   _freeSSL();
   stack_thunk_del_ref();
-  // Clean up any dangling axtls compat structures, if needed
-  _axtls_ta = nullptr;
-  _axtls_chain = nullptr;
-  _axtls_sk = nullptr;
 }
 
 WiFiClientSecure::WiFiClientSecure(ClientContext* client,
@@ -1574,81 +1567,6 @@ bool WiFiClientSecure::probeMaxFragmentLength(IPAddress ip, uint16_t port, uint1
     }
   }
   return _SendAbort(probe, supportsLen);
-}
-
-
-// AXTLS compatibility interfaces
-bool WiFiClientSecure::setCACert(const uint8_t* pk, size_t size) {
-  _axtls_ta = nullptr;
-  _axtls_ta = std::shared_ptr<X509List>(new X509List(pk, size));
-  _ta = _axtls_ta.get();
-  return _ta ? true : false;
-}
-
-bool WiFiClientSecure::setCertificate(const uint8_t* pk, size_t size) {
-  _axtls_chain = nullptr;
-  _axtls_chain = std::shared_ptr<X509List>(new X509List(pk, size));
-  _chain = _axtls_chain.get();
-  return _chain ? true : false;
-}
-
-bool WiFiClientSecure::setPrivateKey(const uint8_t* pk, size_t size) {
-  _axtls_sk = nullptr;
-  _axtls_sk = std::shared_ptr<PrivateKey>(new PrivateKey(pk, size));
-  _sk = _axtls_sk.get();
-  return _sk ? true : false;
-
-}
-
-uint8_t *WiFiClientSecure::_streamLoad(Stream& stream, size_t size) {
-  uint8_t *dest = (uint8_t*)malloc(size);
-  if (!dest) {
-    return nullptr;
-  }
-  if (size != stream.readBytes(dest, size)) {
-    free(dest);
-    return nullptr;
-  }
-  return dest;
-}
-
-bool WiFiClientSecure::loadCACert(Stream& stream, size_t size) {
-  uint8_t *dest = _streamLoad(stream, size);
-  bool ret = false;
-  if (dest) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored  "-Wdeprecated-declarations"
-    ret = setCACert(dest, size);
-#pragma GCC diagnostic pop
-  }
-  free(dest);
-  return ret;
-}
-
-bool WiFiClientSecure::loadCertificate(Stream& stream, size_t size) {
-  uint8_t *dest = _streamLoad(stream, size);
-  bool ret = false;
-  if (dest) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored  "-Wdeprecated-declarations"
-    ret = setCertificate(dest, size);
-#pragma GCC diagnostic pop
-  }
-  free(dest);
-  return ret;
-}
-
-bool WiFiClientSecure::loadPrivateKey(Stream& stream, size_t size) {
-  uint8_t *dest = _streamLoad(stream, size);
-  bool ret = false;
-  if (dest) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored  "-Wdeprecated-declarations"
-    ret = setPrivateKey(dest, size);
-#pragma GCC diagnostic pop
-  }
-  free(dest);
-  return ret;
 }
 
 };

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
@@ -131,68 +131,6 @@ class WiFiClientSecure : public WiFiClient {
     static bool probeMaxFragmentLength(const char *hostname, uint16_t port, uint16_t len);
     static bool probeMaxFragmentLength(const String& host, uint16_t port, uint16_t len);
 
-    ////////////////////////////////////////////////////
-    // AxTLS API deprecated warnings to help upgrading
-
-    #define AXTLS_DEPRECATED \
-      __attribute__((deprecated( \
-        "This is deprecated AxTLS API, " \
-        "check https://github.com/esp8266/Arduino/blob/master/libraries/ESP8266WiFi/src/WiFiClientSecure.h#L25-L99")))
-
-    bool setCACert(const uint8_t* pk, size_t size)      AXTLS_DEPRECATED;
-    bool setCertificate(const uint8_t* pk, size_t size) AXTLS_DEPRECATED;
-    bool setPrivateKey(const uint8_t* pk, size_t size)  AXTLS_DEPRECATED;
-
-    bool loadCACert(Stream& stream, size_t size)        AXTLS_DEPRECATED;
-    bool loadCertificate(Stream& stream, size_t size)   AXTLS_DEPRECATED;
-    bool loadPrivateKey(Stream& stream, size_t size)    AXTLS_DEPRECATED;
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored  "-Wdeprecated-declarations"
-
-    bool setCACert_P(PGM_VOID_P pk, size_t size) AXTLS_DEPRECATED {
-      return setCACert((const uint8_t *)pk, size);
-    }
-
-    bool setCertificate_P(PGM_VOID_P pk, size_t size) AXTLS_DEPRECATED {
-      return setCertificate((const uint8_t *)pk, size);
-    }
-
-    bool setPrivateKey_P(PGM_VOID_P pk, size_t size) AXTLS_DEPRECATED {
-      return setPrivateKey((const uint8_t *)pk, size);
-    }
-
-#pragma GCC diagnostic pop
-
-    template<typename TFile>
-    bool loadCertificate(TFile& file) {
-      return loadCertificate(file, file.size());
-    }
-
-    template<typename TFile>
-    bool loadPrivateKey(TFile& file) {
-      return loadPrivateKey(file, file.size());
-    }
-
-    template<typename TFile>
-    bool loadCACert(TFile& file) {
-      return loadCACert(file, file.size());
-    }
-
-    bool verify(const char* fingerprint, const char* domain_name) AXTLS_DEPRECATED {
-      (void)fingerprint;
-      (void)domain_name;
-      return connected();
-    }
-
-    bool verifyCertChain(const char* domain_name) AXTLS_DEPRECATED {
-      (void)domain_name;
-      return connected();
-    }
-
-    // AxTLS API deprecated section end
-    /////////////////////////////////////
-
   protected:
     bool _connectSSL(const char *hostName); // Do initial SSL handshake
 
@@ -218,14 +156,6 @@ class WiFiClientSecure : public WiFiClient {
     int _iobuf_out_size;
     bool _handshake_done;
     bool _oom_err;
-
-    // AXTLS compatibility shim elements:
-    // AXTLS managed memory for certs and keys, while BearSSL assumes
-    // the app manages these.  Use this local storage for holding the
-    // BearSSL created objects in a shared form.
-    std::shared_ptr<X509List>   _axtls_ta;
-    std::shared_ptr<X509List>   _axtls_chain;
-    std::shared_ptr<PrivateKey> _axtls_sk;
 
     // Optional storage space pointer for session parameters
     // Will be used on connect and updated on close

--- a/libraries/ESP8266WiFi/src/WiFiServerSecureBearSSL.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiServerSecureBearSSL.cpp
@@ -56,8 +56,6 @@ WiFiServerSecure::WiFiServerSecure(const WiFiServerSecure &rhs) : WiFiServer(rhs
 
 WiFiServerSecure::~WiFiServerSecure() {
   stack_thunk_del_ref();
-  _axtls_chain = nullptr;
-  _axtls_sk = nullptr;
 }
 
 // Specify a RSA-signed certificate and key for the server.  Only copies the pointer, the
@@ -102,19 +100,5 @@ WiFiClientSecure WiFiServerSecure::available(uint8_t* status) {
   optimistic_yield(1000);
   return WiFiClientSecure();
 }
-
-
-void WiFiServerSecure::setServerKeyAndCert(const uint8_t *key, int keyLen, const uint8_t *cert, int certLen) {
-  _axtls_chain = nullptr;
-  _axtls_sk = nullptr;
-  _axtls_chain = std::shared_ptr<X509List>(new X509List(cert, certLen));
-  _axtls_sk = std::shared_ptr<PrivateKey>(new PrivateKey(key, keyLen));
-  setRSACert(_axtls_chain.get(), _axtls_sk.get());
-}
-
-void WiFiServerSecure::setServerKeyAndCert_P(const uint8_t *key, int keyLen, const uint8_t *cert, int certLen) {
-  setServerKeyAndCert(key, keyLen, cert, certLen);
-}
-
 
 };

--- a/libraries/ESP8266WiFi/src/WiFiServerSecureBearSSL.h
+++ b/libraries/ESP8266WiFi/src/WiFiServerSecureBearSSL.h
@@ -58,10 +58,6 @@ class WiFiServerSecure : public WiFiServer {
     // If awaiting connection available and authenticated (i.e. client cert), return it.
     WiFiClientSecure available(uint8_t* status = NULL);
 
-    // Compatibility with axTLS interface
-    void setServerKeyAndCert(const uint8_t *key, int keyLen, const uint8_t *cert, int certLen);
-    void setServerKeyAndCert_P(const uint8_t *key, int keyLen, const uint8_t *cert, int certLen);
-
     WiFiServerSecure& operator=(const WiFiServerSecure&) = default;
 
   using ClientType = WiFiClientSecure;
@@ -73,10 +69,6 @@ class WiFiServerSecure : public WiFiServer {
     int _iobuf_in_size = BR_SSL_BUFSIZE_INPUT;
     int _iobuf_out_size = 837;
     const X509List *_client_CA_ta = nullptr;
-
-    // axTLS compat
-    std::shared_ptr<X509List>   _axtls_chain;
-    std::shared_ptr<PrivateKey> _axtls_sk;
 
 };
 

--- a/tests/device/test_sw_http_client/test_sw_http_client.ino
+++ b/tests/device/test_sw_http_client/test_sw_http_client.ino
@@ -1,7 +1,6 @@
 #include <Arduino.h>
 #include <ESP8266WiFi.h>
 #include <ESP8266HTTPClient.h>
-#include <WiFiClientSecureAxTLS.h>
 #include <BSTest.h>
 #include <pgmspace.h>
 
@@ -210,43 +209,6 @@ TEST_CASE("HTTPS GET request", "[HTTPClient]")
             }
         }
     }
-    //
-    // Same tests with axTLS
-    //
-#if !CORE_MOCK
-    {
-        // small request
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-        axTLS::WiFiClientSecure client;
-#pragma GCC diagnostic pop
-        HTTPClient http;
-        http.begin(client, getenv("SERVER_IP"), 8088, "/", fp);
-        auto httpCode = http.GET();
-        REQUIRE(httpCode == HTTP_CODE_OK);
-        String payload = http.getString();
-        REQUIRE(payload == "hello!!!");
-    }
-    {
-        // request which returns 4000 bytes
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-        axTLS::WiFiClientSecure client;
-#pragma GCC diagnostic pop
-        HTTPClient http;
-        http.begin(client, getenv("SERVER_IP"), 8088, "/data?size=4000", fp);
-        auto httpCode = http.GET();
-        REQUIRE(httpCode == HTTP_CODE_OK);
-        String payload = http.getString();
-        auto len = payload.length();
-        REQUIRE(len == 4000);
-        for (size_t i = 0; i < len; ++i) {
-            if (payload[i] != 'a') {
-                REQUIRE(false);
-            }
-        }
-    }
-#endif
 }
 
 void loop()


### PR DESCRIPTION
Remove the axTLS compatability functions from WiFiClient/ServerSecure,
device tests for axTLS, and any document refs to axTLS.