### PR TITLE
OOM debug: warn about String reallocation

### DIFF
--- a/cores/esp8266/WString.cpp
+++ b/cores/esp8266/WString.cpp
@@ -25,6 +25,12 @@
 #include "WString.h"
 #include "stdlib_noniso.h"
 
+#define OOM_STRING_BORDER_DISPLAY           10
+#define OOM_STRING_THRESHOLD_REALLOC_WARN  128
+
+#define __STRHELPER(x) #x
+#define STR(x) __STRHELPER(x) // stringifier
+
 /*********************************************/
 /*  Constructors                             */
 /*********************************************/
@@ -179,12 +185,11 @@ unsigned char String::changeBuffer(unsigned int maxStrLen) {
     // Fallthrough to normal allocator
     size_t newSize = (maxStrLen + 16) & (~0xf);
 #ifdef DEBUG_ESP_OOM
-    if (!isSSO() && maxStrLen > length())
-    {
+    if (!isSSO() && maxStrLen >= OOM_STRING_THRESHOLD_REALLOC_WARN && maxStrLen > capacity()) {
         // warn when badly re-allocating
-        DEBUGV("[String realloc %d->%d ('%.10s ... %.10s')]\n",
+        DEBUGV("[offending String op %d->%d ('%." STR(OOM_STRING_BORDER_DISPLAY) "s ... %." STR(OOM_STRING_BORDER_DISPLAY) "s')]\n",
             len(), maxStrLen, c_str(),
-            len() > 10? c_str() + std::max((int)len() - 10, 10): "");
+            len() > OOM_STRING_BORDER_DISPLAY? c_str() + std::max((int)len() - OOM_STRING_BORDER_DISPLAY, OOM_STRING_BORDER_DISPLAY): "");
     }
 #endif
     // Make sure we can fit newsize in the buffer

--- a/cores/esp8266/WString.cpp
+++ b/cores/esp8266/WString.cpp
@@ -185,7 +185,7 @@ unsigned char String::changeBuffer(unsigned int maxStrLen) {
     // Fallthrough to normal allocator
     size_t newSize = (maxStrLen + 16) & (~0xf);
 #ifdef DEBUG_ESP_OOM
-    if (!isSSO() && maxStrLen >= OOM_STRING_THRESHOLD_REALLOC_WARN && maxStrLen > capacity()) {
+    if (!isSSO() && capacity() >= OOM_STRING_THRESHOLD_REALLOC_WARN && maxStrLen > capacity()) {
         // warn when badly re-allocating
         DEBUGV("[offending String op %d->%d ('%." STR(OOM_STRING_BORDER_DISPLAY) "s ... %." STR(OOM_STRING_BORDER_DISPLAY) "s')]\n",
             len(), maxStrLen, c_str(),

--- a/cores/esp8266/WString.cpp
+++ b/cores/esp8266/WString.cpp
@@ -178,6 +178,15 @@ unsigned char String::changeBuffer(unsigned int maxStrLen) {
     }
     // Fallthrough to normal allocator
     size_t newSize = (maxStrLen + 16) & (~0xf);
+#ifdef DEBUG_ESP_OOM
+    if (!isSSO() && maxStrLen > length())
+    {
+        // warn when badly re-allocating
+        DEBUGV("[String realloc %d->%d ('%.10s ... %.10s')]\n",
+            len(), maxStrLen, c_str(),
+            len() > 10? c_str() + std::max((int)len() - 10, 10): "");
+    }
+#endif
     // Make sure we can fit newsize in the buffer
     if (newSize > CAPACITY_MAX) {
         return 0;


### PR DESCRIPTION
When OOM debug is enabled: User helper to warn about misused Strings

With this sketch:
```cpp
void setup ()
{
    Serial.begin(115200);
    String s;

    Serial.printf("empty\n");
    for (int i = 0; i < 170; i++)
    {
        char c = 'a' + (i % 26);
        s += c;
        Serial.printf("+%c (%2u) %s\n", c, s.length(), s.c_str());
    }
}

void loop ()
{
    delay(1000);
}
```

```
[... no warning from 1 to 140]
22:26:24.074731667 +j (140) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghij
22:26:24.076687969 +k (141) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk
22:26:24.095628380 +l (142) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl
22:26:24.097935792 +m (143) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklm
22:26:24.105040649 [offending String op 143->144 ('abcdefghij ... defghijklm')]
22:26:24.123835556 +n (144) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmn
22:26:24.144697970 +o (145) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmno
22:26:24.150967332 +p (146) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnop
22:26:24.167547088 +q (147) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopq
22:26:24.188924455 +r (148) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqr
22:26:24.196662949 +s (149) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrs
22:26:24.211387159 +t (150) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst
22:26:24.213691185 +u (151) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstu
22:26:24.232972928 +v (152) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuv
22:26:24.254602860 +w (153) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvw
22:26:24.256531706 +x (154) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwx
22:26:24.277578340 +y (155) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxy
22:26:24.299916179 +z (156) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
22:26:24.302642315 +a (157) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyza
22:26:24.321516961 +b (158) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzab
22:26:24.332390725 +c (159) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabc
22:26:24.334352380 [offending String op 159->160 ('abcdefghij ... tuvwxyzabc')]
22:26:24.351496870 +d (160) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcd
22:26:24.373622505 +e (161) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcde
22:26:24.375705812 +f (162) abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef
```
