### PR TITLE
Fix long password validation in WebServer

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
@@ -26,6 +26,7 @@
 #include "WiFiClient.h"
 #include "ESP8266WebServer.h"
 #include "FS.h"
+#include "base64.h"
 #include "detail/RequestHandlersImpl.h"
 
 static const char AUTHORIZATION_HEADER[] PROGMEM = "Authorization";
@@ -98,21 +99,19 @@ bool ESP8266WebServerTemplate<ServerType>::authenticate(const char * username, c
         authReq = "";
         return false;
       }
-      char *encoded = new (std::nothrow) char[base64_encode_expected_len(toencodeLen)+1];
-      if(encoded == NULL){
+      sprintf(toencode, "%s:%s", username, password);
+      String encoded = base64::encode((uint8_t *)toencode, toencodeLen, false);
+      if(!encoded){
         authReq = "";
         delete[] toencode;
         return false;
       }
-      sprintf(toencode, "%s:%s", username, password);
-      if(base64_encode_chars(toencode, toencodeLen, encoded) > 0 && authReq.equalsConstantTime(encoded)) {
+      if(authReq.equalsConstantTime(encoded)) {
         authReq = "";
         delete[] toencode;
-        delete[] encoded;
         return true;
       }
       delete[] toencode;
-      delete[] encoded;
     } else if(authReq.startsWith(F("Digest"))) {
       String _realm    = _extractParam(authReq, F("realm=\""));
       String _H1 = credentialHash((String)username,_realm,(String)password);


### PR DESCRIPTION
Use a base64 encode that doesn't add CRs to the output when comparing
username:password values for authentication.

Fixes #7664

@arendst, can you please give this patch a try?  I've tested a 100 character password with the HTTPBasicAuth example and it works for me.