### PR TITLE
Remove include and lib folders removed since 3.0.0 core

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -115,8 +115,6 @@ env.Append(
 
     CPPPATH=[
         join(FRAMEWORK_DIR, "tools", "sdk", "include"),
-        join(FRAMEWORK_DIR, "tools", "sdk", "libc",
-             "xtensa-lx106-elf", "include"),
         join(FRAMEWORK_DIR, "cores", env.BoardConfig().get("build.core")),
         join(platform.get_package_dir("toolchain-xtensa"), "include")
     ],
@@ -124,8 +122,7 @@ env.Append(
     LIBPATH=[
         join("$BUILD_DIR", "ld"),  # eagle.app.v6.common.ld
         join(FRAMEWORK_DIR, "tools", "sdk", "lib"),
-        join(FRAMEWORK_DIR, "tools", "sdk", "ld"),
-        join(FRAMEWORK_DIR, "tools", "sdk", "libc", "xtensa-lx106-elf", "lib")
+        join(FRAMEWORK_DIR, "tools", "sdk", "ld")
     ],
 
     LIBS=[


### PR DESCRIPTION
Synchronizes the `platformio-build.py` build script with what is actually there in the core folder. The folder `tools/sdk/libc` was removed since [core version 3.0.0](https://github.com/esp8266/Arduino/tree/3.0.0/tools/sdk), (but existed in [2.7.4](https://github.com/esp8266/Arduino/tree/2.7.4/tools/sdk)), however the script was not updated.

This makes users unsure as there is warning about this not-found directory in VSCode then ([source](https://community.platformio.org/t/problems-with-platformio-and-seemingly-missing-file-esp01-1m/22003)). 

Fixed by simply removing the non-existant folders from the build script.