### PR TITLE
Update debug level list link

### DIFF
--- a/doc/Troubleshooting/debugging.rst
+++ b/doc/Troubleshooting/debugging.rst
@@ -74,7 +74,7 @@ Debug Level
 All defines for the different levels starts with ``DEBUG_ESP_``
 
 a full list can be found here in the
-`boards.txt <https://github.com/esp8266/Arduino/blob/master/tools/boards.txt.py#L1045-L1047>`__
+`boards.txt <https://github.com/esp8266/Arduino/blob/04c2322721f6865efe0c518be57e795e8643c183/tools/boards.txt.py#L1308-L1309>`__
 
 Example for own debug messages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The link to the debug levels was broken in that the file changed and it no longer points to the correct lines. Update the line numbers and also include the commit hash in the URL to prevent it from breaking in the future.