### PR TITLE
Invalid read return value fix

### DIFF
--- a/cores/esp8266/FS.cpp
+++ b/cores/esp8266/FS.cpp
@@ -68,7 +68,7 @@ int File::read() {
 
 size_t File::read(uint8_t* buf, size_t size) {
     if (!_p)
-        return -1;
+        return 0;
 
     return _p->read(buf, size);
 }


### PR DESCRIPTION
Fixes #7814.

Return 0, not MAXINT, when a read is called on a File without a backing
instance of a SPIFFS/LittleFS/SD File.