### PR TITLE
Add errors on invalid/missing function return type

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -21,11 +21,11 @@ runtime.tools.mkdir={runtime.platform.path}/tools/mkdir.py
 runtime.tools.cp={runtime.platform.path}/tools/cp.py
 runtime.tools.eboot={runtime.platform.path}/bootloaders/eboot/eboot.elf
 
-compiler.warning_flags=-w
-compiler.warning_flags.none=-w
-compiler.warning_flags.default=
-compiler.warning_flags.more=-Wall
-compiler.warning_flags.all=-Wall -Wextra
+compiler.warning_flags=-w -Werror=return-type
+compiler.warning_flags.none=-w -Werror=return-type
+compiler.warning_flags.default=-Werror=return-type
+compiler.warning_flags.more=-Wall -Werror=return-type
+compiler.warning_flags.all=-Wall -Wextra -Werror=return-type
 
 build.lwip_lib=-llwip_gcc
 build.lwip_include=lwip/include

--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -62,6 +62,7 @@ env.Append(
         "-std=gnu17",
         "-Wpointer-arith",
         "-Wno-implicit-function-declaration",
+        "-Werror=return-type",
         "-Wl,-EL",
         "-fno-inline-functions",
         "-nostdlib"


### PR DESCRIPTION
GCC 10.x seems to have a knack for crashing when a function which is declared
to return a value does not.  Add a warning, present on all builds, when this
is the case.  For more info see
https://github.com/esp8266/Arduino/discussions/8160

Thanks to @hreintke for the tip