### PR TITLE
UART write loop could lead to wdt with low bitrates or large buffers

### DIFF
--- a/cores/esp8266/uart.cpp
+++ b/cores/esp8266/uart.cpp
@@ -506,8 +506,10 @@ uart_write(uart_t* uart, const char* buf, size_t size)
 
     size_t ret = size;
     const int uart_nr = uart->uart_nr;
-    while (size--)
+    while (size--) {
         uart_do_write_char(uart_nr, pgm_read_byte(buf++));
+        optimistic_yield(10000UL);
+    }
 
     return ret;
 }


### PR DESCRIPTION
EspSoftwareSerial successfully uses optimistic_yield for the same purpose already.
Fixes #7746