### PR TITLE
WiFiClientSecure owns context, fix stopAllExcept

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -77,14 +77,14 @@ WiFiClient* SList<WiFiClient>::_s_first = 0;
 
 
 WiFiClient::WiFiClient()
-: _client(0)
+: _client(0), _owner(0)
 {
     _timeout = 5000;
     WiFiClient::_add(this);
 }
 
 WiFiClient::WiFiClient(ClientContext* client)
-: _client(client)
+: _client(client), _owner(0)
 {
     _timeout = 5000;
     _client->ref();
@@ -106,6 +106,7 @@ WiFiClient::WiFiClient(const WiFiClient& other)
     _client = other._client;
     _timeout = other._timeout;
     _localPort = other._localPort;
+    _owner = other._owner;
     if (_client)
         _client->ref();
     WiFiClient::_add(this);
@@ -118,6 +119,7 @@ WiFiClient& WiFiClient::operator=(const WiFiClient& other)
     _client = other._client;
     _timeout = other._timeout;
     _localPort = other._localPort;
+    _owner = other._owner;
     if (_client)
         _client->ref();
     return *this;
@@ -382,7 +384,16 @@ void WiFiClient::stopAll()
 
 void WiFiClient::stopAllExcept(WiFiClient* except)
 {
+    // Stop all will look at the highest-level wrapper connections only
+    // Find the "except" top-level connection
+    while (except->_owner) {
+         except = except->_owner;
+    }
     for (WiFiClient* it = _s_first; it; it = it->_next) {
+        // Find the top-level owner of the current list entry
+        while (it->_owner) {
+            it = it->_owner;
+        }
         if (it != except) {
             it->stop();
         }

--- a/libraries/ESP8266WiFi/src/WiFiClient.h
+++ b/libraries/ESP8266WiFi/src/WiFiClient.h
@@ -144,6 +144,7 @@ protected:
   void _err(int8_t err);
 
   ClientContext* _client;
+  WiFiClient* _owner;
   static uint16_t _localPort;
 };
 

--- a/libraries/ESP8266WiFi/src/WiFiClient.h
+++ b/libraries/ESP8266WiFi/src/WiFiClient.h
@@ -144,7 +144,7 @@ protected:
   void _err(int8_t err);
 
   ClientContext* _client;
-  WiFiClient* _owner;
+  WiFiClient* _owned;
   static uint16_t _localPort;
 };
 

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
@@ -232,8 +232,8 @@ class WiFiClientSecure : public WiFiClient {
 
   public:
 
-    WiFiClientSecure():_ctx(new WiFiClientSecureCtx()) { }
-    WiFiClientSecure(const WiFiClientSecure &rhs): WiFiClient(), _ctx(rhs._ctx) { }
+    WiFiClientSecure():_ctx(new WiFiClientSecureCtx()) { _ctx->_owner = this; }
+    WiFiClientSecure(const WiFiClientSecure &rhs): WiFiClient(), _ctx(rhs._ctx) { if (_ctx) _ctx->_owner = this; }
     ~WiFiClientSecure() override { _ctx = nullptr; }
 
     WiFiClientSecure& operator=(const WiFiClientSecure&) = default; // The shared-ptrs handle themselves automatically

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
@@ -232,8 +232,8 @@ class WiFiClientSecure : public WiFiClient {
 
   public:
 
-    WiFiClientSecure():_ctx(new WiFiClientSecureCtx()) { _ctx->_owner = this; }
-    WiFiClientSecure(const WiFiClientSecure &rhs): WiFiClient(), _ctx(rhs._ctx) { if (_ctx) _ctx->_owner = this; }
+    WiFiClientSecure():_ctx(new WiFiClientSecureCtx()) { _owned = _ctx.get(); }
+    WiFiClientSecure(const WiFiClientSecure &rhs): WiFiClient(), _ctx(rhs._ctx) { if (_ctx) _owned = _ctx.get(); }
     ~WiFiClientSecure() override { _ctx = nullptr; }
 
     WiFiClientSecure& operator=(const WiFiClientSecure&) = default; // The shared-ptrs handle themselves automatically


### PR DESCRIPTION
Fixes #8079

Because WiFiClientSecure inherits WiFiClient, and WiFiClientSecureCtx also
inherits WiFiClient, they both end up in the list of TCP connections that
are used for WiFiClient::stopAllExcept().  This would cause the underlying
SSL connection to be closed whenever you attempted to
stopAllExcept(WiFiClientSecure)

Fix by adding a "_owner" pointer in the WiFiClient object which points to
nullptr (default case) or to the associated upper-layer connection.
When stopping all connections except one, only look at the uppermost
connections.