### PR TITLE
introduce `yieldUntil(untilFonction, timeoutMs)` 

### DIFF
--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -249,3 +249,15 @@ void run_scheduled_recurrent_functions()
 
     fence = false;
 }
+
+
+bool yieldUntil (std::function<bool()> until, uint32_t maxMs) {
+    esp8266::polledTimeout::oneShotFastMs timeOut(maxMs);
+    while (true) {
+        if (until())
+            return true;
+        if (timeOut)
+            return false;
+        yield();
+    }
+}

--- a/cores/esp8266/Schedule.h
+++ b/cores/esp8266/Schedule.h
@@ -88,4 +88,8 @@ bool schedule_recurrent_function_us(const std::function<bool(void)>& fn,
 
 void run_scheduled_recurrent_functions();
 
+// Let a chance for recurrent scheduled functions to run during a waiting delay
+
+bool yieldUntil (std::function<bool()> until, uint32_t maxMs);
+
 #endif // ESP_SCHEDULE_H


### PR DESCRIPTION
`yieldUntil(untilFonction, timeoutMs)` is a delay interruptible under a provided condition.

It is useful for ethernet drivers using recurrent scheduled functions.

replaces #6212 