### PR TITLE
Prevent rewriting Updater_Signing.h if content unchanged

### DIFF
--- a/tools/signing.py
+++ b/tools/signing.py
@@ -74,6 +74,13 @@ def main():
         outdir = os.path.dirname(args.out)
         if not os.path.exists(outdir):
             os.makedirs(outdir)
+        try:
+            with open(args.out, "r") as inp:
+                old_val = inp.read()
+                if old_val == val:
+                    return
+        except Exception:
+            pass
         with open(args.out, "w") as f:
             f.write(val)
         return 0


### PR DESCRIPTION
Updater_Signing.h is rewritten at each compilation forcing the recompilation of some ESP libs.
This fix compares the content if the file already exists and updates it only if changed.

Very similar to "core_version.h" fix in #6414