### PR TITLE
Copy released JSON to board URL, not new one

### DIFF
--- a/.github/workflows/release-to-publish.yml
+++ b/.github/workflows/release-to-publish.yml
@@ -36,26 +36,6 @@ jobs:
       run:
         shell: bash
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-        fetch-depth: 0
-    - uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-    - name: Set GIT tag name
-      run: |
-        TRAVIS_TAG="$(git describe --exact-match --tags)"
-        echo "TRAVIS_TAG=${TRAVIS_TAG}" >> $GITHUB_ENV
     - name: Deploy updated JSON
-      env:
-        TRAVIS_BUILD_DIR: ${{ github.workspace }}
-        BUILD_TYPE: package
-        CI_GITHUB_API_KEY: ${{ secrets.GITHUB_TOKEN }}
-        GHCI_DEPLOY_KEY: ${{ secrets.GHCI_DEPLOY_KEY }}
       run: |
-           bash ./tests/ci/build_package.sh
-           # Only the regenerated JSON file will be used, but it's simpler
-           # than looking for it in a GH release.
            bash ./package/deploy_package_index.sh
-

--- a/package/deploy_package_index.sh
+++ b/package/deploy_package_index.sh
@@ -14,8 +14,11 @@ set -e # Abort with error if anything here does not go as expected!
 git clone git@github.com:esp8266/esp8266.github.io.git
 pushd esp8266.github.io
 
-# Update the package index, copy from published release
+# Copy from published release, ensure JSON valid
+rm -f stable/package_esp8266com_index.json
 wget "https://github.com/esp8266/Arduino/releases/download/$tag/package_esp8266com_index.json" -O stable/package_esp8266com_index.json
+cat stable/package_esp8266com_index.json | jq empty
+
 git add stable/package_esp8266com_index.json
 
 # Commit and push the changes

--- a/package/deploy_package_index.sh
+++ b/package/deploy_package_index.sh
@@ -10,22 +10,12 @@ cd $(dirname "$0")
 
 set -e # Abort with error if anything here does not go as expected!
 
-# Install SSH private key from a GH Secret
-echo $GHCI_DEPLOY_KEY | base64 -d > esp8266_github_io_deploy
-eval "$(ssh-agent -s)"
-chmod 600 esp8266_github_io_deploy
-ssh-add esp8266_github_io_deploy
-mkdir -p ~/.ssh
-chmod go-w ~/.ssh
-echo -e "Host github.com\nStrictHostKeyChecking no\n" >> ~/.ssh/config
-chmod go-w  ~/.ssh/config
-
 # Clone the Github pages repository
 git clone git@github.com:esp8266/esp8266.github.io.git
 pushd esp8266.github.io
 
-# Update the package index
-cp ../versions/*/package_esp8266com_index.json stable/package_esp8266com_index.json
+# Update the package index, copy from published release
+wget "https://github.com/esp8266/Arduino/releases/download/$tag/package_esp8266com_index.json" -O stable/package_esp8266com_index.json
 git add stable/package_esp8266com_index.json
 
 # Commit and push the changes


### PR DESCRIPTION
Fixes #8180

The draft release generates a ZIP and JSON.  Instead of rebuilding the ZIP
on the publish step (which may result in a different SHA256 due to file time
differences in the new ZIP), just copy the one from the published release
directly.

Also clean up and remove unneeded environment variables and CI steps.