### PR TITLE
Release 3.0.1

### DIFF
--- a/.github/workflows/tag-to-draft-release.yml
+++ b/.github/workflows/tag-to-draft-release.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         # Sets an environment variable used in the next steps
         TRAVIS_TAG="$(git describe --exact-match --tags)"
-        echo "TRAVIS_TAG=\"${TRAVIS_TAG}\"" >> $GITHUB_ENV
+        echo "TRAVIS_TAG=${TRAVIS_TAG}" >> $GITHUB_ENV
     - name: Build package JSON
       env:
         TRAVIS_BUILD_DIR: ${{ github.workspace }}


### PR DESCRIPTION
Fix release packager issue.  Seems when variable set in $GITHUB_ENV
quotation marks are not removed, resulting in URLs with
http://ddd.dd/blah/"3.0.1"/release and JSON entries with the same
quotation problem.