### PR TITLE
Scheduled functions: schedule_recurrent_function_us() should be in iram

### DIFF
--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -102,6 +102,7 @@ bool schedule_function(const std::function<void(void)>& fn)
     return true;
 }
 
+IRAM_ATTR // (not only) called from ISR
 bool schedule_recurrent_function_us(const std::function<bool(void)>& fn,
     uint32_t repeat_us, const std::function<bool(void)>& alarm)
 {


### PR DESCRIPTION
It was noticed while checking code in [this comment](https://github.com/esp8266/Arduino/issues/7646#issuecomment-729932874) that `schedule_recurrent_function_us()` should be in IRAM.