### PR TITLE
Fixes #7988: reverse dependency core on libraries: `enableWiFiAtBootTime()`

### DIFF
--- a/cores/esp8266/core_esp8266_features.h
+++ b/cores/esp8266/core_esp8266_features.h
@@ -105,8 +105,6 @@ uint64_t micros64(void);
 void delay(unsigned long);
 void delayMicroseconds(unsigned int us);
 
-void enableWiFiAtBootTime (void) __attribute__((noinline));
-
 #if defined(F_CPU) || defined(CORE_MOCK)
 #ifdef __cplusplus
 constexpr

--- a/doc/esp8266wifi/generic-class.rst
+++ b/doc/esp8266wifi/generic-class.rst
@@ -61,7 +61,7 @@ linker).
 
 .. code:: cpp
 
-    #include <ESP8266WiFi.h>    // necessary to avoid a linker error
+    #include <ESP8266WiFi.h>
 
     void setup () {
     #ifdef WIFI_IS_OFF_AT_BOOT

--- a/libraries/ESP8266WiFi/src/ESP8266WiFi.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFi.h
@@ -53,6 +53,7 @@ extern "C" {
 #define DEBUG_WIFI(...) do { (void)0; } while (0)
 #endif
 
+extern "C" void enableWiFiAtBootTime (void) __attribute__((noinline));
 
 class ESP8266WiFiClass : public ESP8266WiFiGenericClass, public ESP8266WiFiSTAClass, public ESP8266WiFiScanClass, public ESP8266WiFiAPClass {
     public:


### PR DESCRIPTION
Fixes #7988 