### PR TITLE
Add missing menu.UploadTool name definition

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -6,6 +6,7 @@
 
 menu.BoardModel=Model
 menu.ESPModule=Module
+menu.UploadTool=Upload Tool
 menu.led=Builtin Led
 menu.baud=Upload Speed
 menu.xtal=CPU Frequency

--- a/tools/boards.txt.py
+++ b/tools/boards.txt.py
@@ -1621,6 +1621,7 @@ def all_boards ():
     # With Arduino IDE 1.8.7 the order of the menu items will be honored from the tools pull down list.
     print('menu.BoardModel=Model')
     print('menu.ESPModule=Module')
+    print('menu.UploadTool=Upload Tool')
     print('menu.led=Builtin Led')
     print('menu.baud=Upload Speed')
     print('menu.xtal=CPU Frequency')


### PR DESCRIPTION
Hello!

We recently merged Arduino/arduino-cli#1326 on the Arduino CLI, it introduces an enforcement of the platform specifications for [custom board options][custom-board-options]. Boards that define some custom options without their name defined somewhere else in the `boards.txt` won't be loaded, the rest will be loaded without issues if they respect the specifications.

A user reported in Arduino/arduino-cli#1329 that `esp8266:esp8266:espduino` is not loaded because of this change, this PR will fix that issue.

That change has not been released but is only available in the nightly, so most users are not affected as of now but will in the next release. 

[custom-board-options]: https://arduino.github.io/arduino-cli/latest/platform-specification/#custom-board-options