### PR TITLE
Fix header FSM in webserver, fix Windows uploads

### DIFF
--- a/libraries/ESP8266WebServer/src/Parsing-impl.h
+++ b/libraries/ESP8266WebServer/src/Parsing-impl.h
@@ -467,8 +467,14 @@ bool ESP8266WebServerTemplate<ServerType>::_parseForm(ClientType& client, const 
                     for (int i = 0; i < boundaryPtr; i++) {
                         _uploadWriteByte( fastBoundary[ i ] );
                     }
-                    _uploadWriteByte( in );
-                    boundaryPtr = 0;
+                    if (in == fastBoundary[ 0 ]) {
+                       // This could be the start of the real end, mark it so and don't emit/skip it
+                       boundaryPtr = 1;
+                    } else {
+                      // Not the 1st char of our pattern, so emit and ignore
+                      _uploadWriteByte( in );
+                      boundaryPtr = 0;
+                    }
                 }
             }
             // Found the boundary string, finish processing this file upload


### PR DESCRIPTION
When a file upload ends in \r\n (i.e. a Windows formatted text file) the
sequence of bytes on the wire is `\r\n\r\n----...boundary-marker...`.

When the FSM in Webserver was evaluating the stream, that 2nd `\r` would
be written as valid data and the FSM parser would be reset and see `\n`
as the 1st character, which wouldn't match.  This would a) add an extra
`\r` to uploaded files, and b) cause uploads to hang.

Fix by checking on a header FSM mismatch if the next character input
could possibly match our marker, and if so handle it properly.

Fixes #7803