### PR TITLE
BREAKING: Change return type of RSSI()

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
@@ -686,7 +686,7 @@ String ESP8266WiFiSTAClass::BSSIDstr(void) {
  * Return the current network RSSI.
  * @return  RSSI value
  */
-int32_t ESP8266WiFiSTAClass::RSSI(void) {
+int8_t ESP8266WiFiSTAClass::RSSI(void) {
     return wifi_station_get_rssi();
 }
 

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
@@ -81,7 +81,7 @@ class ESP8266WiFiSTAClass {
         uint8_t * BSSID();
         String BSSIDstr();
 
-        int32_t RSSI();
+        int8_t RSSI();
 
         static void enableInsecureWEP (bool enable = true) { _useInsecureWEP = enable; }
 


### PR DESCRIPTION
#Fixes #7641.
Change the return type of RSSI() to match the underlying SDK API.
This is a breaking change because the method signature changes.