### PR TITLE
Fix platform.txt issue #7749 for Windows

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -99,12 +99,12 @@ recipe.hooks.sketch.prebuild.pattern="{runtime.tools.python3.path}/python3" "{ru
 recipe.hooks.prebuild.10.pattern="{runtime.tools.python3.path}/python3" "{runtime.tools.makecorever}" --build_path "{build.path}" --platform_path "{runtime.platform.path}" --version "unix-{version}"
 
 ## Build the app.ld linker file
-recipe.hooks.linking.prelink.11.pattern.windows=cmd /v:on /e:on /c "if not exist {build.path}/ld_h/ (mkdir {build.path}/ld_h/ )"
-recipe.hooks.linking.prelink.12.pattern.windows=copy "{runtime.platform.path}/tools/sdk/ld/{build.flash_ld}" "{build.path}/ld_h/local.eagle.flash.ld.h"
 recipe.hooks.linking.prelink.11.pattern=mkdir -p "{build.path}/ld_h/"
 recipe.hooks.linking.prelink.12.pattern=cp "{runtime.platform.path}/tools/sdk/ld/{build.flash_ld}" "{build.path}/ld_h/local.eagle.flash.ld.h"
 recipe.hooks.linking.prelink.13.pattern="{compiler.path}{compiler.c.cmd}" -CC -E -P {build.vtable_flags} {build.mmuflags} "{build.path}/ld_h/local.eagle.flash.ld.h" -o "{build.path}/local.eagle.flash.ld"
 recipe.hooks.linking.prelink.14.pattern="{compiler.path}{compiler.c.cmd}" -CC -E -P {build.vtable_flags} {build.mmuflags} "{runtime.platform.path}/tools/sdk/ld/eagle.app.v6.common.ld.h" -o "{build.path}/local.eagle.app.v6.common.ld"
+recipe.hooks.linking.prelink.11.pattern.windows=cmd /v:on /e:on /c "if not exist {build.path}\ld_h\ (mkdir {build.path}\ld_h\ )"
+recipe.hooks.linking.prelink.12.pattern.windows=cmd /v:on /e:on /c "copy {runtime.platform.path}\tools\sdk\ld\{build.flash_ld}" "{build.path}\ld_h\local.eagle.flash.ld.h"
 
 ## Compile c files
 recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.cpreprocessor.flags} {compiler.c.flags} -D{build.sdk}=1 -DF_CPU={build.f_cpu} {build.lwip_flags} {build.debug_port} {build.debug_level} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DARDUINO_BOARD="{build.board}" {build.led} {build.flash_flags} {compiler.c.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"


### PR DESCRIPTION
Fixes https://github.com/esp8266/Arduino/issues/7749#issue-760585820

Corrected recipe.hooks.prebuild.1x.pattern.windows in platform.txt and placed in proper order.