### PR TITLE
Table output for segment size script

### DIFF
--- a/tools/sizes.py
+++ b/tools/sizes.py
@@ -17,74 +17,103 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from __future__ import print_function
 import argparse
 import os
 import subprocess
 import sys
+import contextlib
 
-def get_segment_hints(iram):
-    hints = {}
-    hints['ICACHE'] = '          - flash instruction cache'
-    hints['IROM'] = '         - code in flash         (default or ICACHE_FLASH_ATTR)'
-    hints['IRAM'] = '  / ' + str(iram) + ' - code in IRAM          (IRAM_ATTR, ISRs...)'
-    hints['DATA'] = ')         - initialized variables (global, static) in RAM/HEAP'
-    hints['RODATA'] = ') / 81920 - constants             (global, static) in RAM/HEAP'
-    hints['BSS'] = ')         - zeroed variables      (global, static) in RAM/HEAP'
-    return hints
 
-def get_segment_sizes(elf, path):
-    sizes = {}
-    sizes['ICACHE'] = 0
-    sizes['IROM'] = 0
-    sizes['IRAM'] = 0
-    sizes['DATA'] = 0
-    sizes['RODATA'] = 0
-    sizes['BSS'] = 0
-    p = subprocess.Popen([path + "/xtensa-lx106-elf-size", '-A', elf], stdout=subprocess.PIPE, universal_newlines=True )
-    lines = p.stdout.readlines()
-    for line in lines:
-        words = line.split()
-        if line.startswith('.irom0.text'):
-            sizes['IROM'] = sizes['IROM'] + int(words[1])
-        elif line.startswith('.text'): # Gets .text and .text1
-            sizes['IRAM'] = sizes['IRAM'] + int(words[1])
-        elif line.startswith('.data'): # Gets .text and .text1
-            sizes['DATA'] = sizes['DATA'] + int(words[1])
-        elif line.startswith('.rodata'): # Gets .text and .text1
-            sizes['RODATA'] = sizes['RODATA'] + int(words[1])
-        elif line.startswith('.bss'): # Gets .text and .text1
-            sizes['BSS'] = sizes['BSS'] + int(words[1])
+def get_segment_hints():
+    return {
+        "ICACHE": "flash instruction cache",
+        "IROM": "code in flash (default, ICACHE_FLASH_ATTR)",
+        "IRAM": "code in IRAM (IRAM_ATTR, ICACHE_RAM_ATTR)",
+        "DATA": "initialized variables (global, static) in RAM",
+        "RODATA": "constants (global, static) in RAM",
+        "BSS": "zeroed variables (global, static) in RAM",
+    }
+
+
+def get_segment_sizes(elf, path, mmu):
+    sizes = {
+        "ICACHE": [32768, 32768],
+        "IROM": [0, 1048576],
+        "IRAM": [0, 32768],
+        "DATA": [0, 81920],
+        "RODATA": [0, 81920],
+        "BSS": [0, 81920],
+    }
+
+    cmd = [os.path.join(path, "xtensa-lx106-elf-size"), "-A", elf]
+    with subprocess.Popen(cmd, stdout=subprocess.PIPE, universal_newlines=True) as proc:
+        lines = proc.stdout.readlines()
+        for line in lines:
+            words = line.split()
+            if line.startswith(".irom0.text"):
+                sizes["IROM"][0] += int(words[1])
+            elif line.startswith(".text"):
+                sizes["IRAM"][0] += int(words[1])
+            elif line.startswith(".data"):
+                sizes["DATA"][0] += int(words[1])
+            elif line.startswith(".rodata"):
+                sizes["RODATA"][0] += int(words[1])
+            elif line.startswith(".bss"):
+                sizes["BSS"][0] += int(words[1])
+
+    for line in mmu.split():
+        words = line.split("=")
+        if line.startswith("-DMMU_IRAM_SIZE"):
+            sizes["IRAM"][1] = int(words[1], 16)
+        elif line.startswith("-DMMU_ICACHE_SIZE"):
+            sizes["ICACHE"][0] = sizes["ICACHE"][1] = int(words[1], 16)
+
     return sizes
 
