### PR TITLE
New WiFi password manager library

### DIFF
--- a/libraries/ESP8266WiFiPassMan/examples/01-WiFiPassManSetup/01-WiFiPassManSetup.ino
+++ b/libraries/ESP8266WiFiPassMan/examples/01-WiFiPassManSetup/01-WiFiPassManSetup.ino
@@ -1,0 +1,46 @@
+/*
+    This sketch generates encoded WiFi SSID/password.
+*/
+
+#include <ESP8266WiFiPassMan.h>
+
+// WiFi credentials to be encoded
+#define WIFI_SSID   "my-ssid"
+#define WIFI_PASS   "my-secret-password-123456789"
+
+// Use predefined secret key for encoding. Keep 0 to generate new secret key.
+const uint32_t secretKey[4] PROGMEM = {
+  0x00000000, 0x00000000, 0x00000000, 0x00000000
+};
+
+// true:  WiFi credentials can be decoded on this ESP8266 only (recommended).
+// false: WiFi credentials can be decoded on any ESP8266 (less secure).
+bool encodeAPMAC = true;
+
+
+void setup() {
+  // Initialize Serial
+  delay(500);
+  Serial.begin(115200);
+  Serial.println(F("\nESP8266 WiFi password manager setup\n"));
+
+  // Create WiFi password manager object.
+  ESP8266WiFiPassMan wpm(encodeAPMAC);
+
+  // Optional: Run selftest encoding/decoding string up to 63 characters
+  if (!wpm.selftest("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!")) {
+    return;
+  }
+  if (!wpm.selftest(WIFI_SSID)) {
+    return;
+  }
+  if (!wpm.selftest(WIFI_PASS)) {
+    return;
+  }
+
+  // Encode and print WiFi credentials
+  wpm.encodeWiFiCredentials(WIFI_SSID, WIFI_PASS, secretKey);
+}
+
+void loop() {
+}

--- a/libraries/ESP8266WiFiPassMan/examples/02-WiFiPassManConnect/02-WiFiPassManConnect.ino
+++ b/libraries/ESP8266WiFiPassMan/examples/02-WiFiPassManConnect/02-WiFiPassManConnect.ino
@@ -1,0 +1,97 @@
+/*
+    This sketch decodes WiFi SSID/password and connects to the access point.
+*/
+
+#include <ESP8266WiFi.h>
+#include <ESP8266WiFiPassMan.h>
+
+//----------------------------------------------
+// *** DON'T LOOSE YOUR SECRET KEY! ***
+
+// WiFi credentials can be copied to any ESP8266
+#define ENCODE_AP_MAC false
+
+// Secret key for WiFi password manager
+const uint32_t SECRET_KEY[4] PROGMEM = {
+  0x8DD84B5F, 0x642460D9, 0xAB1FA984, 0x677D2D1A
+};
+
+// Encoded WiFi SSID
+const uint32_t WIFI_ENC_SSID[16] PROGMEM = {
+  0x1DD7222B, 0x95059384, 0x4DD5DDBA, 0x90421435,
+  0x1E337631, 0x84A2BE61, 0xE2BD2CDF, 0x5A8D26F4,
+  0xE61D203E, 0x05FAF1B4, 0x2498B611, 0xA61EC580,
+  0xE54CCC21, 0xD16632FF, 0x1B4C0C64, 0x4439A5CB,
+};
+
+// Encoded WiFi password
+const uint32_t WIFI_ENC_PASS[16] PROGMEM = {
+  0xFE06668A, 0xF23554A9, 0xD3A974C9, 0xE60768A6,
+  0x39743699, 0x5FBB5DC9, 0xB6C64C7B, 0xCF4E4D66,
+  0x02AC6FB0, 0x6875CED0, 0x6498BA68, 0xF8D7244D,
+  0xC89461D7, 0xD93F8A3C, 0x465F39D6, 0xD9EC5AC3,
+};
+//----------------------------------------------
+
+void setup() {
+  char wifi_ssid[64];
+  char wifi_pass[64];
+  uint32_t tStart;
+
+  // Never save WiFi configuration in flash when using WiFi password manager
+  WiFi.persistent(false);
+
+  // Initialize Serial
+  delay(500);
+  Serial.begin(115200);
+  Serial.println(F("\nESP8266 WiFi password manager connect"));
+
+  // Create WiFi password manager object.
+  ESP8266WiFiPassMan wpm(ENCODE_AP_MAC);
+
+  // Check if unsecure WiFi password is saved in on-chip flash
+  if (wpm.isWiFiCredentialSaved()) {
+    Serial.println(F("Erasing unsecure WiFi credentials..."));
+    wpm.eraseWiFiPasswords();
+    // ESP8266 reset is generated and does not return here
+  }
+
+  // Start time to measure decoding duration
+  tStart = micros();
+
+  // Decode WiFi SSID
+  if (!wpm.decode_P(SECRET_KEY, WIFI_ENC_SSID, wifi_ssid)) {
+    Serial.println(F("Decode SSID failed"));
+    return;
+  }
+
+  // Decode WiFi password
+  if (!wpm.decode_P(SECRET_KEY, WIFI_ENC_PASS, wifi_pass)) {
+    Serial.println(F("Decode PASS failed"));
+    return;
+  }
+
+  // Print decoding duration
+  Serial.printf(PSTR("Decoding: %dus\n"), micros() - tStart);
+
+  // Set WiFi to station mode
+  WiFi.mode(WIFI_STA);
+
+  // Connect to base station
+  Serial.print(F("Connecting to "));
+  Serial.println(wifi_ssid);
+  // Serial.print(F("Password: "));
+  // Serial.println(wifi_pass);
+
+  WiFi.begin(wifi_ssid, wifi_pass);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+
+  Serial.print("\nWiFi connected, IP: ");
+  Serial.println(WiFi.localIP());
+}
+
+void loop() {
+}

