### PR TITLE
Remove the HAVE_ESP_SUSPEND define.

### DIFF
--- a/cores/esp8266/coredecls.h
+++ b/cores/esp8266/coredecls.h
@@ -2,8 +2,6 @@
 #ifndef __COREDECLS_H
 #define __COREDECLS_H
 
-#define HAVE_ESP_SUSPEND 1
-
 #include "core_esp8266_features.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
The define was in the feature development branch, now after merge into main it is redundant, and should not be part of the next release point.