### PR TITLE
Updated HWDT one missed ICACHE_RAM_ATTR

### DIFF
--- a/cores/esp8266/core_esp8266_app_entry_noextra4k.cpp
+++ b/cores/esp8266/core_esp8266_app_entry_noextra4k.cpp
@@ -28,7 +28,7 @@ extern "C" void call_user_start();
 static cont_t g_cont __attribute__ ((aligned (16)));
 
 #if defined(DEBUG_ESP_HWDT_NOEXTRA4K) || defined(DEBUG_ESP_HWDT)
-extern "C" cont_t * ICACHE_RAM_ATTR get_noextra4k_g_pcont(void)
+extern "C" cont_t * IRAM_ATTR get_noextra4k_g_pcont(void)
 {
     return &g_cont;
 }


### PR DESCRIPTION
Correct missed ICACHE_RAM_ATTR in `cores/esp8266/core_esp8266_app_entry_noextra4k.cpp`.