### PR TITLE
Fix VM Address mask

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -74,10 +74,10 @@ generic.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 generic.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 generic.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 generic.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-generic.menu.mmu.ext128k=128K External 23LC1024
+generic.menu.mmu.ext128k=128K Heap External 23LC1024
 generic.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-generic.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-generic.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+generic.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+generic.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 generic.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 generic.menu.non32xfer.fast.build.non32xferflags=
 generic.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -573,10 +573,10 @@ esp8285.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 esp8285.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 esp8285.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 esp8285.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-esp8285.menu.mmu.ext128k=128K External 23LC1024
+esp8285.menu.mmu.ext128k=128K Heap External 23LC1024
 esp8285.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-esp8285.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-esp8285.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+esp8285.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+esp8285.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 esp8285.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 esp8285.menu.non32xfer.fast.build.non32xferflags=
 esp8285.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -942,10 +942,10 @@ gen4iod.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 gen4iod.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 gen4iod.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 gen4iod.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-gen4iod.menu.mmu.ext128k=128K External 23LC1024
+gen4iod.menu.mmu.ext128k=128K Heap External 23LC1024
 gen4iod.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-gen4iod.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-gen4iod.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+gen4iod.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+gen4iod.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 gen4iod.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 gen4iod.menu.non32xfer.fast.build.non32xferflags=
 gen4iod.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -1224,10 +1224,10 @@ huzzah.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 huzzah.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 huzzah.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 huzzah.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-huzzah.menu.mmu.ext128k=128K External 23LC1024
+huzzah.menu.mmu.ext128k=128K Heap External 23LC1024
 huzzah.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-huzzah.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-huzzah.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+huzzah.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+huzzah.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 huzzah.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 huzzah.menu.non32xfer.fast.build.non32xferflags=
 huzzah.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -1439,10 +1439,10 @@ wifi_slot.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 wifi_slot.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 wifi_slot.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 wifi_slot.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-wifi_slot.menu.mmu.ext128k=128K External 23LC1024
+wifi_slot.menu.mmu.ext128k=128K Heap External 23LC1024
 wifi_slot.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-wifi_slot.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-wifi_slot.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+wifi_slot.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+wifi_slot.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 wifi_slot.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 wifi_slot.menu.non32xfer.fast.build.non32xferflags=
 wifi_slot.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -1780,10 +1780,10 @@ arduino-esp8266.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 arduino-esp8266.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 arduino-esp8266.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 arduino-esp8266.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-arduino-esp8266.menu.mmu.ext128k=128K External 23LC1024
+arduino-esp8266.menu.mmu.ext128k=128K Heap External 23LC1024
 arduino-esp8266.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-arduino-esp8266.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-arduino-esp8266.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+arduino-esp8266.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+arduino-esp8266.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 arduino-esp8266.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 arduino-esp8266.menu.non32xfer.fast.build.non32xferflags=
 arduino-esp8266.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -1996,10 +1996,10 @@ espmxdevkit.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 espmxdevkit.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 espmxdevkit.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 espmxdevkit.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-espmxdevkit.menu.mmu.ext128k=128K External 23LC1024
+espmxdevkit.menu.mmu.ext128k=128K Heap External 23LC1024
 espmxdevkit.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-espmxdevkit.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-espmxdevkit.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+espmxdevkit.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+espmxdevkit.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 espmxdevkit.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 espmxdevkit.menu.non32xfer.fast.build.non32xferflags=
 espmxdevkit.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -2252,10 +2252,10 @@ oak.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 oak.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 oak.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 oak.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-oak.menu.mmu.ext128k=128K External 23LC1024
+oak.menu.mmu.ext128k=128K Heap External 23LC1024
 oak.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-oak.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-oak.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+oak.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+oak.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 oak.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 oak.menu.non32xfer.fast.build.non32xferflags=
 oak.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -2476,10 +2476,10 @@ espduino.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 espduino.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 espduino.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 espduino.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-espduino.menu.mmu.ext128k=128K External 23LC1024
