### PR TITLE
Add verify IRAM sum results using DRAM as reference.

### DIFF
--- a/libraries/esp8266/examples/irammem/irammem.ino
+++ b/libraries/esp8266/examples/irammem/irammem.ino
@@ -54,6 +54,26 @@ uint32_t cyclesToWrite_nKx16(int n, unsigned short *x) {
   return ESP.getCycleCount() - b;
 }
 
+uint32_t cyclesToRead_nKxs16(int n, short *x, int32_t *res) {
+  uint32_t b = ESP.getCycleCount();
+  int32_t sum = 0;
+  for (int i = 0; i < n * 1024; i++) {
+    sum += *(x++);
+  }
+  *res = sum;
+  return ESP.getCycleCount() - b;
+}
+
+uint32_t cyclesToWrite_nKxs16(int n, short *x) {
+  uint32_t b = ESP.getCycleCount();
+  int32_t sum = 0;
+  for (int i = 0; i < n * 1024; i++) {
+    sum += i;
+    *(x++) = sum;
+  }
+  return ESP.getCycleCount() - b;
+}
+
 uint32_t cyclesToRead_nKx8(int n, unsigned char*x, uint32_t *res) {
   uint32_t b = ESP.getCycleCount();
   uint32_t sum = 0;
@@ -97,6 +117,27 @@ uint32_t cyclesToWrite_nKx16_viaInline(int n, unsigned short *x) {
   return ESP.getCycleCount() - b;
 }
 
+uint32_t cyclesToRead_nKxs16_viaInline(int n, short *x, int32_t *res) {
+  uint32_t b = ESP.getCycleCount();
+  int32_t sum = 0;
+  for (int i = 0; i < n * 1024; i++) {
+    sum += mmu_get_int16(x++); //*(x++);
+  }
+  *res = sum;
+  return ESP.getCycleCount() - b;
+}
+
+uint32_t cyclesToWrite_nKxs16_viaInline(int n, short *x) {
+  uint32_t b = ESP.getCycleCount();
+  int32_t sum = 0;
+  for (int i = 0; i < n * 1024; i++) {
+    sum += i;
+    // *(x++) = sum;
+    mmu_set_int16(x++, sum);
+  }
+  return ESP.getCycleCount() - b;
+}
+
 uint32_t cyclesToRead_nKx8_viaInline(int n, unsigned char*x, uint32_t *res) {
   uint32_t b = ESP.getCycleCount();
   uint32_t sum = 0;
@@ -118,39 +159,95 @@ uint32_t cyclesToWrite_nKx8_viaInline(int n, unsigned char*x) {
   return ESP.getCycleCount() - b;
 }
 
-void perfTest_nK(int nK, uint32_t *mem, uint32_t *imem) {
-  uint32_t res;
+bool perfTest_nK(int nK, uint32_t *mem, uint32_t *imem) {
+  uint32_t res, verify_res;
   uint32_t t;
+  bool success = true;
+  int sres, verify_sres;
 
-  t = cyclesToWrite_nKx16(nK, (uint16_t*)imem);
-  Serial.printf("IRAM Memory Write:         %6d cycles for %dK by 16, %3d AVG cycles/transfer\r\n", t, nK, t / (nK * 1024));
-  t = cyclesToRead_nKx16(nK, (uint16_t*)imem, &res);
-  Serial.printf("IRAM Memory Read:          %6d cycles for %dK by 16, %3d AVG cycles/transfer (sum %08x)\r\n", t, nK, t / (nK * 1024), res);
+  Serial.printf("\r\nPerformance numbers for 16 bit access - using inline macros or exception handling for IRAM.\r\n");;
+  t = cyclesToWrite_nKx16(nK, (uint16_t*)mem);
+  Serial.printf("DRAM Memory Write:         %7d cycles for %dK by uint16, %3d AVG cycles/transfer\r\n", t, nK, t / (nK * 1024));
+  t = cyclesToRead_nKx16(nK, (uint16_t*)mem, &verify_res);
+  Serial.printf("DRAM Memory Read:          %7d cycles for %dK by uint16, %3d AVG cycles/transfer (sum %08x)\r\n", t, nK, t / (nK * 1024), verify_res);
+  t = cyclesToWrite_nKxs16(nK, (int16_t*)mem);
+  Serial.printf("DRAM Memory Write:         %7d cycles for %dK by  int16, %3d AVG cycles/transfer\r\n", t, nK, t / (nK * 1024));
+  t = cyclesToRead_nKxs16(nK, (int16_t*)mem, &verify_sres);
+  Serial.printf("DRAM Memory Read:          %7d cycles for %dK by  int16, %3d AVG cycles/transfer (sum %08x)\r\n", t, nK, t / (nK * 1024), verify_sres);
 
   t = cyclesToWrite_nKx16_viaInline(nK, (uint16_t*)imem);
-  Serial.printf("IRAM Memory Write Inline:  %6d cycles for %dK by 16, %3d AVG cycles/transfer\r\n", t, nK, t / (nK * 1024));
+  Serial.printf("IRAM Memory Write Inline:  %7d cycles for %dK by uint16, %3d AVG cycles/transfer\r\n", t, nK, t / (nK * 1024));
   t = cyclesToRead_nKx16_viaInline(nK, (uint16_t*)imem, &res);
-  Serial.printf("IRAM Memory Read Inline:   %6d cycles for %dK by 16, %3d AVG cycles/transfer (sum %08x)\r\n", t, nK, t / (nK * 1024), res);
+  Serial.printf("IRAM Memory Read Inline:   %7d cycles for %dK by uint16, %3d AVG cycles/transfer (sum %08x) ", t, nK, t / (nK * 1024), res);
+  if (res == verify_res) {
+    Serial.printf("- passed\r\n");
+  } else {
+    Serial.printf("!= (sum %08x ) - failed\r\n", verify_res);
+    success = false;
+  }
 
-  t = cyclesToWrite_nKx16(nK, (uint16_t*)mem);
-  Serial.printf("DRAM Memory Write:         %6d cycles for %dK by 16, %3d AVG cycles/transfer\r\n", t, nK, t / (nK * 1024));
-  t = cyclesToRead_nKx16(nK, (uint16_t*)mem, &res);
-  Serial.printf("DRAM Memory Read:          %6d cycles for %dK by 16, %3d AVG cycles/transfer (sum %08x)\r\n", t, nK, t / (nK * 1024), res);
+  t = cyclesToWrite_nKxs16_viaInline(nK, (int16_t*)imem);
+  Serial.printf("IRAM Memory Write Inline:  %7d cycles for %dK by  int16, %3d AVG cycles/transfer\r\n", t, nK, t / (nK * 1024));
+  t = cyclesToRead_nKxs16_viaInline(nK, (int16_t*)imem, &sres);
+  Serial.printf("IRAM Memory Read Inline:   %7d cycles for %dK by  int16, %3d AVG cycles/transfer (sum %08x) ", t, nK, t / (nK * 1024), sres);
+  if (sres == verify_sres) {
+    Serial.printf("- passed\r\n");
+  } else {
+    Serial.printf("!= (sum %08x ) - failed\r\n", verify_sres);
+    success = false;
+  }
 
-  t = cyclesToWrite_nKx8(nK, (uint8_t*)imem);
-  Serial.printf("IRAM Memory Write:         %6d cycles for %dK by  8, %3d AVG cycles/transfer\r\n", t, nK, t / (nK * 1024));
-  t = cyclesToRead_nKx8(nK, (uint8_t*)imem, &res);
-  Serial.printf("IRAM Memory Read:          %6d cycles for %dK by  8, %3d AVG cycles/transfer (sum %08x)\r\n", t, nK, t / (nK * 1024), res);
+  t = cyclesToWrite_nKx16(nK, (uint16_t*)imem);
+  Serial.printf("IRAM Memory Write:         %7d cycles for %dK by uint16, %3d AVG cycles/transfer\r\n", t, nK, t / (nK * 1024));
+  t = cyclesToRead_nKx16(nK, (uint16_t*)imem, &res);
+  Serial.printf("IRAM Memory Read:          %7d cycles for %dK by uint16, %3d AVG cycles/transfer (sum %08x) ", t, nK, t / (nK * 1024), res);
+  if (res == verify_res) {
+    Serial.printf("- passed\r\n");
+  } else {
+    Serial.printf("!= (sum %08x ) - failed\r\n", verify_res);
+    success = false;
+  }
+  t = cyclesToWrite_nKxs16(nK, (int16_t*)imem);
+  Serial.printf("IRAM Memory Write:         %7d cycles for %dK by  int16, %3d AVG cycles/transfer\r\n", t, nK, t / (nK * 1024));
+  t = cyclesToRead_nKxs16(nK, (int16_t*)imem, &sres);
+  Serial.printf("IRAM Memory Read:          %7d cycles for %dK by  int16, %3d AVG cycles/transfer (sum %08x) ", t, nK, t / (nK * 1024), sres);
+  if (sres == verify_sres) {
+    Serial.printf("- passed\r\n");
+  } else {
+    Serial.printf("!= (sum %08x ) - failed\r\n", verify_sres);
+    success = false;
+  }
+
+  Serial.printf("\r\nPerformance numbers for 8 bit access - using inline macros or exception handling for IRAM access.\r\n");;
+  t = cyclesToWrite_nKx8(nK, (uint8_t*)mem);
+  Serial.printf("DRAM Memory Write:         %7d cycles for %dK by  uint8, %3d AVG cycles/transfer\r\n", t, nK, t / (nK * 1024));
+  t = cyclesToRead_nKx8(nK, (uint8_t*)mem, &verify_res);
+  Serial.printf("DRAM Memory Read:          %7d cycles for %dK by  uint8, %3d AVG cycles/transfer (sum %08x)\r\n", t, nK, t / (nK * 1024), verify_res);
 
   t = cyclesToWrite_nKx8_viaInline(nK, (uint8_t*)imem);
-  Serial.printf("IRAM Memory Write Inline:  %6d cycles for %dK by  8, %3d AVG cycles/transfer\r\n", t, nK, t / (nK * 1024));
+  Serial.printf("IRAM Memory Write Inline:  %7d cycles for %dK by  uint8, %3d AVG cycles/transfer\r\n", t, nK, t / (nK * 1024));
   t = cyclesToRead_nKx8_viaInline(nK, (uint8_t*)imem, &res);
-  Serial.printf("IRAM Memory Read Inline:   %6d cycles for %dK by  8, %3d AVG cycles/transfer (sum %08x)\r\n", t, nK, t / (nK * 1024), res);
+  Serial.printf("IRAM Memory Read Inline:   %7d cycles for %dK by  uint8, %3d AVG cycles/transfer (sum %08x) ", t, nK, t / (nK * 1024), res);
+  if (res == verify_res) {
+    Serial.printf("- passed\r\n");
+  } else {
+    Serial.printf("!= (sum %08x ) - failed\r\n", verify_res);
+    success = false;
+  }
 
-  t = cyclesToWrite_nKx8(nK, (uint8_t*)mem);
-  Serial.printf("DRAM Memory Write:         %6d cycles for %dK by  8, %3d AVG cycles/transfer\r\n", t, nK, t / (nK * 1024));
-  t = cyclesToRead_nKx8(nK, (uint8_t*)mem, &res);
-  Serial.printf("DRAM Memory Read:          %6d cycles for %dK by  8, %3d AVG cycles/transfer (sum %08x)\r\n", t, nK, t / (nK * 1024), res);
+  t = cyclesToWrite_nKx8(nK, (uint8_t*)imem);
+  Serial.printf("IRAM Memory Write:         %7d cycles for %dK by  uint8, %3d AVG cycles/transfer\r\n", t, nK, t / (nK * 1024));
+  t = cyclesToRead_nKx8(nK, (uint8_t*)imem, &res);
+  Serial.printf("IRAM Memory Read:          %7d cycles for %dK by  uint8, %3d AVG cycles/transfer (sum %08x) ", t, nK, t / (nK * 1024), res);
+  if (res == verify_res) {
+    Serial.printf("- passed\r\n");
+  } else {
+    Serial.printf("!= (sum %08x ) - failed\r\n", verify_res);
+    success = false;
+  }
+  Serial.println();
+
+  return success;
 }
 
 void setup() {
@@ -207,21 +304,31 @@ void setup() {
   uint32_t res;
   uint32_t t;
   int nK = 1;
-  Serial.println();
-  t = cyclesToWrite_nKx32(nK, imem);
-  Serial.printf("IRAM Memory Write:         %6d cycles for %dK by 32, %3d AVG cycles/transfer\r\n", t, nK, t / (nK * 1024));
-  t = cyclesToRead_nKx32(nK, imem, &res);
-  Serial.printf("IRAM Memory Read:          %6d cycles for %dK by 32, %3d AVG cycles/transfer (sum %08x)\r\n", t, nK, t / (nK * 1024), res);
-
+  Serial.printf("\r\nPerformance numbers for 32 bit access - no exception handler or inline macros needed.\r\n");;
   t = cyclesToWrite_nKx32(nK, mem);
-  Serial.printf("DRAM Memory Write:         %6d cycles for %dK by 32, %3d AVG cycles/transfer\r\n", t, nK, t / (nK * 1024));
+  Serial.printf("DRAM Memory Write:         %7d cycles for %dK by uint32, %3d AVG cycles/transfer\r\n", t, nK, t / (nK * 1024));
   t = cyclesToRead_nKx32(nK, mem, &res);
-  Serial.printf("DRAM Memory Read:          %6d cycles for %dK by 32, %3d AVG cycles/transfer (sum %08x)\r\n", t, nK, t / (nK * 1024), res);
+  Serial.printf("DRAM Memory Read:          %7d cycles for %dK by uint32, %3d AVG cycles/transfer (sum %08x)\r\n", t, nK, t / (nK * 1024), res);
+
+  t = cyclesToWrite_nKx32(nK, imem);
+  Serial.printf("IRAM Memory Write:         %7d cycles for %dK by uint32, %3d AVG cycles/transfer\r\n", t, nK, t / (nK * 1024));
+  t = cyclesToRead_nKx32(nK, imem, &res);
+  Serial.printf("IRAM Memory Read:          %7d cycles for %dK by uint32, %3d AVG cycles/transfer (sum %08x)\r\n", t, nK, t / (nK * 1024), res);
   Serial.println();
-  perfTest_nK(1, mem, imem);
-  Serial.println();
-  perfTest_nK(4, mem, imem);
-  Serial.println();
+
+
+  if (perfTest_nK(1, mem, imem)) {
+    Serial.println();
+  } else {
+    Serial.println("\r\n*******************************");
+    Serial.println("*******************************");
+    Serial.println("**                           **");
+    Serial.println("**  One or more test failed  **");
+    Serial.println("**                           **");
+    Serial.println("*******************************");
+    Serial.println("*******************************\r\n");
+    return;
+  }
 
 #ifdef USE_SET_IRAM_HEAP
   // Let's use IRAM heap to make a big ole' String


### PR DESCRIPTION
Make verify fail more visible.

Updated example irammem.info to show performance and test int16 handling when IRAM is used.

Removed 4K performance test. It didn't show any new information over the 1K test.