### PR TITLE
Remove warnings and an error from host test builds

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -556,7 +556,7 @@ int HTTPClient::sendRequest(const char * type, Stream * stream, size_t size)
     size_t transferred = stream->sendSize(_client.get(), size);
     if (transferred != size)
     {
-        DEBUG_HTTPCLIENT("[HTTP-Client][sendRequest] short write, asked for %d but got %d failed.\n", size, transferred);
+        DEBUG_HTTPCLIENT("[HTTP-Client][sendRequest] short write, asked for %d but got %d failed.\n", (int)size, transferred);
         esp_yield();
         return returnError(HTTPC_ERROR_SEND_PAYLOAD_FAILED);
     }

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
@@ -515,7 +515,7 @@ void ESP8266WebServerTemplate<ServerType>::sendContent(Stream* content, ssize_t 
   ssize_t sent = content->sendSize(&_currentClient, content_length);
   if (sent != content_length)
   {
-    DBGWS("HTTPServer: error: short send after timeout (%d<%d)\n", sent, content_length);
+    DBGWS("HTTPServer: error: short send after timeout (%d<%d)\n", (int)sent, content_length);
   }
   if(_chunked) {
     _currentClient.printf_P(PSTR("\r\n"));

--- a/libraries/ESP8266WiFi/src/ESP8266WiFi.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFi.cpp
@@ -75,12 +75,12 @@ void ESP8266WiFiClass::printDiag(Print& p) {
     char ssid[33]; //ssid can be up to 32chars, => plus null term
     memcpy(ssid, conf.ssid, sizeof(conf.ssid));
     ssid[32] = 0; //nullterm in case of 32 char ssid
-    p.printf_P(PSTR("SSID (%d): %s\n"), strlen(ssid), ssid);
+    p.printf_P(PSTR("SSID (%d): %s\n"), (int)strlen(ssid), ssid);
 
     char passphrase[65];
     memcpy(passphrase, conf.password, sizeof(conf.password));
     passphrase[64] = 0;
-    p.printf_P(PSTR("Passphrase (%d): %s\n"), strlen(passphrase), passphrase);
+    p.printf_P(PSTR("Passphrase (%d): %s\n"), (int)strlen(passphrase), passphrase);
 
     p.print(F("BSSID set: "));
     p.println(conf.bssid_set);

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiAP.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiAP.cpp
@@ -104,13 +104,13 @@ bool ESP8266WiFiAPClass::softAP(const char* ssid, const char* psk, int channel, 
 
     size_t ssid_len = ssid ? strlen(ssid) : 0;
     if(ssid_len == 0 || ssid_len > 32) {
-        DEBUG_WIFI("[AP] SSID length %u, too long or missing!\n", ssid_len);
+        DEBUG_WIFI("[AP] SSID length %d, too long or missing!\n", (int)ssid_len);
         return false;
     }
 
     size_t psk_len = psk ? strlen(psk) : 0;
     if(psk_len > 0 && (psk_len > 64 || psk_len < 8)) {
-        DEBUG_WIFI("[AP] fail psk length %u, too long or short!\n", psk_len);
+        DEBUG_WIFI("[AP] fail psk length %d, too long or short!\n", (int)psk_len);
         return false;
     }
 

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp
@@ -328,7 +328,7 @@ wl_status_t ESP8266WiFiMulti::connectWiFiMulti(uint32_t connectTimeoutMs)
 
             // Check SSID
             if (ssid == entry.ssid) {
-                DEBUG_WIFI_MULTI("[WIFIM] Connecting %s\n", ssid);
+                DEBUG_WIFI_MULTI("[WIFIM] Connecting %s\n", ssid.c_str());
 
                 // Connect to WiFi
                 WiFi.begin(ssid, entry.passphrase, channel, bssid);

--- a/libraries/SD/src/SD.h
+++ b/libraries/SD/src/SD.h
@@ -136,7 +136,7 @@ public:
         uint64_t sz = size64();
 #ifdef DEBUG_ESP_PORT
 	if (sz > (uint64_t)SIZE_MAX) {
-            DEBUG_ESP_PORT.printf_P(PSTR("WARNING: SD card size overflow (%lld>= 4GB).  Please update source to use size64().\n"), sz);
+            DEBUG_ESP_PORT.printf_P(PSTR("WARNING: SD card size overflow (" PRIu64 " >= 4GB).  Please update source to use size64().\n"), sz);
         }
 #endif
         return (size_t)sz;

--- a/libraries/SDFS/src/SDFS.h
+++ b/libraries/SDFS/src/SDFS.h
@@ -117,7 +117,7 @@ public:
 #ifdef DEBUG_ESP_PORT
         if (i.totalBytes > (uint64_t)SIZE_MAX) {
             // This catches both total and used cases, since used must always be < total.
-            DEBUG_ESP_PORT.printf_P(PSTR("WARNING: SD card size overflow (%lld>= 4GB).  Please update source to use info64().\n"), i.totalBytes);
+            DEBUG_ESP_PORT.printf_P(PSTR("WARNING: SD card size overflow (" PRIu64 " >= 4GB).  Please update source to use info64().\n"), i.totalBytes);
         }
 #endif
         info.totalBytes    = (size_t)i.totalBytes;


### PR DESCRIPTION
Debug strings often included format parameters which did not exactly match
the passed in format parameters, resulting in warnings in the host test build
process like
````
/home/runner/work/Arduino/Arduino/libraries/ESP8266WiFi/src/ESP8266WiFiAP.cpp:107:20: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 3 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
  107 |         DEBUG_WIFI("[AP] SSID length %u, too long or missing!\n", ssid_len);
      |                                                                   ~~~~~~~~
      |                                                                   |
      |                                                                   size_t {aka long unsigned int}
````

Fix by applying casting or PRxxx macros as appropriate.

Also, fix one debug message which was trying to use a `String` as a `char *`:
````
/home/runner/work/Arduino/Arduino/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp: In member function ‘wl_status_t ESP8266WiFiMulti::connectWiFiMulti(uint32_t)’:
/home/runner/work/Arduino/Arduino/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp:331:34: warning: format ‘%s’ expects argument of type ‘char*’, but argument 3 has type ‘String’ [-Wformat=]
  331 |                 DEBUG_WIFI_MULTI("[WIFIM] Connecting %s\n", ssid);
````