+espduino.menu.mmu.ext128k=128K Heap External 23LC1024
 espduino.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-espduino.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-espduino.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+espduino.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+espduino.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 espduino.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 espduino.menu.non32xfer.fast.build.non32xferflags=
 espduino.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -2690,10 +2690,10 @@ espectro.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 espectro.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 espectro.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 espectro.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-espectro.menu.mmu.ext128k=128K External 23LC1024
+espectro.menu.mmu.ext128k=128K Heap External 23LC1024
 espectro.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-espectro.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-espectro.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+espectro.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+espectro.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 espectro.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 espectro.menu.non32xfer.fast.build.non32xferflags=
 espectro.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -2905,10 +2905,10 @@ espino.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 espino.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 espino.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 espino.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-espino.menu.mmu.ext128k=128K External 23LC1024
+espino.menu.mmu.ext128k=128K Heap External 23LC1024
 espino.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-espino.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-espino.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+espino.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+espino.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 espino.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 espino.menu.non32xfer.fast.build.non32xferflags=
 espino.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -3123,10 +3123,10 @@ espresso_lite_v1.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 espresso_lite_v1.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 espresso_lite_v1.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 espresso_lite_v1.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-espresso_lite_v1.menu.mmu.ext128k=128K External 23LC1024
+espresso_lite_v1.menu.mmu.ext128k=128K Heap External 23LC1024
 espresso_lite_v1.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-espresso_lite_v1.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-espresso_lite_v1.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+espresso_lite_v1.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+espresso_lite_v1.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 espresso_lite_v1.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 espresso_lite_v1.menu.non32xfer.fast.build.non32xferflags=
 espresso_lite_v1.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -3341,10 +3341,10 @@ espresso_lite_v2.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 espresso_lite_v2.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 espresso_lite_v2.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 espresso_lite_v2.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-espresso_lite_v2.menu.mmu.ext128k=128K External 23LC1024
+espresso_lite_v2.menu.mmu.ext128k=128K Heap External 23LC1024
 espresso_lite_v2.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-espresso_lite_v2.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-espresso_lite_v2.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+espresso_lite_v2.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+espresso_lite_v2.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 espresso_lite_v2.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 espresso_lite_v2.menu.non32xfer.fast.build.non32xferflags=
 espresso_lite_v2.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -3569,10 +3569,10 @@ sonoff.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 sonoff.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 sonoff.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 sonoff.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-sonoff.menu.mmu.ext128k=128K External 23LC1024
+sonoff.menu.mmu.ext128k=128K Heap External 23LC1024
 sonoff.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-sonoff.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-sonoff.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+sonoff.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+sonoff.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 sonoff.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 sonoff.menu.non32xfer.fast.build.non32xferflags=
 sonoff.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -3824,10 +3824,10 @@ inventone.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 inventone.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 inventone.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 inventone.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-inventone.menu.mmu.ext128k=128K External 23LC1024
+inventone.menu.mmu.ext128k=128K Heap External 23LC1024
 inventone.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-inventone.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-inventone.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+inventone.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+inventone.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 inventone.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 inventone.menu.non32xfer.fast.build.non32xferflags=
 inventone.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -4039,10 +4039,10 @@ d1_mini.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 d1_mini.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 d1_mini.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 d1_mini.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-d1_mini.menu.mmu.ext128k=128K External 23LC1024
+d1_mini.menu.mmu.ext128k=128K Heap External 23LC1024
 d1_mini.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-d1_mini.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-d1_mini.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+d1_mini.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+d1_mini.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 d1_mini.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 d1_mini.menu.non32xfer.fast.build.non32xferflags=
 d1_mini.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -4254,10 +4254,10 @@ d1_mini_clone.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 d1_mini_clone.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 d1_mini_clone.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 d1_mini_clone.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-d1_mini_clone.menu.mmu.ext128k=128K External 23LC1024
