### PR TITLE
HW Serial swap and pin setting work only on a few pins

### DIFF
--- a/cores/esp8266/HardwareSerial.h
+++ b/cores/esp8266/HardwareSerial.h
@@ -101,31 +101,31 @@ public:
         return uart_get_rx_buffer_size(_uart);
     }
 
-    void swap()
+    bool swap()
     {
-        swap(1);
+        return swap(1);
     }
-    void swap(uint8_t tx_pin)    //toggle between use of GPIO13/GPIO15 or GPIO3/GPIO(1/2) as RX and TX
+    bool swap(uint8_t tx_pin)    //toggle between use of GPIO13/GPIO15 or GPIO3/GPIO(1/2) as RX and TX
     {
-        uart_swap(_uart, tx_pin);
+        return uart_swap(_uart, tx_pin);
     }
 
     /*
      * Toggle between use of GPIO1 and GPIO2 as TX on UART 0.
      * Note: UART 1 can't be used if GPIO2 is used with UART 0!
      */
-    void set_tx(uint8_t tx_pin)
+    bool set_tx(uint8_t tx_pin)
     {
-        uart_set_tx(_uart, tx_pin);
+        return uart_set_tx(_uart, tx_pin);
     }
 
     /*
      * UART 0 possible options are (1, 3), (2, 3) or (15, 13)
      * UART 1 allows only TX on 2 if UART 0 is not (2, 3)
      */
-    void pins(uint8_t tx, uint8_t rx)
+    bool pins(uint8_t tx, uint8_t rx)
     {
-        uart_set_pins(_uart, tx, rx);
+        return uart_set_pins(_uart, tx, rx);
     }
 
     int available(void) override;

--- a/cores/esp8266/uart.h
+++ b/cores/esp8266/uart.h
@@ -116,9 +116,9 @@ typedef struct uart_ uart_t;
 uart_t* uart_init(int uart_nr, int baudrate, int config, int mode, int tx_pin, size_t rx_size, bool invert);
 void uart_uninit(uart_t* uart);
 
-void uart_swap(uart_t* uart, int tx_pin);
-void uart_set_tx(uart_t* uart, int tx_pin);
-void uart_set_pins(uart_t* uart, int tx, int rx);
+bool uart_swap(uart_t* uart, int tx_pin);
+bool uart_set_tx(uart_t* uart, int tx_pin);
+bool uart_set_pins(uart_t* uart, int tx, int rx);
 bool uart_tx_enabled(uart_t* uart);
 bool uart_rx_enabled(uart_t* uart);
 

--- a/tests/host/common/MockUART.cpp
+++ b/tests/host/common/MockUART.cpp
@@ -407,26 +407,29 @@ uart_uninit(uart_t* uart)
 	free(uart);
 }
 
-void
+bool
 uart_swap(uart_t* uart, int tx_pin)
 {
 	(void) uart;
 	(void) tx_pin;
+	return true;
 }
 
-void
+bool
 uart_set_tx(uart_t* uart, int tx_pin)
 {
 	(void) uart;
 	(void) tx_pin;
+	return true;
 }
 
-void
+bool
 uart_set_pins(uart_t* uart, int tx, int rx)
 {
 	(void) uart;
 	(void) tx;
 	(void) rx;
+	return true;
 }
 
 bool


### PR DESCRIPTION
Change return type from void to bool on affected functions, return false on failure.