### PR TITLE
Fix WiFi events with 32byte wide SSIDs

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -105,7 +105,7 @@ WiFiEventHandler ESP8266WiFiGenericClass::onStationModeConnected(std::function<v
     WiFiEventHandler handler = std::make_shared<WiFiEventHandlerOpaque>(WIFI_EVENT_STAMODE_CONNECTED, [f](System_Event_t* e) {
         auto& src = e->event_info.connected;
         WiFiEventStationModeConnected dst;
-        dst.ssid = String(reinterpret_cast<char*>(src.ssid));
+        dst.ssid.concat(reinterpret_cast<char*>(src.ssid), src.ssid_len);
         memcpy(dst.bssid, src.bssid, 6);
         dst.channel = src.channel;
         f(dst);
@@ -119,7 +119,7 @@ WiFiEventHandler ESP8266WiFiGenericClass::onStationModeDisconnected(std::functio
     WiFiEventHandler handler = std::make_shared<WiFiEventHandlerOpaque>(WIFI_EVENT_STAMODE_DISCONNECTED, [f](System_Event_t* e){
         auto& src = e->event_info.disconnected;
         WiFiEventStationModeDisconnected dst;
-        dst.ssid = String(reinterpret_cast<char*>(src.ssid));
+        dst.ssid.concat(reinterpret_cast<char*>(src.ssid), src.ssid_len);
         memcpy(dst.bssid, src.bssid, 6);
         dst.reason = static_cast<WiFiDisconnectReason>(src.reason);
         f(dst);


### PR DESCRIPTION
Copy using the provided length and directly use the string as a buffer.
Resolve #7929 