+d1_mini_clone.menu.mmu.ext128k=128K Heap External 23LC1024
 d1_mini_clone.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-d1_mini_clone.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-d1_mini_clone.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+d1_mini_clone.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+d1_mini_clone.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 d1_mini_clone.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 d1_mini_clone.menu.non32xfer.fast.build.non32xferflags=
 d1_mini_clone.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -4486,10 +4486,10 @@ d1_mini_lite.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 d1_mini_lite.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 d1_mini_lite.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 d1_mini_lite.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-d1_mini_lite.menu.mmu.ext128k=128K External 23LC1024
+d1_mini_lite.menu.mmu.ext128k=128K Heap External 23LC1024
 d1_mini_lite.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-d1_mini_lite.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-d1_mini_lite.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+d1_mini_lite.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+d1_mini_lite.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 d1_mini_lite.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 d1_mini_lite.menu.non32xfer.fast.build.non32xferflags=
 d1_mini_lite.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -4741,10 +4741,10 @@ d1_mini_pro.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 d1_mini_pro.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 d1_mini_pro.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 d1_mini_pro.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-d1_mini_pro.menu.mmu.ext128k=128K External 23LC1024
+d1_mini_pro.menu.mmu.ext128k=128K Heap External 23LC1024
 d1_mini_pro.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-d1_mini_pro.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-d1_mini_pro.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+d1_mini_pro.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+d1_mini_pro.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 d1_mini_pro.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 d1_mini_pro.menu.non32xfer.fast.build.non32xferflags=
 d1_mini_pro.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -4939,10 +4939,10 @@ d1.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 d1.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 d1.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 d1.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-d1.menu.mmu.ext128k=128K External 23LC1024
+d1.menu.mmu.ext128k=128K Heap External 23LC1024
 d1.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-d1.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-d1.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+d1.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+d1.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 d1.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 d1.menu.non32xfer.fast.build.non32xferflags=
 d1.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -5154,10 +5154,10 @@ agruminolemon.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 agruminolemon.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 agruminolemon.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 agruminolemon.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-agruminolemon.menu.mmu.ext128k=128K External 23LC1024
+agruminolemon.menu.mmu.ext128k=128K Heap External 23LC1024
 agruminolemon.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-agruminolemon.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-agruminolemon.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+agruminolemon.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+agruminolemon.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 agruminolemon.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 agruminolemon.menu.non32xfer.fast.build.non32xferflags=
 agruminolemon.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -5389,10 +5389,10 @@ nodemcu.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 nodemcu.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 nodemcu.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 nodemcu.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-nodemcu.menu.mmu.ext128k=128K External 23LC1024
+nodemcu.menu.mmu.ext128k=128K Heap External 23LC1024
 nodemcu.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-nodemcu.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-nodemcu.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+nodemcu.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+nodemcu.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 nodemcu.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 nodemcu.menu.non32xfer.fast.build.non32xferflags=
 nodemcu.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -5604,10 +5604,10 @@ nodemcuv2.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 nodemcuv2.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 nodemcuv2.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 nodemcuv2.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-nodemcuv2.menu.mmu.ext128k=128K External 23LC1024
+nodemcuv2.menu.mmu.ext128k=128K Heap External 23LC1024
 nodemcuv2.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-nodemcuv2.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-nodemcuv2.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+nodemcuv2.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+nodemcuv2.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 nodemcuv2.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 nodemcuv2.menu.non32xfer.fast.build.non32xferflags=
 nodemcuv2.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -5823,10 +5823,10 @@ modwifi.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 modwifi.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 modwifi.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 modwifi.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-modwifi.menu.mmu.ext128k=128K External 23LC1024
+modwifi.menu.mmu.ext128k=128K Heap External 23LC1024
 modwifi.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-modwifi.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-modwifi.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+modwifi.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+modwifi.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 modwifi.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 modwifi.menu.non32xfer.fast.build.non32xferflags=
 modwifi.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -6073,10 +6073,10 @@ phoenix_v1.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 phoenix_v1.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 phoenix_v1.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 phoenix_v1.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-phoenix_v1.menu.mmu.ext128k=128K External 23LC1024
