### PR TITLE
Test: fixing itoa implementation and clean-up of tests and test Makefile

### DIFF
--- a/cores/esp8266/WString.cpp
+++ b/cores/esp8266/WString.cpp
@@ -25,6 +25,8 @@
 #include "WString.h"
 #include "stdlib_noniso.h"
 
+#include <limits>
+
 #define OOM_STRING_BORDER_DISPLAY           10
 #define OOM_STRING_THRESHOLD_REALLOC_WARN  128
 
@@ -38,7 +40,7 @@
 static String toString(unsigned char value, unsigned char base) {
     String out;
 
-    char buf[1 + 8 * sizeof(unsigned char)];
+    char buf[1 + std::numeric_limits<unsigned char>::digits];
     out = utoa(value, buf, base);
 
     return out;
@@ -47,12 +49,8 @@ static String toString(unsigned char value, unsigned char base) {
 static String toString(int value, unsigned char base) {
     String out;
 
-    char buf[2 + 8 * sizeof(int)];
-    if (base == 10) {
-        out.concat(buf, sprintf(buf, "%d", value));
-    } else {
-        out = itoa(value, buf, base);
-    }
+    char buf[2 + std::numeric_limits<int>::digits];
+    out = itoa(value, buf, base);
 
     return out;
 }
@@ -60,7 +58,7 @@ static String toString(int value, unsigned char base) {
 static String toString(unsigned int value, unsigned char base) {
     String out;
 
-    char buf[1 + 8 * sizeof(unsigned int)];
+    char buf[1 + std::numeric_limits<unsigned int>::digits];
     out = utoa(value, buf, base);
 
     return out;
@@ -69,12 +67,8 @@ static String toString(unsigned int value, unsigned char base) {
 static String toString(long value, unsigned char base) {
     String out;
 
-    char buf[2 + 8 * sizeof(long)];
-    if (base == 10) {
-        out.concat(buf, sprintf(buf, "%ld", value));
-    } else {
-        out = ltoa(value, buf, base);
-    }
+    char buf[2 + std::numeric_limits<long>::digits];
+    out = ltoa(value, buf, base);
 
     return out;
 }
@@ -82,7 +76,7 @@ static String toString(long value, unsigned char base) {
 static String toString(unsigned long value, unsigned char base) {
     String out;
 
-    char buf[1 + 8 * sizeof(unsigned long)];
+    char buf[1 + std::numeric_limits<unsigned long>::digits];
     out = ultoa(value, buf, base);
 
     return out;
@@ -93,12 +87,8 @@ static String toString(unsigned long value, unsigned char base) {
 static String toString(long long value, unsigned char base) {
     String out;
 
-    char buf[2 + 8 * sizeof(long long)];
-    if (base == 10) {
-        out.concat(buf, sprintf(buf, "%lld", value));
-    } else {
-        out = lltoa(value, buf, sizeof(buf), base);
-    }
+    char buf[2 + std::numeric_limits<long long>::digits];
+    out = lltoa(value, buf, sizeof(buf), base);
 
     return out;
 }
@@ -106,21 +96,8 @@ static String toString(long long value, unsigned char base) {
 static String toString(unsigned long long value, unsigned char base) {
     String out;
 
-    char buf[1 + 8 * sizeof(unsigned long long)];
-    if (base == 10) {
-        out.concat(buf, sprintf(buf, "%llu", value));
-    } else {
-        out = ulltoa(value, buf, sizeof(buf), base);
-    }
-
-    return out;
-}
-
-static String toString(float value, unsigned char decimalPlaces) {
-    String out;
-
-    char buf[33];
-    out = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
+    char buf[1 + std::numeric_limits<unsigned long long>::digits];
+    out = ulltoa(value, buf, sizeof(buf), base);
 
     return out;
 }
@@ -132,6 +109,10 @@ static String toString(double value, unsigned char decimalPlaces) {
     out = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
 
     return out;
+}
+
+static String toString(float value, unsigned char decimalPlaces) {
+    return toString(static_cast<double>(value), decimalPlaces);
 }
 
 /*********************************************/

--- a/cores/esp8266/WString.h
+++ b/cores/esp8266/WString.h
@@ -58,6 +58,7 @@ class String {
         String(const String &str);
         String(const __FlashStringHelper *str);
         String(String &&rval) noexcept;
+
         explicit String(char c) {
             sso.buff[0] = c;
             sso.buff[1] = 0;

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -12,30 +12,33 @@ RANLIB ?= ranlib
 
 MAKEFILE = $(word 1, $(MAKEFILE_LIST))
 
-CXX =  $(shell for i in g++-10  g++-9  g++-8  g++;  do which $$i > /dev/null && { echo $$i; break; } done)
-CC  =  $(shell for i in gcc-10  gcc-9  gcc-8  gcc;  do which $$i > /dev/null && { echo $$i; break; } done)
-GCOV = $(shell for i in gcov-10 gcov-9 gcov-8 gcov; do which $$i > /dev/null && { echo $$i; break; } done)
-$(warning using $(CXX))
-ifeq ($(CXX),g++)
-CXXFLAGS += -std=gnu++11
-else
-CXXFLAGS += -std=gnu++17
-endif
-ifeq ($(CC),gcc)
-CFLAGS += -std=gnu11
-else
-CFLAGS += -std=gnu17
-endif
+define find_tool
+	$(shell for name in $(@); do which $$name > /dev/null && { echo $$name; break; } done)
+endef
 
 # I wasn't able to build with clang when -coverage flag is enabled, forcing GCC on OS X
 ifeq ($(shell uname -s),Darwin)
-CC  ?= gcc
-CXX ?= g++
-endif
+CC   ?= gcc
+CXX  ?= g++
 GCOV ?= gcov
+else
+# Prefer GCC10, same as platform.txt / platformio_build.py
+CXX  ?= $(find_tool g++-10 g++)
+CC   ?= $(find_tool gcc-10 gcc)
+GCOV ?= $(find_tool gcov-10 gcov)
+endif
+
+$(warning using $(CXX))
+
+GCOV     ?= gcov
 VALGRIND ?= valgrind
-LCOV ?= lcov --gcov-tool $(GCOV)
-GENHTML ?= genhtml
+LCOV     ?= lcov --gcov-tool $(GCOV)
+GENHTML  ?= genhtml
+
+# Board fild will be built with GCC10, but we have some limited ability to build with older versions
+# *Always* push the standard used in the platform.txt
+CXXFLAGS += -std=gnu++17
+CFLAGS += -std=gnu17
 
 ifeq ($(FORCE32),1)
 SIZEOFLONG = $(shell echo 'int main(){return sizeof(long);}'|$(CXX) -m32 -x c++ - -o sizeoflong 2>/dev/null && ./sizeoflong; echo $$?; rm -f sizeoflong;)
@@ -174,6 +177,8 @@ INC_PATHS += \
 		../../tools/sdk/lwip2/include \
 	)
 
+TEST_ARGS ?=
+
 TEST_CPP_FILES := \
 	fs/test_fs.cpp \
 	core/test_pgmspace.cpp \
@@ -236,7 +241,7 @@ CI:					# run CI
 doCI: build-info $(OUTPUT_BINARY) valgrind test gcov
 
 test: $(OUTPUT_BINARY)			# run host test for CI
-	$(OUTPUT_BINARY)
+	$(OUTPUT_BINARY) $(TEST_ARGS)
 
 .PHONY: clean
 clean: clean-lcov clean-objects

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -12,23 +12,13 @@ RANLIB ?= ranlib
 
 MAKEFILE = $(word 1, $(MAKEFILE_LIST))
 
-define find_tool
-	$(shell for name in $(@); do which $$name > /dev/null && { echo $$name; break; } done)
-endef
+# Prefer named GCC (and, specifically, GCC10), same as platform.txt / platformio_build.py
+find_tool = $(shell for name in $(1) $(2); do which $$name && break; done 2>/dev/null)
+CXX  = $(call find_tool,g++-10,g++)
+CC   = $(call find_tool,gcc-10,gcc)
+GCOV = $(call find_tool,gcov-10,gcov)
 
-# I wasn't able to build with clang when -coverage flag is enabled, forcing GCC on OS X
-ifeq ($(shell uname -s),Darwin)
-CC   ?= gcc
-CXX  ?= g++
-GCOV ?= gcov
-else
-# Prefer GCC10, same as platform.txt / platformio_build.py
-CXX  ?= $(find_tool g++-10 g++)
-CC   ?= $(find_tool gcc-10 gcc)
-GCOV ?= $(find_tool gcov-10 gcov)
-endif
-
-$(warning using $(CXX))
+$(warning using $(CXX) and $(CC))
 
 GCOV     ?= gcov
 VALGRIND ?= valgrind

--- a/tests/host/common/ArduinoCatch.hpp
+++ b/tests/host/common/ArduinoCatch.hpp
@@ -13,26 +13,24 @@
  all copies or substantial portions of the Software.
 */
 
-#define CATCH_CONFIG_MAIN
-#include "ArduinoCatch.hpp"
+#include <Arduino.h>
+#include <sys/time.h>
 
-std::ostream& operator<<(std::ostream& out, const String& str)
-{
-    out.write(str.c_str(), str.length());
-    return out;
-}
+#include <ostream>
 
-namespace Catch
-{
+#include "catch.hpp"
 
-std::string toString(const String& str)
-{
-    return std::string(str.begin(), str.length());
-}
+// Since Catch does not know about Arduino types, help it out so we could have these displayed in the tests output
 
-std::string StringMaker<String>::convert(String const& str)
-{
-    return toString(str);
-}
+std::ostream& operator<<(std::ostream&, const String&);
 
-}  // namespace Catch
+namespace Catch {
+
+std::string toString(const String&);
+
+template<>
+struct StringMaker<String> {
+    static std::string convert(const String&);
+};
+
+} // namespace Catch

--- a/tests/host/common/noniso.c
+++ b/tests/host/common/noniso.c
@@ -65,29 +65,24 @@ char* itoa(int value, char* result, int base)
         *result = 0;
         return result;
     }
-    if (base != 10)
+
+    unsigned uvalue;
+    char*    out = result;
+
+    // after this point we convert the value to unsigned and go to the utoa
+    // only base10 gets minus sign in the front, adhering to the newlib implementation
+    if ((base == 10) && (value < 0))
     {
-        return utoa((unsigned)value, result, base);
+        *result++ = '-';
+        uvalue    = (unsigned)-value;
+    }
+    else
+    {
+        uvalue = (unsigned)value;
     }
 
-    char* out      = result;
-    int   quotient = abs(value);
-
-    do
-    {
-        const int tmp = quotient / base;
-        *out          = "0123456789abcdef"[quotient - (tmp * base)];
-        ++out;
-        quotient = tmp;
-    } while (quotient);
-
-    // Apply negative sign
-    if (value < 0)
-        *out++ = '-';
-
-    reverse(result, out);
-    *out = 0;
-    return result;
+    utoa(uvalue, result, base);
+    return out;
 }
 
 int atoi(const char* s)

--- a/tests/host/core/test_string.cpp
+++ b/tests/host/core/test_string.cpp
@@ -13,11 +13,13 @@
  all copies or substantial portions of the Software.
  */
 
-#include <catch.hpp>
-#include <string.h>
-#include <WString.h>
-#include <limits.h>
+#include <ArduinoCatch.hpp>
 #include <StreamString.h>
+
+#include <string>
+#include <cstring>
+#include <limits>
+#include <climits>
 
 TEST_CASE("String::move", "[core][String]")
 {
@@ -117,8 +119,10 @@ TEST_CASE("String concantenation", "[core][String]")
     str += "bcde";
     str += str;
     str += 987;
-    str += (int)INT_MAX;
-    str += (int)INT_MIN;
+    REQUIRE(str == "abcdeabcde987");
+    str += std::numeric_limits<int>::max();
+    REQUIRE(str == "abcdeabcde9872147483647");
+    str += std::numeric_limits<int>::min();
     REQUIRE(str == "abcdeabcde9872147483647-2147483648");
     str += (unsigned char)69;
     REQUIRE(str == "abcdeabcde9872147483647-214748364869");


### PR DESCRIPTION
Update itoa to be the same as newlib, also fixing edgecase of abs(INT_MIN)
Update WString.cpp:toString() integer conversions to use noniso funcs
Update WString to use C++ limits lib
Remove legacy gcc versions from Makefile and allow overrides
Don't fallback to c11 and c++11, source cannot support that

Additionally, allow test binary to accept arguments
```
~/d/e/t/host> make TEST_ARGS=[core][String] test
Makefile:31: using g++
Makefile:46: Cannot compile in 32 bit mode (g++-multilib is missing?), switching to native mode
Makefile:57: compiling in native mode
/home/runner/dev/esp8266-Arduino/tests/host/bin/host_tests [core][String]
===============================================================================
All tests passed (288 assertions in 20 test cases)
```

As mentioned by @d-a-v in the Matrix channel
Not really sure if it's the best idea feature-wise, but it keeps this weird Arduino legacy output throughout the class. Like, the way `-100` with base `16` gets converted into `ffffff9c` instead of `-64` (which what I'd expect here, with any other sane API :). Main reason for that is Arduino API does printf equivalent of `%X`. But, it is consistent with other implementations, and there's no branching required to the printf
ref. https://github.com/arduino/ArduinoCore-API/blob/master/test/src/itoa.cpp, https://github.com/espressif/arduino-esp32/blob/6cfe4613e4b4846e1ab08c7f78b7ea241f52c7da/cores/esp32/WString.cpp#L80-L89

Just using the noniso funcs saves a little bit of code. For example checking on the `nm` output for `int` ctor when building the test binary
```diff
- 0000000000000150 T String::String(int, unsigned char)
+ 0000000000000121 T String::String(int, unsigned char)
```

I'd like to run these on the board before pushing though, since I have only tried the host test