### PR TITLE
BREAKING: Change return type of channel()

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -254,7 +254,7 @@ void ESP8266WiFiGenericClass::_eventCallback(void* arg)
  * Return the current channel associated with the network
  * @return channel (1-13)
  */
-int32_t ESP8266WiFiGenericClass::channel(void) {
+uint8_t ESP8266WiFiGenericClass::channel(void) {
     return wifi_get_channel();
 }
 

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.h
@@ -74,7 +74,7 @@ class ESP8266WiFiGenericClass {
         WiFiEventHandler onSoftAPModeProbeRequestReceived(std::function<void(const WiFiEventSoftAPModeProbeRequestReceived&)>);
         WiFiEventHandler onWiFiModeChange(std::function<void(const WiFiEventModeChange&)>);
 
-        int32_t channel(void);
+        uint8_t channel(void);
 
         bool setSleepMode(WiFiSleepType_t type, uint8_t listenInterval = 0);
 


### PR DESCRIPTION
Fixes #7643.
Change return type of channel to match the return type of the underlying SDK API
This is a breaking change because the method signature changes. 