### PR TITLE
adding esp32's ArduinoOTAClass::end function to esp8266

### DIFF
--- a/libraries/ArduinoOTA/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/ArduinoOTA.cpp
@@ -349,6 +349,18 @@ void ArduinoOTAClass::_runUpdate() {
   }
 }
 
+void ArduinoOTAClass::end() {
+    _initialized = false;
+    _udp_ota->unref();
+    _udp_ota = 0;
+    if(_useMDNS){
+        MDNS.end();
+    }
+    _state = OTA_IDLE;
+    #ifdef OTA_DEBUG
+    OTA_DEBUG.printf("OTA server stopped.\n");
+    #endif    
+}
 //this needs to be called in the loop()
 void ArduinoOTAClass::handle() {
   if (_state == OTA_RUNUPDATE) {

--- a/libraries/ArduinoOTA/ArduinoOTA.h
+++ b/libraries/ArduinoOTA/ArduinoOTA.h
@@ -62,6 +62,8 @@ class ArduinoOTAClass
     //Starts the ArduinoOTA service
     void begin(bool useMDNS = true);
 
+    //Ends the ArduinoOTA service
+    void end();
     //Call this in loop() to run the service. Also calls MDNS.update() when begin() or begin(true) is used.
     void handle();
 


### PR DESCRIPTION
This adds the end() function for the ArduinoOTA class.

ESP32 has this implemented, however ESP8266 was lacking this.