### PR TITLE
tools/sizes.py: Restore to the prior behavior regarding output destination

### DIFF
--- a/tools/sizes.py
+++ b/tools/sizes.py
@@ -20,7 +20,9 @@
 import argparse
 import os
 import subprocess
+import sys
 
+sys.stdout = sys.stderr
 
 def get_segment_sizes(elf, path, mmu):
     iram_size = 0


### PR DESCRIPTION
once `tools/sizes.py` outputted to `stderr` rather `stdout` before da4a19fdacd7a859da395e014c9e0fded99aa985

(Arduino IDE 1.8.19 for Windows doesn't capture `stdout`, 2.0.0-rc6 does)