### PR TITLE
Update OTA HTTP Server Header Information

### DIFF
--- a/doc/ota_updates/readme.rst
+++ b/doc/ota_updates/readme.rst
@@ -571,15 +571,16 @@ Example header data:
 
 ::
 
-        [HTTP_USER_AGENT] => ESP8266-http-Update
-        [HTTP_X_ESP8266_STA_MAC] => 18:FE:AA:AA:AA:AA
-        [HTTP_X_ESP8266_AP_MAC] => 1A:FE:AA:AA:AA:AA
-        [HTTP_X_ESP8266_FREE_SPACE] => 671744
-        [HTTP_X_ESP8266_SKETCH_SIZE] => 373940
-        [HTTP_X_ESP8266_SKETCH_MD5] => a56f8ef78a0bebd812f62067daf1408a
-        [HTTP_X_ESP8266_CHIP_SIZE] => 4194304
-        [HTTP_X_ESP8266_SDK_VERSION] => 1.3.0
-        [HTTP_X_ESP8266_VERSION] => DOOR-7-g14f53a19
+        [User-Agent] => ESP8266-http-Update
+        [x-ESP8266-STA-MAC] => 18:FE:AA:AA:AA:AA
+        [x-ESP8266-AP-MAC] => 1A:FE:AA:AA:AA:AA
+        [x-ESP8266-free-space] => 671744
+        [x-ESP8266-sketch-size] => 373940
+        [x-ESP8266-sketch-md5] => a56f8ef78a0bebd812f62067daf1408a
+        [x-ESP8266-chip-size] => 4194304
+        [x-ESP8266-sdk-version] => 1.3.0
+        [x-ESP8266-version] => DOOR-7-g14f53a19
+        [x-ESP8266-mode] => sketch
 
 With this information the script now can check if an update is needed. It is also possible to deliver different binaries based on the MAC address, as in the following example:
 
@@ -608,20 +609,20 @@ With this information the script now can check if an update is needed. It is als
         readfile($path);
     }
 
-    if(!check_header('HTTP_USER_AGENT', 'ESP8266-http-Update')) {
+    if(!check_header('User-Agent', 'ESP8266-http-Update')) {
         header($_SERVER["SERVER_PROTOCOL"].' 403 Forbidden', true, 403);
         echo "only for ESP8266 updater!\n";
         exit();
     }
 
     if(
-        !check_header('HTTP_X_ESP8266_STA_MAC') ||
-        !check_header('HTTP_X_ESP8266_AP_MAC') ||
-        !check_header('HTTP_X_ESP8266_FREE_SPACE') ||
-        !check_header('HTTP_X_ESP8266_SKETCH_SIZE') ||
-        !check_header('HTTP_X_ESP8266_SKETCH_MD5') ||
-        !check_header('HTTP_X_ESP8266_CHIP_SIZE') ||
-        !check_header('HTTP_X_ESP8266_SDK_VERSION')
+        !check_header('x-ESP8266-STA-MAC') ||
+        !check_header('x-ESP8266-AP-MAC') ||
+        !check_header('x-ESP8266-free-space') ||
+        !check_header('x-ESP8266-sketch-size') ||
+        !check_header('x-ESP8266-sketch-md5') ||
+        !check_header('x-ESP8266-chip-size') ||
+        !check_header('x-ESP8266-sdk-version')
     ) {
         header($_SERVER["SERVER_PROTOCOL"].' 403 Forbidden', true, 403);
         echo "only for ESP8266 updater! (header)\n";
@@ -633,17 +634,17 @@ With this information the script now can check if an update is needed. It is als
         "18:FE:AA:AA:AA:BB" => "TEMP-1.0.0"
     );
 
-    if(!isset($db[$_SERVER['HTTP_X_ESP8266_STA_MAC']])) {
+    if(!isset($db[$_SERVER['x-ESP8266-STA-MAC']])) {
         header($_SERVER["SERVER_PROTOCOL"].' 500 ESP MAC not configured for updates', true, 500);
     }
 
-    $localBinary = "./bin/".$db[$_SERVER['HTTP_X_ESP8266_STA_MAC']].".bin";
+    $localBinary = "./bin/".$db[$_SERVER['x-ESP8266-STA-MAC']].".bin";
 
     // Check if version has been set and does not match, if not, check if
     // MD5 hash between local binary and ESP8266 binary do not match if not.
     // then no update has been found.
-    if((!check_header('HTTP_X_ESP8266_SDK_VERSION') && $db[$_SERVER['HTTP_X_ESP8266_STA_MAC']] != $_SERVER['HTTP_X_ESP8266_VERSION'])
-        || $_SERVER["HTTP_X_ESP8266_SKETCH_MD5"] != md5_file($localBinary)) {
+    if((!check_header('x-ESP8266-sdk-version') && $db[$_SERVER['x-ESP8266-STA-MAC']] != $_SERVER['x-ESP8266-version'])
+        || $_SERVER["x-ESP8266-sketch-md5"] != md5_file($localBinary)) {
         sendFile($localBinary);
     } else {
         header($_SERVER["SERVER_PROTOCOL"].' 304 Not Modified', true, 304);


### PR DESCRIPTION
The headers sent when an OTA update is requested of an HTTP server have changed in the code. This change is to update the documentation accordingly. PHP sample code was changed but not tested.