### PR TITLE
Removed obsolete debug code

### DIFF
--- a/cores/esp8266/core_esp8266_main.cpp
+++ b/cores/esp8266/core_esp8266_main.cpp
@@ -317,14 +317,6 @@ extern "C" void app_entry_redefinable(void)
     cont_t s_cont __attribute__((aligned(16)));
     g_pcont = &s_cont;
 
-#ifdef DEV_DEBUG_MMU_IRAM
-    DBG_MMU_PRINT_STATUS();
-
-    DBG_MMU_PRINT_IRAM_BANK_REG(0, "");
-
-    DBG_MMU_PRINTF("\nCall call_user_start()\n");
-#endif
-
     /* Call the entry point of the SDK code. */
     call_user_start();
 }


### PR DESCRIPTION
Removed obsolete debug block from `core_esp8266_main.cpp`.