### PR TITLE
Free String memory on assign of "" or clear()

### DIFF
--- a/cores/esp8266/WString.cpp
+++ b/cores/esp8266/WString.cpp
@@ -258,7 +258,7 @@ String &String::operator =(String &&rval) noexcept {
 }
 
 String &String::operator =(const char *cstr) {
-    if (cstr)
+    if (cstr && cstr[0])
         copy(cstr, strlen(cstr));
     else
         invalidate();

--- a/cores/esp8266/WString.h
+++ b/cores/esp8266/WString.h
@@ -88,7 +88,7 @@ class String {
             return buffer() ? len() : 0;
         }
         void clear(void) {
-            setLen(0);
+            invalidate();
         }
         bool isEmpty(void) const {
             return length() == 0;


### PR DESCRIPTION
Fixes #8485

Whenever the empty C string is assigned or the .clear() method
called, free any heap allocated with the String.