### PR TITLE
A clock phase correction in write_start(void) (I2C)

### DIFF
--- a/cores/esp8266/core_esp8266_si2c.cpp
+++ b/cores/esp8266/core_esp8266_si2c.cpp
@@ -248,9 +248,9 @@ bool Twi::write_start(void)
     }
     busywait(twi_dcount);
     SDA_LOW(twi_sda);
-    busywait(twi_dcount / 2);
+    busywait(twi_dcount);
     SCL_LOW(twi_scl);
-    busywait((twi_dcount / 2) + (twi_dcount % 2));
+    busywait(twi_dcount);
     return true;
 }
 

--- a/cores/esp8266/core_esp8266_si2c.cpp
+++ b/cores/esp8266/core_esp8266_si2c.cpp
@@ -248,9 +248,9 @@ bool Twi::write_start(void)
     }
     busywait(twi_dcount);
     SDA_LOW(twi_sda);
-    busywait(twi_dcount/2);
+    busywait(twi_dcount / 2);
     SCL_LOW(twi_scl);
-    busywait((twi_dcount/2) + (twi_dcount % 2));
+    busywait((twi_dcount / 2) + (twi_dcount % 2));
     return true;
 }
 

--- a/cores/esp8266/core_esp8266_si2c.cpp
+++ b/cores/esp8266/core_esp8266_si2c.cpp
@@ -248,7 +248,9 @@ bool Twi::write_start(void)
     }
     busywait(twi_dcount);
     SDA_LOW(twi_sda);
-    busywait(twi_dcount);
+    busywait(twi_dcount/2);
+    SCL_LOW(twi_scl);
+    busywait((twi_dcount/2) + (twi_dcount % 2));
     return true;
 }
 

--- a/cores/esp8266/core_esp8266_si2c.cpp
+++ b/cores/esp8266/core_esp8266_si2c.cpp
@@ -247,8 +247,10 @@ bool Twi::write_start(void)
         return false;
     }
     busywait(twi_dcount);
+    // A high-to-low transition on the SDA line while the SCL is high defines a START condition.
     SDA_LOW(twi_sda);
     busywait(twi_dcount);
+    // An additional delay between the SCL line high-to-low transition and setting up the SDA line to prevent a STOP condition execute.
     SCL_LOW(twi_scl);
     busywait(twi_dcount);
     return true;
@@ -262,6 +264,7 @@ bool Twi::write_stop(void)
     SCL_HIGH(twi_scl);
     WAIT_CLOCK_STRETCH();
     busywait(twi_dcount);
+    // A low-to-high transition on the SDA line while the SCL is high defines a STOP condition.
     SDA_HIGH(twi_sda);
     busywait(twi_dcount);
     return true;


### PR DESCRIPTION
Some devices require the data wire SDA to be held down at the moment while the clock wire is pulled down too to execute the start condition (e.g. devices using "TinyWires.h" library). This change follows a behaviour of Arduino Wire.h library, where the SCL signal is pulled down in half of period of start condition.

![obrazek](https://user-images.githubusercontent.com/78907070/142902150-2f5bb669-59f8-421d-9c08-792964fcb265.png)
