### PR TITLE
Fix WiFiEventHandlerOpaque, now implemented correctly in header and i…

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -53,29 +53,23 @@ extern "C" {
 // ------------------------------------------------- Generic WiFi function -----------------------------------------------
 // -----------------------------------------------------------------------------------------------------------------------
 
-struct WiFiEventHandlerOpaque
+
+WiFiEventHandlerOpaque::WiFiEventHandlerOpaque(WiFiEvent_t event, std::function<void(System_Event_t*)> handler)
+: mEvent(event), mHandler(handler)
 {
-    WiFiEventHandlerOpaque(WiFiEvent_t event, std::function<void(System_Event_t*)> handler)
-    : mEvent(event), mHandler(handler)
-    {
-    }
+}
 
-    void operator()(System_Event_t* e)
-    {
-        if (static_cast<WiFiEvent>(e->event) == mEvent || mEvent == WIFI_EVENT_ANY) {
-            mHandler(e);
-        }
+void WiFiEventHandlerOpaque::operator()(System_Event_t* e)
+{
+    if (static_cast<WiFiEvent>(e->event) == mEvent || mEvent == WIFI_EVENT_ANY) {
+        mHandler(e);
     }
+}
 
-    bool canExpire()
-    {
-        return mCanExpire;
-    }
-
-    WiFiEvent_t mEvent;
-    std::function<void(System_Event_t*)> mHandler;
-    bool mCanExpire = true; /* stopgap solution to handle deprecated void onEvent(cb, evt) case */
-};
+bool WiFiEventHandlerOpaque::canExpire()
+{
+    return mCanExpire;
+}
 
 static std::list<WiFiEventHandler> sCbEventList;
 

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.h
@@ -37,7 +37,15 @@
 #define DEBUG_WIFI_GENERIC(...) do { (void)0; } while (0)
 #endif
 
-struct WiFiEventHandlerOpaque;
+struct WiFiEventHandlerOpaque {
+    WiFiEventHandlerOpaque(WiFiEvent_t event, std::function<void(System_Event_t*)> handler);
+    void operator()(System_Event_t* e);    
+    bool canExpire();
+
+    WiFiEvent_t mEvent;
+    std::function<void(System_Event_t*)> mHandler;
+    bool mCanExpire = true; /* stopgap solution to handle deprecated void onEvent(cb, evt) case */
+};
 typedef std::shared_ptr<WiFiEventHandlerOpaque> WiFiEventHandler;
 
 typedef void (*WiFiEventCb)(WiFiEvent_t);


### PR DESCRIPTION
I was trying out the library and noticed that when calling

`WiFiEventHandler handler = WiFi.onStationModeConnected(
        [](WiFiEventStationModeConnected e) { ... });`

the variable "handler" (which is typedef'd as a std::shared_ptr<WiFiEventHandlerOpaque>) was basically a shared pointer with an empty struct inside, since WiFiEventHandlerOpaque in ESP8266WiFiGeneric.h was just declared like this.

`struct WiFiEventHandlerOpaque;`

This leads to a "pointer to incomplete class type is not allowed" compile time error, because the interface is missing and no method or member variable can be accessed from "handler".