### PR TITLE
Fix deprecation of bzero, prefer POSIX over GNU newlib extensions

### DIFF
--- a/cores/esp8266/LwipDhcpServer.cpp
+++ b/cores/esp8266/LwipDhcpServer.cpp
@@ -383,7 +383,7 @@ uint8_t* DhcpServer::add_offer_options(uint8_t *optptr)
 #define ipadd (_netif->ip_addr)
 
     //struct ip_info if_ip;
-    //bzero(&if_ip, sizeof(struct ip_info));
+    //memset(&if_ip, 0, sizeof(struct ip_info));
     //wifi_get_ip_info(SOFTAP_IF, &if_ip);
 #define if_ip (*_netif)
 
@@ -1008,7 +1008,7 @@ void DhcpServer::init_dhcps_lease(uint32 ip)
             local_ip ++;
         }
 
-        bzero(&dhcps_lease, sizeof(dhcps_lease));
+        memset(&dhcps_lease, 0, sizeof(dhcps_lease));
         dhcps_lease.start_ip.addr = softap_ip | local_ip;
         dhcps_lease.end_ip.addr = softap_ip | (local_ip + DHCPS_MAX_LEASE - 1);
         dhcps_lease.start_ip.addr = htonl(dhcps_lease.start_ip.addr);
@@ -1162,7 +1162,7 @@ bool DhcpServer::set_dhcps_lease(struct dhcps_lease *please)
             return false;
         }
 
-        bzero(&dhcps_lease, sizeof(dhcps_lease));
+        memset(&dhcps_lease, 0, sizeof(dhcps_lease));
         //      dhcps_lease.start_ip.addr = start_ip;
         //      dhcps_lease.end_ip.addr = end_ip;
         dhcps_lease.start_ip.addr = please->start_ip.addr;
@@ -1206,7 +1206,7 @@ bool DhcpServer::get_dhcps_lease(struct dhcps_lease *please)
     }
     else
     {
-        //      bzero(please, sizeof(dhcps_lease));
+        //      memset(please, 0, sizeof(dhcps_lease));
         //      if (!isRunning()){
         //          please->start_ip.addr = htonl(dhcps_lease.start_ip.addr);
         //          please->end_ip.addr = htonl(dhcps_lease.end_ip.addr);
@@ -1214,7 +1214,7 @@ bool DhcpServer::get_dhcps_lease(struct dhcps_lease *please)
     }
 
     //  if (isRunning()){
-    //      bzero(please, sizeof(dhcps_lease));
+    //      memset(please, 0, sizeof(dhcps_lease));
     //      please->start_ip.addr = dhcps_lease.start_ip.addr;
     //      please->end_ip.addr = dhcps_lease.end_ip.addr;
     //  }

--- a/platform.txt
+++ b/platform.txt
@@ -56,7 +56,7 @@ compiler.path={runtime.tools.xtensa-lx106-elf-gcc.path}/bin/
 compiler.sdk.path={runtime.platform.path}/tools/sdk
 
 compiler.libc.path={runtime.platform.path}/tools/sdk/libc/xtensa-lx106-elf
-compiler.cpreprocessor.flags=-D__ets__ -DICACHE_FLASH -U__STRICT_ANSI__ "-I{compiler.sdk.path}/include" "-I{compiler.sdk.path}/{build.lwip_include}" "-I{compiler.libc.path}/include" "-I{build.path}/core"
+compiler.cpreprocessor.flags=-D__ets__ -DICACHE_FLASH -U__STRICT_ANSI__ -D_XOPEN_SOURCE=700 -D_DEFAULT_SOURCE "-I{compiler.sdk.path}/include" "-I{compiler.sdk.path}/{build.lwip_include}" "-I{compiler.libc.path}/include" "-I{build.path}/core"
 
 compiler.c.cmd=xtensa-lx106-elf-gcc
 compiler.c.flags=-c {compiler.warning_flags} -std=gnu17 {build.stacksmash_flags} -Os -g -free -fipa-pta -Wpointer-arith -Wno-implicit-function-declaration -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals -falign-functions=4 -MMD -ffunction-sections -fdata-sections {build.exception_flags} {build.sslflags} {build.mmuflags} {build.non32xferflags}

--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -73,6 +73,8 @@ env.Append(
         "-mtext-section-literals",
         "-falign-functions=4",
         "-U__STRICT_ANSI__",
+        "-D_XOPEN_SOURCE=700",
+        "-D_DEFAULT_SOURCE",
         "-ffunction-sections",
         "-fdata-sections",
         "-Wall",


### PR DESCRIPTION
Fixes #8122.
Bzero was once deprecated, apparently compiler optimizations could remove the zeroing, which for obvious reasons is a serious security issue.