### PR TITLE
Use smarter cache key, cache Arduino IDE

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ./tools/dist
-        key: key-linux-toolchain
+        key: ${{ runner.os }}-${{ hashFiles('package/package_esp8266com_index.template.json', 'tests/common.sh') }}
     - name: Build Sketches
       env:
         TRAVIS_BUILD_DIR: ${{ github.workspace }}
@@ -62,7 +62,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ./tools/dist
-        key: key-linux-toolchain
+        key: ${{ runner.os }}-${{ hashFiles('package/package_esp8266com_index.template.json', 'tests/common.sh') }}
     - name: Build Sketches
       env:
         TRAVIS_BUILD_DIR: ${{ github.workspace }}
@@ -90,7 +90,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ./tools/dist
-        key: key-windows-toolchain
+        key: ${{ runner.os }}-${{ hashFiles('package/package_esp8266com_index.template.json', 'tests/common.sh') }}
     - name: Build Sketch
       env:
         TRAVIS_BUILD_DIR: ${{ github.workspace }}
@@ -122,7 +122,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ./tools/dist
-        key: key-mac-toolchain
+        key: ${{ runner.os }}-${{ hashFiles('package/package_esp8266com_index.template.json', 'tests/common.sh') }}
     - name: Build Sketch
       env:
         TRAVIS_BUILD_DIR: ${{ github.workspace }}
@@ -260,7 +260,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ./tools/dist
-        key: key-linux-toolchain
+        key: ${{ runner.os }}-${{ hashFiles('package/package_esp8266com_index.template.json', 'tests/common.sh') }}
     - name: Boards.txt diff
       env:
         TRAVIS_BUILD_DIR: ${{ github.workspace }}

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -164,9 +164,10 @@ function install_ide()
     local ide_path=$1
     local core_path=$2
     local debug=$3
+    mkdir -p ${core_path}/tools/dist
     if [ "$WINDOWS" = "1" ]; then
-        test -r arduino-windows.zip || curl --output arduino-windows.zip -L "${ideurl}-windows.zip"
-        unzip -q arduino-windows.zip
+        test -r ${core_path}/tools/dist/arduino-windows.zip || curl --output ${core_path}/tools/dist/arduino-windows.zip -L "${ideurl}-windows.zip"
+        unzip -q ${core_path}/tools/dist/arduino-windows.zip
         mv arduino-${idever} arduino-distrib
     elif [ "$MACOSX" = "1" ]; then
         # MACOS only has next-to-obsolete Python2 installed.  Install Python 3 from python.org
@@ -175,13 +176,13 @@ function install_ide()
         # Install the Python3 certificates, because SSL connections fail w/o them and of course they aren't installed by default.
         ( cd "/Applications/Python 3.7/" && sudo "./Install Certificates.command" )
         # Hack to place arduino-builder in the same spot as sane OSes
-        test -r arduino-macos.zip || wget -q -O arduino-macos.zip "${ideurl}-macosx.zip"
-        unzip -q arduino-macos.zip
+        test -r ${core_path}/tools/dist/arduino-macos.zip || wget -q -O ${core_path}/tools/dist/arduino-macos.zip "${ideurl}-macosx.zip"
+        unzip -q ${core_path}/tools/dist/arduino-macos.zip
         mv Arduino.app arduino-distrib
         mv arduino-distrib/Contents/Java/* arduino-distrib/.
     else
-        test -r arduino-linux.tar.xz || wget -q -O arduino-linux.tar.xz "${ideurl}-linux64.tar.xz"
-        tar xf arduino-linux.tar.xz
+        test -r ${core_path}/tools/dist/arduino-linux.tar.xz || wget -q -O ${core_path}/tools/dist/arduino-linux.tar.xz "${ideurl}-linux64.tar.xz"
+        tar xf ${core_path}/tools/dist/arduino-linux.tar.xz
         mv arduino-${idever} arduino-distrib
     fi
     mv arduino-distrib $ide_path


### PR DESCRIPTION
Thanks to @mcspr.  Make sure the cached toolchain is only valid when the
package.json file is identical.  Also, add the Arduino IDE to the cache
to avoid re-downloads.