### PR TITLE
Normalize platform.txt pattern numbers

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -96,15 +96,15 @@ compiler.elf2hex.extra_flags=
 ## needs git
 recipe.hooks.sketch.prebuild.pattern="{runtime.tools.python3.path}/python3" "{runtime.tools.signing}" --mode header --publickey "{build.source.path}/public.key" --out "{build.path}/core/Updater_Signing.h"
 # This is quite a working hack. This form of prebuild hook, while intuitive, is not explicitly documented.
-recipe.hooks.prebuild.10.pattern="{runtime.tools.python3.path}/python3" "{runtime.tools.makecorever}" --build_path "{build.path}" --platform_path "{runtime.platform.path}" --version "unix-{version}"
+recipe.hooks.prebuild.pattern="{runtime.tools.python3.path}/python3" "{runtime.tools.makecorever}" --build_path "{build.path}" --platform_path "{runtime.platform.path}" --version "unix-{version}"
 
 ## Build the app.ld linker file
-recipe.hooks.linking.prelink.11.pattern=mkdir -p "{build.path}/ld_h/"
-recipe.hooks.linking.prelink.12.pattern=cp "{runtime.platform.path}/tools/sdk/ld/{build.flash_ld}" "{build.path}/ld_h/local.eagle.flash.ld.h"
-recipe.hooks.linking.prelink.13.pattern="{compiler.path}{compiler.c.cmd}" -CC -E -P {build.vtable_flags} {build.mmuflags} "{build.path}/ld_h/local.eagle.flash.ld.h" -o "{build.path}/local.eagle.flash.ld"
-recipe.hooks.linking.prelink.14.pattern="{compiler.path}{compiler.c.cmd}" -CC -E -P {build.vtable_flags} {build.mmuflags} "{runtime.platform.path}/tools/sdk/ld/eagle.app.v6.common.ld.h" -o "{build.path}/local.eagle.app.v6.common.ld"
-recipe.hooks.linking.prelink.11.pattern.windows=cmd /v:on /e:on /c "if not exist {build.path}\ld_h\ (mkdir {build.path}\ld_h\ )"
-recipe.hooks.linking.prelink.12.pattern.windows=cmd /v:on /e:on /c "copy {runtime.platform.path}\tools\sdk\ld\{build.flash_ld}" "{build.path}\ld_h\local.eagle.flash.ld.h"
+recipe.hooks.linking.prelink.1.pattern=mkdir -p "{build.path}/ld_h/"
+recipe.hooks.linking.prelink.1.pattern.windows=cmd /v:on /e:on /c "if not exist {build.path}\ld_h\ (mkdir {build.path}\ld_h\ )"
+recipe.hooks.linking.prelink.2.pattern=cp "{runtime.platform.path}/tools/sdk/ld/{build.flash_ld}" "{build.path}/ld_h/local.eagle.flash.ld.h"
+recipe.hooks.linking.prelink.2.pattern.windows=cmd /v:on /e:on /c "copy {runtime.platform.path}\tools\sdk\ld\{build.flash_ld}" "{build.path}\ld_h\local.eagle.flash.ld.h"
+recipe.hooks.linking.prelink.3.pattern="{compiler.path}{compiler.c.cmd}" -CC -E -P {build.vtable_flags} {build.mmuflags} "{build.path}/ld_h/local.eagle.flash.ld.h" -o "{build.path}/local.eagle.flash.ld"
+recipe.hooks.linking.prelink.4.pattern="{compiler.path}{compiler.c.cmd}" -CC -E -P {build.vtable_flags} {build.mmuflags} "{runtime.platform.path}/tools/sdk/ld/eagle.app.v6.common.ld.h" -o "{build.path}/local.eagle.app.v6.common.ld"
 
 ## Compile c files
 recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.cpreprocessor.flags} {compiler.c.flags} -D{build.sdk}=1 -DF_CPU={build.f_cpu} {build.lwip_flags} {build.debug_port} {build.debug_level} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DARDUINO_BOARD="{build.board}" {build.led} {build.flash_flags} {compiler.c.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"


### PR DESCRIPTION
Some tools have issues with pattern.XX numbers above 9 in platform.txt.
Adjust all pattern.XX numbering to start at 1 and remove the numbering
when there is only one step.