### PR TITLE
Implement move operations for HTTPClient

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -62,6 +62,54 @@ HTTPClient::~HTTPClient()
     }
 }
 
+
+HTTPClient::HTTPClient(HTTPClient&& other): _client(std::move(other._client)),
+    _host(std::move(other._host)), _port(std::move(other._port)), _reuse(std::move(other._reuse)),
+    _tcpTimeout(std::move(other._tcpTimeout)), _useHTTP10(std::move(other._useHTTP10)),
+    _uri(std::move(other._uri)), _protocol(std::move(other._protocol)),
+    _headers(std::move(other._headers)), _userAgent(std::move(other._userAgent)),
+    _base64Authorization(std::move(other._base64Authorization)),
+    _currentHeaders(std::move(other._currentHeaders)),
+    _headerKeysCount(std::move(other._headerKeysCount)),
+    _returnCode(std::move(other._returnCode)), _canReuse(std::move(other._canReuse)),
+    _followRedirects(std::move(other._followRedirects)),
+    _redirectLimit(std::move(other._redirectLimit)), _location(std::move(other._location)),
+    _transferEncoding(std::move(other._transferEncoding)), _payload(std::move(other._payload)) {
+    other._client = nullptr;
+    other._currentHeaders = nullptr;
+    other = HTTPClient();
+}
+
+
+HTTPClient::HTTPClient& operator=(HTTPClient&& other) {
+    _client = std::move(other._client);
+    _host = std::move(other._host);
+    _port = std::move(other._port);
+    _reuse = std::move(other._reuse);
+    _tcpTimeout = std::move(other._tcpTimeout);
+    _useHTTP10 = std::move(other._useHTTP10);
+    _uri = std::move(other._uri);
+    _protocol = std::move(other._protocol);
+    _headers = std::move(other._headers);
+    _userAgent = std::move(other._userAgent);
+    _base64Authorization = std::move(other._base64Authorization);
+    _currentHeaders = std::move(other._currentHeaders);
+    _headerKeysCount = std::move(other._headerKeysCount);
+    _returnCode = std::move(other._returnCode);
+    _canReuse = std::move(other._canReuse);
+    _followRedirects = std::move(other._followRedirects);
+    _redirectLimit = std::move(other._redirectLimit);
+    _location = std::move(other._location);
+    _transferEncoding = std::move(other._transferEncoding);
+    _payload = std::move(other._payload);
+
+    other._client = nullptr;
+    other._currentHeaders = nullptr;
+    other = HTTPClient();
+    return *this;
+}
+
+
 void HTTPClient::clear()
 {
     _returnCode = 0;

--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -81,7 +81,7 @@ HTTPClient::HTTPClient(HTTPClient&& other): _client(std::move(other._client)),
 }
 
 
-HTTPClient::HTTPClient& operator=(HTTPClient&& other) {
+HTTPClient& HTTPClient::operator=(HTTPClient&& other) {
     _client = std::move(other._client);
     _host = std::move(other._host);
     _port = std::move(other._port);

--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -28,6 +28,11 @@
 #include <StreamDev.h>
 #include <base64.h>
 
+static_assert(std::is_default_constructible_v<HTTPClient>, "");
+static_assert(!std::is_copy_constructible_v<HTTPClient>, "");
+static_assert(std::is_move_constructible_v<HTTPClient>, "");
+static_assert(std::is_move_assignable_v<HTTPClient>, "");
+
 static int StreamReportToHttpClientReport (Stream::Report streamSendError)
 {
     switch (streamSendError)

--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.h
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.h
@@ -217,6 +217,9 @@ public:
     const String& getString(void);
     static String errorToString(int error);
 
+    HTTPClient(HTTPClient&& other);
+    HTTPClient& operator=(HTTPClient&& other);
+
 protected:
     struct RequestArgument {
         String key;

--- a/tests/device/test_sw_http_client/test_sw_http_client.ino
+++ b/tests/device/test_sw_http_client/test_sw_http_client.ino
@@ -212,17 +212,6 @@ TEST_CASE("HTTPS GET request", "[HTTPClient]")
     }
 }
 
-TEST_CASE("Move constructible", "[HTTPClient]")
-{
-   {
-       std::optional<HTTPClient> maybe;
-       maybe = std::make_optional(HTTPClient());
-   }
-   {
-       HTTPClient http(std::move(HTTPClient()));
-   }
-}
-
 void loop()
 {
 }

--- a/tests/device/test_sw_http_client/test_sw_http_client.ino
+++ b/tests/device/test_sw_http_client/test_sw_http_client.ino
@@ -3,6 +3,7 @@
 #include <ESP8266HTTPClient.h>
 #include <BSTest.h>
 #include <pgmspace.h>
+#include <optional>
 
 BS_ENV_DECLARE();
 
@@ -209,6 +210,12 @@ TEST_CASE("HTTPS GET request", "[HTTPClient]")
             }
         }
     }
+}
+
+TEST_CASE("Move constructible", "[HTTPClient]")
+{
+   std::optional<HTTPClient> maybe;
+   maybe = std::make_optional(HTTPClient());
 }
 
 void loop()

--- a/tests/device/test_sw_http_client/test_sw_http_client.ino
+++ b/tests/device/test_sw_http_client/test_sw_http_client.ino
@@ -214,8 +214,13 @@ TEST_CASE("HTTPS GET request", "[HTTPClient]")
 
 TEST_CASE("Move constructible", "[HTTPClient]")
 {
-   std::optional<HTTPClient> maybe;
-   maybe = std::make_optional(HTTPClient());
+   {
+       std::optional<HTTPClient> maybe;
+       maybe = std::make_optional(HTTPClient());
+   }
+   {
+       HTTPClient http(std::move(HTTPClient()));
+   }
 }
 
 void loop()


### PR DESCRIPTION
Fixes #8231

This implements move constructor and assignment for HTTPClient, intended to support std::optional<HTTPClient> proper usage. It's not clear to me if this is the right place to test for compilation errors.