### PR TITLE
Make `enablePhaseLockedWaveform()` visible from `Arduino.h`

### DIFF
--- a/cores/esp8266/core_esp8266_features.h
+++ b/cores/esp8266/core_esp8266_features.h
@@ -122,6 +122,9 @@ inline int esp_get_cpu_freq_mhz()
 }
 #endif
 
+// Call this function in your setup() to cause the phase locked version of the generator to
+// be linked in automatically.  Otherwise, the default PWM locked version will be used.
+void enablePhaseLockedWaveform(void);
 
 #ifdef __cplusplus
 }

--- a/cores/esp8266/core_esp8266_waveform.h
+++ b/cores/esp8266/core_esp8266_waveform.h
@@ -72,11 +72,6 @@
 extern "C" {
 #endif
 
-// Call this function in your setup() to cause the phase locked version of the generator to
-// be linked in automatically.  Otherwise, the default PWM locked version will be used.
-void enablePhaseLockedWaveform(void);
-
-
 // Start or change a waveform of the specified high and low times on specific pin.
 // If runtimeUS > 0 then automatically stop it after that many usecs, relative to the next
 // full period.

--- a/libraries/esp8266/examples/FadePolledTimeout/FadePolledTimeout.ino
+++ b/libraries/esp8266/examples/FadePolledTimeout/FadePolledTimeout.ino
@@ -23,7 +23,6 @@
   Note that this sketch uses LED_BUILTIN to find the pin with the internal LED
 */
 
-#include <core_esp8266_waveform.h>
 #include <PolledTimeout.h>
 
 esp8266::polledTimeout::periodicFastUs stepPeriod(50000);
@@ -33,8 +32,8 @@ void setup() {
   Serial.begin(115200);
   Serial.println();
 
-  // This next line will call will cause the code to use the Phase-Locked waveform generator
-  // instead of the default one.  Comment it out to try the default version.
+  // This next line will cause the code to use the Phase-Locked waveform generator
+  // instead of the default PWM-Locked one.  Comment it out to try the default version.
   // For more information on choosing between the two options, see the following pull requests:
   // Phase-Locked generator: https://github.com/esp8266/Arduino/pull/7022
   // PWM-Locked generator:   https://github.com/esp8266/Arduino/pull/7231


### PR DESCRIPTION
Move the prototype for `enablePhaseLockedWaveform()` linker magic into header that's included by default instead of particular internal core header.
Fixes #7976 .