### PR TITLE
ESP8266WebServer - Drop inactive connection when another is waiting to improve page load time

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
@@ -335,11 +335,14 @@ void ESP8266WebServerTemplate<ServerType>::handleClient() {
         } // switch _parseRequest()
       } else {
         // !_currentClient.available(): waiting for more data
-        if (millis() - _statusChange <= HTTP_MAX_DATA_WAIT) {
-          keepCurrentClient = true;
+        if (_server.available().available())
+          DBGWS("webserver: closing since there's another connection to read from\n");
+        else {
+          if (millis() - _statusChange <= HTTP_MAX_DATA_WAIT)
+            keepCurrentClient = true;
+          else
+            DBGWS("webserver: closing after read timeout\n");
         }
-        else
-          DBGWS("webserver: closing after read timeout\n");
         callYield = true;
       }
       break;


### PR DESCRIPTION
When loading pages with Safari from an HTTP ESP8266WebServer, Safari appears to occasionally open up two TCP connections and sends the GET request over the second one (found using Wireshark). In its current state, the library waits for data on the first connection, and, since there isn't any data, it sits there until it times out after 5 seconds (`HTTP_MAX_DATA_WAIT`). After the timeout, it moves on to the second connection which has the GET request waiting then calls the configured callback functions to serve the page content. I don't know why Safari does this, but it causes pages to take 5 seconds to load when they should be almost instant.

My fix is to simply check for more TCP connections while the server is waiting for more data from the one it's currently working with (connection is in the `HC_WAIT_READ` state). If there is another connection with available data, drop the current one and move on to the new one. This fixes the problem with Safari loading pages slowly as it gets rid of the seemingly pointless first connection once it receives the request on the second one. However, I am not particularly familiar with the other use cases of the library, so if this change in behavior is dumb, please close this PR.