### PR TITLE
Avoid UB and abort on nullptr buffer

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -207,7 +207,7 @@ size_t WiFiClient::write(uint8_t b)
 
 size_t WiFiClient::write(const uint8_t *buf, size_t size)
 {
-    if (!buf || !_client || !size)
+    if (!_client || !size)
     {
         return 0;
     }

--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -207,7 +207,7 @@ size_t WiFiClient::write(uint8_t b)
 
 size_t WiFiClient::write(const uint8_t *buf, size_t size)
 {
-    if (!_client || !size)
+    if (!buf || !_client || !size)
     {
         return 0;
     }

--- a/libraries/Netdump/src/Netdump.cpp
+++ b/libraries/Netdump/src/Netdump.cpp
@@ -162,7 +162,7 @@ void Netdump::tcpDumpProcess(const Packet& np)
     }
     size_t incl_len = np.getPacketSize() > maxPcapLength ? maxPcapLength : np.getPacketSize();
 
-    if (bufferIndex + 16 + incl_len < tcpBufferSize) // only add if enough space available
+    if (packetBuffer && bufferIndex + 16 + incl_len < tcpBufferSize) // only add if enough space available
     {
         struct timeval tv;
         gettimeofday(&tv, nullptr);

--- a/libraries/Netdump/src/Netdump.cpp
+++ b/libraries/Netdump/src/Netdump.cpp
@@ -84,7 +84,7 @@ void Netdump::fileDump(File& outfile, const Filter nf)
         fileDumpProcess(outfile, ndp);
     }, nf);
 }
-void Netdump::tcpDump(WiFiServer &tcpDumpServer, const Filter nf)
+bool Netdump::tcpDump(WiFiServer &tcpDumpServer, const Filter nf)
 {
 
     if (!packetBuffer)
@@ -93,7 +93,7 @@ void Netdump::tcpDump(WiFiServer &tcpDumpServer, const Filter nf)
 
         if (!packetBuffer)
         {
-            return;
+            return false;
         }
     }
     bufferIndex = 0;
@@ -102,6 +102,7 @@ void Netdump::tcpDump(WiFiServer &tcpDumpServer, const Filter nf)
     {
         tcpDumpLoop(tcpDumpServer, nf);
     });
+    return true;
 }
 
 void Netdump::capture(int netif_idx, const char* data, size_t len, int out, int success)

--- a/libraries/Netdump/src/Netdump.cpp
+++ b/libraries/Netdump/src/Netdump.cpp
@@ -91,7 +91,8 @@ void Netdump::tcpDump(WiFiServer &tcpDumpServer, const Filter nf)
     {
         packetBuffer = new (std::nothrow) char[tcpBufferSize];
 
-        if (!packetBuffer) {
+        if (!packetBuffer)
+        {
             return;
         }
     }

--- a/libraries/Netdump/src/Netdump.cpp
+++ b/libraries/Netdump/src/Netdump.cpp
@@ -90,6 +90,10 @@ void Netdump::tcpDump(WiFiServer &tcpDumpServer, const Filter nf)
     if (!packetBuffer)
     {
         packetBuffer = new (std::nothrow) char[tcpBufferSize];
+
+        if (!packetBuffer) {
+            return;
+        }
     }
     bufferIndex = 0;
 
@@ -162,7 +166,7 @@ void Netdump::tcpDumpProcess(const Packet& np)
     }
     size_t incl_len = np.getPacketSize() > maxPcapLength ? maxPcapLength : np.getPacketSize();
 
-    if (packetBuffer && bufferIndex + 16 + incl_len < tcpBufferSize) // only add if enough space available
+    if (bufferIndex + 16 + incl_len < tcpBufferSize) // only add if enough space available
     {
         struct timeval tv;
         gettimeofday(&tv, nullptr);

--- a/libraries/Netdump/src/Netdump.h
+++ b/libraries/Netdump/src/Netdump.h
@@ -53,7 +53,7 @@ public:
 
     void printDump(Print& out, Packet::PacketDetail ndd, const Filter nf = nullptr);
     void fileDump(File& outfile, const Filter nf = nullptr);
-    void tcpDump(WiFiServer &tcpDumpServer, const Filter nf = nullptr);
+    bool tcpDump(WiFiServer &tcpDumpServer, const Filter nf = nullptr);
 
 
 private:


### PR DESCRIPTION
Fixes #7821.

This does not report the OOM to the user. But it already prevents UB from [Netdump::tcpDumpProcess](https://github.com/esp8266/Arduino/blob/7f38e141c7502032af594fdd502c1b1f6049377c/libraries/Netdump/src/Netdump.cpp#L169).