### PR TITLE
Add a few nullptr checks

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
@@ -406,11 +406,6 @@ int WiFiClientSecureCtx::peek() {
 
 size_t WiFiClientSecureCtx::peekBytes(uint8_t *buffer, size_t length) {
   size_t to_copy = 0;
-  if (!buffer) {
-    DEBUG_BSSL("peekBytes: buffer is nullptr\n");
-    return 0;
-  }
-
   if (!ctx_present()) {
     DEBUG_BSSL("peekBytes: Not connected\n");
     return 0;

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
@@ -345,7 +345,7 @@ int WiFiClientSecureCtx::read(uint8_t *buf, size_t size) {
     return -1;
   }
 
-  if (avail && _recvapp_buf) {
+  if (avail) {
     // Take data from the recvapp buffer
     int to_copy = _recvapp_len < size ? _recvapp_len : size;
     memcpy(buf, _recvapp_buf, to_copy);

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
@@ -345,7 +345,7 @@ int WiFiClientSecureCtx::read(uint8_t *buf, size_t size) {
     return -1;
   }
 
-  if (avail) {
+  if (avail && _recvapp_buf) {
     // Take data from the recvapp buffer
     int to_copy = _recvapp_len < size ? _recvapp_len : size;
     memcpy(buf, _recvapp_buf, to_copy);
@@ -406,6 +406,11 @@ int WiFiClientSecureCtx::peek() {
 
 size_t WiFiClientSecureCtx::peekBytes(uint8_t *buffer, size_t length) {
   size_t to_copy = 0;
+  if (!buffer) {
+    DEBUG_BSSL("peekBytes: buffer is nullptr\n");
+    return 0;
+  }
+
   if (!ctx_present()) {
     DEBUG_BSSL("peekBytes: Not connected\n");
     return 0;
@@ -414,6 +419,12 @@ size_t WiFiClientSecureCtx::peekBytes(uint8_t *buffer, size_t length) {
   _startMillis = millis();
   while ((available() < (int) length) && ((millis() - _startMillis) < 5000)) {
     yield();
+  }
+
+  if (!_recvapp_buf)
+  {
+    DEBUG_BSSL("peekBytes: _recvapp_buf is nullptr\n");
+    return 0;
   }
 
   to_copy = _recvapp_len < length ? _recvapp_len : length;


### PR DESCRIPTION
Just a few nullptr checks I found needing while perusing the library.

Technically WiFiClientSecureCtx::read doesn't need them because it calls WiFiClientSecureCtx::available before dereferencing _recvapp_buf, and available sets the buffer with a bearssl function (I'm assuming it can't ever return null). But it didn't seem to hurt.

But in WiFiClientSecureCtx::peekBytes this check is not done, so it seems you can have connected but not called available and then _recvapp_buf will be passed to memcpy. So I added a few checks to ensure a bad usage can't cause a crash (and logs what happened).