-def get_mmu_sizes(mmu, sizes):
-    iram = 0x8000
-    sizes['ICACHE'] = 0x8000
-    lines = mmu.split(' ')
-    for line in lines:
-        words = line.split('=')
-        if line.startswith('-DMMU_IRAM_SIZE'):
-            iram = int(words[1], 16)
-        elif line.startswith('-DMMU_ICACHE_SIZE'):
-            sizes['ICACHE'] = int(words[1], 16)
-    return [iram, sizes]
+
+def percentage(lhs, rhs):
+    return "{}%".format(int(100.0 * float(lhs) / float(rhs)))
+
 
 def main():
-    parser = argparse.ArgumentParser(description='Report the different segment sizes of a compiled ELF file')
-    parser.add_argument('-e', '--elf', action='store', required=True, help='Path to the Arduino sketch ELF')
-    parser.add_argument('-p', '--path', action='store', required=True, help='Path to Xtensa toolchain binaries')
-    parser.add_argument('-i', '--mmu', action='store', required=False, help='MMU build options')
+    parser = argparse.ArgumentParser(
+        description="Report the different segment sizes of a compiled ELF file"
+    )
+    parser.add_argument(
+        "-e",
+        "--elf",
+        action="store",
+        required=True,
+        help="Path to the Arduino sketch ELF",
+    )
+    parser.add_argument(
+        "-p",
+        "--path",
+        action="store",
+        required=True,
+        help="Path to Xtensa toolchain binaries",
+    )
+    parser.add_argument(
+        "-i", "--mmu", action="store", required=False, help="MMU build options"
+    )
 
     args = parser.parse_args()
-    sizes = get_segment_sizes(args.elf, args.path)
-    [iram, sizes] = get_mmu_sizes(args.mmu, sizes)
-    hints = get_segment_hints(iram)
+    sizes = get_segment_sizes(args.elf, args.path, args.mmu)
+    hints = get_segment_hints()
 
-    sys.stderr.write("Executable segment sizes:" + os.linesep)
-    for k in sizes.keys():
-        sys.stderr.write("%-7s: %-5d %s %s" % (k, sizes[k], hints[k], os.linesep))
+    template = "{:<8} {:<8} {:<8} {:<8} {:<16}"
+    header = template.format("SEGMENT", "USED", "TOTAL", "PERCENT", "DESCRIPTION")
+
+    with contextlib.redirect_stdout(sys.stderr):
+        print(header)
+        print(len(header) * "-")
+        for key, (used, total) in sizes.items():
+            print(
+                template.format(key, used, total, percentage(used, total), hints[key])
+            )
 
     return 0
 
-if __name__ == '__main__':
-    sys.exit(main())
+
+if __name__ == "__main__":
+    main()

--- a/tools/sizes.py
+++ b/tools/sizes.py
@@ -23,7 +23,6 @@ import subprocess
 import sys
 import contextlib
 
-
 HINTS = {
     "ICACHE": "reserved space for flash instruction cache",
     "IRAM": "code in IRAM (IRAM_ATTR, ICACHE_RAM_ATTR)",
@@ -88,6 +87,24 @@ def percentage(lhs, rhs):
     return "{}%".format(int(100.0 * float(lhs) / float(rhs)))
 
 
+def prefix(n, segments):
+    if n == len(segments):
+        out = "└──"
+    else:
+        out = "├──"
+
+    return out
+
+
+def safe_prefix(n, segments):
+    if n == len(segments):
+        out = "|__"
+    else:
+        out = "|--"
+
+    return out
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Report the different segment sizes of a compiled ELF file"
@@ -115,13 +132,18 @@ def main():
 
     for group, (segments, total) in sizes:
         used = sum(segments.values())
-        print(f". {group:<8}, total {total} bytes, used {used} bytes ({percentage(used, total)})")
+        print(
+            f". {group:<8}, total {total} bytes, used {used} bytes ({percentage(used, total)})"
+        )
         for n, (segment, size) in enumerate(segments.items(), start=1):
-            if n == len(segments):
-                prefix = "└──"
-            else:
-                prefix = "├──"
-            print(f"{prefix} {segment:<8} {size:<8} {HINTS[segment]:<16}")
+            try:
+                print(
+                    f"{prefix(n, segments)} {segment:<8} {size:<8} {HINTS[segment]:<16}"
+                )
+            except UnicodeEncodeError:
+                print(
+                    f"{safe_prefix(n, segments)} {segment:<8} {size:<8} {HINTS[segment]:<16}"
+                )
 
 
 if __name__ == "__main__":

--- a/tools/sizes.py
+++ b/tools/sizes.py
@@ -25,9 +25,9 @@ import contextlib
 
 
 HINTS = {
-    "ICACHE": "configured flash instruction cache",
-    "IROM": "code in flash (default, ICACHE_FLASH_ATTR)",
+    "ICACHE": "reserved space for flash instruction cache",
     "IRAM": "code in IRAM (IRAM_ATTR, ICACHE_RAM_ATTR)",
+    "IROM": "code in flash (default, ICACHE_FLASH_ATTR)",
     "DATA": "initialized variables (global, static)",
     "RODATA": "constants (global, static)",
     "BSS": "zeroed variables (global, static)",
@@ -51,12 +51,10 @@ def get_segment_sizes(elf, path, mmu):
             "RODATA": 0,
             "BSS": 0,
         }, 80192]],
