### PR TITLE
Protect against server hijacking error handling

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -1125,18 +1125,18 @@ int HTTPClient::handleHeaderResponse()
                     if(transferEncoding.equalsIgnoreCase(F("chunked"))) {
                         _transferEncoding = HTTPC_TE_CHUNKED;
                     } else {
-                        return (_returnCode = HTTPC_ERROR_ENCODING);
+                        _returnCode = HTTPC_ERROR_ENCODING;
+                        return _returnCode;
                     }
                 } else {
                     _transferEncoding = HTTPC_TE_IDENTITY;
                 }
 
-                if(_returnCode > 0) {
-                    return _returnCode;
-                } else {
+                if(_returnCode <= 0) {
                     DEBUG_HTTPCLIENT("[HTTP-Client][handleHeaderResponse] Remote host is not an HTTP Server!");
-                    return (_returnCode = HTTPC_ERROR_NO_HTTP_SERVER);
+                    _returnCode = HTTPC_ERROR_NO_HTTP_SERVER;
                 }
+                return _returnCode;
             }
 
         } else {

--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -1125,17 +1125,17 @@ int HTTPClient::handleHeaderResponse()
                     if(transferEncoding.equalsIgnoreCase(F("chunked"))) {
                         _transferEncoding = HTTPC_TE_CHUNKED;
                     } else {
-                        return HTTPC_ERROR_ENCODING;
+                        return (_returnCode = HTTPC_ERROR_ENCODING);
                     }
                 } else {
                     _transferEncoding = HTTPC_TE_IDENTITY;
                 }
 
-                if(_returnCode) {
+                if(_returnCode > 0) {
                     return _returnCode;
                 } else {
                     DEBUG_HTTPCLIENT("[HTTP-Client][handleHeaderResponse] Remote host is not an HTTP Server!");
-                    return HTTPC_ERROR_NO_HTTP_SERVER;
+                    return (_returnCode = HTTPC_ERROR_NO_HTTP_SERVER);
                 }
             }
 


### PR DESCRIPTION
If a server returns "HTTP/1.x -8 OK", for example, it can misguide an application developer into freeing less-important memory so the request can be retried and succeed, when the problem is in the server.

_returnCode is never used anywhere else, but it could still contain a negative value returned by a broken server and therefore could cause troubles in the future (if _returnCode is in fact used)