### PR TITLE
Ticker callbacks must be in IRAM

### DIFF
--- a/libraries/Ticker/examples/TickerFunctional/TickerFunctional.ino
+++ b/libraries/Ticker/examples/TickerFunctional/TickerFunctional.ino
@@ -19,12 +19,12 @@ class ExampleClass {
     int _pin, _duration;
     Ticker _myTicker;
 
-    void classBlink() {
+    IRAM_ATTR void classBlink() {
       digitalWrite(_pin, !digitalRead(_pin));
     }
 };
 
-void staticBlink() {
+IRAM_ATTR void staticBlink() {
   digitalWrite(LED2, !digitalRead(LED2));
 }
 
@@ -32,7 +32,7 @@ void scheduledBlink() {
   digitalWrite(LED3, !digitalRead(LED2));
 }
 
-void parameterBlink(int p) {
+IRAM_ATTR void parameterBlink(int p) {
   digitalWrite(p, !digitalRead(p));
 }
 
@@ -55,7 +55,7 @@ void setup() {
   parameterTicker.attach_ms(100, std::bind(parameterBlink, LED4));
 
   pinMode(LED5, OUTPUT);
-  lambdaTicker.attach_ms(100, []() {
+  lambdaTicker.attach_ms_scheduled_accurate(100, []() {
     digitalWrite(LED5, !digitalRead(LED5));
   });
 }

--- a/libraries/Ticker/examples/TickerParameter/TickerParameter.ino
+++ b/libraries/Ticker/examples/TickerParameter/TickerParameter.ino
@@ -17,19 +17,19 @@ Ticker tickerSetLow;
 Ticker tickerSetHigh;
 Ticker tickerSetChar;
 
-void setPinLow() {
+IRAM_ATTR void setPinLow() {
   digitalWrite(LED_BUILTIN, 0);
 }
 
-void setPinHigh() {
+IRAM_ATTR void setPinHigh() {
   digitalWrite(LED_BUILTIN, 1);
 }
 
-void setPin(int state) {
+IRAM_ATTR void setPin(int state) {
   digitalWrite(LED_BUILTIN, state);
 }
 
-void setPinChar(char state) {
+IRAM_ATTR void setPinChar(char state) {
   digitalWrite(LED_BUILTIN, state);
 }
 

--- a/libraries/Ticker/src/Ticker.cpp
+++ b/libraries/Ticker/src/Ticker.cpp
@@ -63,7 +63,7 @@ bool Ticker::active() const
     return _timer;
 }
 
-void Ticker::_static_callback(void* arg)
+IRAM_ATTR void Ticker::_static_callback(void* arg)
 {
     Ticker* _this = reinterpret_cast<Ticker*>(arg);
     if (_this && _this->_callback_function)

--- a/libraries/Ticker/src/Ticker.h
+++ b/libraries/Ticker/src/Ticker.h
@@ -38,7 +38,7 @@ public:
     // callback will be called at following loop() after ticker fires
     void attach_scheduled(float seconds, callback_function_t callback)
     {
-        _callback_function = [callback]() { schedule_function(callback); };
+        _callback_function = std::bind(schedule_function, callback);
         _attach_ms(1000UL * seconds, true);
     }
 
@@ -52,14 +52,15 @@ public:
     // callback will be called at following loop() after ticker fires
     void attach_ms_scheduled(uint32_t milliseconds, callback_function_t callback)
     {
-        _callback_function = [callback]() { schedule_function(callback); };
+        _callback_function = std::bind(schedule_function, callback);
         _attach_ms(milliseconds, true);
     }
 
     // callback will be called at following yield() after ticker fires
     void attach_ms_scheduled_accurate(uint32_t milliseconds, callback_function_t callback)
     {
-        _callback_function = [callback]() { schedule_recurrent_function_us([callback]() { callback(); return false; }, 0); };
+        _callback_function = std::bind(schedule_recurrent_function_us,
+            [callback]() { callback(); return false; }, 0, nullptr);
         _attach_ms(milliseconds, true);
     }
 
@@ -95,7 +96,7 @@ public:
     // callback will be called at following loop() after ticker fires
     void once_scheduled(float seconds, callback_function_t callback)
     {
-        _callback_function = [callback]() { schedule_function(callback); };
+        _callback_function = std::bind(schedule_function, callback);
         _attach_ms(1000UL * seconds, false);
     }
 
@@ -109,7 +110,7 @@ public:
     // callback will be called at following loop() after ticker fires
     void once_ms_scheduled(uint32_t milliseconds, callback_function_t callback)
     {
-        _callback_function = [callback]() { schedule_function(callback); };
+        _callback_function = std::bind(schedule_function, callback);
         _attach_ms(milliseconds, false);
     }
 


### PR DESCRIPTION
Unless I'm mistaken, the Ticker callbacks are performed by an ISR, and belong into IRAM to prevent flash memory races.
IIRC, lambdas are only safe, that is, in IRAM, if they are without closures, while bind is OK.