### PR TITLE
Add the missing 'rename' method wrapper in SD library.

### DIFF
--- a/libraries/SD/src/SD.h
+++ b/libraries/SD/src/SD.h
@@ -68,6 +68,14 @@ public:
         return (boolean)SDFS.exists(filepath.c_str());
     }
 
+    boolean rename(const char* filepathfrom, const char* filepathto) {
+        return (boolean)SDFS.rename(filepathfrom, filepathto);
+    }
+
+    boolean rename(const String &filepathfrom, const String &filepathto) {
+        return (boolean)rename(filepathfrom.c_str(), filepathto.c_str());
+    }
+
     boolean mkdir(const char *filepath) {
         return (boolean)SDFS.mkdir(filepath);
     }


### PR DESCRIPTION
The included SD library is missing the 'rename' method. Fortunately, the underlying SDFS library has full support for this method, so we just had to create the proper wrapper in SD.h, preserving the style of the other wrapper methods. This is a minor and convenient addition.