### PR TITLE
MDNS.begin() conflict? Added isRunning() test first.

### DIFF
--- a/libraries/ArduinoOTA/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/ArduinoOTA.cpp
@@ -122,7 +122,7 @@ void ArduinoOTAClass::begin(bool useMDNS) {
   
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_MDNS)
   if(_useMDNS) {
-    MDNS.begin(_hostname.c_str());
+    if (!MDNS.isRunning()) MDNS.begin(_hostname.c_str());
 
     if (_password.length()) {
       MDNS.enableArduino(_port, true);


### PR DESCRIPTION
Please make sure this one-line change is correct.
I had only one mdns service found in my scans.
If I'm understanding, a service (library) calling MDNS.begin() will cause a reset, so multiple libs can conflict.  This will test MDNS.isRunning() to ensure it's not called again.
This change has resolved my conflict and all libs' MDNS entries are now available.
