### PR TITLE
update release github action

### DIFF
--- a/.github/workflows/release-to-publish.yml
+++ b/.github/workflows/release-to-publish.yml
@@ -36,12 +36,13 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+        fetch-depth: 0
     - uses: actions/setup-python@v2
       with:
         python-version: '3.x'
     - name: Set GIT tag name
       run: |
-        echo "::set-env name=TRAVIS_TAG::$(git describe --exact-match --tags)"
+        echo "TRAVIS_TAG=$(git describe --exact-match --tags)" >> $GITHUB_ENV
     - name: Deploy updated JSON
       env:
         TRAVIS_BUILD_DIR: ${{ github.workspace }}


### PR DESCRIPTION
- following this error message
  Error: Unable to process command '::set-env name=TRAVIS_TAG::3.0.0' successfully.
  Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
- this guide:
  https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#environment-files