### PR TITLE
Provide wl_tcp_state as tcp_state alias

### DIFF
--- a/cores/esp8266/wl_definitions.h
+++ b/cores/esp8266/wl_definitions.h
@@ -69,20 +69,8 @@ enum wl_enc_type {  /* Values map to 802.11 encryption suites... */
         ENC_TYPE_AUTO = 8
 };
 
-#if !defined(LWIP_INTERNAL) && !defined(__LWIP_TCP_H__) && !defined(LWIP_HDR_TCPBASE_H)
-enum wl_tcp_state {
-  CLOSED      = 0,
-  LISTEN      = 1,
-  SYN_SENT    = 2,
-  SYN_RCVD    = 3,
-  ESTABLISHED = 4,
-  FIN_WAIT_1  = 5,
-  FIN_WAIT_2  = 6,
-  CLOSE_WAIT  = 7,
-  CLOSING     = 8,
-  LAST_ACK    = 9,
-  TIME_WAIT   = 10
-};
-#endif
+#include <lwip/init.h>
+#include <lwip/tcpbase.h>
+using wl_tcp_state = tcp_state;
 
 #endif /* WL_DEFINITIONS_H_ */

--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -20,8 +20,6 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#define LWIP_INTERNAL
-
 extern "C"
 {
     #include "wl_definitions.h"

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp
@@ -20,8 +20,6 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#define LWIP_INTERNAL
-
 #include <list>
 #include <errno.h>
 #include <algorithm>

--- a/libraries/ESP8266WiFi/src/WiFiServer.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiServer.cpp
@@ -21,8 +21,6 @@
 */
 
 
-#define LWIP_INTERNAL
-
 extern "C" {
     #include "osapi.h"
     #include "ets_sys.h"

--- a/libraries/ESP8266WiFi/src/WiFiServerSecureBearSSL.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiServerSecureBearSSL.cpp
@@ -19,8 +19,6 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#define LWIP_INTERNAL
-
 extern "C" {
 #include "osapi.h"
 #include "ets_sys.h"

--- a/libraries/ESP8266WiFi/src/WiFiUdp.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiUdp.cpp
@@ -20,7 +20,6 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#define LWIP_INTERNAL
 #include <functional>
 
 extern "C"


### PR DESCRIPTION
resolve #7249

type is still there, if someone needs it for whatever reason
```cpp
void something(wl_tcp_state state) {
...
}
```