### PR TITLE
Release process fix & major/minor/rev macro addition

### DIFF
--- a/cores/esp8266/core_version.h
+++ b/cores/esp8266/core_version.h
@@ -6,6 +6,18 @@
 #define ARDUINO_ESP8266_GIT_DESC unspecified
 #endif
 
+#ifndef ARDUINO_ESP8266_MAJOR
+#define ARDUINO_ESP8266_MAJOR     0
+#endif
+
+#ifndef ARDUINO_ESP8266_MINOR
+#define ARDUINO_ESP8266_MINOR     0
+#endif
+
+#ifndef ARDUINO_ESP8266_REVISION
+#define ARDUINO_ESP8266_REVISION  0
+#endif
+
 // ARDUINO_ESP8266_RELEASE is defined for released versions as a string containing the version name, i.e. "2_3_0_RC1"
 // ARDUINO_ESP8266_RELEASE is used in the core internally. Please use ESP.getCoreVersion() function instead.
 

--- a/package/README.md
+++ b/package/README.md
@@ -76,7 +76,7 @@ Here is a rough overview of the effective release process. See the section below
     * Prepare release notes in Markdown format.
 
     * For changes that are breaking, duplicate those changes and put the duplicate lines into a separate group called Breaking Changes. That group should go at the top of the Changelog. The original lines for the breaking changes should be marked by appending "(Breaking change)" to the line. Example:
