### PR TITLE
Allow attribute get on root

### DIFF
--- a/cores/esp8266/FS.cpp
+++ b/cores/esp8266/FS.cpp
@@ -441,6 +441,13 @@ bool FS::rename(const String& pathFrom, const String& pathTo) {
     return rename(pathFrom.c_str(), pathTo.c_str());
 }
 
+time_t FS::getCreationTime() {
+    if (!_impl) {
+        return 0;
+    }
+    return _impl->getCreationTime();
+}
+
 void FS::setTimeCallback(time_t (*cb)(void)) {
     if (!_impl)
         return;

--- a/cores/esp8266/FS.h
+++ b/cores/esp8266/FS.h
@@ -235,6 +235,8 @@ public:
     bool gc();
     bool check();
 
+    time_t getCreationTime();
+
     void setTimeCallback(time_t (*cb)(void));
 
     friend class ::SDClass; // More of a frenemy, but SD needs internal implementation to get private FAT bits

--- a/cores/esp8266/FSImpl.h
+++ b/cores/esp8266/FSImpl.h
@@ -115,7 +115,7 @@ public:
     virtual bool rmdir(const char* path) = 0;
     virtual bool gc() { return true; } // May not be implemented in all file systems.
     virtual bool check() { return true; } // May not be implemented in all file systems.
-    virtual time_t getCreationTime() { return -1; } // May not be implemented in all file systems.
+    virtual time_t getCreationTime() { return 0; } // May not be implemented in all file systems.
 
     // Filesystems *may* support a timestamp per-file, so allow the user to override with
     // their own callback for all files on this FS.  The default implementation simply

--- a/cores/esp8266/FSImpl.h
+++ b/cores/esp8266/FSImpl.h
@@ -115,6 +115,7 @@ public:
     virtual bool rmdir(const char* path) = 0;
     virtual bool gc() { return true; } // May not be implemented in all file systems.
     virtual bool check() { return true; } // May not be implemented in all file systems.
+    virtual time_t getCreationTime() { return -1; } // May not be implemented in all file systems.
 
     // Filesystems *may* support a timestamp per-file, so allow the user to override with
     // their own callback for all files on this FS.  The default implementation simply

--- a/libraries/LittleFS/src/LittleFS.h
+++ b/libraries/LittleFS/src/LittleFS.h
@@ -221,6 +221,26 @@ public:
             return false;
         }
 
+        if(_timeCallback && _tryMount()) {
+            // Mounting is required to set attributes
+
+            time_t t = _timeCallback();
+            rc = lfs_setattr(&_lfs, "/", 'c', &t, 8);
+            if (rc != 0) {
+                DEBUGV("lfs_format, lfs_setattr 'c': rc=%d\n", rc);
+                return false;
+            }
+
+            rc = lfs_setattr(&_lfs, "/", 't', &t, 8);
+            if (rc != 0) {
+                DEBUGV("lfs_format, lfs_setattr 't': rc=%d\n", rc);
+                return false;
+            }
+            
+            lfs_unmount(&_lfs);
+            _mounted = false;
+        }
+
         if (wasMounted) {
             return _tryMount();
         }

--- a/libraries/LittleFS/src/LittleFS.h
+++ b/libraries/LittleFS/src/LittleFS.h
@@ -228,6 +228,19 @@ public:
         return true;
     }
 
+    time_t getCreationTime() override {
+        time_t t;
+        uint32_t t32b;
+
+        if (lfs_getattr(&_lfs, "/", 'c', &t, 8) == 8) {
+            return t;
+        } else if (lfs_getattr(&_lfs, "/", 'c', &t32b, 4) == 4) {
+            return (time_t)t32b;
+        } else {
+            return 0;
+        }
+    }
+
 
 protected:
     friend class LittleFSFileImpl;


### PR DESCRIPTION
This PR enables attributes on the root, such as [creation/modification time of volume](https://github.com/earlephilhower/mklittlefs/pull/15).

```cpp
  fs::Dir fs = LittleFS.openDir("/");
  Serial.print("FS creation timestamp: ");
  Serial.println(fs.fileCreationTime());
```

After quite some testing I believe the attached changed is the only one required. It didn't seem to break anything in my tests, though I'm not 100% sure, because the use and value of `_valid` in undocumented and unclear to me.

Test project available: [LittleFSTest](https://github.com/qistoph/LittleFSTest)

Effects of checking 'c' and 't' attributes on a root node, if:
1. **attribute present**: return its value (mklittlefs since [PR15](https://github.com/earlephilhower/mklittlefs/pull/15))
2. **attribute unavailable at root and sub nodes**: return 0 (older version of mklittlefs)
3. **attribute unavailable at root, but available at sub node**: return (last?) sub node's value

I'm haven't been able to figure out why situation 3. doesn't respond like 2. If this is an undesirable side effect, I'm hoping someone has a suggestion on fixing it or where to look.