### PR TITLE
Place deprecated attribute in front of function

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClient.h
+++ b/libraries/ESP8266WiFi/src/WiFiClient.h
@@ -59,7 +59,8 @@ public:
   virtual size_t write(uint8_t) override;
   virtual size_t write(const uint8_t *buf, size_t size) override;
   virtual size_t write_P(PGM_P buf, size_t size);
-  size_t write(Stream& stream) [[ deprecated("use stream.sendHow(client...)") ]];
+  [[ deprecated("use stream.sendHow(client...)") ]]
+  size_t write(Stream& stream);
 
   virtual int available() override;
   virtual int read() override;


### PR DESCRIPTION
This is the standards-compliant way to mark functions as deprecated (see https://en.cppreference.com/w/cpp/language/attributes/deprecated).