### PR TITLE
Ota explicit host ip

### DIFF
--- a/libraries/ArduinoOTA/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/ArduinoOTA.cpp
@@ -170,6 +170,7 @@ String ArduinoOTAClass::readStringUntil(char end){
 void ArduinoOTAClass::_onRx(){
   if(!_udp_ota->next()) return;
   IPAddress ota_ip;
+  IPAddress ota_ip2;
 
   if (_state == OTA_IDLE) {
     int cmd = parseInt();
@@ -183,8 +184,33 @@ void ArduinoOTAClass::_onRx(){
     _udp_ota->read();
     _md5 = readStringUntil('\n');
     _md5.trim();
+#ifdef OTA_DEBUG
+    OTA_DEBUG.printf("Read md5 %s\n", _md5.c_str());
+#endif  
     if(_md5.length() != 32)
       return;
+
+    // Use provided IP address for TCP communication if provided and valid
+    if(_udp_ota->peek() > 0){
+      String ipstring = readStringUntil('\n');
+      ipstring.trim();
+      ota_ip2.fromString(ipstring);
+    }
+
+    if(ota_ip2.isSet())
+    {
+#ifdef OTA_DEBUG
+      OTA_DEBUG.printf("Using TCP IP from message: %s\n", _ota_ip.toString().c_str());
+#endif      
+      _ota_ip2 = ota_ip2;
+    }
+    else
+    {
+#ifdef OTA_DEBUG
+      OTA_DEBUG.printf("Using TCP IP from UDP socket: %s\n", _ota_ip.toString().c_str());
+#endif
+      _ota_ip2 = _ota_ip;
+    }
 
     ota_ip = _ota_ip;
 
@@ -276,9 +302,9 @@ void ArduinoOTAClass::_runUpdate() {
   }
 
   WiFiClient client;
-  if (!client.connect(_ota_ip, _ota_port)) {
+  if (!client.connect(_ota_ip2, _ota_port)) {
 #ifdef OTA_DEBUG
-    OTA_DEBUG.printf("Connect Failed\n");
+    OTA_DEBUG.printf("Connect Failed to %s:%d\n", _ota_ip2.toString().c_str(), _ota_port);
 #endif
     _udp_ota->listen(IP_ADDR_ANY, _port);
     if (_error_callback) {

--- a/libraries/ArduinoOTA/ArduinoOTA.h
+++ b/libraries/ArduinoOTA/ArduinoOTA.h
@@ -90,6 +90,7 @@ class ArduinoOTAClass
     uint16_t _ota_port = 0;
     uint16_t _ota_udp_port = 0;
     IPAddress _ota_ip;
+    IPAddress _ota_ip2;
     String _md5;
 
     THandlerFunction _start_callback = nullptr;

--- a/tools/espota.py
+++ b/tools/espota.py
@@ -72,7 +72,7 @@ def update_progress(progress):
 def serve(remoteAddr, localAddr, remotePort, localPort, password, filename, command = FLASH):
   # Create a TCP/IP socket
   sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-  server_address = (localAddr, localPort)
+  server_address = ("", localPort)
   logging.info('Starting on %s:%s', str(server_address[0]), str(server_address[1]))
   try:
     sock.bind(server_address)
@@ -94,8 +94,8 @@ def serve(remoteAddr, localAddr, remotePort, localPort, password, filename, comm
   file_md5 = hashlib.md5(f.read()).hexdigest()
   f.close()
   logging.info('Upload size: %d', content_size)
-  message = '%d %d %d %s\n' % (command, localPort, content_size, file_md5)
 
+  message = '%d %d %d %s\n%s\n' % (command, localPort, content_size, file_md5, localAddr)
   # Wait for a connection
   logging.info('Sending invitation to: %s', remoteAddr)
   sock2 = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)


### PR DESCRIPTION
This PR is a cleaned up version of what I outlined in #8510. 

The python script explicitly transfers the host's IP to the client because the UdpContext did not reliably return the correct remote address.

I changed the meaning of the `host_ip` argument. Previously this was the IP the host's TCP socket binds to. Now it always binds to [`INADDR_ANY`](https://docs.python.org/3/library/socket.html#socket-families) because why not -- I'm no expert in networking regards so this change has to be discussed.
Instead of chaning the existing argument we could also introduce a new `host_ip_remote` or 

Other than the `host_ip` it should be fully backwards compatible so you can use the new python script with the old cpp implementation and vice versa.

