### PR TITLE
WifiClient(Secure): Make connect accept very low timeout

### DIFF
--- a/libraries/ESP8266WiFi/examples/ConnectNoTimeout/ConnectNoTimeout.ino
+++ b/libraries/ESP8266WiFi/examples/ConnectNoTimeout/ConnectNoTimeout.ino
@@ -1,0 +1,74 @@
+/*
+    This sketch tries to connect to a remote server with 0 timeout.
+    This causes, for the first call, to fail to connect, but a further call
+    can return successfully if in the meantime the connection has been
+    established.
+*/
+
+#include <ESP8266WiFi.h>
+#include <PolledTimeout.h>
+
+#ifndef STASSID
+#define STASSID "your-ssid"
+#define STAPSK  "your-password"
+#endif
+
+const char* ssid     = STASSID;
+const char* password = STAPSK;
+
+const char* host = "djxmmx.net";
+const uint16_t port = 17;
+
+WiFiClient client;
+
+void setup() {
+  Serial.begin(115200);
+
+  // We start by connecting to a WiFi network
+
+  Serial.println();
+  Serial.println();
+  Serial.print("Connecting to ");
+  Serial.println(ssid);
+
+  /* Explicitly set the ESP8266 to be a WiFi-client, otherwise, it by default,
+     would try to act as both a client and an access-point and could cause
+     network-issues with your other WiFi-devices on your WiFi-network. */
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(ssid, password);
+
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+
+  // Set timeout to 0 to make it sort of async
+  client.setTimeout(0);
+
+  Serial.println("");
+  Serial.println("WiFi connected");
+  Serial.println("IP address: ");
+  Serial.println(WiFi.localIP());
+}
+
+void loop() {
+  // Use WiFiClient class to create TCP connections
+  if (client.disconnected()) {
+    client.connect(host, port);
+  }
+  /* This loop will exit if client has connected or
+     if the connection has failed (e.g. due to lwip timeout)
+  */
+  while (!client.keepConnecting() && !client.disconnected()) {
+    // do stuff while trying to connect
+    delay(500);
+    Serial.println("Trying to connect");
+  }
+  if (client.connected()) {
+    //do some stuff when connected
+    Serial.println("Finally connected");
+  } else {
+    Serial.println("Failed to connect");
+  }
+  delay(2000);
+}

--- a/libraries/ESP8266WiFi/keywords.txt
+++ b/libraries/ESP8266WiFi/keywords.txt
@@ -132,6 +132,9 @@ peekBytes	KEYWORD2
 flush	KEYWORD2
 stop	KEYWORD2
 connected	KEYWORD2
+connecting  KEYWORD2
+keepConnecting  KEYWORD2
+disconnected    KEYWORD2
 bool	KEYWORD2
 remoteIP	KEYWORD2
 remotePort	KEYWORD2

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -614,7 +614,7 @@ int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResul
 int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResult, uint32_t timeout_ms)
 {
     ip_addr_t addr;
-    aResult = static_cast<uint32_t>(INADDR_NONE);
+    aResult.clear();
 
     if(aResult.fromString(aHostname)) {
         // Host name is a IP address use it!
@@ -641,7 +641,9 @@ int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResul
         }
     }
 
