### PR TITLE
feat(ESP8266HTTPUpdateServer): add option `_rebootOnUpdate`

### DIFF
--- a/libraries/ESP8266HTTPUpdateServer/src/ESP8266HTTPUpdateServer-impl.h
+++ b/libraries/ESP8266HTTPUpdateServer/src/ESP8266HTTPUpdateServer-impl.h
@@ -70,7 +70,9 @@ void ESP8266HTTPUpdateServerTemplate<ServerType>::setup(ESP8266WebServerTemplate
         _server->send_P(200, PSTR("text/html"), successResponse);
         delay(100);
         _server->client().stop();
-        ESP.restart();
+        if (_rebootOnUpdate) {
+          ESP.restart();
+        }
       }
     },[&](){
       // handler for the file upload, gets the sketch bytes, and writes

--- a/libraries/ESP8266HTTPUpdateServer/src/ESP8266HTTPUpdateServer.h
+++ b/libraries/ESP8266HTTPUpdateServer/src/ESP8266HTTPUpdateServer.h
@@ -35,6 +35,11 @@ class ESP8266HTTPUpdateServerTemplate
       _password = password;
     }
 
+    void rebootOnUpdate(bool reboot)
+    {
+      _rebootOnUpdate = reboot;
+    }
+
   protected:
     void _setUpdaterError();
 
@@ -45,6 +50,7 @@ class ESP8266HTTPUpdateServerTemplate
     String _password;
     bool _authenticated;
     String _updaterError;
+    bool _rebootOnUpdate = true;
 };
 
 };


### PR DESCRIPTION
Add this option just like what ESP8266httpUpdate does. 

Now system restaerts after updating Firmware and also FileSystem. Sometimes new Firmware to update is rely on a new FileSystem, only when we update both Firmware and FileSystem then safe to perform restart.