### PR TITLE
Catch a possible null-dereference

### DIFF
--- a/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.cpp
+++ b/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.cpp
@@ -254,6 +254,12 @@ HTTPUpdateResult ESP8266HTTPUpdate::handleUpdate(HTTPClient& http, const String&
                 }
 
                 WiFiClient * tcp = http.getStreamPtr();
+                if (!tcp) {
+                    DEBUG_HTTP_UPDATE("[httpUpdate] WiFiClient connection unexpectedly absent\n");
+                    _setLastError(HTTPC_ERROR_CONNECTION_LOST);
+                    http.end();
+                    return HTTP_UPDATE_FAILED;
+                }
 
                 if (_closeConnectionsOnUpdate) {
                     WiFiUDP::stopAll();


### PR DESCRIPTION
In testing, I had an HTTP server that would server a 200 OK header, then crash, killing the connection.

The result was an exception in HTTPUpdater, which turned out to be due to passing a null pointer to `WiFiClient::stopAllExcept`

In catching this, I've chosen to return `HTTPC_ERROR_CONNECTION_LOST`.  This is an HTTPClient definition, rather than an HTTPUpdate one, which makes me a little uneasy.  I've justified it to myself on the basis that:
1. There is no pre-existing HTTPUpdate value that seems appropriate, and
2. The ones that _are_ defined are preceded by the comment: `/// note we use HTTP client errors too [...]` 