### PR TITLE
Typo error in ESP8266WiFiGeneric.h

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.h
@@ -1,6 +1,6 @@
 /*
  ESP8266WiFiGeneric.h - esp8266 Wifi support.
- Based on WiFi.h from Ardiono WiFi shield library.
+ Based on WiFi.h from Arduino WiFi shield library.
  Copyright (c) 2011-2014 Arduino.  All right reserved.
  Modified by Ivan Grokhotkov, December 2014
  Reworked by Markus Sattler, December 2015


### PR DESCRIPTION
Error in copyright text about Arduino Wifi library.

I have seen this error in several repositories inhereted from this one.