-        ["Instruction cache", [{
-            "ICACHE": icache_size,
-        }, icache_size]],
         ["Instruction RAM", [{
+            "ICACHE": icache_size,
             "IRAM": 0,
-        }, iram_size]],
+        }, 65536]],
         ["Code in flash", [{
             "IROM": 0
         }, 1048576]],
@@ -116,13 +114,14 @@ def main():
     sizes = get_segment_sizes(args.elf, args.path, args.mmu)
 
     for group, (segments, total) in sizes:
-        print(f". {group:<8} (total {total} bytes)")
+        used = sum(segments.values())
+        print(f". {group:<8}, total {total} bytes, used {used} bytes ({percentage(used, total)})")
         for n, (segment, size) in enumerate(segments.items(), start=1):
             if n == len(segments):
                 prefix = "└──"
             else:
                 prefix = "├──"
-            print(f"{prefix} {segment:<8} {size:<8} - {HINTS[segment]:<16}")
+            print(f"{prefix} {segment:<8} {size:<8} {HINTS[segment]:<16}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Re-format the file, hints and clean-up the resulting data dict

Also include maximum aka total for every segment key, so now we could also display it every time
```
(penv) ~\D\A\s\test> C:\\Users\\maxim\\Documents\\Arduino\\hardware\\esp8266com\\esp8266/tools/python3/python3 \
  -I "C:\\Users\\maxim\\Documents\\Arduino\\hardware\\esp8266com\\esp8266/tools/sizes.py" \
  --elf "C:\\Users\\maxim\\AppData\\Local\\Temp\\arduino-sketch-47C53BFFA994BDA8380BC89E427DA2CA/test.ino.elf" \
  --path "C:\\Users\\maxim\\Documents\\Arduino\\hardware\\esp8266com\\esp8266/tools/xtensa-lx106-elf/bin" \
  --mmu "-DMMU_IRAM_SIZE=0x8000 -DMMU_ICACHE_SIZE=0x8000"
```
```
SEGMENT  USED     TOTAL    PERCENT  DESCRIPTION
----------------------------------------------------
ICACHE   32768    32768    100%     flash instruction cache
IROM     232088   1048576  22%      code in flash (default, ICACHE_FLASH_ATTR)
IRAM     26205    32768    79%      code in IRAM (IRAM_ATTR, ICACHE_RAM_ATTR)
DATA     1496     81920    1%       initialized variables (global, static) in RAM
RODATA   876      81920    1%       constants (global, static) in RAM
BSS      25520    81920    31%      zeroed variables (global, static) in RAM
```
vs. old
```
Executable segment sizes:
ICACHE : 32768           - flash instruction cache
IROM   : 232088          - code in flash         (default or ICACHE_FLASH_ATTR)
IRAM   : 26205   / 32768 - code in IRAM          (IRAM_ATTR, ISRs...)
DATA   : 1496  )         - initialized variables (global, static) in RAM/HEAP
RODATA : 876   ) / 81920 - constants             (global, static) in RAM/HEAP
BSS    : 25520 )         - zeroed variables      (global, static) in RAM/HEAP
```

idk about the percentage, though... whether it should be for specific segment, or for the memory overall. we could combine data + rodata + bss percentages as "User-data RAM" and IRAM & ICACHE as... "Instruction RAM"?
could just remove it too