### PR TITLE
Adding custom buffer_length using I2C_BUFFER_LENGTH

### DIFF
--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -29,7 +29,11 @@
 
 
 
-#define BUFFER_LENGTH 128
+#ifndef I2C_BUFFER_LENGTH
+    #define BUFFER_LENGTH 128
+#else
+    #define BUFFER_LENGTH I2C_BUFFER_LENGTH
+#endif
 
 class TwoWire : public Stream
 {

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -30,9 +30,9 @@
 
 
 #ifndef I2C_BUFFER_LENGTH
-    #define BUFFER_LENGTH 128
+#define BUFFER_LENGTH 128
 #else
-    #define BUFFER_LENGTH I2C_BUFFER_LENGTH
+#define BUFFER_LENGTH I2C_BUFFER_LENGTH
 #endif
 
 class TwoWire : public Stream


### PR DESCRIPTION
New PR that expands on https://github.com/esp8266/Arduino/pull/8388.

Changed it so it's the same setting name (`I2C_BUFFER_LENGTH`) on both ESP8266 and ESP32 Wire library.