### PR TITLE
WiFiServer.cpp: Fix warning

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiServer.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiServer.cpp
@@ -115,9 +115,10 @@ WiFiClient WiFiServer::available(byte* status) {
         WiFiClient result(_unclaimed);
 
         // pcb can be null when peer has already closed the connection
-        if (_unclaimed->getPCB())
+        if (_unclaimed->getPCB()) {
             // give permission to lwIP to accept one more peer
             tcp_backlog_accepted(_unclaimed->getPCB());
+        }
 
         _unclaimed = _unclaimed->next();
         result.setNoDelay(getNoDelay());


### PR DESCRIPTION
* fix warning as below:

```
...\libraries\ESP8266WiFi\src\WiFiServer.cpp: In member function 'WiFiClient WiFiServer::available(byte*)':
...\libraries\ESP8266WiFi\src\WiFiServer.cpp:120:55: warning: suggest braces around empty body in an 'if' statement [-Wempty-body]
  120 |             tcp_backlog_accepted(_unclaimed->getPCB());
      |                                                       ^
```