--- a/libraries/ESP8266WiFiPassMan/examples/03-WiFiPassManErase/03-WiFiPassManErase.ino
+++ b/libraries/ESP8266WiFiPassMan/examples/03-WiFiPassManErase/03-WiFiPassManErase.ino
@@ -1,0 +1,85 @@
+/*
+    This sketch demonstrates weakness of the Espressif ESP8266 chip design to
+    store WiFi passwords plain text in flash.
+
+    Use the ESP8266WiFiPassMan to encode WiFi credentials.
+*/
+
+#include <ESP8266WiFi.h>
+#include <ESP8266WiFiPassMan.h>
+
+bool dumpWiFiPasswords() {
+  // Fixed number of WiFi configurations
+  const uint8_t numConfigs = 5;
+  struct station_config config[numConfigs];
+  bool retval;
+
+  // Clear config
+  memset(config, 0, sizeof(config));
+
+  // Print configs
+  retval = wifi_station_get_ap_info(config);
+  for (uint8_t i = 0; i < numConfigs; i++) {
+    Serial.printf(PSTR("Config %d:\n"), i);
+    Serial.printf(PSTR("  ssid:      %s\n"), config[i].ssid);
+    Serial.printf(PSTR("  password:  %s\n"), config[i].password);
+    Serial.printf(PSTR("  bssid_set: %d\n"), config[i].bssid_set);
+    Serial.printf(PSTR("  bssid:     %02x:%02x:%02x:%02x:%02x\n"),
+                  config[i].bssid[0], config[i].bssid[1], config[i].bssid[2],
+                  config[i].bssid[3], config[i].bssid[4], config[i].bssid[5]);
+    Serial.printf(PSTR("  threshold.rssi: %d\n"), config[i].threshold.rssi);
+    Serial.printf(PSTR("  threshold.authmode: %d\n"), (uint8_t)config[i].threshold.authmode);
+  }
+
+  return retval;
+}
+
+void serialReadAnswer() {
+  static char readBuffer[5];
+  static uint8_t readIndex;
+
+  while (1) {
+    if (Serial.available()) {
+      char c = Serial.read();
+      Serial.print(c);
+      if (c == '\n') {
+        if (strncmp(readBuffer, "YES", 3) == 0) {
+          Serial.println(F("Erasing WiFi credentials..."));
+
+          // The erase includes system_restore() and system_restart()
+          ESP8266WiFiPassMan wpm;
+          wpm.eraseWiFiPasswords();
+        } else {
+          Serial.println(F("Aborted."));
+          break;
+        }
+        readIndex = 0;
+      } else {
+        readBuffer[readIndex] = c;
+        readIndex++;
+        if (readIndex > sizeof(readBuffer)) {
+          readIndex = 0;
+        }
+      }
+    }
+  }
+}
+
+void setup() {
+  // Initialize Serial
+  delay(500);
+  Serial.begin(115200);
+  Serial.println(F("\nESP8266 erase WiFi credentials example"));
+
+  // Print all plain text WiFi credentials stored in flash
+  if (dumpWiFiPasswords()) {
+    Serial.println(F("Would you like to erase all plain text WiFi passwords?"));
+    Serial.println(F("Type YES + ENTER to erase"));
+    serialReadAnswer();
+  } else {
+    Serial.println(F("No plain text WiFi passwords found"));
+  }
+}
+
+void loop() {
+}

--- a/libraries/ESP8266WiFiPassMan/keywords.txt
+++ b/libraries/ESP8266WiFiPassMan/keywords.txt
@@ -1,0 +1,46 @@
+#######################################
+# Syntax Coloring Map For ESP8266WiFiPassMan
+#######################################
+
+#######################################
+# Library (KEYWORD3)
+#######################################
+
+WiFiPasswordManager	KEYWORD3
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+wpm	KEYWORD1
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+
+generateteKey	KEYWORD2
+
+checkSecretKey	KEYWORD2
+checkSecretKey_P	KEYWORD2
+
+printKey	KEYWORD2
+printKey_P	KEYWORD2
+encodeString	KEYWORD2
+setAPMAC	KEYWORD2
+encodeWiFiCredentials	KEYWORD2
+decodeWiFiCredentials_P	KEYWORD2
+encode	KEYWORD2
+encode_P	KEYWORD2
+decode	KEYWORD2
+decode_P	KEYWORD2
+selftest	KEYWORD2
+
+isWiFiCredentialSaved	KEYWORD2
+eraseWiFiPasswords	KEYWORD2
+
+#######################################
+# Constants (LITERAL1)
+#######################################
+
+XTEA_BUFFER_LEN_B	LITERAL1
+ENCODE_AP_MAC	LITERAL1

--- a/libraries/ESP8266WiFiPassMan/library.properties
+++ b/libraries/ESP8266WiFiPassMan/library.properties
@@ -1,0 +1,10 @@
+name=ESP8266WiFiPassMan
+version=1.0.0
+author=Erriez
+maintainer=Erriez <Erriez@users.noreply.github.com>
+sentence=ESP8266 WiFi password manager.
+paragraph=This library can encode/decode WiFi SSID/password with XTEA and detect/erase unsecure saved WiFi credentials as plain text in on-chip flash.
+category=Data Storage
+url=
+architectures=esp8266
+dot_a_linkage=true

