### PR TITLE
github action: enforce issue detection with bash 

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -84,9 +84,6 @@ jobs:
   build-windows:
     name: Windows
     runs-on: windows-latest
-    defaults:
-      run:
-        shell: bash
     steps:
     - uses: actions/checkout@v2
       with:
@@ -253,6 +250,9 @@ jobs:
   mock-check:
     name: Mock trivial test
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,6 +15,9 @@ jobs:
   build-linux:
     name: Build ${{ matrix.chunk }}
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
         chunk: [0, 1, 2, 3, 4, 5, 6, 7]
@@ -47,6 +50,9 @@ jobs:
   build-debug-ipv6:
     name: Debug IPv6 ${{ matrix.chunk }}
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
         chunk: [0, 1, 2, 3, 4, 5, 6, 7]
@@ -78,6 +84,9 @@ jobs:
   build-windows:
     name: Windows
     runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v2
       with:
@@ -110,6 +119,9 @@ jobs:
   build-mac:
     name: Mac
     runs-on: macOS-latest
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v2
       with:
@@ -139,6 +151,9 @@ jobs:
   build-pio:
     name: Build Platform.IO
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v2
       with:
@@ -163,6 +178,9 @@ jobs:
   host-tests:
     name: Host tests
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v2
       with:
@@ -184,6 +202,9 @@ jobs:
   documentation:
     name: Documentation
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v2
       with:
@@ -208,6 +229,9 @@ jobs:
   style-check:
     name: Style and formatting
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v2
       with:
@@ -248,6 +272,9 @@ jobs:
   boards-check:
     name: Boards.txt check
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v2
       with:
@@ -275,6 +302,9 @@ jobs:
   code-spell:
     name: Check spelling
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/release-to-publish.yml
+++ b/.github/workflows/release-to-publish.yml
@@ -32,6 +32,9 @@ jobs:
   package:
     name: Update master JSON file
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/release-to-publish.yml
+++ b/.github/workflows/release-to-publish.yml
@@ -45,7 +45,8 @@ jobs:
         python-version: '3.x'
     - name: Set GIT tag name
       run: |
-        echo "TRAVIS_TAG=$(git describe --exact-match --tags)" >> $GITHUB_ENV
+        TRAVIS_TAG="$(git describe --exact-match --tags)"
+        echo "TRAVIS_TAG=\"${TRAVIS_TAG}\"" >> $GITHUB_ENV
     - name: Deploy updated JSON
       env:
         TRAVIS_BUILD_DIR: ${{ github.workspace }}

--- a/.github/workflows/tag-to-draft-release.yml
+++ b/.github/workflows/tag-to-draft-release.yml
@@ -28,8 +28,8 @@ jobs:
     - name: Set GIT tag name
       run: |
         # Sets an environment variable used in the next steps
-        TRAVIS_TAG=$(git describe --exact-match --tags)"
-        echo "TRAVIS_TAG=${TRAVIS_TAG}" >> $GITHUB_ENV
+        TRAVIS_TAG="$(git describe --exact-match --tags)"
+        echo "TRAVIS_TAG=\"${TRAVIS_TAG}\"" >> $GITHUB_ENV
     - name: Build package JSON
       env:
         TRAVIS_BUILD_DIR: ${{ github.workspace }}

--- a/.github/workflows/tag-to-draft-release.yml
+++ b/.github/workflows/tag-to-draft-release.yml
@@ -14,6 +14,9 @@ jobs:
   package:
     name: Package
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v2
       with:
@@ -25,7 +28,8 @@ jobs:
     - name: Set GIT tag name
       run: |
         # Sets an environment variable used in the next steps
-        echo "TRAVIS_TAG=$(git describe --exact-match --tags)" >> $GITHUB_ENV
+        TRAVIS_TAG=$(git describe --exact-match --tags)"
+        echo "TRAVIS_TAG=${TRAVIS_TAG}" >> $GITHUB_ENV
     - name: Build package JSON
       env:
         TRAVIS_BUILD_DIR: ${{ github.workspace }}


### PR DESCRIPTION
Per discussion with @mcspr.

When not specifiying `bash` as running shell, default options do not include `-o pipefail` [as it should](https://github.com/actions/runner/issues/353).
It may not prevent a script to stop when one component of a pipe chain fails (ex: `false | true` won't fail but it should).
As a consequence in this PR, `bash` is [explicitely specified as default shell](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-2).

Also enforcing issue detection by breaking down commands
`echo "$(command)" >> file`  =>  `var=$(command)` then `echo ${var} >> file`