### PR TITLE
Avoid copying null in concat, unused + breaks views

### DIFF
--- a/cores/esp8266/WString.cpp
+++ b/cores/esp8266/WString.cpp
@@ -305,7 +305,7 @@ bool String::concat(const char *cstr, unsigned int length) {
         return true;
     if (!reserve(newlen))
         return false;
-    memmove_P(wbuffer() + len(), cstr, length + 1);
+    memmove_P(wbuffer() + len(), cstr, length);
     setLen(newlen);
     wbuffer()[newlen] = 0;
     return true;

--- a/tests/host/core/test_string.cpp
+++ b/tests/host/core/test_string.cpp
@@ -602,4 +602,5 @@ TEST_CASE("String concat OOB #8198", "[core][String]")
     String s = "abcd";
     s.concat(p, 16);
     REQUIRE(!strcmp(s.c_str(), "abcdxxxxxxxxxxxxxxxx"));
+    free(p);
 }

--- a/tests/host/core/test_string.cpp
+++ b/tests/host/core/test_string.cpp
@@ -594,3 +594,12 @@ TEST_CASE("String chaining", "[core][String]")
     REQUIRE(static_cast<const void*>(result.c_str()) == static_cast<const void*>(ptr));
   }
 }
+
+TEST_CASE("String concat OOB #8198", "[core][String]")
+{
+    char *p = (char*)malloc(16);
+    memset(p, 'x', 16);
+    String s = "abcd";
+    s.concat(p, 16);
+    REQUIRE(!strcmp(s.c_str(), "abcdxxxxxxxxxxxxxxxx"));
+}


### PR DESCRIPTION
We use a few non-null terminated views and it seems String::concat(char*, size_t) breaks those because it always copies the null terminator, but since the function immediately overwrites it, it doesn't need to.

This change makes String::concat support non-null terminated char* without any side effect.

Fixes #8200