### PR TITLE
Handle breakpoints via postmortem when GDB is not running.

### DIFF
--- a/cores/esp8266/core_esp8266_main.cpp
+++ b/cores/esp8266/core_esp8266_main.cpp
@@ -327,6 +327,7 @@ extern "C" void preinit (void)
 {
     /* do nothing by default */
 }
+extern "C" void postmortem_init(void);
 
 extern "C" void user_init(void) {
     struct rst_info *rtc_info_ptr = system_get_rst_info();
@@ -341,6 +342,10 @@ extern "C" void user_init(void) {
     experimental::initFlashQuirks(); // Chip specific flash init.
 
     cont_init(g_pcont);
+
+#if defined(DEBUG_ESP_PORT) || defined(DEBUG_ESP_EXCEPTIONS)
+    postmortem_init();
+#endif
 
     preinit(); // Prior to C++ Dynamic Init (not related to above init() ). Meant to be user redefinable.
 


### PR DESCRIPTION
In the absence of GDB, install a small breakpoint handler that clears EXCM and
executes an illegal instruction. This leverages the existing exception
handling code in the SDK for `ill` instruction. At postmortem processing,
the real event is identified and reported. This allows for alerting of embedded
breakpoints. In the stack trace, `epc1` is updated with the value of `epc2` so
that the "ESP Exception Decoder" will identify the line where the BP occurred.

The SDKs default behavior was to loop on breakpoints waiting for interrupts
`>2` until the HWDT kicks in. The current "C++" compiler will embed breakpoints
when it detects a divide by zero at compile time.

Expand technique to preserve more of the current state and to also report
Kernel and Double exceptions through postmortem.