### PR TITLE
Fix: cannot build after #7060 on Win64

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -17,6 +17,8 @@ runtime.tools.signing={runtime.platform.path}/tools/signing.py
 runtime.tools.elf2bin={runtime.platform.path}/tools/elf2bin.py
 runtime.tools.sizes={runtime.platform.path}/tools/sizes.py
 runtime.tools.makecorever={runtime.platform.path}/tools/makecorever.py
+runtime.tools.mkdir={runtime.platform.path}/tools/mkdir.py
+runtime.tools.cp={runtime.platform.path}/tools/cp.py
 runtime.tools.eboot={runtime.platform.path}/bootloaders/eboot/eboot.elf
 
 compiler.warning_flags=-w
@@ -60,7 +62,7 @@ compiler.c.cmd=xtensa-lx106-elf-gcc
 compiler.c.flags=-c {compiler.warning_flags} -std=gnu17 {build.stacksmash_flags} -Os -g -Wpointer-arith -Wno-implicit-function-declaration -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals -falign-functions=4 -MMD -ffunction-sections -fdata-sections {build.exception_flags} {build.sslflags} {build.waveform} {build.mmuflags} {build.non32xferflags}
 
 compiler.S.cmd=xtensa-lx106-elf-gcc
-compiler.S.flags=-c -g -x assembler-with-cpp -MMD -mlongcalls -I{runtime.tools.xtensa-lx106-elf-gcc.path}/include/
+compiler.S.flags=-c -g -x assembler-with-cpp -MMD -mlongcalls "-I{runtime.tools.xtensa-lx106-elf-gcc.path}/include/"
 
 compiler.c.elf.flags=  -g {compiler.warning_flags} -Os -nostdlib -Wl,--no-check-sections -u app_entry {build.float} -Wl,-static "-L{compiler.sdk.path}/lib" "-L{compiler.sdk.path}/lib/{build.sdk}" "-L{build.path}" "-L{compiler.libc.path}/lib" "-Tlocal.eagle.flash.ld" -Wl,--gc-sections -Wl,-wrap,system_restart_local -Wl,-wrap,spi_flash_read
 
@@ -99,10 +101,8 @@ recipe.hooks.sketch.prebuild.pattern="{runtime.tools.python3.path}/python3" "{ru
 recipe.hooks.prebuild.pattern="{runtime.tools.python3.path}/python3" "{runtime.tools.makecorever}" --build_path "{build.path}" --platform_path "{runtime.platform.path}" --version "unix-{version}"
 
 ## Build the app.ld linker file
-recipe.hooks.linking.prelink.1.pattern=mkdir -p "{build.path}/ld_h/"
-recipe.hooks.linking.prelink.1.pattern.windows=cmd /v:on /e:on /c "if not exist {build.path}\ld_h\ (mkdir {build.path}\ld_h\ )"
-recipe.hooks.linking.prelink.2.pattern=cp "{runtime.platform.path}/tools/sdk/ld/{build.flash_ld}" "{build.path}/ld_h/local.eagle.flash.ld.h"
-recipe.hooks.linking.prelink.2.pattern.windows=cmd /v:on /e:on /c "copy {runtime.platform.path}\tools\sdk\ld\{build.flash_ld}" "{build.path}\ld_h\local.eagle.flash.ld.h"
+recipe.hooks.linking.prelink.1.pattern="{runtime.tools.python3.path}/python3" "{runtime.tools.mkdir}" -p "{build.path}/ld_h/"
+recipe.hooks.linking.prelink.2.pattern="{runtime.tools.python3.path}/python3" "{runtime.tools.cp}" "{runtime.platform.path}/tools/sdk/ld/{build.flash_ld}" "{build.path}/ld_h/local.eagle.flash.ld.h"
 recipe.hooks.linking.prelink.3.pattern="{compiler.path}{compiler.c.cmd}" -CC -E -P {build.vtable_flags} {build.mmuflags} "{build.path}/ld_h/local.eagle.flash.ld.h" -o "{build.path}/local.eagle.flash.ld"
 recipe.hooks.linking.prelink.4.pattern="{compiler.path}{compiler.c.cmd}" -CC -E -P {build.vtable_flags} {build.mmuflags} "{runtime.platform.path}/tools/sdk/ld/eagle.app.v6.common.ld.h" -o "{build.path}/local.eagle.app.v6.common.ld"
 

--- a/tools/cp.py
+++ b/tools/cp.py
@@ -7,9 +7,9 @@ import shutil
 import sys
 
 def main():
-    parser = argparse.ArgumentParser(description="Platform-independent single-file `cp`")
-    parser.add_argument("src", action="store")
-    parser.add_argument("dst", action="store")
+    parser = argparse.ArgumentParser(description='Platform-independent single-file `cp`')
+    parser.add_argument('src', action='store')
+    parser.add_argument('dst', action='store')
     ns = parser.parse_args()
     shutil.copyfile(ns.src, ns.dst)
     return 0

--- a/tools/cp.py
+++ b/tools/cp.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Platform-independent single-file `cp`
+
+import argparse
+import shutil
+import sys
+
+def main():
+    parser = argparse.ArgumentParser(description="Platform-independent single-file `cp`")
+    parser.add_argument("src", action="store")
+    parser.add_argument("dst", action="store")
+    ns = parser.parse_args()
+    shutil.copyfile(ns.src, ns.dst)
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/mkdir.py
+++ b/tools/mkdir.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+# Platform-independent 'mkdir'
+
+import argparse
+import pathlib
+import sys
+
+def main():
+    parser = argparse.ArgumentParser(description="Platform-independent 'mkdir'")
+    parser.add_argument("-p", "--parents", action="store_true", required=False, help="no error if existing, make parent directories as needed")
+    parser.add_argument("dir", action="store", nargs="+")
+    ns = parser.parse_args()
+    for p in ns.dir:
+        pathlib.Path(p).mkdir(parents=ns.parents, exist_ok=True)
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/mkdir.py
+++ b/tools/mkdir.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 
-# Platform-independent 'mkdir'
+# Platform-independent `mkdir`
 
 import argparse
 import pathlib
 import sys
 
 def main():
-    parser = argparse.ArgumentParser(description="Platform-independent 'mkdir'")
-    parser.add_argument("-p", "--parents", action="store_true", required=False, help="no error if existing, make parent directories as needed")
-    parser.add_argument("dir", action="store", nargs="+")
+    parser = argparse.ArgumentParser(description='Platform-independent `mkdir`')
+    parser.add_argument('-p', '--parents', action='store_true', required=False, help='no error if existing, make parent directories as needed')
+    parser.add_argument('dir', action='store', nargs='+')
     ns = parser.parse_args()
     for p in ns.dir:
         pathlib.Path(p).mkdir(parents=ns.parents, exist_ok=True)


### PR DESCRIPTION
* add double-quotes to `compiler.S.flags`

* fix windows-specific processes (`recipe.hooks.linking.prelink.[12].pattern.windows`)

* rewrite processing of "mkdir" and "cp" in python because of platform-independence

* make consistent with the use of quotation marks in other `*.py` files