-   
+
     ```
     Breaking Changes
     ================
@@ -141,7 +141,7 @@ The following points assume work in a direct clone of the repository, and not in
 8. Wait for Travis CI build for the tag to pass, see https://travis-ci.org/esp8266/Arduino/builds,
 
 
-9. Check that the new (draft) release has been created (no editing at this point!), see https://github.com/esp8266/Arduino/releases. 
+9. Check that the new (draft) release has been created (no editing at this point!), see https://github.com/esp8266/Arduino/releases.
 
 10. Check that the boards manager package .zip file has been successfully uploaded as a release artifact.
 
@@ -167,41 +167,39 @@ The following points assume work in a direct clone of the repository, and not in
 --------------COPY BELOW THIS LINE--------------
 [Reference](https://github.com/esp8266/Arduino/tree/master/package#creating-a-release-for-maintainers) for details.
 
-- [ ] 1. Open a new issue to track activities. 
+- [ ] 1. Make sure that no issues or PRs are assigned to the milestone to be released.
 
-- [ ] 2. Make sure that no issues or PRs are assigned to the milestone to be released.
+- [ ] 2. Open a new issue to track activities.
 
 - [ ] 3. Assemble release notes.
 
-- [ ] 4. Make a PR with the following, [wait for Travis CI](https://travis-ci.org/github/esp8266/Arduino/builds/), and merge.
+- [ ] 4. Make a PR with the following, [wait for CI](https://github.com/esp8266/Arduino/pull/8034/checks), and merge.
 
    * [platform.txt](https://github.com/esp8266/Arduino/blob/master/platform.txt)
    * [package.json](https://github.com/esp8266/Arduino/blob/master/package.json)
-   * [cores/esp8266/TZ.h](https://github.com/esp8266/Arduino/blob/master/cores/esp8266/TZ.h)
+   * [TZ.h](https://github.com/esp8266/Arduino/blob/master/cores/esp8266/TZ.h) (<= `cd tools; ./TZupdate.sh`)
 
-- [ ] 5. Wait until the release notes have been checked by other maintainers
+- [ ] 5. Wait until the release notes have been checked by other maintainers (can be changed afterwards anyway)
 
-- [ ] 6. Navigate to [Travis CI options](https://travis-ci.org/esp8266/Arduino/settings), enable ´Build pushed branches´ (before tagging in next step)
+- [ ] 6. Tag the latest commit on the master branch, then push it to esp8266/Arduino
+      add: `git tag -a -m "Release 3.0.0" 3.0.0; git push origin 3.0.0`
+      remove: `git tag -d X.Y.Z; git push --delete origin X.Y.Z`
 
-- [ ] 7. Tag the latest commit on the master branch, then push it to esp8266/Arduino
+- [ ] 7. Wait for CI build for the tag to pass (in `Actions` menu)
 
-- [ ] 8. Wait for Travis CI build for the tag to pass, see https://travis-ci.org/esp8266/Arduino/builds,
+- [ ] 8. Check that the new (draft) release has been created (no editing at this point!), see https://github.com/esp8266/Arduino/releases.
 
-- [ ] 9. Check that the new (draft) release has been created (no editing at this point!), see https://github.com/esp8266/Arduino/releases. 
+- [ ] 9. Check that the boards manager package .zip file has been successfully uploaded as a release artifact.
 
-- [ ] 10. Check that the boards manager package .zip file has been successfully uploaded as a release artifact.
+- [ ] 10. Check that the package index downloaded from https://arduino.esp8266.com/stable/package_esp8266com_index.json contains an entry for the new version (it may not be the first one).
 
-- [ ] 11. Check that the package index downloaded from https://arduino.esp8266.com/stable/package_esp8266com_index.json contains an entry for the new version (it may not be the first one).
+- [ ] 11. Navigate to [release list in Github](https://github.com/esp8266/Arduino/releases), press "Edit" button to edit release description, paste release notes, and publish it.
 
-- [ ] 12. Return to the [Travis CI options](https://travis-ci.org/esp8266/Arduino/settings) and disable `Build pushed branches`.
+- [ ] 12. In the issue tracker, remove "staged-for-release" label for all issues which have it, and close them. Close the milestone associated with the released version (the milestone should be empty per point 1 above)
 
-- [ ] 13. Navigate to [release list in Github](https://github.com/esp8266/Arduino/releases), press "Edit" button to edit release description, paste release notes, and publish it.
+- [ ] 13. Check that https://arduino-esp8266.readthedocs.io/en/latest/ has a new doc build for the new tag, and that "stable" points to that build. If a new build did not trigger, log into readthedoc's home here https://readthedocs.org/ (account must have been added to project as maintainer) and trigger it manually.
 
-- [ ] 14. In the issue tracker, remove "staged-for-release" label for all issues which have it, and close them. Close the milestone associated with the released version (the milestone should be empty per point 2 above)
-
-- [ ] 15. Check that https://arduino-esp8266.readthedocs.io/en/latest/ has a new doc build for the new tag, and that "stable" points to that build. If a new build did not trigger, log into readthedoc's home here https://readthedocs.org/ (account must have been added to project as maintainer) and trigger it manually.
-
-- [ ] 16. Create a commit to the master branch, updating:
+- [ ] 14. Create a commit to the master branch, updating:
 
     * The version in platform.txt and package.json files. This should correspond to the version of the *next* milestone, plus `-dev` suffix. E.g. `3.1.0-dev`.
     * In main README.md go to "Latest release" section, change version number in the readthedocs link to the version which was just released, and verify that all links work.

--- a/package/build_boards_manager_package.sh
+++ b/package/build_boards_manager_package.sh
@@ -110,11 +110,12 @@ $SED -E "s/name=([a-zA-Z0-9\ -]+).*/name=\1(${ver})/g"\
 
 # Put core version and short hash of git version into core_version.h
 ver_define=`echo "${plain_ver}" | tr "[:lower:]." "[:upper:]_"`
-echo "ver_define: ${ver_define}  (plain_ver: ${plain_ver})"
-echo "#define ARDUINO_ESP8266_GIT_VER 0x`git rev-parse --short=8 HEAD 2>/dev/null`" >${outdir}/cores/esp8266/core_version.h
-echo "#define ARDUINO_ESP8266_GIT_DESC `git describe --tags 2>/dev/null`" >>${outdir}/cores/esp8266/core_version.h
-echo "#define ARDUINO_ESP8266_RELEASE_${ver_define}" >>${outdir}/cores/esp8266/core_version.h
-echo "#define ARDUINO_ESP8266_RELEASE \"${ver_define}\"" >>${outdir}/cores/esp8266/core_version.h
+#echo "ver_define: ${ver_define}  (plain_ver: ${plain_ver})"
+#echo "#define ARDUINO_ESP8266_GIT_VER 0x`git rev-parse --short=8 HEAD 2>/dev/null`" >${outdir}/cores/esp8266/core_version.h
+#echo "#define ARDUINO_ESP8266_GIT_DESC `git describe --tags 2>/dev/null`" >>${outdir}/cores/esp8266/core_version.h
+#echo "#define ARDUINO_ESP8266_RELEASE_${ver_define}" >>${outdir}/cores/esp8266/core_version.h
+#echo "#define ARDUINO_ESP8266_RELEASE \"${ver_define}\"" >>${outdir}/cores/esp8266/core_version.h
+python3 ${srcdir}/tools/makecorever -b ${outdir} -i cores/esp8266 -p ${srcdir} -v ${ver_define}
 
 # Zip the package
 pushd package/versions/${visiblever}

--- a/package/build_boards_manager_package.sh
+++ b/package/build_boards_manager_package.sh
@@ -115,7 +115,7 @@ ver_define=`echo "${plain_ver}" | tr "[:lower:]." "[:upper:]_"`
 #echo "#define ARDUINO_ESP8266_GIT_DESC `git describe --tags 2>/dev/null`" >>${outdir}/cores/esp8266/core_version.h
 #echo "#define ARDUINO_ESP8266_RELEASE_${ver_define}" >>${outdir}/cores/esp8266/core_version.h
 #echo "#define ARDUINO_ESP8266_RELEASE \"${ver_define}\"" >>${outdir}/cores/esp8266/core_version.h
-python3 ${srcdir}/tools/makecorever -b ${outdir} -i cores/esp8266 -p ${srcdir} -v ${ver_define}
+python3 ${srcdir}/tools/makecorever.py -b ${outdir} -i cores/esp8266 -p ${srcdir} -v ${ver_define}
 
 # Zip the package
 pushd package/versions/${visiblever}

--- a/package/build_boards_manager_package.sh
+++ b/package/build_boards_manager_package.sh
@@ -109,13 +109,13 @@ $SED -E "s/name=([a-zA-Z0-9\ -]+).*/name=\1(${ver})/g"\
  > ${outdir}/platform.txt
 
 # Put core version and short hash of git version into core_version.h
-ver_define=`echo "${plain_ver}" | tr "[:lower:]." "[:upper:]_"`
+#ver_define=`echo "${plain_ver}" | tr "[:lower:]." "[:upper:]_"`
 #echo "ver_define: ${ver_define}  (plain_ver: ${plain_ver})"
 #echo "#define ARDUINO_ESP8266_GIT_VER 0x`git rev-parse --short=8 HEAD 2>/dev/null`" >${outdir}/cores/esp8266/core_version.h
 #echo "#define ARDUINO_ESP8266_GIT_DESC `git describe --tags 2>/dev/null`" >>${outdir}/cores/esp8266/core_version.h
 #echo "#define ARDUINO_ESP8266_RELEASE_${ver_define}" >>${outdir}/cores/esp8266/core_version.h
 #echo "#define ARDUINO_ESP8266_RELEASE \"${ver_define}\"" >>${outdir}/cores/esp8266/core_version.h
-python3 ${srcdir}/tools/makecorever.py -b ${outdir} -i cores/esp8266 -p ${srcdir} -v ${ver_define}
+python3 ${srcdir}/tools/makecorever.py -b ${outdir} -i cores/esp8266 -p ${srcdir} -v ${plain_ver}
 
 # Zip the package
 pushd package/versions/${visiblever}

--- a/package/build_boards_manager_package.sh
+++ b/package/build_boards_manager_package.sh
@@ -115,7 +115,7 @@ $SED -E "s/name=([a-zA-Z0-9\ -]+).*/name=\1(${ver})/g"\
 #echo "#define ARDUINO_ESP8266_GIT_DESC `git describe --tags 2>/dev/null`" >>${outdir}/cores/esp8266/core_version.h
 #echo "#define ARDUINO_ESP8266_RELEASE_${ver_define}" >>${outdir}/cores/esp8266/core_version.h
 #echo "#define ARDUINO_ESP8266_RELEASE \"${ver_define}\"" >>${outdir}/cores/esp8266/core_version.h
-python3 ${srcdir}/tools/makecorever.py -b ${outdir} -i cores/esp8266 -p ${srcdir} -v ${plain_ver}
+python3 ${srcdir}/tools/makecorever.py -b ${outdir} -i cores/esp8266 -p ${srcdir} -v ${plain_ver} -r
 
 # Zip the package
 pushd package/versions/${visiblever}

--- a/tools/makecorever.py
+++ b/tools/makecorever.py
@@ -39,19 +39,21 @@ def generate(path, platform_path, git_ver="ffffffff", platform_version="unspecif
 
     text = "#define ARDUINO_ESP8266_GIT_VER   0x{}\n".format(git_ver)
     text += "#define ARDUINO_ESP8266_GIT_DESC  {}\n".format(git_desc)
-    text += "#define ARDUINO_ESP8266_GIT_DESC2 {}\n\n".format(re.sub("[-\.]", "_", git_desc))
+    text += "\n"
 
     version = re.split("\.", platform_version)
     # major: if present, skip "unix-" in "unix-3"
     text += "#define ARDUINO_ESP8266_MAJOR     {}\n".format(re.split("-", version[0])[-1])
     text += "#define ARDUINO_ESP8266_MINOR     {}\n".format(version[1])
-    # revision can be ".x" or ".x-dev"
+    # revision can be ".n" or ".n-dev"
     revision = re.split("-", version[2])
-    text += "#define ARDUINO_ESP8266_REVISION  {}\n\n".format(revision[0])
+    text += "#define ARDUINO_ESP8266_REVISION  {}\n".format(revision[0])
+    text += "\n"
     if len(revision) > 1:
         text += "#define ARDUINO_ESP8266_DEV       1 // developpment version\n"
-    else:
-        text += "#define ARDUINO_ESP8266_RELEASE   1 // release version\n"
+
+    text += "#define ARDUINO_ESP8266_RELEASE   {}\n".format(git_desc)
+    text += "#define ARDUINO_ESP8266_RELEASE_{}\n".format(re.sub("[-\.]", "_", git_desc))
 
     try:
         with open(path, "r") as inp:

--- a/tools/makecorever.py
+++ b/tools/makecorever.py
@@ -51,9 +51,9 @@ def generate(path, platform_path, git_ver="ffffffff", platform_version="unspecif
     text += "\n"
     if len(revision) > 1:
         text += "#define ARDUINO_ESP8266_DEV       1 // developpment version\n"
-
-    text += "#define ARDUINO_ESP8266_RELEASE   {}\n".format(git_desc)
-    text += "#define ARDUINO_ESP8266_RELEASE_{}\n".format(re.sub("[-\.]", "_", git_desc))
+    else:
+        text += "#define ARDUINO_ESP8266_RELEASE   \"{}\"\n".format(git_desc)
+        text += "#define ARDUINO_ESP8266_RELEASE_{}\n".format(re.sub("[-\.]", "_", git_desc))
 
     try:
         with open(path, "r") as inp:

--- a/tools/makecorever.py
+++ b/tools/makecorever.py
@@ -22,35 +22,49 @@ import os
 import subprocess
 
 
-def generate(path, platform_path, git_ver="ffffffff", platform_version="unspecified", release = False):
+def generate(path, platform_path, version="unspecified", release = False):
     def git(*args):
         cmd = ["git", "-C", platform_path]
         cmd.extend(args)
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, universal_newlines=True, stderr=subprocess.DEVNULL)
         return proc.stdout.readlines()[0].strip()
 
-    git_desc = platform_version;
+    text = ""
+
     try:
-        git_ver = git("rev-parse", "--short=8", "HEAD")
+        text = "#define ARDUINO_ESP8266_GIT_VER   0x{}\n".format(git("rev-parse", "--short=8", "HEAD"))
+    except Exception:
+        pass
+
+    # version is
+    # - using Arduino-CLI:
+    #   - blah-5.6.7     (official release, coming from platform.txt)
+    #   - blah-5.6.7-dev (intermediate / unofficial / testing release)
+    # - using git:
+    #   - 5.6.7            (from release script, official release)
+    #   - 5.6.7-42-g00d1e5 (from release script, test release)
+    git_desc = version
+    try:
+        # in any case, get a better version when git is around
         git_desc = git("describe", "--tags")
     except Exception:
         pass
 
-    text = "#define ARDUINO_ESP8266_GIT_VER   0x{}\n".format(git_ver)
     text += "#define ARDUINO_ESP8266_GIT_DESC  {}\n".format(git_desc)
     text += "\n"
 
-    version = platform_version.split(".")
+    version_split = version.split(".")
     # major: if present, skip "unix-" in "unix-3"
-    text += "#define ARDUINO_ESP8266_MAJOR     {}\n".format(version[0].split("-")[-1])
-    text += "#define ARDUINO_ESP8266_MINOR     {}\n".format(version[1])
-    # revision can be ".n" or ".n-dev"
-    revision = version[2].split("-")
+    text += "#define ARDUINO_ESP8266_MAJOR     {}\n".format(version_split[0].split("-")[-1])
+    text += "#define ARDUINO_ESP8266_MINOR     {}\n".format(version_split[1])
+    # revision can be ".n" or ".n-dev" or ".n-42-g00d1e5"
+    revision = version_split[2].split("-")
     text += "#define ARDUINO_ESP8266_REVISION  {}\n".format(revision[0])
     text += "\n"
+
+    # release or dev
     if release:
         text += "#define ARDUINO_ESP8266_RELEASE   \"{}\"\n".format(git_desc)
-        #text += "#define ARDUINO_ESP8266_RELEASE_{}\n".format(re.sub("[-\.]", "_", git_desc))
         text += "#define ARDUINO_ESP8266_RELEASE_{}\n".format(git_desc.replace("-","_").replace(".","_"))
     else:
         text += "#define ARDUINO_ESP8266_DEV       1 // developpment version\n"
@@ -97,6 +111,6 @@ if __name__ == "__main__":
     generate(
         os.path.join(include_dir, "core_version.h"),
         args.platform_path,
-        platform_version=args.version,
+        version=args.version,
         release=args.release
     )


### PR DESCRIPTION

- Release process update is based on #8034.
- `makecorever.py` is now used as part of the release process script.
- `MAJOR`/`MINOR`/`REVISION` are added in `core_version.h` based on `platform.txt`'s `version` when building with Arduino-CLI, or git tag when releasing. PlatformIO will have to be updated too (this is not addressed here).

This is WIP but is going to be merged anyway in order to try the release script executed remotely by CI.
A tag will be added (3.0.1) and removed right after that (this gymnastic happens quite often while releasing these days).
This will allow to check generated logs and archive to address #8049 
