### PR TITLE
Respect linking order of libraries

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -253,14 +253,12 @@ elif "PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH" in flatten_cppdefines:
     env.Append(
         CPPDEFINES=[("TCP_MSS", 536), ("LWIP_FEATURES", 0), ("LWIP_IPV6", 0)],
         CPPPATH=[join(FRAMEWORK_DIR, "tools", "sdk", "lwip2", "include")],
-        LIBS=["lwip2-536"]
     )
     inject_lib_at_position_from_front(env, "lwip2-536", 4)
 elif "PIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH" in flatten_cppdefines:
     env.Append(
         CPPDEFINES=[("TCP_MSS", 1460), ("LWIP_FEATURES", 0), ("LWIP_IPV6", 0)],
         CPPPATH=[join(FRAMEWORK_DIR, "tools", "sdk", "lwip2", "include")],
-        LIBS=["lwip2-1460"]
     )
     inject_lib_at_position_from_front(env, "lwip2-1460", 4)
 # PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY (default)


### PR DESCRIPTION
Fixes #8262.

Arduino IDE link order:

>-lhal -lphy -lpp -lnet80211 -llwip2-536-feat -lwpa -lcrypto -lmain -lwps -lbearssl -lespnow -lsmartconfig -lairkiss -lwpa2 -lstdc++ -lm -lc -lgcc

PlatformIO link order before this fix:

>-lhal -lphy -lpp -lnet80211 -lwpa -lcrypto -lmain -lwps -lbearssl -lespnow -lsmartconfig -lairkiss -lwpa2 -lm -lc -lgcc -llwip2-536-feat -lstdc++

(^ which causes the linking failure in regards to the math library in the referenced issue)

PlatformIO link order after this fix:

>-lhal -lphy -lpp -lnet80211 -llwip2-536-feat -lwpa -lcrypto -lmain -lwps -lbearssl -lespnow -lsmartconfig -lairkiss -lwpa2 -lstdc++ -lm -lc -lgcc 

Aka, now equivalent to the Arduino IDE linking order.

The code refactors setting `env["LIBS"]` further down the script where it knows the system libraries to be built, and then creates the array with the correct linking order.

The previous `env.Append(LIBS = ...)` is wrong here because it appends to the back and hence does not respect the original linker order laid out in the `platform.txt`

https://github.com/esp8266/Arduino/blob/5f04fbbf5fa77c5e71172f4032df095af3766e25/platform.txt#L70