+phoenix_v1.menu.mmu.ext128k=128K Heap External 23LC1024
 phoenix_v1.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-phoenix_v1.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-phoenix_v1.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+phoenix_v1.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+phoenix_v1.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 phoenix_v1.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 phoenix_v1.menu.non32xfer.fast.build.non32xferflags=
 phoenix_v1.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -6291,10 +6291,10 @@ phoenix_v2.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 phoenix_v2.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 phoenix_v2.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 phoenix_v2.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-phoenix_v2.menu.mmu.ext128k=128K External 23LC1024
+phoenix_v2.menu.mmu.ext128k=128K Heap External 23LC1024
 phoenix_v2.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-phoenix_v2.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-phoenix_v2.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+phoenix_v2.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+phoenix_v2.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 phoenix_v2.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 phoenix_v2.menu.non32xfer.fast.build.non32xferflags=
 phoenix_v2.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -6509,10 +6509,10 @@ eduinowifi.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 eduinowifi.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 eduinowifi.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 eduinowifi.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-eduinowifi.menu.mmu.ext128k=128K External 23LC1024
+eduinowifi.menu.mmu.ext128k=128K Heap External 23LC1024
 eduinowifi.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-eduinowifi.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-eduinowifi.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+eduinowifi.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+eduinowifi.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 eduinowifi.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 eduinowifi.menu.non32xfer.fast.build.non32xferflags=
 eduinowifi.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -6724,10 +6724,10 @@ wiolink.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 wiolink.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 wiolink.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 wiolink.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-wiolink.menu.mmu.ext128k=128K External 23LC1024
+wiolink.menu.mmu.ext128k=128K Heap External 23LC1024
 wiolink.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-wiolink.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-wiolink.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+wiolink.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+wiolink.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 wiolink.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 wiolink.menu.non32xfer.fast.build.non32xferflags=
 wiolink.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -6939,10 +6939,10 @@ blynk.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 blynk.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 blynk.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 blynk.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-blynk.menu.mmu.ext128k=128K External 23LC1024
+blynk.menu.mmu.ext128k=128K Heap External 23LC1024
 blynk.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-blynk.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-blynk.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+blynk.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+blynk.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 blynk.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 blynk.menu.non32xfer.fast.build.non32xferflags=
 blynk.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -7154,10 +7154,10 @@ thing.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 thing.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 thing.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 thing.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-thing.menu.mmu.ext128k=128K External 23LC1024
+thing.menu.mmu.ext128k=128K Heap External 23LC1024
 thing.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-thing.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-thing.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+thing.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+thing.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 thing.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 thing.menu.non32xfer.fast.build.non32xferflags=
 thing.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -7369,10 +7369,10 @@ thingdev.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 thingdev.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 thingdev.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 thingdev.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-thingdev.menu.mmu.ext128k=128K External 23LC1024
+thingdev.menu.mmu.ext128k=128K Heap External 23LC1024
 thingdev.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-thingdev.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-thingdev.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+thingdev.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+thingdev.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 thingdev.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 thingdev.menu.non32xfer.fast.build.non32xferflags=
 thingdev.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -7584,10 +7584,10 @@ esp210.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 esp210.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 esp210.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 esp210.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-esp210.menu.mmu.ext128k=128K External 23LC1024
+esp210.menu.mmu.ext128k=128K Heap External 23LC1024
 esp210.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-esp210.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-esp210.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+esp210.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+esp210.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 esp210.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 esp210.menu.non32xfer.fast.build.non32xferflags=
 esp210.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -7799,10 +7799,10 @@ espinotee.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 espinotee.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 espinotee.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 espinotee.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-espinotee.menu.mmu.ext128k=128K External 23LC1024
+espinotee.menu.mmu.ext128k=128K Heap External 23LC1024
 espinotee.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-espinotee.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-espinotee.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+espinotee.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+espinotee.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 espinotee.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 espinotee.menu.non32xfer.fast.build.non32xferflags=
 espinotee.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -8014,10 +8014,10 @@ wifi_kit_8.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 wifi_kit_8.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 wifi_kit_8.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 wifi_kit_8.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-wifi_kit_8.menu.mmu.ext128k=128K External 23LC1024
