### PR TITLE
byte: workaround for c++17 std::byte definition

### DIFF
--- a/cores/esp8266/Arduino.h
+++ b/cores/esp8266/Arduino.h
@@ -21,6 +21,12 @@
 #define Arduino_h
 
 #ifdef __cplusplus
+#if __cplusplus >= 201703L
+#include <cstddef>                // std::byte
+#include <functional>             // std::byte
+#include <bits/cpp_type_traits.h> // std::byte
+#define byte arduino_byte
+#endif
 extern "C" {
 #endif
 


### PR DESCRIPTION

This patch renames the Arduino type `byte` to something else in order to avoid ambiguous/conflicting types when c++17, `byte`, and `using namespace std` are used together.
This follows up https://github.com/esp8266/Arduino/issues/8089#issuecomment-877534925, https://github.com/gmag11/NtpClient/pull/115 and https://github.com/things4u/ESP-1ch-Gateway/issues/82.

This [comment](https://github.com/esp8266/Arduino/issues/8089#issuecomment-877573502) is true but libraries and projects will prefer to use previous version of this core than to fix.
In the Arduino world, ascendant compatibility still prevails.

This is a hack, relying on the following facts
- Arduino `byte` is always defined in `Arduino.h`
- `std::byte` is declared only in `<cstddef>` `<functional>` and `<bits/cpp_type_traits.h>`.
  The two latters were found with `grep` after noticing that the first was not sufficient.

fixes #8089