### PR TITLE
WString: remove operator==(const __FlashStringHelper*)

### DIFF
--- a/cores/esp8266/WString.h
+++ b/cores/esp8266/WString.h
@@ -227,9 +227,6 @@ class String {
         bool operator ==(const char *cstr) const {
             return equals(cstr);
         }
-        bool operator ==(const __FlashStringHelper *rhs) const {
-            return equals(rhs);
-        }
         bool operator ==(std::nullptr_t) const {
             return length() == 0;
         }
@@ -238,9 +235,6 @@ class String {
         }
         bool operator !=(const char *cstr) const {
             return !equals(cstr);
-        }
-        bool operator !=(const __FlashStringHelper *rhs) const {
-            return !equals(rhs);
         }
         bool operator !=(std::nullptr_t) const {
             return length() != 0;

--- a/cores/esp8266/WString.h
+++ b/cores/esp8266/WString.h
@@ -211,9 +211,10 @@ class String {
             return *this;
         }
 
-        // checks whether the String is empty
+        // checks whether the internal buffer pointer is set.
+        // (should not be the case for us, since we always reset the pointer to the SSO buffer instead of setting it to nullptr)
         explicit operator bool() const {
-            return length() != 0;
+            return buffer() != nullptr;
         }
 
         int compareTo(const String &s) const;

--- a/cores/esp8266/WString.h
+++ b/cores/esp8266/WString.h
@@ -230,6 +230,33 @@ class String {
         bool operator ==(const __FlashStringHelper *rhs) const {
             return equals(rhs);
         }
+        bool operator ==(std::nullptr_t) const {
+            return length() == 0;
+        }
+        bool operator ==(int num) const {
+            return equals(String(num));
+        }
+        bool operator ==(unsigned int num) const {
+            return equals(String(num));
+        }
+        bool operator ==(long num) const {
+            return equals(String(num));
+        }
+        bool operator ==(unsigned long num) const {
+            return equals(String(num));
+        }
+        bool operator ==(long long num) const {
+            return equals(String(num));
+        }
+        bool operator ==(unsigned long long num) const {
+            return equals(String(num));
+        }
+        bool operator ==(float num) const {
+            return equals(String(num));
+        }
+        bool operator ==(double num) const {
+            return equals(String(num));
+        }
         bool operator !=(const String &rhs) const {
             return !equals(rhs);
         }
@@ -238,6 +265,33 @@ class String {
         }
         bool operator !=(const __FlashStringHelper *rhs) const {
             return !equals(rhs);
+        }
+        bool operator !=(std::nullptr_t) const {
+            return length() != 0;
+        }
+        bool operator !=(int num) const {
+            return !equals(String(num));
+        }
+        bool operator !=(unsigned int num) const {
+            return !equals(String(num));
+        }
+        bool operator !=(long num) const {
+            return !equals(String(num));
+        }
+        bool operator !=(unsigned long num) const {
+            return !equals(String(num));
+        }
+        bool operator !=(long long num) const {
+            return !equals(String(num));
+        }
+        bool operator !=(unsigned long long num) const {
+            return !equals(String(num));
+        }
+        bool operator !=(float num) const {
+            return !equals(String(num));
+        }
+        bool operator !=(double num) const {
+            return !equals(String(num));
         }
         bool operator <(const String &rhs) const;
         bool operator >(const String &rhs) const;

--- a/cores/esp8266/WString.h
+++ b/cores/esp8266/WString.h
@@ -233,30 +233,6 @@ class String {
         bool operator ==(std::nullptr_t) const {
             return length() == 0;
         }
-        bool operator ==(int num) const {
-            return equals(String(num));
-        }
-        bool operator ==(unsigned int num) const {
-            return equals(String(num));
-        }
-        bool operator ==(long num) const {
-            return equals(String(num));
-        }
-        bool operator ==(unsigned long num) const {
-            return equals(String(num));
-        }
-        bool operator ==(long long num) const {
-            return equals(String(num));
-        }
-        bool operator ==(unsigned long long num) const {
-            return equals(String(num));
-        }
-        bool operator ==(float num) const {
-            return equals(String(num));
-        }
-        bool operator ==(double num) const {
-            return equals(String(num));
-        }
         bool operator !=(const String &rhs) const {
             return !equals(rhs);
         }
@@ -268,30 +244,6 @@ class String {
         }
         bool operator !=(std::nullptr_t) const {
             return length() != 0;
-        }
-        bool operator !=(int num) const {
-            return !equals(String(num));
-        }
-        bool operator !=(unsigned int num) const {
-            return !equals(String(num));
-        }
-        bool operator !=(long num) const {
-            return !equals(String(num));
-        }
-        bool operator !=(unsigned long num) const {
-            return !equals(String(num));
-        }
-        bool operator !=(long long num) const {
-            return !equals(String(num));
-        }
-        bool operator !=(unsigned long long num) const {
-            return !equals(String(num));
-        }
-        bool operator !=(float num) const {
-            return !equals(String(num));
-        }
-        bool operator !=(double num) const {
-            return !equals(String(num));
         }
         bool operator <(const String &rhs) const;
         bool operator >(const String &rhs) const;

--- a/cores/esp8266/WString.h
+++ b/cores/esp8266/WString.h
@@ -226,31 +226,11 @@ class String {
         bool operator ==(const char *cstr) const {
             return equals(cstr);
         }
-        bool operator ==(const __FlashStringHelper *rhs) const {
-            return equals(rhs);
-        }
-        bool operator ==(std::nullptr_t) const {
-            return length() == 0;
-        }
-        [[deprecated("use nullptr instead of NULL")]]
-        bool operator ==(decltype(NULL)) const {
-            return length() == 0;
-        }
         bool operator !=(const String &rhs) const {
             return !equals(rhs);
         }
         bool operator !=(const char *cstr) const {
             return !equals(cstr);
-        }
-        bool operator !=(const __FlashStringHelper *rhs) const {
-            return !equals(rhs);
-        }
-        bool operator !=(std::nullptr_t) const {
-            return length() != 0;
-        }
-        [[deprecated("use nullptr instead of NULL")]]
-        bool operator !=(decltype(NULL)) const {
-            return length() != 0;
         }
         bool operator <(const String &rhs) const;
         bool operator >(const String &rhs) const;

--- a/cores/esp8266/WString.h
+++ b/cores/esp8266/WString.h
@@ -232,6 +232,7 @@ class String {
         bool operator ==(std::nullptr_t) const {
             return length() == 0;
         }
+        [[deprecated("use nullptr instead of NULL")]]
         bool operator ==(decltype(NULL)) const {
             return length() == 0;
         }
@@ -247,6 +248,7 @@ class String {
         bool operator !=(std::nullptr_t) const {
             return length() != 0;
         }
+        [[deprecated("use nullptr instead of NULL")]]
         bool operator !=(decltype(NULL)) const {
             return length() != 0;
         }

--- a/cores/esp8266/WString.h
+++ b/cores/esp8266/WString.h
@@ -211,10 +211,9 @@ class String {
             return *this;
         }
 
-        // checks whether the internal buffer pointer is set.
-        // (should not be the case for us, since we always reset the pointer to the SSO buffer instead of setting it to nullptr)
+        // checks whether the String is empty
         explicit operator bool() const {
-            return buffer() != nullptr;
+            return length() != 0;
         }
 
         int compareTo(const String &s) const;
@@ -227,7 +226,13 @@ class String {
         bool operator ==(const char *cstr) const {
             return equals(cstr);
         }
+        bool operator ==(const __FlashStringHelper *rhs) const {
+            return equals(rhs);
+        }
         bool operator ==(std::nullptr_t) const {
+            return length() == 0;
+        }
+        bool operator ==(decltype(NULL)) const {
             return length() == 0;
         }
         bool operator !=(const String &rhs) const {
@@ -236,7 +241,13 @@ class String {
         bool operator !=(const char *cstr) const {
             return !equals(cstr);
         }
+        bool operator !=(const __FlashStringHelper *rhs) const {
+            return !equals(rhs);
+        }
         bool operator !=(std::nullptr_t) const {
+            return length() != 0;
+        }
+        bool operator !=(decltype(NULL)) const {
             return length() != 0;
         }
         bool operator <(const String &rhs) const;


### PR DESCRIPTION
fixes https://gitter.im/esp8266/Arduino?at=627fee0ed30b6b44ebeaa803

@bwjohns4 @jandrassy ~~there will still be a warning, because `nullptr` should be used instead of `NULL`~~.
