### PR TITLE
Fix typo in 32-bit Windows package JSON

### DIFF
--- a/package/package_esp8266com_index.template.json
+++ b/package/package_esp8266com_index.template.json
@@ -157,7 +157,7 @@
                   {
                      "host": "i686-mingw32",
                      "url": "https://github.com/earlephilhower/esp-quick-toolchain/releases/download/2.5.0-4/python3-3.7.2.post1-embed-win32v2a.zip",
-                     "archiveFileName": "python3-3.7.2.post1-embed-win32va2.zip",
+                     "archiveFileName": "python3-3.7.2.post1-embed-win32v2a.zip",
                      "checksum": "SHA-256:f57cb2daf86176d2929e7c58990c2ac32554e3219d454dcac10e464ddda35bf2",
                      "size": "6428926"
                   },


### PR DESCRIPTION
Fatfingered the 32-bit Windows pointer to the Python interpreter.  Our
CI and my own testing missed due to being on 64-bit Windows.

For 2.7.4 release, I'll add a file of the appropriate name to the
release for now, but this will correct things for 3.0.0 and forward.