### PR TITLE
Hexdump fix&update

### DIFF
--- a/cores/esp8266/debug.cpp
+++ b/cores/esp8266/debug.cpp
@@ -43,7 +43,7 @@ void hexdump(const void *mem, uint32_t len, uint8_t cols)
         for (uint32_t i = 0; i < linesize; i++)
         {
             unsigned char c = *(src + i);
-            os_printf("%c", c >= 32 && c <= 127 ? c : '.');
+            os_putc(isprint(c) ? c : '.');
         }
         src += linesize;
         len -= linesize;

--- a/cores/esp8266/debug.cpp
+++ b/cores/esp8266/debug.cpp
@@ -22,6 +22,7 @@
 #include "debug.h"
 #include "osapi.h"
 
+#if 0
 void ICACHE_RAM_ATTR hexdump(const void *mem, uint32_t len, uint8_t cols) {
     const uint8_t* src = (const uint8_t*) mem;
     os_printf("\n[HEXDUMP] Address: 0x%08X len: 0x%X (%d)", (ptrdiff_t)src, len, len);
@@ -35,3 +36,32 @@ void ICACHE_RAM_ATTR hexdump(const void *mem, uint32_t len, uint8_t cols) {
     }
     os_printf("\n");
 }
+#else
+void ICACHE_RAM_ATTR hexdump(const void *mem, uint32_t len, uint8_t cols)
+{
+    const char* src = (const char*)mem;
+    os_printf("\n[HEXDUMP] Address: %p len: 0x%X (%d)", src, len, len);
+    while (len > 0)
+    {
+        uint32_t linesize = cols > len? len: cols;
+        os_printf("\n[%p] 0x%04x: ", src, src - (const char*)mem);
+        for (uint32_t i = 0; i < linesize; i++)
+        {
+            os_printf("%02x ", *(src + i));
+        }
+        os_printf("  ");
+        for (uint32_t i = linesize; i < cols; i++)
+        {
+            os_printf("   ");
+        }
+        for (uint32_t i = 0; i < linesize; i++)
+        {
+            unsigned char c = *(src + i);
+            os_printf("%c", c >= 32 && c <= 127? c: '.');
+        }
+        src += linesize;
+        len -= linesize;
+    }
+    os_printf("\n");
+}
+#endif

--- a/cores/esp8266/debug.cpp
+++ b/cores/esp8266/debug.cpp
@@ -1,49 +1,35 @@
 /*
- debug.cpp - debug helper functions
- Copyright (c) 2015 Markus Sattler. All rights reserved.
- This file is part of the esp8266 core for Arduino environment.
+    debug.cpp - debug helper functions
+    Copyright (c) 2015 Markus Sattler. All rights reserved.
+    This file is part of the esp8266 core for Arduino environment.
 
- This library is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation; either
- version 2.1 of the License, or (at your option) any later version.
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
 
- This library is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
 
- You should have received a copy of the GNU Lesser General Public
- License along with this library; if not, write to the Free Software
- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- */
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
 
 #include "Arduino.h"
 #include "debug.h"
 #include "osapi.h"
 
-#if 0
-void ICACHE_RAM_ATTR hexdump(const void *mem, uint32_t len, uint8_t cols) {
-    const uint8_t* src = (const uint8_t*) mem;
-    os_printf("\n[HEXDUMP] Address: 0x%08X len: 0x%X (%d)", (ptrdiff_t)src, len, len);
-    for(uint32_t i = 0; i < len; i++) {
-        if(i % cols == 0) {
-            os_printf("\n[0x%08X] 0x%08X: ", (ptrdiff_t)src, i);
-            yield();
-        }
-        os_printf("%02X ", *src);
-        src++;
-    }
-    os_printf("\n");
-}
-#else
-void ICACHE_RAM_ATTR hexdump(const void *mem, uint32_t len, uint8_t cols)
+IRAM_ATTR
+void hexdump(const void *mem, uint32_t len, uint8_t cols)
 {
     const char* src = (const char*)mem;
     os_printf("\n[HEXDUMP] Address: %p len: 0x%X (%d)", src, len, len);
     while (len > 0)
     {
-        uint32_t linesize = cols > len? len: cols;
+        uint32_t linesize = cols > len ? len : cols;
         os_printf("\n[%p] 0x%04x: ", src, src - (const char*)mem);
         for (uint32_t i = 0; i < linesize; i++)
         {
@@ -57,11 +43,11 @@ void ICACHE_RAM_ATTR hexdump(const void *mem, uint32_t len, uint8_t cols)
         for (uint32_t i = 0; i < linesize; i++)
         {
             unsigned char c = *(src + i);
-            os_printf("%c", c >= 32 && c <= 127? c: '.');
+            os_printf("%c", c >= 32 && c <= 127 ? c : '.');
         }
         src += linesize;
         len -= linesize;
+        yield();
     }
     os_printf("\n");
 }
-#endif

--- a/cores/esp8266/debug.h
+++ b/cores/esp8266/debug.h
@@ -13,7 +13,7 @@
 #endif
 
 #ifdef __cplusplus
-void hexdump(const void *mem, uint32_t len, uint8_t cols = 16);
+extern "C" void hexdump(const void *mem, uint32_t len, uint8_t cols = 16);
 #else
 void hexdump(const void *mem, uint32_t len, uint8_t cols);
 #endif

--- a/tests/host/common/mock.h
+++ b/tests/host/common/mock.h
@@ -103,6 +103,7 @@ extern "C" {
 int ets_printf (const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
 #define os_printf_plus printf
 #define ets_vsnprintf vsnprintf
+inline void ets_putc (char c) { putchar(c); }
 
 int mockverbose (const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
 

--- a/tests/restyle.sh
+++ b/tests/restyle.sh
@@ -16,6 +16,7 @@ libraries/Wire
 libraries/lwIP*
 cores/esp8266/Lwip*
 cores/esp8266/core_esp8266_si2c.cpp
+cores/esp8266/debug*
 libraries/Netdump
 "
 


### PR DESCRIPTION
- `hexdump()` must be declared as `"C"` like its C counterpart.
- add ascii data in dump
- avoid caps
