### PR TITLE
Don't crash when includeing LittleFS.h w/no FS

### DIFF
--- a/libraries/LittleFS/src/LittleFS.h
+++ b/libraries/LittleFS/src/LittleFS.h
@@ -183,7 +183,7 @@ public:
     }
 
     bool begin() override {
-        if (_size <= 0) {
+        if ((_blockSize <= 0) || (_size <= 0)) {
             DEBUGV("LittleFS size is <= zero");
             return false;
         }
@@ -205,7 +205,7 @@ public:
     }
 
     bool format() override {
-        if (_size == 0) {
+        if ((_blockSize <= 0) || (_size <= 0)) {
             DEBUGV("lfs size is zero\n");
             return false;
         }

--- a/libraries/LittleFS/src/LittleFS.h
+++ b/libraries/LittleFS/src/LittleFS.h
@@ -59,24 +59,26 @@ public:
           _mounted(false) {
         memset(&_lfs, 0, sizeof(_lfs));
         memset(&_lfs_cfg, 0, sizeof(_lfs_cfg));
-        _lfs_cfg.context = (void*) this;
-        _lfs_cfg.read = lfs_flash_read;
-        _lfs_cfg.prog = lfs_flash_prog;
-        _lfs_cfg.erase = lfs_flash_erase;
-        _lfs_cfg.sync = lfs_flash_sync;
-        _lfs_cfg.read_size = 64;
-        _lfs_cfg.prog_size = 64;
-        _lfs_cfg.block_size =  _blockSize;
-        _lfs_cfg.block_count =_blockSize? _size / _blockSize: 0;
-        _lfs_cfg.block_cycles = 16; // TODO - need better explanation
-        _lfs_cfg.cache_size = 64;
-        _lfs_cfg.lookahead_size = 64;
-        _lfs_cfg.read_buffer = nullptr;
-        _lfs_cfg.prog_buffer = nullptr;
-        _lfs_cfg.lookahead_buffer = nullptr;
-        _lfs_cfg.name_max = 0;
-        _lfs_cfg.file_max = 0;
-        _lfs_cfg.attr_max = 0;
+        if (_size && _blockSize) {
+            _lfs_cfg.context = (void*) this;
+            _lfs_cfg.read = lfs_flash_read;
+            _lfs_cfg.prog = lfs_flash_prog;
+            _lfs_cfg.erase = lfs_flash_erase;
+            _lfs_cfg.sync = lfs_flash_sync;
+            _lfs_cfg.read_size = 64;
+            _lfs_cfg.prog_size = 64;
+            _lfs_cfg.block_size =  _blockSize;
+            _lfs_cfg.block_count = _size / _blockSize;
+            _lfs_cfg.block_cycles = 16; // TODO - need better explanation
+            _lfs_cfg.cache_size = 64;
+            _lfs_cfg.lookahead_size = 64;
+            _lfs_cfg.read_buffer = nullptr;
+            _lfs_cfg.prog_buffer = nullptr;
+            _lfs_cfg.lookahead_buffer = nullptr;
+            _lfs_cfg.name_max = 0;
+            _lfs_cfg.file_max = 0;
+            _lfs_cfg.attr_max = 0;
+        }
     }
 
     ~LittleFSImpl() {


### PR DESCRIPTION
The LittleFS constructor could cause a divide-by-zero error and crash the
chip during pre-main startup (i.e. when the constructors were called).

Avoid by only initializing the LittleFS control structure when there is
a filesystem specified in the flash layout.

As identified by @drzony on https://gitter.im/esp8266/Arduino