### PR TITLE
emulation on host: various minor fixes

### DIFF
--- a/cores/esp8266/debug.cpp
+++ b/cores/esp8266/debug.cpp
@@ -20,6 +20,7 @@
 
 #include "Arduino.h"
 #include "debug.h"
+#include "osapi.h"
 
 void ICACHE_RAM_ATTR hexdump(const void *mem, uint32_t len, uint8_t cols) {
     const uint8_t* src = (const uint8_t*) mem;

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -62,11 +62,13 @@ VERBC   = @echo "C   $@";
 VERBCXX = @echo "C++ $@";
 VERBLD  = @echo "LD  $@";
 VERBAR  = @echo "AR  $@";
+VERBRANLIB = @echo "RANLIB $@";
 else
 VERBC   =
 VERBCXX =
 VERBLD  =
 VERBAR  =
+VERBRANLIB =
 endif
 
 $(shell mkdir -p $(BINDIR))
@@ -383,7 +385,7 @@ FULLCORE_OBJECTS_ISOLATED = $(FULLCORE_OBJECTS:%.o=$(BINDIR)/%.o)
 
 $(BINDIR)/fullcore.a: $(FULLCORE_OBJECTS_ISOLATED)
 	$(VERBAR) $(AR) rc $@ $^
-	$(VERBAR) $(RANLIB) $@
+	$(VERBRANLIB) $(RANLIB) $@
 
 ifeq ($(INO),)
 

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -73,6 +73,7 @@ $(shell mkdir -p $(BINDIR))
 
 CORE_CPP_FILES := \
 	$(addprefix $(abspath $(CORE_PATH))/,\
+		debug.cpp \
 		StreamString.cpp \
 		Stream.cpp \
 		WString.cpp \
@@ -226,7 +227,10 @@ test: $(OUTPUT_BINARY)			# run host test for CI
 	$(OUTPUT_BINARY)
 
 .PHONY: clean
-clean: clean-objects
+clean: clean-lcov clean-objects
+
+.PHONY: clean-lcov
+clean-lcov:
 	rm -rf $(LCOV_DIRECTORY)
 
 .PHONY: clean-objects
@@ -392,7 +396,7 @@ else
 	$(VERBLD) $(CXX) $(LDFLAGS) $< $(BINDIR)/fullcore.a $(LIBSSL) -o $@
 	mkdir -p $(BINDIR)/$(lastword $(subst /, ,$@))
 	ln -sf $@ $(BINDIR)/$(lastword $(subst /, ,$@))
-	@echo "----> $(BINDIR)/ <----"
+	@echo "----> $(BINDIR)/$(lastword $(subst /, ,$@))/$(lastword $(subst /, ,$@)) <----"
 	@[ "$(R)" = noexec ] && echo '(not running it, use `make R="[<options>]" ...` for valgrind+gdb)' || $(dir $(MAKEFILE))/valgdb $@ $(R)
 
 FORCE:


### PR DESCRIPTION
- include debug.cpp (`hexdump()`)
- fix Makefile messages
- fix cleaning (lcov was not removed)