### PR TITLE
Allow configuring Wire.h buffer size

### DIFF
--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -28,8 +28,11 @@
 #include "Stream.h"
 
 
-
+#ifndef ARDUINO_WIRE_BUFFER_LENGTH
 #define BUFFER_LENGTH 128
+#else
+#define BUFFER_LENGTH ARDUINO_WIRE_BUFFER_LENGTH
+#endif
 
 class TwoWire : public Stream
 {


### PR DESCRIPTION
This is needed since in some applications, we need much much larger buffers.

See https://github.com/flaviut/emporia-vue2-reversing/issues/1#issuecomment-978174665