### PR TITLE
StreamConstPtr: fix doc + reading flash space byte-by-byte

### DIFF
--- a/cores/esp8266/StreamDev.h
+++ b/cores/esp8266/StreamDev.h
@@ -179,12 +179,16 @@ public:
 
     virtual int read() override
     {
-        return _peekPointer < _size ? _buffer[_peekPointer++] : -1;
+        //if (_byteAddressable)
+        //    return _peekPointer < _size ? _buffer[_peekPointer++] : -1;
+        return _peekPointer < _size ? pgm_read_byte(&_buffer[_peekPointer++]) : -1;
     }
 
     virtual int peek() override
     {
-        return _peekPointer < _size ? _buffer[_peekPointer] : -1;
+        //if (_byteAddressable)
+        //    return _peekPointer < _size ? _buffer[_peekPointer] : -1;
+        return _peekPointer < _size ? pgm_read_byte(&_buffer[_peekPointer]) : -1;
     }
 
     virtual size_t readBytes(char* buffer, size_t len) override

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -441,7 +441,7 @@ Stream extensions
 
     Two additional classes are provided.
 
-    - ``StreamPtr::`` is designed to hold a constant buffer (in ram or flash).
+    - ``StreamConstPtr::`` is designed to hold a constant buffer (in ram or flash).
 
       With this class, a ``Stream::`` can be made from ``const char*``,
       ``F("some words in flash")`` or ``PROGMEM`` strings.  This class makes
@@ -451,7 +451,7 @@ Stream extensions
 
       .. code:: cpp
 
-        StreamPtr css(F("my long css data")); // CSS data not copied to RAM
+        StreamConstPtr css(F("my long css data")); // CSS data not copied to RAM
         server.sendAll(css);
 
     - ``S2Stream::`` is designed to make a ``Stream::`` out of a ``String::`` without copy.


### PR DESCRIPTION
Should fix #7928

In the following code
```
        //if (_byteAddressable)
        //    return _peekPointer < _size ? _buffer[_peekPointer++] : -1;
        return _peekPointer < _size ? pgm_read_byte(&_buffer[_peekPointer++]) : -1;
```
I wonder if it is worth uncommenting the two first lines, which are valid.