--- a/libraries/ESP8266WiFiPassMan/src/ESP8266WiFiPassMan.cpp
+++ b/libraries/ESP8266WiFiPassMan/src/ESP8266WiFiPassMan.cpp
@@ -1,0 +1,747 @@
+/*
+  ESP8266WiFiPassMan.h - Library for ESP8266.
+  Copyright (c) 2020 Arduino.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/**
+ * @brief ESP8266 WiFi SSID/password encoding/decoding library
+ * @file ESP8266WiFiPassMan.cpp
+ * @details
+ *      By default, the ESP8266 saves WiFi passwords in plain text to on-chip
+ *      flash and can be easily retrieved. This is a known design flaw in the
+ *      ESP8266 which cannot be resolved by software. This library makes it more
+ *      difficult to retrieve the WiFi SSID and password by encoding the
+ *      credentials with a fast XTEA algorithm. Decoding SSID and password on a
+ *      ESP8266 at 80MHZ takes around 0.5ms.
+ *
+ *      A hacker can simply dump the credentials by overwriting the
+ *      sketch when it has physical access to the ESP8266 device, or remotely
+ *      using OTA. The retrieved SSID and password can then be misused to login
+ *      to this network.
+ *
+ *      For this reason, WiFi credentials must never be saved to flash and
+ *      requires WiFi.persistent(false); at the beginning of each sketch.
+ *      The disadvantage is that fast-connect at startup is disabled.
+ *
+ *      This library checks for WiFi SSID and password saved on on-chip flash
+ *      in plain text. The application designer is responsible to securely erase
+ *      saved WiFi SSID and password with system_restore() followed by
+ *      system_reset().
+ *
+ *      USAGE
+ *
+ *      The application designer generates a secret key and encodes the WiFi
+ *      SSID (optional) and password (required) by calling
+ *      encodeWiFiCredentials(). This results in tables in flash which must be
+ *      included in each sketch for decoding. Writing a new sketch to the
+ *      ESP8266 overwrites the secret key and encoded WiFi SSID/password.
+ *      Decoding must be performed once before calling WiFi.begin(SSID, PASS).
+ *
+ *      Encoding/decoding uses the hardware AP MAC address by default to bind to
+ *      only one specific ESP8266 device. In this case the encoded WiFi
+ *      SSID/password flash table cannot be copied to another ESP8266 with a
+ *      different MAC address and requires a re-encoding.
+ *
+ *      DISCLAIMER
+ *
+ *      Encoding WiFi SSID and password is always better than saving it in plain
+ *      text. The XTEA algorithm contains known and documented attacks and
+ *      therefore the wording encoding is used instead of real encryption.
+ *
+ *      Macro XTEA_NUM_ROUNDS can be increased to 128 or higher to increase
+ *      complexity. The duration also increases.
+ *
+ *      A hacker with physical access to the device can dump the entire flash
+ *      to a binary file and analyze the location of the secret key with encoded
+ *      WiFi SSID/password. For this architecture, it is technically not
+ *      possible to protect the flash for readout. It requires a lot of research
+ *      to attack decoding when the addresses are known.
+ *
+ *      100% security does not exist. It is up to crypto experts to determine
+ *      the safeness of the used algorithm and library.
+ *      Confusing the enemy is always better than doing nothing.
+ */
+
+#include <Arduino.h>
+#include <ESP8266WiFi.h>
+
+#include "ESP8266WiFiPassMan.h"
+#include "PrintBuffer.h"
+
+// XTEA uses 64-bit blocks, 64 bits is 8 bytes
+#define XTEA_BLOCK_SIZE     8               //!< XTEA fixed 8 Byte block size
+#define XTEA_DELTA          0x9E3779B9      //!< XTEA fixed delta calculation
+#define XTEA_NUM_ROUNDS     64              //!< XTEA fixed number of rounds
+
+
+/*!
+ * @brief XTEA encode
+ * @details
+ *      https://en.wikipedia.org/wiki/XTEA
+ * @param v
+ *      64-bit data in/out
+ * @param k
+ *      128-bit secret key in
+ */
+static void xtea_encode(uint32_t v[2], const uint32_t k[4])
+{
+    uint32_t v0 = v[0];
+    uint32_t v1 = v[1];
+    uint32_t sum = 0;
+
+    for (uint8_t i = 0; i < XTEA_NUM_ROUNDS; i++) {
+        v0 += ((v1 << 4 ^ v1 >> 5) + v1) ^ (sum + k[sum & 3]);
+        sum += XTEA_DELTA;
+        v1 += ((v0 << 4 ^ v0 >> 5) + v0) ^ (sum + k[sum>>11 & 3]);
+    }
+
+    v[0] = v0;
+    v[1] = v1;
+}
+
+/**
+ * @brief XTEA decode
+ * @param v
+ *      64-bit data in/out
+ * @param k
+ *      128-bit secret key in
+ */
+static void xtea_decode(uint32_t v[2], const uint32_t k[4])
+{
+    uint32_t v0 = v[0];
+    uint32_t v1 = v[1];
+    uint32_t sum = (XTEA_DELTA * XTEA_NUM_ROUNDS);
+
+    for (uint8_t i = 0; i < XTEA_NUM_ROUNDS; i++) {
+        v1 -= ((v0 << 4 ^ v0 >> 5) + v0) ^ (sum + k[sum>>11 & 3]);
+        sum -= XTEA_DELTA;
+        v0 -= ((v1 << 4 ^ v1 >> 5) + v1) ^ (sum + k[sum & 3]);
+    }
+
+    v[0] = v0;
+    v[1] = v1;
+}
+
+/**
+ * @brief WiFi Password Manager constructor
+ * @param encodeAPMAC
+ *      true: Scramble secret key with AP MAC address. This protects decoding
+ *            on another ESP8266.
+ *      false: Skip scrambling secret key. Decoding works on any ESP8266.
+ * @param stream
+ *      Stream pointer. Default: Serial
+ */
+ESP8266WiFiPassMan::ESP8266WiFiPassMan(bool encodeAPMAC, Stream *stream) :
+    _encodeAPMAC(encodeAPMAC), _APMAC(NULL), _stream(stream)
+{
+}
+
+/**
+ * @brief WiFi Password Manager destructor
+ */
+ESP8266WiFiPassMan::~ESP8266WiFiPassMan()
+{
+}
+
+/**
+ * @brief Generate pseudorandom secret key
+ * @details
+ *      It is recommended to press the reset button multiple times to increase
+ *      randomness. The random generator uses RANDOM_REG32. Up to crypto experts
+ *      to determine if this is safe enough for this encoding.
+ * @param key
+ *      Return secret key.
+ * @retval true
+ *      Success
+ * @retval false
+ *      Failed
+ */
+bool ESP8266WiFiPassMan::generateKey(uint32_t key[4])
+{
+    // Generate pseudo random key
+    for (uint8_t i = 0; i < 255; i++) {
+        key[0] = RANDOM_REG32;
+        key[1] = RANDOM_REG32;
+        key[2] = RANDOM_REG32;
+        key[3] = RANDOM_REG32;
+
+        if (checkSecretKey(key)) {
+            return true;
+        }
+    }
+
+    // Random generate defect
+    return false;
+}
+
+/**
+ * @brief Print secret key RAM
+ * @param key
+ *      Secret key input
+ * @retval true
+ *      Success
+ * @retval false
+ *      Stream pointer zero
+ */
+bool ESP8266WiFiPassMan::printKey(const uint32_t key[4])
+{
+    if (_stream == NULL) {
+        return false;
+    }
+
+    // Print secret key
+    _stream->printf(PSTR("// Secret key for WiFi password manager\n"));
+    _stream->printf(PSTR("const uint32_t SECRET_KEY[4] PROGMEM = {\n"));
+    _stream->printf(PSTR("  0x%08X, 0x%08X, 0x%08X, 0x%08X\n"),
+                    key[0], key[1], key[2], key[3]);
+    _stream->printf(PSTR("};\n"));
+
+    return true;
+}
+
+/**
+ * @brief Print secret key from flash
+ * @param key
+ *      Secret key input
+ * @return
+ *      see printKey()
+ */
+bool ESP8266WiFiPassMan::printKey_P(const uint32_t key[4])
+{
+    uint32_t _key[4];
+
+    memcpy_P(_key, key, sizeof(_key));
+
+    return printKey(_key);
+}
+
+/**
+ * @brief XTEA encode char string up to 63 characters + NULL character
+ * @param key
+ *      Secret key input
+ * @param bufferName
+ *      Buffer name
+ * @param buffer
+ *      Encoded buffer output
+ * @param str
+ *      Input char array
+ * @retval true
+ *      Success
+ * @retval false
+ *      Stream pointer zero
+ */
+bool ESP8266WiFiPassMan::encodeString(const uint32_t key[4],
+                                      const char *bufferName, uint32_t *buffer,
+                                      const char *str)
+{
+    if (!encode(key, str, buffer)) {
+        if (_stream) _stream->printf(PSTR("Error: Encode failed"));
+        return false;
+    }
+
+    // Print encoded buffer
+    if (_stream) _stream->printf(PSTR("const uint32_t %s[16] PROGMEM = {"), bufferName);
+    for (uint8_t i = 0; i < XTEA_BUFFER_LEN_W; i++) {
+        if ((i % 4) == 0) {
+            Serial.print(F("\n  "));
+        }
+        if (_stream) _stream->printf(PSTR("0x%08X, "), buffer[i]);
+    }
+    if (_stream) _stream->printf(PSTR("\n"));
+    if (_stream) _stream->printf(PSTR("};\n"));
+
+    return true;
+}
+
+/**
+ * @brief Set AP MAC address for secret key scrambling
+ * @param APMAC
+ *      AP MAC address
+ */
+void ESP8266WiFiPassMan::setAPMAC(uint8_t *APMAC)
+{
+    _APMAC = APMAC;
+}
+
+/**
+ * @brief Encode WiFi SSID (optional) and password (required)
+ * @details
+ *      This function prints encoded flash tables on Stream port (default
+ *      Serial) to be copied to the WiFi connect sketch.
+ * @param ssid
+ *      Optional SSID input char array up to 63 characters + NULL character
+ *      Set to NULL to skip SSID encoding
+ * @param password
+ *      Password input char array up to 63 characters + NULL character
+ * @param key
+ *      Secret key input
+ * @retval true
+ *      Success
+ * @retval false
+ *      Failure
+ */
+bool ESP8266WiFiPassMan::encodeWiFiCredentials(const char *ssid,
+                                               const char *password,
+                                               const uint32_t key[4])
+{
+    uint32_t _key[4];
+    uint32_t buffer[XTEA_BUFFER_LEN_W];
+
+    // Check stream pointer
+    if (_stream == NULL) {
+        return false;
+    }
+
+    // Clear key or copy key from flash
+    if (key == NULL) {
+        memset(_key, 0, sizeof(_key));
+    } else {
+        memcpy_P(_key, key, sizeof(_key));
+    }
+
+    // Check which key should be used for encoding
+    if (_key[0] == 0) {
+        if (!generateKey(_key)) {
+            _stream->printf(PSTR("Generate key failed\n"));
+            return false;
+        }
+        _stream->printf(PSTR("New secret key generated\n\n"));
+    } else {
+        _stream->printf(PSTR("Using existing secret key\n\n"));
+    }
+
+    _stream->printf(PSTR("//----------------------------------------------\n"));
+    _stream->printf(PSTR("// *** DON'T LOOSE YOUR SECRET KEY! ***\n\n"));
+
+    // Print macro ENCODE_AP_MAC
+    if (_encodeAPMAC) {
+        uint8_t mac[6];
+
+        // Get user or AP MAC
+        getAPMAC(mac);
+
+        _stream->printf(PSTR("// WiFi credentials can be decoded on "
+                             "%02X:%02X:%02X:%02X:%02X:%02X only\n"),
+                        mac[0],mac[1],mac[2],mac[3],mac[4],mac[5]);
+        _stream->printf(PSTR("#define ENCODE_AP_MAC %s\n\n"),
+                        _encodeAPMAC ? "true" : "false");
+    } else {
+        _stream->printf(PSTR("// WiFi credentials can be copied to any ESP8266\n"));
+        _stream->printf(PSTR("#define ENCODE_AP_MAC false\n\n"));
+    }
+
+    // Print key
+    printKey(_key);
+
+    // Encode SSID
+    if (ssid) {
+        _stream->printf(PSTR("\n// Encoded WiFi SSID\n"));
+        encodeString(_key, "WIFI_ENC_SSID", buffer, ssid);
+    }
+
+    // Encode WiFi password
+    _stream->printf(PSTR("\n// Encoded WiFi password\n"));
+    encodeString(_key, "WIFI_ENC_PASS", buffer, password);
+
+    _stream->printf(PSTR("//----------------------------------------------\n"));
+
+    // Print usage
+    _stream->printf(PSTR("\nCopy the encoded block to the WiFi connect sketch\n\n"));
+
+    return true;
+}
+
+/**
+ * @brief Check weakness secret key
+ * @param key
+ *      Secret key input
+ * @retval true
+ *      Secret key is strong enough
+ * @retval false
+ *      Secret key does not contain enough '1' or '0' bits
+ */
+bool ESP8266WiFiPassMan::checkSecretKey(const uint32_t key[4])
+{
+    uint8_t ones;
+    uint8_t zeros;
+
+    for (uint8_t i = 0; i < 4; i++) {
+        ones = 0;
+        zeros = 0;
+
+        for (uint8_t j = 0; j < 32; j++) {
+            if (key[i] & (1<<j)) {
+                ones++;
+            } else {
+                zeros++;
+            }
+        }
+
+        if ((ones < 4) || (zeros < 4)) {
+            // Weak key
+            DEBUG_PASS_ENC("[WPM] Weak key!");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * @brief Check secret key in flash
+ * @param key
+ *      Secret key input
+ * @return
+ *      See checkSecretKey()
+ */
+bool ESP8266WiFiPassMan::checkSecretKey_P(const uint32_t key[4])
+{
+    uint32_t _key[4];
+
+    // Copy key
+    memcpy_P(_key, key, sizeof(_key));
+
+    return checkSecretKey(_key);
+}
+
+/**
+ * @brief Get user or AP MAC
+ * @param mac
+ *      User or AP MAC output
+ */
+bool ESP8266WiFiPassMan::getAPMAC(uint8_t mac[6])
+{
+    // Clear MAC
+    memset(mac, 0, 6);
+
+    if (!_encodeAPMAC) {
+        // AP MAC encoding disabled
+        DEBUG_PASS_ENC("[WPM] HW AP MAC disabled");
+        return false;
+    }
+
+    if (_APMAC) {
+        // Copy AP MAC from RAM to local buffer
+        DEBUG_PASS_ENC("[WPM] User MAC:");
+        memcpy(mac, _APMAC, 6);
+    }
+
+    if ((mac[0] == 0) && (mac[5] == 0)) {
+        // Get hardware AP MAC address
+        DEBUG_PASS_ENC("[WPM] Get HW AP MAC:");
+        WiFi.macAddress(mac);
+    }
+
+    return true;
+}
+
+/**
+ * @brief Scramble secret key with unique AP MAC address
+ * @param key
+ *      Secret key input/output
+ */
+void ESP8266WiFiPassMan::scrambleKeyAPMAC(uint32_t key[4])
+{
+    uint8_t mac[6];
+
+    getAPMAC(mac);
+
+    DEBUG_PASS_ENC("[WPM] MAC:");
+    for (uint8_t i = 0; i < 6; i++) {
+        DEBUG_PASS_ENC(" ");
+        DEBUG_PASS_ENC("%02X", mac[i]);
+    }
+    DEBUG_PASS_ENC("\n");
+
+    DEBUG_PASS_ENC("[WPM] Key in: ");
+    for (uint8_t i = 0; i < 4; i++) {
+        DEBUG_PASS_ENC(" ");
+        DEBUG_PASS_ENC("%02X", key[i]);
+    }
+    DEBUG_PASS_ENC("\n");
+
+    // XOR MAC Bytes with key to confuse the enemy and bind the encoding to
+    // one unique ESP8266
+    for (uint8_t i = 0; i < 32; i++) {
+        ((uint8_t *)key)[i % 16] ^= mac[i % 6];
+    }
+
+    DEBUG_PASS_ENC("[WPM] Key out:");
+    for (uint8_t i = 0; i < 4; i++) {
+        DEBUG_PASS_ENC(" ");
+        DEBUG_PASS_ENC("%02X", key[i]);
+    }
+    DEBUG_PASS_ENC("\n");
+}
+
+/**
+ * @brief XTEA encode char array
+ * @param key
+ *      Secret key in flash
+ * @param str
+ *      Char array 63 characters + NULL in flash
+ * @param buffer
+ *      Buffer (Fixed 64/4 words) output encoded
+ * @return
+ *      See encode()
+ */
+bool ESP8266WiFiPassMan::encode_P(const uint32_t key[4], const char *str,
+                                  uint32_t buffer[XTEA_BUFFER_LEN_W])
+{
+    char _str[XTEA_BUFFER_LEN_B];
+
+    // Copy str from flash to RAM
+    strcpy_P(_str, str);
+
+    // Encode RAM str
+    return encode(key, _str, buffer);
+}
+
+/**
+ * @brief XTEA encode char array
+ * @param key
+ *      Secret key
+ * @param str
+ *      Char array 63 characters + NULL in RAM
+ * @param buffer
+ *      Buffer (Fixed 64/4 words) output encoded
+ * @retval true
+ *      Success
+ * @retval false
+ *      Failure
+ */
+bool ESP8266WiFiPassMan::encode(const uint32_t key[4], const char *str,
+                                uint32_t buffer[XTEA_BUFFER_LEN_W])
+{
+    size_t strLength;
+    uint32_t _key[4];
+
+    // Check arguments
+    if ((str == NULL) || (buffer == NULL)) {
+        return false;
+    }
+
+    // Check str length
+    strLength = strlen(str);
+    if (strLength > (XTEA_BUFFER_LEN_B - 1)) {
+        return false;
+    }
+
+    // Fill buffer with random ASCII data
+    strcpy((char *)buffer, str);
+    for (uint8_t i = strLength + 1; i < XTEA_BUFFER_LEN_B; i++) {
+        // Generate random ASCII char space..~
+        ((uint8_t *)buffer)[i] = ' ' + ((uint8_t)RANDOM_REG32 % 94);
+    }
+
+#ifdef DEBUG_ESP_PORT
+    DEBUG_PASS_ENC("[WPM] Plain buffer:\n");
+    printBuffer((uint8_t *)buffer, XTEA_BUFFER_LEN_B);
+#endif
+
+    // Copy secret key from flash
+    memcpy_P(_key, key, sizeof(_key));
+
+    // Scramble key with MAC address
+    if (_encodeAPMAC) {
+        scrambleKeyAPMAC(_key);
+    }
+
+    // Encode
+    for (uint8_t i = 0; i < XTEA_BLOCK_SIZE; i++) {
+        xtea_encode(&buffer[i * (XTEA_BLOCK_SIZE / sizeof(uint32_t))], _key);
+    }
+
+#ifdef DEBUG_ESP_PORT
+    DEBUG_PASS_ENC("[WPM] Encoded buffer:\n");
+    printBuffer((uint8_t *)buffer, XTEA_BUFFER_LEN_B);
+#endif
+
+    return true;
+}
+
+/**
+ * @brief XTEA encode char array
+ * @param key
+ *      Secret key in flash
+ * @param buffer
+ *      Encoded input buffer (Fixed 64/4 words) in flash
+ * @param str
+ *      Char array 63 characters + NULL output
+ * @return
+ *      See encode()
+ */
+bool ESP8266WiFiPassMan::decode_P(const uint32_t key[4],
+                                  const uint32_t buffer[XTEA_BUFFER_LEN_W],
+                                  char *str)
+{
+    uint32_t _buffer[XTEA_BUFFER_LEN_W];
+
+    // Copy str from flash to RAM
+    memcpy_P(_buffer, buffer, sizeof(_buffer));
+
+    // Encode RAM str
+    return decode(key, _buffer, str);
+}
+
+/**
+ * @brief XTEA encode char array
+ * @param key
+ *      Secret key
+ * @param buffer
+ *      Input/output buffer (Fixed 64/4 words) in RAM
+ * @param str
+ *      Char array 63 characters + NULL output
+ * @retval true
+ *      Success
+ * @retval false
+ *      Failure
+ */
+bool ESP8266WiFiPassMan::decode(const uint32_t key[4],
+                                uint32_t buffer[XTEA_BUFFER_LEN_W],
+                                char *str)
+{
+    size_t strLength;
+    uint32_t _key[4];
+
+    // Check arguments
+    if ((buffer == NULL) || (str == NULL)) {
+        return false;
+    }
+
+#ifdef DEBUG_ESP_PORT
+    DEBUG_PASS_ENC("[WPM] Encoded buffer:\n");
+    printBuffer((uint8_t *)buffer, XTEA_BUFFER_LEN_B);
+#endif
+
+    // Copy secret key from flash
+    memcpy_P(_key, key, sizeof(_key));
+
+    // Scramble key with MAC address
+    if (_encodeAPMAC) {
+        scrambleKeyAPMAC(_key);
+    }
+
+    // Decode
+    for (uint8_t i = 0; i < XTEA_BLOCK_SIZE; i++) {
+        xtea_decode(&buffer[i * (XTEA_BLOCK_SIZE / sizeof(uint32_t))], _key);
+    }
+
+#ifdef DEBUG_ESP_PORT
+    DEBUG_PASS_ENC("[WPM] Decoded buffer:\n");
+    printBuffer((uint8_t *)buffer, XTEA_BUFFER_LEN_B);
+#endif
+
+    // Check str length
+    strLength = strlen((char *)buffer);
+    if (strLength > (XTEA_BUFFER_LEN_B - 1)) {
+        DEBUG_PASS_ENC("[WPM] Decoded length error:\n");
+        str[0] = '\0';
+        return false;
+    }
+
+    // Copy str
+    strcpy(str, (char *)buffer);
+
+    return true;
+}
+
+/**
+ * @brief Run XTEA encode/decode/very on an input char array
+ * @param str
+ *      Char array
+ * @retval true
+ *      Success
+ * @retval false
+ *      Failed. Recommended to enable debug prints.
+ */
+bool ESP8266WiFiPassMan::selftest(const char *str)
+{
+    uint32_t key[4];
+    uint32_t buffer[XTEA_BUFFER_LEN_W];
+    char strOut[64];
+
+    if (_stream) _stream->print(F("Starting selftest..."));
+
+    if (!generateKey(key)) {
+        if (_stream) _stream->println(F("Generate key failed"));
+        return false;
+    }
+
+    if (!encode(key, str, buffer)) {
+        if (_stream) _stream->println(F("Encode failed"));
+        return false;
+    }
+
+    if (!decode(key, buffer, strOut)) {
+        if (_stream) _stream->println(F("Decode failed"));
+        return false;
+    }
+
+    if (strcmp(str, strOut) != 0) {
+        if (_stream) _stream->println(F("Verify failed"));
+        return false;
+    }
+
+    if (_stream) _stream->println(F("Passed"));
+
+    return true;
+}
+
+/**
+ * @brief Check if unsecure WiFi credentials are saved to on-chip flash
+ * @retval true
+ *      Unsecure: WiFi SSID/password saved as plain text to on-chip flash
+ * @retval false
+ *      Secure: No unsecure WiFi SSID/password found
+ */
+bool ESP8266WiFiPassMan::isWiFiCredentialSaved()
+{
+    struct station_config config;
+
+    // Clear station config
+    memset(&config, 0, sizeof(station_config));
+
+    // Get current config from flash
+    wifi_station_get_config_default(&config);
+
+    // Check if unsecure WiFi password saved in on-chip flash which can be
+    // easily retrieved
+    if (strlen((const char *)config.ssid) > 0) {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * @brief Erase unsecure saved WiFi credentials on-chip flash
+ * @details
+ *      system_restore() followed by system_restart()
+ */
+void ESP8266WiFiPassMan::eraseWiFiPasswords()
+{
+    // Erase all saved WiFi credentials from on-chip flash
+    system_restore();
+    // Generate restart
+    system_restart();
+    // The ESP8266 will not restart immediately.
+    // Do not call other functions after calling this API.
+    while (1) {
+        ;
+    }
+}

--- a/libraries/ESP8266WiFiPassMan/src/ESP8266WiFiPassMan.h
+++ b/libraries/ESP8266WiFiPassMan/src/ESP8266WiFiPassMan.h
@@ -1,0 +1,93 @@
+/*
+  WiFiPassMan.h - Library for ESP8266.
+  Copyright (c) 2020 Arduino.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/**
+ * @brief ESP8266 WiFi SSID/password encoding/decoding library
+ * @file ESP8266WiFiPassMan.h
+ */
+
+#ifndef ESP8266_WIFI_PASSWORD_MANAGER_H_
+#define ESP8266_WIFI_PASSWORD_MANAGER_H_
+
+#include <stdint.h>
+
+// XTEA buffer size is 63 characters + NULL char
+#define XTEA_BUFFER_LEN_B   64
+// XTEA buffer size in words
+#define XTEA_BUFFER_LEN_W   (XTEA_BUFFER_LEN_B / sizeof(uint32_t))
+
+#ifdef DEBUG_ESP_WIFI
+#ifdef DEBUG_ESP_PORT
+#define DEBUG_PASS_ENC(fmt, ...) DEBUG_ESP_PORT.printf_P( (PGM_P)PSTR(fmt), ##__VA_ARGS__ )
+#endif
+#endif
+
+#ifndef DEBUG_PASS_ENC
+#define DEBUG_PASS_ENC(...) do { (void)0; } while (0)
+#endif
+
+/**
+ * @brief WiFi password encoding/decoding class
+ */
+class ESP8266WiFiPassMan
+{
+public:
+    ESP8266WiFiPassMan(bool encodeAPMAC=true, Stream *stream=&Serial);
+    ~ESP8266WiFiPassMan();
+
+    bool generateKey(uint32_t key[4]);
+    bool checkSecretKey(const uint32_t key[4]);
+    bool checkSecretKey_P(const uint32_t key[4]);
+    bool printKey(const uint32_t key[4]);
+    bool printKey_P(const uint32_t key[4]);
+    bool encodeString(const uint32_t key[4],
+                      const char *bufferName, uint32_t *buffer,
+                      const char *str);
+    void setAPMAC(uint8_t *APMAC);
+    bool encodeWiFiCredentials(const char *ssid,
+                               const char *password,
+                               const uint32_t key[4]=NULL);
+    bool decodeWiFiCredentials_P(const uint32_t key[4],
+                                 char *ssid,
+                                 char *password);
+
+    bool encode(const uint32_t key[4],
+                const char *str,  uint32_t buffer[XTEA_BUFFER_LEN_W]);
+    bool encode_P(const uint32_t key[4],
+                  const char *str, uint32_t buffer[XTEA_BUFFER_LEN_W]);
+    bool decode(const uint32_t key[4],
+                uint32_t buffer[XTEA_BUFFER_LEN_W], char *str);
+    bool decode_P(const uint32_t key[4],
+                  const uint32_t buffer[XTEA_BUFFER_LEN_W], char *str);
+
+    bool selftest(const char *str);
+
+    bool isWiFiCredentialSaved();
+    void eraseWiFiPasswords();
+
+private:
+    bool _encodeAPMAC;
+    uint8_t *_APMAC;
+    Stream *_stream;
+
+    bool getAPMAC(uint8_t mac[6]);
+    void scrambleKeyAPMAC(uint32_t key[4]);
+};
+
+#endif // ESP8266_WIFI_PASSWORD_MANAGER_H_

--- a/libraries/ESP8266WiFiPassMan/src/PrintBuffer.cpp
+++ b/libraries/ESP8266WiFiPassMan/src/PrintBuffer.cpp
@@ -1,0 +1,104 @@
+/*
+  PrintBuffer.h - Library for ESP8266.
+  Copyright (c) 2020 Arduino.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include <Arduino.h>
+
+#include "PrintBuffer.h"
+
+/*
+ *  printBuffer - output a hex dump of a buffer
+ *
+ *  fd is file descriptor to write to
+ *  data is pointer to the buffer
+ *  length is length of buffer to write
+ *  linelen is number of chars to output per line
+ *  split is number of chars in each chunk on a line
+ */
+void printBuffer(void const *data, size_t length, int linelen, int split)
+{
+    char buffer[512];
+    char *ptr;
+    char *inptr;
+    int pos;
+    int remaining = length;
+
+    inptr = (char *)data;
+
+    // Loop through each line remaining
+    while (remaining > 0) {
+        int lrem;
+        int splitcount;
+        ptr = buffer;
+
+        // Loop through the hex chars of this line
+        lrem = remaining;
+        splitcount = 0;
+        for (pos = 0; pos < linelen; pos++) {
+            // Split hex section if required
+            if (split == splitcount++) {
+                sprintf(ptr, "  ");
+                ptr += 2;
+                splitcount = 1;
+            }
+
+            // If still remaining chars, output, else leave a space
+            if (lrem) {
+                sprintf(ptr, "%.2X ", *((unsigned char *) inptr + pos));
+                lrem--;
+            } else {
+                sprintf(ptr, "   ");
+            }
+            ptr += 3;
+        }
+
+        *ptr++ = ' ';
+        *ptr++ = ' ';
+
+        // Loop through the ASCII chars of this line
+        lrem = remaining;
+        splitcount = 0;
+        for (pos = 0; pos < linelen; pos++) {
+            unsigned char c;
+
+            /* Split ASCII section if required */
+            if (split == splitcount++) {
+                sprintf(ptr, "  ");
+                ptr += 2;
+                splitcount = 1;
+            }
+
+            if (lrem) {
+                c = *((unsigned char *)inptr + pos);
+                if (c > 31 && c < 127) {
+                    sprintf(ptr, "%c", c);
+                } else {
+                    sprintf(ptr, ".");
+                }
+                lrem--;
+            }
+            ptr++;
+        }
+
+        *ptr = '\0';
+        Serial.println(buffer);
+
+        inptr += linelen;
+        remaining -= linelen;
+    }
+}

--- a/libraries/ESP8266WiFiPassMan/src/PrintBuffer.h
+++ b/libraries/ESP8266WiFiPassMan/src/PrintBuffer.h
@@ -1,0 +1,27 @@
+/*
+  PrintBuffer.h - Library for ESP8266.
+  Copyright (c) 2020 Arduino.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef PRINT_BUFFER_H_
+#define PRINT_BUFFER_H_
+
+#include <stdint.h>
+
+void printBuffer(void const *data, size_t length, int linelen=16, int split=8);
+
+#endif // PRINT_BUFFER_H_


### PR DESCRIPTION
New WiFi password manager library to encode/decode WiFi SSID/password with XTEA algorithm.

@devyte @earlephilhower,
I'm looking for someone to discuss/review technical details of this full functional proof of concept.

---

**The problem**

By default, the ESP8266 saves WiFi passwords in plain text to on-chip flash and can be easily retrieved. This is a known design flaw in the ESP8266 which cannot be resolved by software. A hacker can simply dump the credentials by overwriting the sketch when it has physical access to the ESP8266 device, or remotely using OTA. The retrieved SSID and password can then be misused to login to this network.

To improve security, WiFi credentials must never be saved in plain text to on-chip flash and requires at least `WiFi.persistent(false);` at the beginning of each sketch. The disadvantage is that fast-connect at startup is disabled which takes more time to connect.

**Proof of concept**

This library makes it more difficult for hackers to retrieve the WiFi SSID and password by encoding the credentials with a fast and simple XTEA algorithm. Decoding SSID and password on a ESP8266 at 80MHZ takes around 0.5ms.

The application designer is responsible to check if WiFi credentials are saved into on-chip flash with `isWiFiCredentialSaved()` and securely erase it with `eraseWiFiPasswords()`. This function uses SDK functions `system_restore()` followed by `system_reset()` to generate a CPU reset.

**Usage**

The library consists of 3 sketches:

Sketch | Function
---------  | ------------
01-WiFiPassManSetup.ino | Generate secret key / encode WiFi SSID/password
02-WiFiPassManConnect.ino | Decode WiFi SSID/password and connect to AP
03-WiFiPassManErase.ino | Dump plain text password and erase it

The application designer generates a unique 128-bit secret key and encodes the WiFi SSID (optional) and password (required) by calling `encodeWiFiCredentials()`. Maximum length SSID and password is 63 characters + NULL. By default the output is printed to the `Serial` and the flash tables must be included in each sketch for decoding.

Writing a new sketch to the ESP8266 overwrites the secret key and encoded WiFi SSID/password. By design, the `LittleFS` is not used, otherwise another sketch can be used to read and print the secret key.

Decoding must be performed once before calling `WiFi.begin(SSID, PASS)`.

Encoding/decoding uses the hardware AP MAC address by default to bind to only one specific ESP8266 device. In this case the encoded WiFi SSID/password flash table cannot be decoded on another ESP8266 with a different MAC address and requires a re-encoding.

**DISCLAIMER**

The XTEA algorithm contains known and documented attacks and therefore the wording encoding is used instead of real encryption.

Macro XTEA_NUM_ROUNDS can be increased to 128 or higher to increase complexity. This also increases the decoding time.

Note: A hacker with physical access to the device can dump the entire flash to a binary file and analyze the location of the secret key with encoded WiFi SSID/password table. For this architecture, it is technically not possible to protect the flash for readout. It requires a lot of research for the hacker to decode the WiFi credentials, hardware/software and crypto knowledge.

100% security does not exist. It is up to crypto experts to determine the safeness of the used algorithm and library.
Encoding WiFi SSID and password is always better than saving it in plain text which can be read by everyone.