### PR TITLE
Remove temporary buffer in ConfigFile.ino

### DIFF
--- a/libraries/esp8266/examples/ConfigFile/ConfigFile.ino
+++ b/libraries/esp8266/examples/ConfigFile/ConfigFile.ino
@@ -11,6 +11,9 @@
 #include "FS.h"
 #include <LittleFS.h>
 
+// more and possibly updated information can be found at:
+// https://arduinojson.org/v6/example/config/
+
 bool loadConfig() {
   File configFile = LittleFS.open("/config.json", "r");
   if (!configFile) {
@@ -18,22 +21,8 @@ bool loadConfig() {
     return false;
   }
 
-  size_t size = configFile.size();
-  if (size > 1024) {
-    Serial.println("Config file size is too large");
-    return false;
-  }
-
-  // Allocate a buffer to store contents of the file.
-  std::unique_ptr<char[]> buf(new char[size]);
-
-  // We don't use String here because ArduinoJson library requires the input
-  // buffer to be mutable. If you don't use ArduinoJson, you may as well
-  // use configFile.readString instead.
-  configFile.readBytes(buf.get(), size);
-
   StaticJsonDocument<200> doc;
-  auto error = deserializeJson(doc, buf.get());
+  auto error = deserializeJson(doc, configFile);
   if (error) {
     Serial.println("Failed to parse config file");
     return false;


### PR DESCRIPTION
Hi,

Thank you guys for maintaining this critical piece of software that is at the heart of so many projects 👍 

This PR simplifies the `ConfigFile.ino` example by removing the temporary buffer and passing the `File` directly to [`deserializeJson()`](https://arduinojson.org/v6/api/json/deserializejson/).

When reading from a `Stream`, using a temporary buffer is counterproductive because it complexifies the code and increases memory usage. It's also a source of confusion because it can create dangling pointers in the [`JsonDocument`](https://arduinojson.org/v6/api/jsondocument/).
The only benefit of using a buffer is the reading speed, but I don't think speed is the focus in this example; if it were, it would use a buffer in `saveConfig()` too.

By the way, this example has been the origin of many issues in ArduinoJson's tracker:

* https://github.com/bblanchon/ArduinoJson/issues/1643
* https://github.com/bblanchon/ArduinoJson/issues/1473
* https://github.com/bblanchon/ArduinoJson/issues/1461
* https://github.com/bblanchon/ArduinoJson/issues/1445
* https://github.com/bblanchon/ArduinoJson/issues/1276
* https://github.com/bblanchon/ArduinoJson/issues/1273
* https://github.com/bblanchon/ArduinoJson/issues/1222
* https://github.com/bblanchon/ArduinoJson/issues/1215
* https://github.com/bblanchon/ArduinoJson/issues/1159
* https://github.com/bblanchon/ArduinoJson/issues/1084
* https://github.com/bblanchon/ArduinoJson/issues/1049
* https://github.com/bblanchon/ArduinoJson/issues/998
* https://github.com/bblanchon/ArduinoJson/issues/958
* https://github.com/bblanchon/ArduinoJson/issues/785
* https://github.com/bblanchon/ArduinoJson/issues/715
* https://github.com/bblanchon/ArduinoJson/issues/610
* https://github.com/bblanchon/ArduinoJson/issues/593
* https://github.com/bblanchon/ArduinoJson/issues/582
* https://github.com/bblanchon/ArduinoJson/issues/570
* https://github.com/bblanchon/ArduinoJson/issues/553
* https://github.com/bblanchon/ArduinoJson/issues/514
* https://github.com/bblanchon/ArduinoJson/issues/497
* https://github.com/bblanchon/ArduinoJson/issues/493
* https://github.com/bblanchon/ArduinoJson/issues/421
* https://github.com/bblanchon/ArduinoJson/issues/400
* https://github.com/bblanchon/ArduinoJson/issues/342
* https://github.com/bblanchon/ArduinoJson/issues/285

It seems that I've been doing the customer service for this example, so I wonder if it's wise to keep it considering there is [a comparable example in ArduinoJson](https://arduinojson.org/v6/example/config/), with the differences that it uses SD instead of LittleFS and it shows how to apply best practices by copying the data in a `struct`.

Please let me know what you think.

Best regards,
Benoit