### PR TITLE
Obsolete PWMRANGE still defined as LITERAL1 in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -19,4 +19,3 @@ enablePhaseLockedWaveform	KEYWORD2
 # Constants (LITERAL1)
 #######################################
 INPUT_PULLDOWN_16	LITERAL1
-PWMRANGE	LITERAL1


### PR DESCRIPTION
PWMRANGE was defined up until v2.7.4:

```
$ cd ~/Library/Arduino15/packages/esp8266/hardware/esp8266
$ grep -R "PWMRANGE" 2.7.4
2.7.4/keywords.txt:PWMRANGE	LITERAL1
2.7.4/tests/host/common/Arduino.h:#define PWMRANGE 1023
2.7.4/cores/esp8266/core_esp8266_wiring_pwm.cpp:static int32_t analogScale = PWMRANGE;
2.7.4/cores/esp8266/Arduino.h:#define PWMRANGE 1023
```

The define was removed in favour of the Arduino standard value of 255
but the keyword coloring was left behind:

```
$ cd ~/Library/Arduino15/packages/esp8266/hardware/esp8266
$ grep -R "PWMRANGE" 3.0.2
3.0.2/keywords.txt:PWMRANGE	LITERAL1
```

In the Arduino IDE, the coloring makes it look like PWMRANGE still
exists, when it doesn't, which is confusing.

Signed-off-by: Phill Kelley <pmk.57t49@lgosys.com>