### PR TITLE
Correctly using fs:: namespace in SD & SDFS

### DIFF
--- a/libraries/SD/src/SD.h
+++ b/libraries/SD/src/SD.h
@@ -32,8 +32,8 @@
 
 class SDClass {
 public:
-    boolean begin(uint8_t csPin, uint32_t cfg = SPI_HALF_SPEED) {
-	SDFS.setConfig(SDFSConfig(csPin, cfg));
+    bool begin(uint8_t csPin, uint32_t cfg = SPI_HALF_SPEED) {
+        SDFS.setConfig(SDFSConfig(csPin, cfg));
         return (boolean)SDFS.begin();
     }
 
@@ -44,19 +44,19 @@ public:
         }
     }
 
-    File open(const char *filename, uint8_t mode = FILE_READ) {
+    fs::File open(const char *filename, uint8_t mode = FILE_READ) {
         return SDFS.open(filename, getMode(mode));
     }
 
-    File open(const char *filename, const char *mode) {
+    fs::File open(const char *filename, const char *mode) {
         return SDFS.open(filename, mode);
     }
 
-    File open(const String &filename, uint8_t mode = FILE_READ) {
+    fs::File open(const String &filename, uint8_t mode = FILE_READ) {
         return open(filename.c_str(), mode);
     }
 
-    File open(const String &filename, const char *mode) {
+    fs::File open(const String &filename, const char *mode) {
         return open(filename.c_str(), mode);
     }
 

--- a/libraries/SDFS/src/SDFS.h
+++ b/libraries/SDFS/src/SDFS.h
@@ -29,20 +29,17 @@
  */
 #include <limits>
 #include <assert.h>
-#include "FS.h"
-#include "FSImpl.h"
+#include <FSImpl.h>
 #include "debug.h"
 #include <SPI.h>
 #include <SdFat.h>
 #include <FS.h>
 
-using namespace fs;
-
 namespace sdfs {
 
 class SDFSFileImpl;
 class SDFSDirImpl;
-class SDFSConfig : public FSConfig
+class SDFSConfig : public fs::FSConfig
 {
 public:
     static constexpr uint32_t FSId = 0x53444653;
@@ -72,26 +69,26 @@ public:
     uint32_t  _spiSettings;
 };
 
-class SDFSImpl : public FSImpl
+class SDFSImpl : public fs::FSImpl
 {
 public:
     SDFSImpl() : _mounted(false)
     {
     }
 
-    FileImplPtr open(const char* path, OpenMode openMode, AccessMode accessMode) override;
+    fs::FileImplPtr open(const char* path, fs::OpenMode openMode, fs::AccessMode accessMode) override;
 
     bool exists(const char* path) override {
         return _mounted ? _fs.exists(path) : false;
     }
 
-    DirImplPtr openDir(const char* path) override;
+    fs::DirImplPtr openDir(const char* path) override;
 
     bool rename(const char* pathFrom, const char* pathTo) override {
         return _mounted ? _fs.rename(pathFrom, pathTo) : false;
     }
 
-    bool info64(FSInfo64& info) override {
+    bool info64(fs::FSInfo64& info) override {
         if (!_mounted) {
             DEBUGV("SDFS::info: FS not mounted\n");
             return false;
@@ -105,8 +102,8 @@ public:
         return true;
     }
 
-    bool info(FSInfo& info) override {
-        FSInfo64 i;
+    bool info(fs::FSInfo& info) override {
+        fs::FSInfo64 i;
         if (!info64(i)) {
             return false;
         }
@@ -137,7 +134,7 @@ public:
         return _mounted ?_fs.rmdir(path) : false;
     }
 
-    bool setConfig(const FSConfig &cfg) override
+    bool setConfig(const fs::FSConfig &cfg) override
     {
         if ((cfg._type != SDFSConfig::FSId) || _mounted) {
             DEBUGV("SDFS::setConfig: invalid config or already mounted\n");
@@ -234,23 +231,23 @@ protected:
     }
 
 
-    static uint8_t _getFlags(OpenMode openMode, AccessMode accessMode) {
+    static uint8_t _getFlags(fs::OpenMode openMode, fs::AccessMode accessMode) {
         uint8_t mode = 0;
-        if (openMode & OM_CREATE) {
-            mode |= O_CREAT;
+        if (openMode & fs::OM_CREATE) {
+            mode |= fs::O_CREAT;
         }
-        if (openMode & OM_APPEND) {
-            mode |= O_AT_END;
+        if (openMode & fs::OM_APPEND) {
+            mode |= fs::O_AT_END;
         }
-        if (openMode & OM_TRUNCATE) {
-            mode |= O_TRUNC;
+        if (openMode & fs::OM_TRUNCATE) {
+            mode |= fs::O_TRUNC;
         }
-        if ((accessMode & (AM_READ | AM_WRITE)) == (AM_READ | AM_WRITE)) {
-            mode |= O_RDWR;
-        } else if (accessMode & AM_READ) {
-            mode |= O_READ;
-        } else if (accessMode & AM_WRITE) {
-            mode |= O_WRITE;
+        if ((accessMode & (fs::AM_READ | fs::AM_WRITE)) == (fs::AM_READ | fs::AM_WRITE)) {
+            mode |= fs::O_RDWR;
+        } else if (accessMode & fs::AM_READ) {
+            mode |= fs::O_READ;
+        } else if (accessMode & fs::AM_WRITE) {
+            mode |= fs::O_WRITE;
         }
         return mode;
     }
@@ -261,7 +258,7 @@ protected:
 };
 
 
-class SDFSFileImpl : public FileImpl
+class SDFSFileImpl : public fs::FileImpl
 {
 public:
     SDFSFileImpl(SDFSImpl *fs, std::shared_ptr<File32> fd, const char *name)
@@ -299,22 +296,22 @@ public:
         }
     }
 
-    bool seek(uint32_t pos, SeekMode mode) override
+    bool seek(uint32_t pos, fs::SeekMode mode) override
     {
         if (!_opened) {
             return false;
         }
         switch (mode) {
-            case SeekSet:
+            case fs::SeekSet:
                 return _fd->seekSet(pos);
-            case SeekEnd:
+            case fs::SeekEnd:
                 return _fd->seekEnd(-pos); // TODO again, odd from POSIX
-            case SeekCur:
+            case fs::SeekCur:
                 return _fd->seekCur(pos);
             default:
                 // Should not be hit, we've got an invalid seek mode
                 DEBUGV("SDFSFileImpl::seek: invalid seek mode %d\n", mode);
-		assert((mode==SeekSet) || (mode==SeekEnd) || (mode==SeekCur)); // Will fail and give meaningful assert message
+		assert((mode==fs::SeekSet) || (mode==fs::SeekEnd) || (mode==fs::SeekCur)); // Will fail and give meaningful assert message
 		return false;
         }
     }
@@ -406,7 +403,7 @@ protected:
     bool                     _opened;
 };
 
-class SDFSDirImpl : public DirImpl
+class SDFSDirImpl : public fs::DirImpl
 {
 public:
     SDFSDirImpl(const String& pattern, SDFSImpl* fs, std::shared_ptr<File32> dir, const char *dirPath = nullptr)
@@ -423,10 +420,10 @@ public:
         _dir->close();
     }
 
-    FileImplPtr openFile(OpenMode openMode, AccessMode accessMode) override
+    fs::FileImplPtr openFile(fs::OpenMode openMode, fs::AccessMode accessMode) override
     {
         if (!_valid) {
-            return FileImplPtr();
+            return fs::FileImplPtr();
         }
         // MAX_PATH on FAT32 is potentially 260 bytes per most implementations
         char tmpName[260];
@@ -532,7 +529,7 @@ protected:
 }; // namespace sdfs
 
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SDFS)
-extern FS SDFS;
+extern fs::FS SDFS;
 using sdfs::SDFSConfig;
 #endif
 

--- a/libraries/SDFS/src/SDFS.h
+++ b/libraries/SDFS/src/SDFS.h
@@ -234,20 +234,20 @@ protected:
     static uint8_t _getFlags(fs::OpenMode openMode, fs::AccessMode accessMode) {
         uint8_t mode = 0;
         if (openMode & fs::OM_CREATE) {
-            mode |= fs::O_CREAT;
+            mode |= O_CREAT;
         }
         if (openMode & fs::OM_APPEND) {
-            mode |= fs::O_AT_END;
+            mode |= O_AT_END;
         }
         if (openMode & fs::OM_TRUNCATE) {
-            mode |= fs::O_TRUNC;
+            mode |= O_TRUNC;
         }
         if ((accessMode & (fs::AM_READ | fs::AM_WRITE)) == (fs::AM_READ | fs::AM_WRITE)) {
-            mode |= fs::O_RDWR;
+            mode |= O_RDWR;
         } else if (accessMode & fs::AM_READ) {
-            mode |= fs::O_READ;
+            mode |= O_READ;
         } else if (accessMode & fs::AM_WRITE) {
-            mode |= fs::O_WRITE;
+            mode |= O_WRITE;
         }
         return mode;
     }


### PR DESCRIPTION
Remove `using namespace fs;` from SDFS.h
Fix everything that depended on it

As noticed in the #8483 