### PR TITLE
emulation on host: avoid closing STDIN

### DIFF
--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -374,8 +374,8 @@ ssl:							# download source and build BearSSL
 	cd ../../tools/sdk/ssl && $(MAKE) native$(N32)
 
 ULIBPATHS = $(shell echo $(ULIBDIRS) | sed 's,:, ,g')
-USERLIBDIRS = $(shell test -z "$(ULIBPATHS)" || for d in $(ULIBPATHS); do for dd in $$d $$d/src; do test -d $$dd && { echo -I$$dd; echo "userlib: using directory '$$dd'" 1>&2; } done; done)
-USERLIBSRCS = $(shell test -z "$(ULIBPATHS)" || for d in $(ULIBPATHS); do for ss in $$d/*.cpp $$d/src/*.cpp $$d/src/utility/*.cpp; do test -r $$ss && echo $$ss; done; done)
+USERLIBDIRS = $(shell test -z "$(ULIBPATHS)" || for d in $(ULIBPATHS); do for dd in $$d $$d/utility $$d/src $$d/src/utility; do test -d $$dd && echo -I$$dd; done; done)
+USERLIBSRCS = $(shell test -z "$(ULIBPATHS)" || for d in $(USERLIBDIRS); do for ss in $$d/*.cpp; do test -r $$ss && echo $$ss; done; done)
 INC_PATHS += $(USERLIBDIRS)
 INC_PATHS += -I$(INODIR)/..
 CPP_OBJECTS_CORE_EMU = $(CPP_SOURCES_CORE_EMU:.cpp=.cpp.o) $(USERLIBSRCS:.cpp=.cpp.o) $(USERCXXSOURCES:.cpp=.cpp.o)

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -374,9 +374,10 @@ ssl:							# download source and build BearSSL
 	cd ../../tools/sdk/ssl && $(MAKE) native$(N32)
 
 ULIBPATHS = $(shell echo $(ULIBDIRS) | sed 's,:, ,g')
-USERLIBDIRS = $(shell test -z "$(ULIBPATHS)" || for d in $(ULIBPATHS); do for dd in $$d $$d/utility $$d/src $$d/src/utility; do test -d $$dd && echo -I$$dd; done; done)
-USERLIBSRCS = $(shell test -z "$(ULIBPATHS)" || for d in $(USERLIBDIRS); do for ss in $$d/*.cpp; do test -r $$ss && echo $$ss; done; done)
-INC_PATHS += $(USERLIBDIRS)
+USERLIBDIRS = $(shell test -z "$(ULIBPATHS)" || for d in $(ULIBPATHS); do for dd in $$d $$d/utility $$d/src $$d/src/utility; do test -d $$dd && echo $$dd; done; done)
+USERLIBSRCS := $(shell test -z "$(USERLIBDIRS)" || for d in $(USERLIBDIRS); do for ss in $$d/*.c $$d/*.cpp; do test -r $$ss && echo $$ss; done; done)
+USERLIBINCS = $(shell for d in $(USERLIBDIRS); do echo -I$$d; done)
+INC_PATHS += $(USERLIBINCS)
 INC_PATHS += -I$(INODIR)/..
 CPP_OBJECTS_CORE_EMU = $(CPP_SOURCES_CORE_EMU:.cpp=.cpp.o) $(USERLIBSRCS:.cpp=.cpp.o) $(USERCXXSOURCES:.cpp=.cpp.o)
 C_OBJECTS_CORE_EMU = $(USERCSOURCES:.c=.c.o)

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -374,8 +374,8 @@ ssl:							# download source and build BearSSL
 	cd ../../tools/sdk/ssl && $(MAKE) native$(N32)
 
 ULIBPATHS = $(shell echo $(ULIBDIRS) | sed 's,:, ,g')
-USERLIBDIRS = $(shell test -z "$(ULIBPATHS)" || for d in $(ULIBPATHS); do for dd in $$d $$d/src $$d/src/libmad; do test -d $$dd && { echo -I$$dd; echo "userlib: using directory '$$dd'" 1>&2; } done; done)
-USERLIBSRCS = $(shell test -z "$(ULIBPATHS)" || for d in $(ULIBPATHS); do for ss in $$d/*.cpp $$d/src/*.cpp $$d/src/libmad/*.c; do test -r $$ss && echo $$ss; done; done)
+USERLIBDIRS = $(shell test -z "$(ULIBPATHS)" || for d in $(ULIBPATHS); do for dd in $$d $$d/src; do test -d $$dd && { echo -I$$dd; echo "userlib: using directory '$$dd'" 1>&2; } done; done)
+USERLIBSRCS = $(shell test -z "$(ULIBPATHS)" || for d in $(ULIBPATHS); do for ss in $$d/*.cpp $$d/src/*.cpp $$d/src/utility/*.cpp; do test -r $$ss && echo $$ss; done; done)
 INC_PATHS += $(USERLIBDIRS)
 INC_PATHS += -I$(INODIR)/..
 CPP_OBJECTS_CORE_EMU = $(CPP_SOURCES_CORE_EMU:.cpp=.cpp.o) $(USERLIBSRCS:.cpp=.cpp.o) $(USERCXXSOURCES:.cpp=.cpp.o)

--- a/tests/host/common/ArduinoMain.cpp
+++ b/tests/host/common/ArduinoMain.cpp
@@ -115,10 +115,13 @@ static int mock_stop_uart(void)
 
 static uint8_t mock_read_uart(void)
 {
-    uint8_t ch = 0;
-    int ret = read(STDIN, &ch, 1);
+    uint8_t ch  = 0;
+    int     ret = read(STDIN, &ch, 1);
     if (ret == -1)
+    {
         perror("read(STDIN,1)");
+        return 0;
+    }
     return (ret == 1) ? ch : 0;
 }
 

--- a/tests/host/common/ArduinoMain.cpp
+++ b/tests/host/common/ArduinoMain.cpp
@@ -113,7 +113,7 @@ static int mock_stop_uart(void)
     return (0);
 }
 
-uint8_t mock_read_uart(void)
+static uint8_t mock_read_uart(void)
 {
     uint8_t ch = 0;
     int ret = read(STDIN, &ch, 1);

--- a/tests/host/common/ArduinoMain.cpp
+++ b/tests/host/common/ArduinoMain.cpp
@@ -113,10 +113,13 @@ static int mock_stop_uart(void)
     return (0);
 }
 
-static uint8_t mock_read_uart(void)
+uint8_t mock_read_uart(void)
 {
     uint8_t ch = 0;
-    return (read(STDIN, &ch, 1) == 1) ? ch : 0;
+    int ret = read(STDIN, &ch, 1);
+    if (ret == -1)
+        perror("read(STDIN,1)");
+    return (ret == 1) ? ch : 0;
 }
 
 void help(const char* argv0, int exitcode)

--- a/tests/host/common/MockWiFiServerSocket.cpp
+++ b/tests/host/common/MockWiFiServerSocket.cpp
@@ -129,7 +129,7 @@ bool WiFiServer::hasClient()
 
 void WiFiServer::close()
 {
-    if (pcb2int(_listen_pcb) >= 0)
+    if (pcb2int(_listen_pcb) >= 3) // 0=stdin 1=stdout 2=stderr
         ::close(pcb2int(_listen_pcb));
     _listen_pcb = int2pcb(-1);
 }

--- a/tests/host/common/MockWiFiServerSocket.cpp
+++ b/tests/host/common/MockWiFiServerSocket.cpp
@@ -129,7 +129,7 @@ bool WiFiServer::hasClient()
 
 void WiFiServer::close()
 {
-    if (pcb2int(_listen_pcb) >= 3) // 0=stdin 1=stdout 2=stderr
+    if (pcb2int(_listen_pcb) >= 3)  // 0=stdin 1=stdout 2=stderr
         ::close(pcb2int(_listen_pcb));
     _listen_pcb = int2pcb(-1);
 }

--- a/tests/host/sys/pgmspace.h
+++ b/tests/host/sys/pgmspace.h
@@ -75,10 +75,12 @@ inline int vsnprintf_P(char* str, size_t size, const char* format, va_list ap)
 #define memmove_P memmove
 #define strncpy_P strncpy
 #define strcmp_P strcmp
+#define strcasecmp_P strcasecmp
 #define memccpy_P memccpy
 #define snprintf_P snprintf
 #define sprintf_P sprintf
 #define strncmp_P strncmp
+#define strncasecmp_P strncasecmp
 #define strcat_P strcat
 
 #endif


### PR DESCRIPTION
also:
- less verbose during compilation
- better handling user directories
- missing `str{,n}case_P` declarations