### PR TITLE
Supersede #3856, remove undef min/max

### DIFF
--- a/cores/esp8266/spiffs_api.h
+++ b/cores/esp8266/spiffs_api.h
@@ -26,8 +26,6 @@
  */
 #include <limits>
 #include "FS.h"
-#undef max
-#undef min
 #include "FSImpl.h"
 extern "C" {
     #include "spiffs/spiffs.h"


### PR DESCRIPTION
Remove a straggler `undef min/max` from core header
Supersedes #3856