### PR TITLE
Rewrite multipart boundary detection

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -246,7 +246,7 @@ protected:
   bool _parseForm(ClientType& client, const String& boundary, uint32_t len);
   bool _parseFormUploadAborted();
   void _uploadWriteByte(uint8_t b);
-  uint8_t _uploadReadByte(ClientType& client);
+  int _uploadReadByte(ClientType& client);
   void _prepareHeader(String& response, int code, const char* content_type, size_t contentLength);
   bool _collectHeader(const char* headerName, const char* headerValue);
 

--- a/libraries/ESP8266WebServer/src/Parsing-impl.h
+++ b/libraries/ESP8266WebServer/src/Parsing-impl.h
@@ -347,14 +347,14 @@ void ESP8266WebServerTemplate<ServerType>::_uploadWriteByte(uint8_t b){
 }
 
 template <typename ServerType>
-uint8_t ESP8266WebServerTemplate<ServerType>::_uploadReadByte(ClientType& client){
+int ESP8266WebServerTemplate<ServerType>::_uploadReadByte(ClientType& client){
   int res = client.read();
   if(res == -1){
     while(!client.available() && client.connected())
       yield();
     res = client.read();
   }
-  return (uint8_t)res;
+  return res;
 }
 
 
@@ -449,11 +449,12 @@ bool ESP8266WebServerTemplate<ServerType>::_parseForm(ClientType& client, const 
             snprintf(fastBoundary, fastBoundaryLen, "\r\n--%s", boundary.c_str());
             int boundaryPtr = 0;
             while ( true ) {
-                if ( !client.connected() ) {
-                    // Unexpected disconnection, abort!
+                int ret = _uploadReadByte(client);
+                if (ret < 0) {
+                    // Unexpected, we should have had data available per above
                     return _parseFormUploadAborted();
                 }
-                char in = _uploadReadByte(client);
+                char in = (char) ret;
                 if (in == fastBoundary[ boundaryPtr ]) {
                     // The input matched the current expected character, advance and possibly exit this file
                     boundaryPtr++;


### PR DESCRIPTION
Use a simpler, cleaner implementation of multipart form detection as
defined in https://tools.ietf.org/html/rfc7578 .

Implements a simple state machine that detects the `\r\n--<boundary>`
stream in input a character at a time, instead of buffering and
comparing in chunks which can miss things due to alignment issues and
which also had a problem with replacing characters in a binary stream.

Fixes #7723