### PR TITLE
Correction to run_CI_locall.sh

### DIFF
--- a/tests/run_CI_locally.sh
+++ b/tests/run_CI_locally.sh
@@ -115,7 +115,7 @@ elif [ "$BUILD_TYPE" = host ]; then
     tests/ci/host_test.sh
 
 elif [ "$BUILD_TYPE" = style ]; then
-    tests/ci/check_restyle.sh
+    tests/ci/style_check.sh
     tests/restyle.sh
 
 else


### PR DESCRIPTION
`tests/ci/check_restyle.sh` does not exist; however, `tests/ci/style_check.sh` does.
Changed `run_CI_locally.sh` to run `style_check.sh` from `ci` directory.