+wifi_kit_8.menu.mmu.ext128k=128K Heap External 23LC1024
 wifi_kit_8.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-wifi_kit_8.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-wifi_kit_8.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+wifi_kit_8.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+wifi_kit_8.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 wifi_kit_8.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 wifi_kit_8.menu.non32xfer.fast.build.non32xferflags=
 wifi_kit_8.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -8229,10 +8229,10 @@ wifiduino.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 wifiduino.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 wifiduino.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 wifiduino.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-wifiduino.menu.mmu.ext128k=128K External 23LC1024
+wifiduino.menu.mmu.ext128k=128K Heap External 23LC1024
 wifiduino.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-wifiduino.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-wifiduino.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+wifiduino.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+wifiduino.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 wifiduino.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 wifiduino.menu.non32xfer.fast.build.non32xferflags=
 wifiduino.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -8461,10 +8461,10 @@ wifinfo.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 wifinfo.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 wifinfo.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 wifinfo.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-wifinfo.menu.mmu.ext128k=128K External 23LC1024
+wifinfo.menu.mmu.ext128k=128K Heap External 23LC1024
 wifinfo.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-wifinfo.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-wifinfo.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+wifinfo.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+wifinfo.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 wifinfo.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 wifinfo.menu.non32xfer.fast.build.non32xferflags=
 wifinfo.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)
@@ -8723,10 +8723,10 @@ cw01.menu.mmu.4816H=16KB cache + 48KB IRAM and 2nd Heap (shared)
 cw01.menu.mmu.4816H.build.mmuflags=-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP
 cw01.menu.mmu.3216=16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)
 cw01.menu.mmu.3216.build.mmuflags=-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000
-cw01.menu.mmu.ext128k=128K External 23LC1024
+cw01.menu.mmu.ext128k=128K Heap External 23LC1024
 cw01.menu.mmu.ext128k.build.mmuflags=-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
-cw01.menu.mmu.ext1024k=1M External 64 MBit PSRAM
-cw01.menu.mmu.ext1024k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
+cw01.menu.mmu.ext8192k=8M w/256K Heap External 64 MBit PSRAM
+cw01.menu.mmu.ext8192k.build.mmuflags=-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000
 cw01.menu.non32xfer.fast=Use pgm_read macros for IRAM/PROGMEM
 cw01.menu.non32xfer.fast.build.non32xferflags=
 cw01.menu.non32xfer.safe=Byte/Word access to IRAM/PROGMEM (very slow)

--- a/cores/esp8266/Esp-frag.cpp
+++ b/cores/esp8266/Esp-frag.cpp
@@ -23,25 +23,36 @@
 #include "coredecls.h"
 #include "Esp.h"
 
-void EspClass::getHeapStats(uint32_t* hfree, uint16_t* hmax, uint8_t* hfrag)
+void EspClass::getHeapStats(uint32_t* hfree, uint32_t* hmax, uint8_t* hfrag)
 {
     // L2 / Euclidean norm of free block sizes.
     // Having getFreeHeap()=sum(hole-size), fragmentation is given by
     // 100 * (1 - sqrt(sum(hole-size²)) / sum(hole-size))
-
     umm_info(NULL, false);
 
     uint32_t free_size = umm_free_heap_size_core(umm_get_current_heap());
     if (hfree)
         *hfree = free_size;
     if (hmax)
-        *hmax = (uint16_t)umm_max_block_size_core(umm_get_current_heap());
+        *hmax = umm_max_block_size_core(umm_get_current_heap());
     if (hfrag) {
       if (free_size) {
         *hfrag = umm_fragmentation_metric_core(umm_get_current_heap());
       } else {
         *hfrag = 0;
       }
+    }
+}
+
+void EspClass::getHeapStats(uint32_t* hfree, uint16_t* hmax, uint8_t* hfrag)
+{
+    uint32_t hmax32;
+    getHeapStats(hfree, &hmax32, hfrag);
+    if (hmax) {
+      // With the MMU_EXTERNAL_HEAP option, hmax could overflow for heaps larger
+      // then 64KB. return UINT16_MAX (saturation) for those cases.
+      // Added deprecated attribute and message.
+      *hmax = (hmax32 > UINT16_MAX) ? UINT16_MAX : hmax32;
     }
 }
 