-    if(err != 0) {
+    if (err == ERR_INPROGRESS) {
+        DEBUG_WIFI_GENERIC("[hostByName] Host: %s search in progress!\n", aHostname);
+    } else if(err != 0) {
         DEBUG_WIFI_GENERIC("[hostByName] Host: %s lookup error: %d!\n", aHostname, (int)err);
     } else {
         DEBUG_WIFI_GENERIC("[hostByName] Host: %s IP: %s\n", aHostname, aResult.toString().c_str());
@@ -655,7 +657,7 @@ int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResul
 {
     ip_addr_t addr;
     err_t err;
-    aResult = static_cast<uint32_t>(INADDR_NONE);
+    aResult.clear();
 
     if(aResult.fromString(aHostname)) {
         // Host name is a IP address use it!
@@ -691,7 +693,9 @@ int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResul
         }
     }
 
-    if(err != 0) {
+    if (err == ERR_INPROGRESS) {
+        DEBUG_WIFI_GENERIC("[hostByName] Host: %s search in progress!\n", aHostname);
+    } else if(err != 0) {
         DEBUG_WIFI_GENERIC("[hostByName] Host: %s lookup error: %d!\n", aHostname, (int)err);
     } else {
         DEBUG_WIFI_GENERIC("[hostByName] Host: %s IP: %s\n", aHostname, aResult.toString().c_str());

--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -80,6 +80,7 @@ WiFiClient::WiFiClient()
 {
     _timeout = 5000;
     WiFiClient::_add(this);
+    _state = WFC_DISCONNECTED;
 }
 
 WiFiClient::WiFiClient(ClientContext* client)
@@ -88,6 +89,7 @@ WiFiClient::WiFiClient(ClientContext* client)
     _timeout = 5000;
     _client->ref();
     WiFiClient::_add(this);
+    _state = WFC_DISCONNECTED;
 
     setSync(defaultSync);
     setNoDelay(defaultNoDelay);
@@ -105,6 +107,7 @@ WiFiClient::WiFiClient(const WiFiClient& other)
     _client = other._client;
     _timeout = other._timeout;
     _localPort = other._localPort;
+    _state = other._state;
     if (_client)
         _client->ref();
     WiFiClient::_add(this);
@@ -117,6 +120,7 @@ WiFiClient& WiFiClient::operator=(const WiFiClient& other)
     _client = other._client;
     _timeout = other._timeout;
     _localPort = other._localPort;
+    _state = other._state;
     if (_client)
         _client->ref();
     return *this;
@@ -128,6 +132,7 @@ int WiFiClient::connect(const char* host, uint16_t port)
     if (WiFi.hostByName(host, remote_addr, _timeout))
     {
         return connect(remote_addr, port);
+    _state = WFC_DNS_ENQUEUED;
     }
     return 0;
 }
@@ -139,6 +144,7 @@ int WiFiClient::connect(const String& host, uint16_t port)
 
 int WiFiClient::connect(IPAddress ip, uint16_t port)
 {
+    _state = WFC_CONNECTING;
     if (_client) {
         stop();
         _client->unref();
@@ -319,6 +325,7 @@ bool WiFiClient::stop(unsigned int maxWaitMs)
     bool ret = flush(maxWaitMs); // virtual, may be ssl's
     if (_client->close() != ERR_OK)
         ret = false;
+    _state = WFC_DISCONNECTED;
     return ret;
 }
 

--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -135,6 +135,7 @@ int WiFiClient::connect(const char* host, uint16_t port)
     if (!WiFi.hostByName(_host.c_str(), _ip, _timeout)) { // If successful, _ip has been set
         return 0;
     }
+    connect(_ip, _port);
     return _calculateState() == WFC_CONNECTED;
 }
 

--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -149,8 +149,6 @@ int WiFiClient::connect(IPAddress ip, uint16_t port)
     _port = port; // Saved for keepConnecting()
     _state = WFC_CONNECTING;
     if (_client) {
-        _client->unref();
-        _client = nullptr;
         stop(); // stop handles client unref
     }
 
@@ -167,8 +165,6 @@ int WiFiClient::connect(IPAddress ip, uint16_t port)
     _client->setTimeout(_timeout);
     int res = _client->connect(ip, port);
     if (res == 0) {
-        _client->unref();
-        _client = nullptr;
         return 0;
     }
 
@@ -328,6 +324,8 @@ bool WiFiClient::stop(unsigned int maxWaitMs)
     bool ret = flush(maxWaitMs); // virtual, may be ssl's
     if (_client->close() != ERR_OK)
         ret = false;
+    _client->unref();
+    _client = nullptr;
     _state = WFC_DISCONNECTED;
     return ret;
 }

--- a/libraries/ESP8266WiFi/src/WiFiClient.h
+++ b/libraries/ESP8266WiFi/src/WiFiClient.h
@@ -63,6 +63,7 @@ public:
   virtual int connect(IPAddress ip, uint16_t port) override;
   virtual int connect(const char *host, uint16_t port) override;
   virtual int connect(const String& host, uint16_t port);
+  virtual bool keepConnecting();
   virtual size_t write(uint8_t) override;
   virtual size_t write(const uint8_t *buf, size_t size) override;
   virtual size_t write_P(PGM_P buf, size_t size);
@@ -86,6 +87,8 @@ public:
   bool flush(unsigned int maxWaitMs);
   bool stop(unsigned int maxWaitMs);
   virtual uint8_t connected() override;
+  virtual uint8_t connecting();
+  virtual uint8_t disconnected();
   virtual operator bool() override;
 
   IPAddress remoteIP();
@@ -152,6 +155,8 @@ protected:
 
   int8_t _connected(void* tpcb, int8_t err);
   void _err(int8_t err);
+
+  uint8_t _calculateState();
 
   ClientContext* _client;
   static uint16_t _localPort;

--- a/libraries/ESP8266WiFi/src/WiFiClient.h
+++ b/libraries/ESP8266WiFi/src/WiFiClient.h
@@ -42,6 +42,13 @@
 class ClientContext;
 class WiFiServer;
 
+enum state_e_2 {
+  WFC_DISCONNECTED = 0,
+  WFC_DNS_ENQUEUED = 1,
+  WFC_CONNECTING = 2,
+  WFC_CONNECTED = 3
+};
+
 class WiFiClient : public Client, public SList<WiFiClient> {
 protected:
   WiFiClient(ClientContext* client);
@@ -148,6 +155,7 @@ protected:
 
   ClientContext* _client;
   static uint16_t _localPort;
+  uint8_t _state;
 };
 
 #endif

--- a/libraries/ESP8266WiFi/src/WiFiClient.h
+++ b/libraries/ESP8266WiFi/src/WiFiClient.h
@@ -161,6 +161,9 @@ protected:
   ClientContext* _client;
   static uint16_t _localPort;
   uint8_t _state;
+  String _host;
+  IPAddress _ip;
+  uint16_t _port;
 };
 
 #endif

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
@@ -73,7 +73,6 @@ namespace BearSSL {
 
 void WiFiClientSecureCtx::_clear() {
   // TLS handshake may take more than the 5 second default timeout
-  _timeout = 15000;
 
   _sc = nullptr;
   _sc_svr = nullptr;
@@ -249,7 +248,6 @@ void WiFiClientSecureCtx::_freeSSL() {
   _recvapp_len = 0;
   // This connection is toast
   _handshake_done = false;
-  _timeout = 15000;
 }
 
 bool WiFiClientSecureCtx::_clientConnected() {
@@ -510,7 +508,7 @@ int WiFiClientSecureCtx::_run_until(unsigned target, bool blocking) {
     return -1;
   }
 
-  esp8266::polledTimeout::oneShotMs loopTimeout(_timeout);
+  esp8266::polledTimeout::oneShotMs loopTimeout(15000);
 
   for (int no_work = 0; blocking || no_work < 2;) {
     optimistic_yield(100);
@@ -1230,9 +1228,6 @@ bool WiFiClientSecureCtx::_connectSSL(const char* hostName) {
   _x509_minimal = nullptr;
   _x509_insecure = nullptr;
   _x509_knownkey = nullptr;
-
-  // reduce timeout after successful handshake to fail fast if server stop accepting our data for whathever reason
-  if (ret) _timeout = 5000;
 
   return ret;
 }

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
@@ -42,8 +42,11 @@ class WiFiClientSecureCtx : public WiFiClient {
     int connect(IPAddress ip, uint16_t port) override;
     int connect(const String& host, uint16_t port) override;
     int connect(const char* name, uint16_t port) override;
+    bool keepConnecting() override;
 
     uint8_t connected() override;
+    uint8_t connecting() override;
+    uint8_t disconnected() override;
     size_t write(const uint8_t *buf, size_t size) override;
     size_t write_P(PGM_P buf, size_t size) override;
     size_t write(Stream& stream); // Note this is not virtual
@@ -142,6 +145,7 @@ class WiFiClientSecureCtx : public WiFiClient {
 
   protected:
     bool _connectSSL(const char *hostName); // Do initial SSL handshake
+    uint8_t _calculateState();
 
   private:
     void _clear();
@@ -165,6 +169,9 @@ class WiFiClientSecureCtx : public WiFiClient {
     int _iobuf_out_size;
     bool _handshake_done;
     bool _oom_err;
+
+    bool _has_name = false;
+    uint8_t _state;
 
     // Optional storage space pointer for session parameters
     // Will be used on connect and updated on close
@@ -193,6 +200,7 @@ class WiFiClientSecureCtx : public WiFiClient {
     int _run_until(unsigned target, bool blocking = true);
     size_t _write(const uint8_t *buf, size_t size, bool pmem);
     bool _wait_for_handshake(); // Sets and return the _handshake_done after connecting
+    bool _ssl_connected(); // SSL layer connected?
 
     // Optional client certificate
     const X509List *_chain;
@@ -242,8 +250,11 @@ class WiFiClientSecure : public WiFiClient {
     int connect(IPAddress ip, uint16_t port) override { return _ctx->connect(ip, port); }
     int connect(const String& host, uint16_t port) override { return _ctx->connect(host, port); }
     int connect(const char* name, uint16_t port) override { return _ctx->connect(name, port); }
+    bool keepConnecting() override { return _ctx->keepConnecting(); };
 
     uint8_t connected() override { return _ctx->connected(); }
+    uint8_t connecting() override { return _ctx->connecting(); }
+    uint8_t disconnected() override { return _ctx->disconnected(); }
     size_t write(const uint8_t *buf, size_t size) override { return _ctx->write(buf, size); }
     size_t write_P(PGM_P buf, size_t size) override { return _ctx->write_P(buf, size); }
     size_t write(const char *buf) { return write((const uint8_t*)buf, strlen(buf)); }

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
@@ -259,6 +259,8 @@ class WiFiClientSecure : public WiFiClient {
     bool stop(unsigned int maxWaitMs) { return _ctx->stop(maxWaitMs); }
     void flush() override { (void)flush(0); }
     void stop() override { (void)stop(0); }
+    unsigned long getTimeout() { return _ctx->getTimeout(); }
+    void setTimeout(unsigned long timeout) { _ctx->setTimeout(timeout); }
 
     // Allow sessions to be saved/restored automatically to a memory area
     void setSession(Session *session) { _ctx->setSession(session); }

--- a/tests/ci/host_test.sh
+++ b/tests/ci/host_test.sh
@@ -10,6 +10,7 @@ cd $TRAVIS_BUILD_DIR/tests/host
 make -j2 FORCE32=0 ssl
 for i in ../../libraries/ESP8266WiFi/examples/WiFiClient/WiFiClient \
 	../../libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation \
+	../../libraries/ESP8266WiFi/examples/ConnectNoTimeout/ConnectNoTimeout \
 	../../libraries/ESP8266WebServer/examples/HelloServer/HelloServer \
 	../../libraries/SD/examples/Files/Files \
 	../../libraries/LittleFS/examples/LittleFS_Timestamp/LittleFS_Timestamp \


### PR DESCRIPTION
Change a bit connect methods of `WiFiClient` and `WiFiClientSecure`.
With very low timeout, connection may not be established in time and in this case connection is aborted.
Using low timeout makes connections sort of "async" (there's no callback, but can be done in a future PR)
and doesn't block the context waiting for the establishment.
Added `keepConnecting` to handle DNS query response.
The SSL layer is left untouched (so it may still block during handshake).
Added example