### PR TITLE
Waveform, fix callback return to CPU cycles instead of µs (wrt PR 7022)

### DIFF
--- a/cores/esp8266/core_esp8266_waveform_phase.cpp
+++ b/cores/esp8266/core_esp8266_waveform_phase.cpp
@@ -405,7 +405,7 @@ static ICACHE_RAM_ATTR void timer1Interrupt() {
 
   int32_t callbackCcys = 0;
   if (waveform.timer1CB) {
-    callbackCcys = scaleCcys(microsecondsToClockCycles(waveform.timer1CB()), isCPU2X);
+    callbackCcys = scaleCcys(waveform.timer1CB(), isCPU2X);
   }
   now = ESP.getCycleCount();
   int32_t nextEventCcys = waveform.nextEventCcy - now;

--- a/cores/esp8266/core_esp8266_waveform_phase.h
+++ b/cores/esp8266/core_esp8266_waveform_phase.h
@@ -75,7 +75,7 @@ int startWaveformClockCycles(uint8_t pin, uint32_t timeHighCcys, uint32_t timeLo
 int stopWaveform(uint8_t pin);
 
 // Add a callback function to be called on *EVERY* timer1 trigger.  The
-// callback returns the number of microseconds until the next desired call.
+// callback must return the number of CPU clock cycles until the next desired call.
 // However, since it is called every timer1 interrupt, it may be called
 // again before this period.  It should therefore use the ESP Cycle Counter
 // to determine whether or not to perform an operation.

--- a/cores/esp8266/core_esp8266_waveform_pwm.h
+++ b/cores/esp8266/core_esp8266_waveform_pwm.h
@@ -62,7 +62,7 @@ int startWaveformClockCycles(uint8_t pin, uint32_t timeHighCycles, uint32_t time
 int stopWaveform(uint8_t pin);
 
 // Add a callback function to be called on *EVERY* timer1 trigger.  The
-// callback returns the number of microseconds until the next desired call.
+// callback must return the number of CPU clock cycles until the next desired call.
 // However, since it is called every timer1 interrupt, it may be called
 // again before this period.  It should therefore use the ESP Cycle Counter
 // to determine whether or not to perform an operation.


### PR DESCRIPTION
And also fix inline documentaton for both waveform "flavors".