### PR TITLE
Normalize I2S core header's include guard.

### DIFF
--- a/cores/esp8266/core_esp8266_i2s.h
+++ b/cores/esp8266/core_esp8266_i2s.h
@@ -18,8 +18,8 @@
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
-#ifndef I2S_h
-#define I2S_h
+#ifndef CORE_ESP8266_I2S_H
+#define CORE_ESP8266_I2S_H
 
 #define I2S_HAS_BEGIN_RXTX_DRIVE_CLOCKS 1
 


### PR DESCRIPTION
Complements fix PR #8108  for #8107 