### PR TITLE
Handle recent python versions in device tests

### DIFF
--- a/tests/device/Makefile
+++ b/tests/device/Makefile
@@ -65,8 +65,8 @@ $(TEST_LIST):
 ifeq ("$(MOCK)", "1")
 	@echo Compiling $(notdir $@)
 	(cd ../host; make D=$(V) ULIBDIRS=../device/libraries/BSTest ../device/$(@:%.ino=%))
-	$(SILENT)source $(BS_DIR)/virtualenv/bin/activate && \
-		$(PYTHON) $(BS_DIR)/runner.py \
+	$(SILENT)$(BS_DIR)/virtualenv/bin/python \
+		$(BS_DIR)/runner.py \
 			$(RUNNER_DEBUG_FLAG) \
 			-e "$(ESP8266_CORE_PATH)/tests/host/bin/$(@:%.ino=%)" \
 			-n $(basename $(notdir $@)) \
@@ -120,8 +120,8 @@ ifneq ("$(NO_RUN)","1")
 		--port $(UPLOAD_PORT) \
 		--baud $(UPLOAD_BAUD) \
 		read_flash_status $(REDIR) # reset
-	$(SILENT)source $(BS_DIR)/virtualenv/bin/activate && \
-		$(PYTHON) $(BS_DIR)/runner.py \
+	$(SILENT)$(BS_DIR)/virtualenv/bin/python \
+		$(BS_DIR)/runner.py \
 			$(RUNNER_DEBUG_FLAG) \
 			-p $(UPLOAD_PORT) \
 			-n $(basename $(notdir $@)) \

--- a/tests/device/libraries/BSTest/Makefile
+++ b/tests/device/libraries/BSTest/Makefile
@@ -11,11 +11,11 @@ clean:
 	rm -rf $(TEST_EXECUTABLE)
 
 $(PYTHON_ENV_DIR):
-	virtualenv --python=$(PYTHON) --no-site-packages $(PYTHON_ENV_DIR)
-	. $(PYTHON_ENV_DIR)/bin/activate && pip install -r requirements.txt
+	$(PYTHON) -mvenv $(PYTHON_ENV_DIR)
+	$(PYTHON_ENV_DIR)/bin/pip install -r requirements.txt
 
 test: $(TEST_EXECUTABLE) $(PYTHON_ENV_DIR)
-	. $(PYTHON_ENV_DIR)/bin/activate && $(PYTHON) runner.py -e $(TEST_EXECUTABLE) -m test/test.py
+	$(PYTHON_ENV_DIR)/bin/python runner.py -e $(TEST_EXECUTABLE) -m test/test.py
 
 $(TEST_EXECUTABLE): test/test.cpp
 	g++ -std=c++11 -Isrc -o $@ test/test.cpp

--- a/tests/device/libraries/BSTest/runner.py
+++ b/tests/device/libraries/BSTest/runner.py
@@ -8,7 +8,9 @@ import time
 import argparse
 import serial
 import subprocess
-import imp
+
+from importlib.machinery import SourceFileLoader
+
 try:
     from configparser import ConfigParser
 except:
@@ -278,12 +280,12 @@ def main():
     if args.env_file is not None:
         cfg = ConfigParser()
         cfg.optionxform = str
-        with args.env_file as fp:
-            cfg.readfp(fp)
+        with args.env_file as env:
+            cfg.read_file(env)
         env_vars = cfg.items('global')
     mocks = {}
     if args.mock is not None:
-        mocks_mod = imp.load_source('mocks', args.mock)
+        mocks_mod = SourceFileLoader('mocks', args.mock).load_module()
         mocks = mock_decorators.env
     with spawn_func(spawn_arg) as sp:
         ts = run_tests(sp, name, mocks, env_vars)


### PR DESCRIPTION
Update soon-to-be deprecated code in the runner.py
https://docs.python.org/3/library/imp.html is deprecated since 3.4, will be removed in 3.12
https://docs.python.org/3/library/configparser.html readfp is replaced with read_file since 3.2, will be removed in 3.12

Use venv instead of virtualenv. We don't really use any of the extended features, and might as well  simplify installation requirements.
virtualenv/bin/python can execute runner.py inside of venv, no need to activate beforehand.