### PR TITLE
Add functionality to copy generated SIGNED binaries into sketch folder

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -130,8 +130,10 @@ recipe.objcopy.hex.2.pattern="{runtime.tools.python3.path}/python3" -I "{runtime
 recipe.objcopy.hex.3.pattern="{runtime.tools.python3.path}/python3" -I "{runtime.tools.sizes}" --elf "{build.path}/{build.project_name}.elf" --path "{runtime.tools.xtensa-lx106-elf-gcc.path}/bin" --mmu "{build.mmuflags}"
 
 ## Save hex
-recipe.output.tmp_file={build.project_name}.bin
-recipe.output.save_file={build.project_name}.{build.variant}.bin
+recipe.output.tmp_file.1={build.project_name}.bin
+recipe.output.save_file.1={build.project_name}.{build.variant}.bin
+recipe.output.tmp_file.2={build.project_name}.bin.signed
+recipe.output.save_file.2={build.project_name}.{build.variant}.bin.signed
 
 ## Compute size
 recipe.size.pattern="{compiler.path}{compiler.size.cmd}" -A "{build.path}/{build.project_name}.elf"


### PR DESCRIPTION
The current platform.txt doesn't define the entries to copy signed binaries when performing a "Export compiled Binary".
This pull request adds the nessesary enties.

Whit this (extra) entries) both binaries are copied to the sketch folder (.bin & .bin.signed)