--- a/cores/esp8266/Esp.cpp
+++ b/cores/esp8266/Esp.cpp
@@ -222,7 +222,7 @@ uint32_t EspClass::getFreeHeap(void)
     return system_get_free_heap_size();
 }
 
-uint16_t EspClass::getMaxFreeBlockSize(void)
+uint32_t EspClass::getMaxFreeBlockSize(void)
 {
     return umm_max_block_size();
 }

--- a/cores/esp8266/Esp.h
+++ b/cores/esp8266/Esp.h
@@ -114,9 +114,10 @@ class EspClass {
         static uint32_t getChipId();
 
         static uint32_t getFreeHeap();
-        static uint16_t getMaxFreeBlockSize();
+        static uint32_t getMaxFreeBlockSize();
         static uint8_t getHeapFragmentation(); // in %
-        static void getHeapStats(uint32_t* free = nullptr, uint16_t* max = nullptr, uint8_t* frag = nullptr);
+        static void getHeapStats(uint32_t* free = nullptr, uint16_t* max = nullptr, uint8_t* frag = nullptr) __attribute__((deprecated("Use 'uint32_t*' on max, 2nd argument")));
+        static void getHeapStats(uint32_t* free = nullptr, uint32_t* max = nullptr, uint8_t* frag = nullptr);
 
         static uint32_t getFreeContStack();
         static void resetFreeContStack();

--- a/cores/esp8266/core_esp8266_vm.cpp
+++ b/cores/esp8266/core_esp8266_vm.cpp
@@ -56,7 +56,7 @@
  * Higher density PSRAM (ESP-PSRAM64H/etc.) works as well, but may be too
    large to effectively use with UMM.  Only 256K is available vial malloc,
    but addresses above 256K do work and can be used for fixed buffers.
- 
+
 */
 
 #ifdef MMU_EXTERNAL_HEAP
@@ -70,6 +70,8 @@
 
 
 extern "C" {
+
+#define VM_OFFSET_MASK  0x007fffffu
 
 #define SHORT_MASK  0x000008u
 #define LOAD_MASK   0x00f00fu
@@ -324,21 +326,21 @@ static IRAM_ATTR void loadstore_exception_handler(struct __exception_frame *ef, 
     uint32_t val = ef->a_reg[regno];
     uint32_t what = insn & STORE_MASK;
     if (what == S8I_MATCH) {
-       spi_ramwrite(spi1, excvaddr & 0x1ffff, 8-1, val);
+       spi_ramwrite(spi1, excvaddr & VM_OFFSET_MASK, 8-1, val);
     } else if (what == S16I_MATCH) {
-      spi_ramwrite(spi1, excvaddr & 0x1ffff, 16-1, val);
+      spi_ramwrite(spi1, excvaddr & VM_OFFSET_MASK, 16-1, val);
     } else {
-      spi_ramwrite(spi1, excvaddr & 0x1ffff, 32-1, val);
+      spi_ramwrite(spi1, excvaddr & VM_OFFSET_MASK, 32-1, val);
     }
   } else {
     if (insn & L32_MASK) {
-      ef->a_reg[regno] = spi_ramread(spi1, excvaddr & 0x1ffff, 32-1);
+      ef->a_reg[regno] = spi_ramread(spi1, excvaddr & VM_OFFSET_MASK, 32-1);
     } else if (insn & L16_MASK) {
-      ef->a_reg[regno] = spi_ramread(spi1, excvaddr & 0x1ffff, 16-1);
+      ef->a_reg[regno] = spi_ramread(spi1, excvaddr & VM_OFFSET_MASK, 16-1);
       if ((insn & SIGNED_MASK ) && (ef->a_reg[regno] & 0x8000))
         ef->a_reg[regno] |= 0xffff0000;
     } else {
-      ef->a_reg[regno] = spi_ramread(spi1, excvaddr & 0x1ffff, 8-1);
+      ef->a_reg[regno] = spi_ramread(spi1, excvaddr & VM_OFFSET_MASK, 8-1);
     }
   }
 }

--- a/cores/esp8266/core_esp8266_vm.cpp
+++ b/cores/esp8266/core_esp8266_vm.cpp
@@ -391,6 +391,11 @@ void install_vm_exception_handler()
     __vm_cache_line[cache_ways - 1].next = NULL;
   }
 
