### PR TITLE
back to dev (3.0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Arduino core for ESP8266 WiFi chip
 
 # Quick links
 
-- [Latest release documentation](https://arduino-esp8266.readthedocs.io/en/2.7.4_a/)
+- [Latest release documentation](https://arduino-esp8266.readthedocs.io/en/3.0.0/)
 - [Current "git version" documentation](https://arduino-esp8266.readthedocs.io/en/latest/)
 - [Install git version](https://arduino-esp8266.readthedocs.io/en/latest/installing.html#using-git-version) ([sources](doc/installing.rst#using-git-version))
 
@@ -36,7 +36,7 @@ Starting with 1.6.4, Arduino allows installation of third-party platform package
 #### Latest release [![Latest release](https://img.shields.io/github/release/esp8266/Arduino.svg)](https://github.com/esp8266/Arduino/releases/latest/)
 Boards manager link: `https://arduino.esp8266.com/stable/package_esp8266com_index.json`
 
-Documentation: [https://arduino-esp8266.readthedocs.io/en/2.7.4_a/](https://arduino-esp8266.readthedocs.io/en/2.7.4_a/)
+Documentation: [https://arduino-esp8266.readthedocs.io/en/3.0.0/](https://arduino-esp8266.readthedocs.io/en/3.0.0/)
 
 ### Using git version
 [![Linux build status](https://travis-ci.org/esp8266/Arduino.svg)](https://travis-ci.org/esp8266/Arduino)

--- a/package.json
+++ b/package.json
@@ -2,5 +2,5 @@
     "name": "framework-arduinoespressif8266",
     "description": "Arduino Wiring-based Framework (ESP8266 Core)",
     "url": "https://github.com/esp8266/Arduino",
-    "version": "3.0.0"
+    "version": "3.0.1-dev"
 }

--- a/platform.txt
+++ b/platform.txt
@@ -5,8 +5,8 @@
 # For more info:
 # https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5-3rd-party-Hardware-specification
 
-name=ESP8266 Boards (3.0.0)
-version=3.0.0
+name=ESP8266 Boards (3.0.1-dev)
+version=3.0.1-dev
 
 # These will be removed by the packager script when doing a JSON release
 runtime.tools.xtensa-lx106-elf-gcc.path={runtime.platform.path}/tools/xtensa-lx106-elf


### PR DESCRIPTION
closes #8035 

*edit*: 
For some reason the sha256 from the release page https://github.com/esp8266/Arduino/releases/download/3.0.0/package_esp8266com_index.json (b3d4a5477acb17e8d84d6e492701c950d0d9cc3bb828e02bd3117c45833c1210 which is right)
differs from the one used by Arduino IDE one from esp8266.github.io
https://arduino.esp8266.com/stable/package_esp8266com_index.json
(9f6929a182c97a96c093137720ce85a0749b06bfd1a8850b401cc5ab0c50e758)

This need to be sorted out by @igrr or @earlephilhower 