### PR TITLE
ESP8266 Web Server: Fix send stream by reference

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -171,7 +171,9 @@ public:
   void send_P(int code, PGM_P content_type, PGM_P content, size_t contentLength);
 
   void send(int code, const char* content_type, Stream* stream, size_t content_length = 0);
-  void send(int code, const char* content_type, Stream& stream, size_t content_length = 0);
+  void send(int code, const char* content_type, Stream& stream, size_t content_length = 0) {
+    send(code, content_type, &stream, content_length);
+  }
 
   void setContentLength(const size_t contentLength);
   void sendHeader(const String& name, const String& value, bool first = false);


### PR DESCRIPTION
There is no implementation for the variant of the `ESP8266WebServer::send` function that takes a reference to a `Stream`.

This fixes the error by calling the version that takes a pointer.