### PR TITLE
fix WiFiClient::write(from flash or iram)

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -40,6 +40,7 @@ extern "C"
 #include "lwip/netif.h"
 #include <include/ClientContext.h>
 #include "c_types.h"
+#include <StreamDev.h>
 
 uint16_t WiFiClient::_localPort = 0;
 

--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -212,7 +212,8 @@ size_t WiFiClient::write(const uint8_t *buf, size_t size)
         return 0;
     }
     _client->setTimeout(_timeout);
-    return _client->write(buf, size);
+    StreamConstPtr ptr(buf, size);
+    return _client->write(ptr);
 }
 
 size_t WiFiClient::write(Stream& stream, size_t unused)
@@ -227,8 +228,12 @@ size_t WiFiClient::write(Stream& stream)
     {
         return 0;
     }
-    _client->setTimeout(_timeout);
-    return _client->write(stream);
+    if (stream.hasPeekBufferAPI())
+    {
+        _client->setTimeout(_timeout);
+        return _client->write(stream);
+    }
+    return stream.sendAvailable(this);
 }
 
 size_t WiFiClient::write_P(PGM_P buf, size_t size)
@@ -238,7 +243,8 @@ size_t WiFiClient::write_P(PGM_P buf, size_t size)
         return 0;
     }
     _client->setTimeout(_timeout);
-    return _client->write_P(buf, size);
+    StreamConstPtr nopeek(buf, size);
+    return nopeek.sendAll(this);
 }
 
 int WiFiClient::available()

--- a/libraries/ESP8266WiFi/src/include/ClientContext.h
+++ b/libraries/ESP8266WiFi/src/include/ClientContext.h
@@ -31,6 +31,7 @@ extern "C" void esp_schedule();
 
 #include <assert.h>
 #include <StreamDev.h>
+#include <esp_priv.h>
 
 bool getDefaultPrivateGlobalSyncValue ();
 
@@ -372,30 +373,13 @@ public:
         return _pcb->state;
     }
 
-    size_t write(const uint8_t* data, size_t size)
-    {
-        if (!_pcb) {
-            return 0;
-        }
-        StreamConstPtr ptr(data, size);
-        return _write_from_source(&ptr);
-    }
-
     size_t write(Stream& stream)
     {
         if (!_pcb) {
             return 0;
         }
+        assert(stream.hasPeekBufferAPI());
         return _write_from_source(&stream);
-    }
-
-    size_t write_P(PGM_P buf, size_t size)
-    {
-        if (!_pcb) {
-            return 0;
-        }
-        StreamConstPtr ptr(buf, size);
-        return _write_from_source(&ptr);
     }
 
     void keepAlive (uint16_t idle_sec = TCP_DEFAULT_KEEPALIVE_IDLE_SEC, uint16_t intv_sec = TCP_DEFAULT_KEEPALIVE_INTERVAL_SEC, uint8_t count = TCP_DEFAULT_KEEPALIVE_COUNT)
@@ -504,7 +488,6 @@ protected:
                // Give scheduled functions a chance to run (e.g. Ethernet uses recurrent)
                delay(1);
                // will resume on timeout or when _write_some_from_cb or _notify_error fires
-
             }
             _send_waiting = false;
         } while(true);


### PR DESCRIPTION
`WiFiClient`'s `ClientContext` was originally designed to take data from a Stream through a specific `DataSource` class which is now removed by the `Stream::send` changes.
Ability to stream from flash or dram to `WiFiClient` was missing from these changes, this is now restored. 

Fixes #7928 ([comment](https://github.com/esp8266/Arduino/issues/7928#issuecomment-804574643))