### PR TITLE
LittleFS: add overrides for Stream::send

### DIFF
--- a/cores/esp8266/FS.h
+++ b/cores/esp8266/FS.h
@@ -118,6 +118,18 @@ public:
     time_t getCreationTime();
     void setTimeCallback(time_t (*cb)(void));
 
+    // Stream::send configuration
+
+    bool inputCanTimeout () override {
+        // unavailable data can't become later available
+        return false;
+    }
+
+    bool outputCanTimeout () override {
+        // free space for write can't increase later
+        return false;
+    }
+
 protected:
     FileImplPtr _p;
     time_t (*_timeCallback)(void) = nullptr;

--- a/libraries/LittleFS/examples/SpeedTest/SpeedTest.ino
+++ b/libraries/LittleFS/examples/SpeedTest/SpeedTest.ino
@@ -132,6 +132,16 @@ void DoTest(FS *fs) {
   f.close();
   stop = millis();
   Serial.printf("==> Time to read 64KB in 1b chunks = %lu milliseconds = %s\n", stop - start, rate(start, stop, 65536));
+
+
+  start = millis();
+  auto dest = fs->open("/test1bw.bin", "w");
+  f = fs->open("/test1b.bin", "r");
+  auto copysize = f.sendAll(dest);
+  dest.close();
+  stop = millis();
+  Serial.printf("==> Time to copy %d = %zd bytes = %lu milliseconds = %s\n", f.size(), copysize, stop - start, rate(start, stop, f.size()));
+  f.close();
 }
 
 void setup() {
@@ -139,6 +149,7 @@ void setup() {
   Serial.printf("Beginning test\n");
   Serial.flush();
   DoTest(&TESTFS);
+  Serial.println("done");
 }
 
 void loop() {

--- a/libraries/LittleFS/src/LittleFS.h
+++ b/libraries/LittleFS/src/LittleFS.h
@@ -373,17 +373,20 @@ public:
     }
 
     int availableForWrite () override {
+        if (!_opened || !_fd) {
+            return 0;
+        }
+
         const auto f = _getFD();
         const auto fs = _fs->getFS();
 
         // check for remaining size in current block
-        // ignore inline feature
-        // (per code in lfs_file_rawwrite())
+        // ignore inline feature (per code in lfs_file_rawwrite())
         auto afw = fs->cfg->block_size - f->off;
 
         if (afw == 0) {
             // current block is full
-            // check for filesystem full per code in lfs_alloc()
+            // check for filesystem full (per code in lfs_alloc())
             if (!(fs->free.i == fs->free.size && fs->free.ack == 0)) {
                 // fs is not full, return a full sector as free space
                 afw = fs->cfg->block_size;

--- a/libraries/LittleFS/src/LittleFS.h
+++ b/libraries/LittleFS/src/LittleFS.h
@@ -241,7 +241,7 @@ public:
                 DEBUGV("lfs_format, lfs_setattr 't': rc=%d\n", rc);
                 return false;
             }
-            
+
             lfs_unmount(&_lfs);
             _mounted = false;
         }
@@ -370,6 +370,27 @@ public:
         if (_opened) {
             close();
         }
+    }
+
+    int availableForWrite () override {
+        const auto f = _getFD();
+        const auto fs = _fs->getFS();
+
+        // check for remaining size in current block
+        // ignore inline feature
+        // (per code in lfs_file_rawwrite())
+        auto afw = fs->cfg->block_size - f->off;
+
+        if (afw == 0) {
+            // current block is full
+            // check for filesystem full per code in lfs_alloc()
+            if (!(fs->free.i == fs->free.size && fs->free.ack == 0)) {
+                // fs is not full, return a full sector as free space
+                afw = fs->cfg->block_size;
+            }
+        }
+
+        return afw;
     }
 
     size_t write(const uint8_t *buf, size_t size) override {


### PR DESCRIPTION
fixes #8384 

`::availableForWrite()` could unconditionnally return a full sector as free space like proposed in #8384.

This proposal aims at returning a non-0 size fitting the current file block.
If the block is full and the filesystem is not full, it returns a full-FS-block size.
This way, the API allows users to take proper actions without losing data from the input stream when the filesystem is full, even if there is generally little to do in such case.