### PR TITLE
Prevent nullptr dereference on OOM

### DIFF
--- a/libraries/ESP8266AVRISP/src/ESP8266AVRISP.cpp
+++ b/libraries/ESP8266AVRISP/src/ESP8266AVRISP.cpp
@@ -359,8 +359,12 @@ uint8_t ESP8266AVRISP::flash_read(uint8_t hilo, int addr) {
                            0);
 }
 
-void ESP8266AVRISP::flash_read_page(int length) {
+bool ESP8266AVRISP::flash_read_page(int length) {
     uint8_t *data = (uint8_t *) malloc(length + 1);
+    if (!data)
+    {
+        return false;
+    }
     for (int x = 0; x < length; x += 2) {
         *(data + x) = flash_read(LOW, here);
         *(data + x + 1) = flash_read(HIGH, here);
@@ -369,12 +373,16 @@ void ESP8266AVRISP::flash_read_page(int length) {
     *(data + length) = Resp_STK_OK;
     _client.write((const uint8_t *)data, (size_t)(length + 1));
     free(data);
-    return;
+    return true;
 }
 
-void ESP8266AVRISP::eeprom_read_page(int length) {
+bool ESP8266AVRISP::eeprom_read_page(int length) {
     // here again we have a word address
     uint8_t *data = (uint8_t *) malloc(length + 1);
+    if (!data)
+    {
+        return false;
+    }
     int start = here * 2;
     for (int x = 0; x < length; x++) {
         int addr = start + x;
@@ -384,7 +392,7 @@ void ESP8266AVRISP::eeprom_read_page(int length) {
     *(data + length) = Resp_STK_OK;
     _client.write((const uint8_t *)data, (size_t)(length + 1));
     free(data);
-    return;
+    return true;
 }
 
 void ESP8266AVRISP::read_page() {

--- a/libraries/ESP8266AVRISP/src/ESP8266AVRISP.h
+++ b/libraries/ESP8266AVRISP/src/ESP8266AVRISP.h
@@ -89,8 +89,8 @@ protected:
     void commit(int addr);
     void program_page();
     uint8_t flash_read(uint8_t hilo, int addr);
-    void flash_read_page(int length);
-    void eeprom_read_page(int length);
+    bool flash_read_page(int length);
+    bool eeprom_read_page(int length);
     void read_page();
     void read_signature();
 

--- a/libraries/ESP8266WiFi/src/BearSSLHelpers.cpp
+++ b/libraries/ESP8266WiFi/src/BearSSLHelpers.cpp
@@ -526,6 +526,10 @@ namespace brssl {
       case BR_KEYTYPE_EC:
         ek = br_skey_decoder_get_ec(dc.get());
         sk = (private_key*)malloc(sizeof * sk);
+        if (!sk)
+        {
+          return nullptr;
+        }
         sk->key_type = BR_KEYTYPE_EC;
         sk->key.ec.curve = ek->curve;
         sk->key.ec.x = (uint8_t*)malloc(ek->xlen);


### PR DESCRIPTION
Based on my last PR I grepped for malloc and found these places where the null check was missing.