### PR TITLE
fix Stream.read into buffer ignoring every second byte 

### DIFF
--- a/cores/esp8266/Stream.cpp
+++ b/cores/esp8266/Stream.cpp
@@ -274,7 +274,7 @@ int Stream::read (uint8_t* buffer, size_t maxLen)
         int c = read();
         if (c == -1)
             break;
-        buffer[nbread++] = read();
+        buffer[nbread++] = c;
     }
     return nbread;
 }


### PR DESCRIPTION
As shown in #8452, the default implementation for `int Stream::read (uint8_t* buffer, size_t maxLen)` only writes every second byte into the given buffer.

fixes #8452