### PR TITLE
Fix improper GENERIC board IDs

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -3550,7 +3550,7 @@ sonoff.menu.baud.3000000.upload.speed=3000000
 
 ##############################################################
 inventone.name=Invent One
-inventone.build.board=ESP8266_GENERIC
+inventone.build.board=ESP8266_INVENT_ONE
 inventone.build.variant=inventone
 inventone.upload.tool=esptool
 inventone.upload.maximum_data_size=81920
@@ -7448,7 +7448,7 @@ wifinfo.menu.baud.3000000.upload.speed=3000000
 
 ##############################################################
 cw01.name=XinaBox CW01
-cw01.build.board=ESP8266_GENERIC
+cw01.build.board=ESP8266_XINABOX_CW01
 cw01.build.variant=xinabox
 cw01.upload.tool=esptool
 cw01.upload.maximum_data_size=81920

--- a/tools/boards.txt.py
+++ b/tools/boards.txt.py
@@ -337,7 +337,7 @@ boards = collections.OrderedDict([
     ( 'inventone', {
         'name': 'Invent One',
         'opts': {
-            '.build.board': 'ESP8266_GENERIC',
+            '.build.board': 'ESP8266_INVENT_ONE',
             '.build.variant': 'inventone',
             },
         'macro': [
@@ -354,7 +354,7 @@ boards = collections.OrderedDict([
     ( 'cw01', {
         'name': 'XinaBox CW01',
         'opts': {
-            '.build.board': 'ESP8266_GENERIC',
+            '.build.board': 'ESP8266_XINABOX_CW01',
             '.build.variant': 'xinabox',
             },
         'macro': [


### PR DESCRIPTION
A couple board types reported ESP8266_GENERIC instead of their proper
types in boards.txt (and in defined generated therefrom/etc.).

Give them proper board types based on their names, like other modules.