### PR TITLE
i2s: adds i2s_rxtxdrive_begin(enableRx, enableTx, driveRxClocks, driveTxClocks)

### DIFF
--- a/cores/esp8266/i2s.h
+++ b/cores/esp8266/i2s.h
@@ -21,6 +21,8 @@
 #ifndef I2S_h
 #define I2S_h
 
+#define I2S_HAS_BEGIN_RXTXDAC 1
+
 /*
 How does this work? Basically, to get sound, you need to:
 - Connect an I2S codec to the I2S pins on the ESP.
@@ -41,6 +43,7 @@ extern "C" {
 #endif
 
 void i2s_begin(); // Enable TX only, for compatibility
+bool i2s_rxtxdac_begin(bool enableRx, bool enableTx, bool txDAC); // Allow TX and/or RX, returns false on OOM error
 bool i2s_rxtx_begin(bool enableRx, bool enableTx); // Allow TX and/or RX, returns false on OOM error
 void i2s_end();
 void i2s_set_rate(uint32_t rate);//Sample Rate in Hz (ex 44100, 48000)

--- a/cores/esp8266/i2s.h
+++ b/cores/esp8266/i2s.h
@@ -21,7 +21,7 @@
 #ifndef I2S_h
 #define I2S_h
 
-#define I2S_HAS_BEGIN_RXTXDAC 1
+#define I2S_HAS_BEGIN_RXTX_DRIVE_CLOCKS 1
 
 /*
 How does this work? Basically, to get sound, you need to:

--- a/cores/esp8266/i2s.h
+++ b/cores/esp8266/i2s.h
@@ -43,8 +43,8 @@ extern "C" {
 #endif
 
 void i2s_begin(); // Enable TX only, for compatibility
-bool i2s_rxtxdac_begin(bool enableRx, bool enableTx, bool txDAC); // Allow TX and/or RX, returns false on OOM error
 bool i2s_rxtx_begin(bool enableRx, bool enableTx); // Allow TX and/or RX, returns false on OOM error
+bool i2s_rxtxdrive_begin(bool enableRx, bool enableTx, bool driveRxClocks, bool driveTxClocks);
 void i2s_end();
 void i2s_set_rate(uint32_t rate);//Sample Rate in Hz (ex 44100, 48000)
 void i2s_set_dividers(uint8_t div1, uint8_t div2);//Direct control over output rate


### PR DESCRIPTION
~~A `dac`~~ rx/rxDrive/tx/txDrive parameters are added to allow using only i2s in/out data pin without clock pins.
This is necessary for example in no-DAC mode when i2so-bck and i2so-ws are repurposed,
Found when using SDFS because SPI SS GPIO was overlapped.

*edit*: Related: https://github.com/earlephilhower/ESP8266Audio/pull/344