### PR TITLE
digitalWrite() in `enablePhaseLockedWaveform` mode: need IRAM_ATTR on all `stopPWM()` impls

### DIFF
--- a/cores/esp8266/core_esp8266_waveform_phase.cpp
+++ b/cores/esp8266/core_esp8266_waveform_phase.cpp
@@ -55,7 +55,7 @@ extern "C" void enablePhaseLockedWaveform (void)
 
 // No-op calls to override the PWM implementation
 extern "C" void _setPWMFreq_weak(uint32_t freq) { (void) freq; }
-extern "C" bool _stopPWM_weak(int pin) { (void) pin; return false; }
+extern "C" IRAM_ATTR bool _stopPWM_weak(int pin) { (void) pin; return false; }
 extern "C" bool _setPWM_weak(int pin, uint32_t val, uint32_t range) { (void) pin; (void) val; (void) range; return false; }
 
 


### PR DESCRIPTION
Even if a very small function, loading any code from flash while in ISR can and will eventually crash the MCU.
Added IRAM_ATTR to _stopPWM() so that digitalWrite() would work inside ISR.
Fixes #8043