### PR TITLE
Smartconfig begin takes an optional user callback

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
@@ -28,6 +28,7 @@
 #include "ESP8266WiFiGeneric.h"
 #include "user_interface.h"
 #include "LwipIntf.h"
+#include "smartconfig.h"
 
 
 class ESP8266WiFiSTAClass: public LwipIntf {
@@ -96,6 +97,7 @@ class ESP8266WiFiSTAClass: public LwipIntf {
 
         bool beginWPSConfig(void);
         bool beginSmartConfig();
+        bool beginSmartConfig(sc_callback_t userCallback);
         bool stopSmartConfig();
         bool smartConfigDone();
 
@@ -105,6 +107,7 @@ class ESP8266WiFiSTAClass: public LwipIntf {
         static bool _smartConfigDone;
 
         static void _smartConfigCallback(uint32_t status, void* result);
+        static sc_callback_t _smartConfigUserCallback;
 
 };
 


### PR DESCRIPTION
In the current state of the smart config using Arduino core, mobile has to broadcast the ssid and password unencrypted. And the esp will connect to the wifi credentials received directly. 
By adding support for this optional callback, mobile can send an encrypted password string which can be handled/decrypted by user callback and then connect the esp to the network using the parsed credentials. This does not make it fully secure, but at least a pre-shared key based encryption can be implemented(up to the user). 
