### PR TITLE
Fix Netdump library architecture

### DIFF
--- a/libraries/Netdump/library.properties
+++ b/libraries/Netdump/library.properties
@@ -6,4 +6,4 @@ sentence=tcpdump-like logger for esp8266/Arduino
 paragraph=Dumps input / output packets on "Print"able type, or provide a TCP server for the real tcpdump. Check examples. Some other unrelated and independant tools are included.
 category=Communication
 url=https://
-architectures=esp8266 lwip
+architectures=esp8266


### PR DESCRIPTION
When building with the Netdump library, the IDE generates the following warning:
> WARNING: library Netdump claims to run on (esp8266 lwip) architecture(s) and may be incompatible with your current board which runs on (esp8266) architecture(s).

Fix the library.properties to call the architecture just "esp8266"