### PR TITLE
AP & dhcp-server: fix uninitialized variables

### DIFF
--- a/cores/esp8266/LwipDhcpServer.cpp
+++ b/cores/esp8266/LwipDhcpServer.cpp
@@ -1140,16 +1140,9 @@ bool DhcpServer::set_dhcps_lease(struct dhcps_lease *please)
         // logic below is subject for improvement
         // - is wrong
         // - limited to /24 address plans
-#if 1
-        softap_ip = ip_2_ip4(&_netif->ip_addr)->addr;
-#else
-        struct ip_info info;
-        bzero(&info, sizeof(struct ip_info));
-        wifi_get_ip_info(SOFTAP_IF, &info);
-        softap_ip = htonl(info.ip.addr);
+        softap_ip = htonl(ip_2_ip4(&_netif->ip_addr)->addr);
         start_ip = htonl(please->start_ip.addr);
         end_ip = htonl(please->end_ip.addr);
-#endif
         /*config ip information can't contain local ip*/
         if ((start_ip <= softap_ip) && (softap_ip <= end_ip))
         {

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiAP.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiAP.cpp
@@ -224,6 +224,7 @@ bool ESP8266WiFiAPClass::softAPConfig(IPAddress local_ip, IPAddress gateway, IPA
     }
 
     struct dhcps_lease dhcp_lease;
+    dhcp_lease.enable = true;
     IPAddress ip = local_ip;
     ip[3] += 99;
     dhcp_lease.start_ip.addr = ip.v4();
@@ -264,8 +265,7 @@ bool ESP8266WiFiAPClass::softAPConfig(IPAddress local_ip, IPAddress gateway, IPA
             DEBUG_WIFI("[APConfig] IP config Invalid?!\n");
             ret = false;
         } else if(local_ip.v4() != info.ip.addr) {
-            ip = info.ip.addr;
-            DEBUG_WIFI("[APConfig] IP config not set correct?! new IP: %s\n", ip.toString().c_str());
+            DEBUG_WIFI("[APConfig] IP config not set correct?! new IP: %s\n", IPAddress(info.ip.addr).toString().c_str());
             ret = false;
         }
     } else {


### PR DESCRIPTION
Although legacy logic is greatly improvable, at least AP now seems to run like before, offering 192.168.4.100+ addresses, whether debug mode enabled or not.
Fixes #7880 
Fixes #7795 

The difference between debug mode enabled (not `DHCPS_DEBUG` but general debug options) had an effect on one of the uninitialized variables.