+  // Our umm_malloc configuration can only support a maximum of 256K RAM. A
+  // change would affect the block size of all heaps, and a larger block size
+  // would result in wasted space in the smaller heaps.
+  static_assert(MMU_EXTERNAL_HEAP <= 256, "Heap size must not exceed 256K");
+
   // Hook into memory manager
   umm_init_vm( (void *)0x10000000, MMU_EXTERNAL_HEAP * 1024);
 }

--- a/cores/esp8266/umm_malloc/umm_local.c
+++ b/cores/esp8266/umm_malloc/umm_local.c
@@ -192,15 +192,15 @@ void umm_print_stats(int force) {
     umm_heap_context_t *_context = umm_get_current_heap();
 
     DBGLOG_FORCE(force, "umm heap statistics:\n");
-    DBGLOG_FORCE(force,   "  Heap ID           %5u\n", _context->id);
-    DBGLOG_FORCE(force,   "  Free Space        %5u\n", _context->UMM_FREE_BLOCKS * sizeof(umm_block));
-    DBGLOG_FORCE(force,   "  OOM Count         %5u\n", _context->UMM_OOM_COUNT);
+    DBGLOG_FORCE(force,   "  Heap ID           %7u\n", _context->id);
+    DBGLOG_FORCE(force,   "  Free Space        %7u\n", _context->UMM_FREE_BLOCKS * sizeof(umm_block));
+    DBGLOG_FORCE(force,   "  OOM Count         %7u\n", _context->UMM_OOM_COUNT);
     #if defined(UMM_STATS_FULL)
-    DBGLOG_FORCE(force,   "  Low Watermark     %5u\n", _context->stats.free_blocks_min * sizeof(umm_block));
-    DBGLOG_FORCE(force,   "  Low Watermark ISR %5u\n", _context->stats.free_blocks_isr_min * sizeof(umm_block));
-    DBGLOG_FORCE(force,   "  MAX Alloc Request %5u\n", _context->stats.alloc_max_size);
+    DBGLOG_FORCE(force,   "  Low Watermark     %7u\n", _context->stats.free_blocks_min * sizeof(umm_block));
+    DBGLOG_FORCE(force,   "  Low Watermark ISR %7u\n", _context->stats.free_blocks_isr_min * sizeof(umm_block));
+    DBGLOG_FORCE(force,   "  MAX Alloc Request %7u\n", _context->stats.alloc_max_size);
     #endif
-    DBGLOG_FORCE(force,   "  Size of umm_block %5u\n", sizeof(umm_block));
+    DBGLOG_FORCE(force,   "  Size of umm_block %7u\n", sizeof(umm_block));
     DBGLOG_FORCE(force, "+--------------------------------------------------------------+\n");
 }
 #endif

--- a/libraries/esp8266/examples/HeapMetric/HeapMetric.ino
+++ b/libraries/esp8266/examples/HeapMetric/HeapMetric.ino
@@ -10,11 +10,11 @@ void stats(const char* what) {
   // we could use getFreeHeap() getMaxFreeBlockSize() and getHeapFragmentation()
   // or all at once:
   uint32_t free;
-  uint16_t max;
+  uint32_t max;
   uint8_t frag;
   ESP.getHeapStats(&free, &max, &frag);
 
-  Serial.printf("free: %5d - max: %5d - frag: %3d%% <- ", free, max, frag);
+  Serial.printf("free: %7u - max: %7u - frag: %3d%% <- ", free, max, frag);
   // %s requires a malloc that could fail, using println instead:
   Serial.println(what);
 }
