### PR TITLE
Delete operator=(Self&) when copy constructor is deleted

### DIFF
--- a/libraries/ESP8266WiFi/src/BearSSLHelpers.h
+++ b/libraries/ESP8266WiFi/src/BearSSLHelpers.h
@@ -58,6 +58,7 @@ class PublicKey {
 
     // Disable the copy constructor, we're pointer based
     PublicKey(const PublicKey& that) = delete;
+    PublicKey& operator=(const PublicKey& that) = delete;
 
   private:
     brssl::public_key *_key;
@@ -86,6 +87,7 @@ class PrivateKey {
 
     // Disable the copy constructor, we're pointer based
     PrivateKey(const PrivateKey& that) = delete;
+    PrivateKey& operator=(const PrivateKey& that) = delete;
 
   private:
     brssl::private_key *_key;
@@ -122,6 +124,7 @@ class X509List {
 
     // Disable the copy constructor, we're pointer based
     X509List(const X509List& that) = delete;
+    X509List& operator=(const X509List& that) = delete;
 
   private:
     size_t _count;

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
@@ -34,7 +34,7 @@ namespace BearSSL {
 class WiFiClientSecureCtx : public WiFiClient {
   public:
     WiFiClientSecureCtx();
-    WiFiClientSecureCtx(const WiFiClientSecure &rhs) = delete;
+    WiFiClientSecureCtx(const WiFiClientSecureCtx &rhs) = delete;
     ~WiFiClientSecureCtx() override;
 
     WiFiClientSecureCtx& operator=(const WiFiClientSecureCtx&) = delete;
@@ -43,7 +43,7 @@ class WiFiClientSecureCtx : public WiFiClient {
     // TODO: don't remove just yet to avoid including the WiFiClient default implementation and unintentionally causing
     //       a 'slice' that this method tries to avoid in the first place
     std::unique_ptr<WiFiClient> clone() const override {
-        return std::unique_ptr<WiFiClient>(new WiFiClientSecureCtx(*this));
+        return nullptr;
     }
 
     int connect(IPAddress ip, uint16_t port) override;


### PR DESCRIPTION
Fixes #8534

This brings two questions tho, should we break backwards compatibility with a usage that is literally broken, so nobody should be actually depending on this? As these changes technically make some broken code to stop compiling. I'm out of the loop on how the community decides on situations like this.

And what is with the fake `WiFiClientSecureCtx::clone`? With my changes it actually always fails to compile, so I moved to causing a runtime failure that will be more explicit. What do you all think? I am open to suggestions.

I see that there is a different PR tackling a similar issue (targeting the original issue), and it might expand the functionalities, but I see this as orthogonal, if we decide to support copy operations in some of those classes in the future we can remove the two deletes, but it doesn't seem a decided issue.