### PR TITLE
ci: make sure to kill gpg related processes

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -246,6 +246,7 @@ jobs:
           gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$LLVM_SNAPSHOT_KEY"
           gpg --batch --armor --export "$LLVM_SNAPSHOT_KEY" | \
             sudo tee /etc/apt/trusted.gpg.d/llvm-snapshot.gpg.asc
+          gpgconf --kill all
           rm -r $GNUPGHOME
           echo "deb http://apt.llvm.org/focal/     llvm-toolchain-focal-13   main" | \
             sudo tee /etc/apt/sources.list.d/llvm.list


### PR DESCRIPTION
Removing the directory while gpg-agent and dirmngr are running is not always possible, causing random errors during CI runs.