### PR TITLE
WebServer: use String when working with Basic authentication

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
@@ -108,13 +108,12 @@ bool ESP8266WebServerTemplate<ServerType>::authenticate(const char * username, c
 
       String raw;
       raw.reserve(username_len + password_len + 1);
-      if(!raw.length()) {
-        return false;
-      }
-
       raw.concat(username, username_len);
       raw += ':';
       raw.concat(password, password_len);
+      if(!raw.length()) {
+        return false;
+      }
 
       String encoded = base64::encode(raw, false);
       if(!encoded.length()){

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
@@ -102,31 +102,32 @@ bool ESP8266WebServerTemplate<ServerType>::authenticate(const char * username, c
     if(authReq.startsWith(F("Basic"))){
       authReq = authReq.substring(6);
       authReq.trim();
-      char toencodeLen = strlen(username)+strlen(password)+1;
-      char *toencode = new (std::nothrow) char[toencodeLen + 1];
-      if(toencode == NULL){
-        authReq = "";
+
+      const size_t username_len = strlen(username);
+      const size_t password_len = strlen(password);
+
+      String raw;
+      raw.reserve(username_len + password_len + 1);
+      if(!raw.length()) {
         return false;
       }
-      sprintf(toencode, "%s:%s", username, password);
-      String encoded = base64::encode((uint8_t *)toencode, toencodeLen, false);
-      if(!encoded){
-        authReq = "";
-        delete[] toencode;
+
+      raw.concat(username, username_len);
+      raw += ':';
+      raw.concat(password, password_len);
+
+      String encoded = base64::encode(raw, false);
+      if(!encoded.length()){
         return false;
       }
       if(authReq.equalsConstantTime(encoded)) {
-        authReq = "";
-        delete[] toencode;
         return true;
       }
-      delete[] toencode;
     } else if(authReq.startsWith(F("Digest"))) {
       String _realm    = _extractParam(authReq, F("realm=\""));
-      String _H1 = credentialHash((String)username,_realm,(String)password);
-      return authenticateDigest((String)username,_H1);
+      String _H1 = credentialHash(username,_realm,password);
+      return authenticateDigest(username,_H1);
     }
-    authReq = "";
   }
   return false;
 }


### PR DESCRIPTION
Avoid blowing up user code when `$user:$password` string is longer than
127 bytes. Use String to both manage the memory and handle concatenation.

Also clean-up historical quicks such as
- `if(StringObject)` that is always true since we implemented SSO
- `authReq = "";` / `authReq = String();`, which will happen anyway
- `(String)...` casts that happen anyway, implicitly