### PR TITLE
Avoid writing to const storage

### DIFF
--- a/cores/esp8266/WString.cpp
+++ b/cores/esp8266/WString.cpp
@@ -682,14 +682,9 @@ int String::lastIndexOf(char ch) const {
 int String::lastIndexOf(char ch, unsigned int fromIndex) const {
     if (fromIndex >= len())
         return -1;
-    char *writeTo = wbuffer();
-    char tempchar = writeTo[fromIndex + 1]; // save the replaced character
-    writeTo[fromIndex + 1] = '\0';
-    char *temp = strrchr(writeTo, ch);
-    writeTo[fromIndex + 1] = tempchar; // restore character
-    if (temp == NULL)
-        return -1;
-    return temp - writeTo;
+    int index = fromIndex + 1;
+    while (index-- > 0 && buffer()[index] != ch);
+    return index;
 }
 
 int String::lastIndexOf(const String &s2) const {
@@ -732,11 +727,7 @@ String String::substring(unsigned int left, unsigned int right) const {
         return out;
     if (right > len())
         right = len();
-    char *writeTo = wbuffer();
-    char tempchar = writeTo[right]; // save the replaced character
-    writeTo[right] = '\0';
-    out = writeTo + left; // pointer arithmetic
-    writeTo[right] = tempchar; // restore character
+    out.concat(buffer() + left, right - left);
     return out;
 }
 

--- a/cores/esp8266/WString.h
+++ b/cores/esp8266/WString.h
@@ -263,8 +263,8 @@ class String {
         void setCapacity(int cap) { if (!isSSO()) ptr.cap = cap; }
         void setBuffer(char *buff) { if (!isSSO()) ptr.buff = buff; }
         // Buffer accessor functions
-        const char *buffer() const { return wbuffer(); }
-        char *wbuffer() const { return isSSO() ? const_cast<char *>(sso.buff) : ptr.buff; } // Writable version of buffer
+        const char *buffer() const { return isSSO() ? sso.buff : ptr.buff; }
+        char *wbuffer() { return const_cast<char *>(buffer()); } // Writable version of buffer
 
         // concatenation is done via non-member functions
         // make sure we still have access to internal methods, since we optimize based on capacity of both sides and want to manipulate internal buffers directly


### PR DESCRIPTION
Fixes #8462 

This avoids the null termination requirement of both `String::substring` and `String::lastIndexOf` by using APIs that don't require it. So we can stop writing to the buffer inside of const functions.

There might be a off by one error there, I need to take a better look at the code and would love if someone could review.