### PR TITLE
Allow UART1 to be inverted

### DIFF
--- a/cores/esp8266/uart.cpp
+++ b/cores/esp8266/uart.cpp
@@ -696,7 +696,7 @@ uart_init(int uart_nr, int baudrate, int config, int mode, int tx_pin, size_t rx
     }
 
     uart_set_baudrate(uart, baudrate);
-    if(uart->uart_nr == UART0 && invert)
+    if((uart->uart_nr == UART0 || uart->uart_nr == UART1) && invert)
     {
         config |= BIT(UCDTRI) | BIT(UCRTSI) | BIT(UCTXI) | BIT(UCDSRI) | BIT(UCCTSI) | BIT(UCRXI);
     }


### PR DESCRIPTION
The intention of this change is to allow UART1 to be inverted.
I have done limited testing, but it seems to work as intended.