### PR TITLE
Wire buffer length improvments.

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -40,12 +40,12 @@ extern "C" {
 
 // Initialize Class Variables //////////////////////////////////////////////////
 
-uint8_t TwoWire::rxBuffer[BUFFER_LENGTH];
+uint8_t TwoWire::rxBuffer[I2C_BUFFER_LENGTH];
 uint8_t TwoWire::rxBufferIndex = 0;
 uint8_t TwoWire::rxBufferLength = 0;
 
 uint8_t TwoWire::txAddress = 0;
-uint8_t TwoWire::txBuffer[BUFFER_LENGTH];
+uint8_t TwoWire::txBuffer[I2C_BUFFER_LENGTH];
 uint8_t TwoWire::txBufferIndex = 0;
 uint8_t TwoWire::txBufferLength = 0;
 
@@ -122,9 +122,9 @@ void TwoWire::setClockStretchLimit(uint32_t limit)
 
 size_t TwoWire::requestFrom(uint8_t address, size_t size, bool sendStop)
 {
-    if (size > BUFFER_LENGTH)
+    if (size > I2C_BUFFER_LENGTH)
     {
-        size = BUFFER_LENGTH;
+        size = I2C_BUFFER_LENGTH;
     }
     size_t read = (twi_readFrom(address, rxBuffer, size, sendStop) == 0) ? size : 0;
     rxBufferIndex = 0;
@@ -183,7 +183,7 @@ size_t TwoWire::write(uint8_t data)
 {
     if (transmitting)
     {
-        if (txBufferLength >= BUFFER_LENGTH)
+        if (txBufferLength >= I2C_BUFFER_LENGTH)
         {
             setWriteError();
             return 0;

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -41,13 +41,13 @@ extern "C" {
 // Initialize Class Variables //////////////////////////////////////////////////
 
 uint8_t TwoWire::rxBuffer[I2C_BUFFER_LENGTH];
-uint8_t TwoWire::rxBufferIndex = 0;
-uint8_t TwoWire::rxBufferLength = 0;
+size_t TwoWire::rxBufferIndex = 0;
+size_t TwoWire::rxBufferLength = 0;
 
 uint8_t TwoWire::txAddress = 0;
 uint8_t TwoWire::txBuffer[I2C_BUFFER_LENGTH];
-uint8_t TwoWire::txBufferIndex = 0;
-uint8_t TwoWire::txBufferLength = 0;
+size_t TwoWire::txBufferIndex = 0;
+size_t TwoWire::txBufferLength = 0;
 
 uint8_t TwoWire::transmitting = 0;
 void (*TwoWire::user_onRequest)(void);

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -28,11 +28,10 @@
 #include "Stream.h"
 
 
-
 #ifndef I2C_BUFFER_LENGTH
+// DEPRECATED: Do not use BUFFER_LENGTH, prefer I2C_BUFFER_LENGTH
 #define BUFFER_LENGTH 128
-#else
-#define BUFFER_LENGTH I2C_BUFFER_LENGTH
+#define I2C_BUFFER_LENGTH BUFFER_LENGTH
 #endif
 
 class TwoWire : public Stream

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -38,13 +38,13 @@ class TwoWire : public Stream
 {
 private:
     static uint8_t rxBuffer[];
-    static uint8_t rxBufferIndex;
-    static uint8_t rxBufferLength;
+    static size_t rxBufferIndex;
+    static size_t rxBufferLength;
 
     static uint8_t txAddress;
     static uint8_t txBuffer[];
-    static uint8_t txBufferIndex;
-    static uint8_t txBufferLength;
+    static size_t txBufferIndex;
+    static size_t txBufferLength;
 
     static uint8_t transmitting;
     static void (*user_onRequest)(void);


### PR DESCRIPTION
## Enable I2C_BUFFER_LENGTH definition for Wire lib
 
Based on
https://github.com/paclema/arduino-esp32/commit/375a89ed58f341a8aae26dab505713f3ef0edb3d
 
We should have been very careful when #defining things to not use a name
that could conflict with the user's own code, so this marks that old
define as deprecated.
 
If you opt-into the new behavior, you do not get the old BUFFER_LENGTH
constant.

## Increase buffer indexing variable size
 
I looked over the users of these variables and they should be fine with
no additional changes. The existing methods already have an option to
use size_t rather than uint8_t.
 
There's a few methods which return int instead of size_t, which isn't
great from a portability perspective but will be fine since this only is
designed to run on the ESP8266.'

Fixes https://github.com/esp8266/Arduino/issues/8391

------

Feel free to use this patchset in full or in part.