@@ -109,6 +109,7 @@ void tryit(int blocksize) {
 void setup() {
   Serial.begin(115200);
   WiFi.mode(WIFI_OFF);
+  delay(50);
 
   Serial.printf("\r\nDemo Heap Metrics for DRAM\r\n");
   tryit(8000);
@@ -124,6 +125,26 @@ void setup() {
   {
     HeapSelectIram ephemeral;
     Serial.printf("\r\nDemo Heap Metrics for IRAM\r\n");
+    tryit(8000);
+    tryit(4000);
+    tryit(2000);
+    tryit(1000);
+    tryit(500);
+    tryit(200);
+    tryit(100);
+    tryit(50);
+    tryit(15);
+  }
+#endif
+#ifdef MMU_EXTERNAL_HEAP
+  {
+    HeapSelect ephemeral = HeapSelect(UMM_HEAP_EXTERNAL);
+    Serial.printf("\r\nDemo Heap Metrics for External RAM\r\n");
+#if (MMU_EXTERNAL_HEAP > 64)
+    tryit(64000);
+    tryit(32000);
+#endif
+    tryit(16000);
     tryit(8000);
     tryit(4000);
     tryit(2000);

--- a/libraries/esp8266/examples/irammem/irammem.ino
+++ b/libraries/esp8266/examples/irammem/irammem.ino
@@ -592,7 +592,7 @@ void setup() {
     size_t free_iram = ESP.getFreeHeap();
     ETS_PRINTF("IRAM free: %6d\n", free_iram);
     uint32_t hfree;
-    uint16_t hmax;
+    uint32_t hmax;
     uint8_t hfrag;
     ESP.getHeapStats(&hfree, &hmax, &hfrag);
     ETS_PRINTF("ESP.getHeapStats(free: %u, max: %u, frag: %u)\n",

--- a/tests/host/common/MockEsp.cpp
+++ b/tests/host/common/MockEsp.cpp
@@ -108,7 +108,7 @@ uint32_t EspClass::getFreeHeap()
 	return 30000;
 }
 
-uint16_t EspClass::getMaxFreeBlockSize()
+uint32_t EspClass::getMaxFreeBlockSize()
 {
 	return 20000;
 }

--- a/tools/boards.txt.py
+++ b/tools/boards.txt.py
@@ -1270,10 +1270,10 @@ macros = {
         ( '.menu.mmu.4816H.build.mmuflags', '-DMMU_IRAM_SIZE=0xC000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_IRAM_HEAP' ),
         ( '.menu.mmu.3216', '16KB cache + 32KB IRAM + 16KB 2nd Heap (not shared)' ),
         ( '.menu.mmu.3216.build.mmuflags', '-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x4000 -DMMU_SEC_HEAP=0x40108000 -DMMU_SEC_HEAP_SIZE=0x4000' ),
-        ( '.menu.mmu.ext128k', '128K External 23LC1024' ),
+        ( '.menu.mmu.ext128k', '128K Heap External 23LC1024' ),
         ( '.menu.mmu.ext128k.build.mmuflags', '-DMMU_EXTERNAL_HEAP=128 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000' ),
-        ( '.menu.mmu.ext1024k', '1M External 64 MBit PSRAM' ),
-        ( '.menu.mmu.ext1024k.build.mmuflags', '-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000' ),
+        ( '.menu.mmu.ext8192k', '8M w/256K Heap External 64 MBit PSRAM' ),
+        ( '.menu.mmu.ext8192k.build.mmuflags', '-DMMU_EXTERNAL_HEAP=256 -DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000' ),
         ]),
 
     ######################## Non 32-bit load/store exception handler


### PR DESCRIPTION
Adjust VM Address mask to allow up to 8M Byte parts.

Allow for free heap size values over 64K
  `ESP.getHeapStats(, uint32_t,)`
  `uint32_t getMaxFreeBlockSize();`