### PR TITLE
Longer delays for Ticker and some internal updates

### DIFF
--- a/libraries/Ticker/src/Ticker.cpp
+++ b/libraries/Ticker/src/Ticker.cpp
@@ -46,7 +46,7 @@ void Ticker::_attach(Ticker::Milliseconds milliseconds, bool repeat)
     _tick.repeat = repeat;
 
     if (milliseconds > DurationMax) {
-        _tick.total += 1;
+        _tick.total = 1;
         while (milliseconds > DurationMax) {
             _tick.total *= 2;
             milliseconds /= 2;
@@ -62,13 +62,7 @@ void Ticker::detach()
     if (_timer) {
         os_timer_disarm(_timer);
         _timer = nullptr;
-
-        _tick = callback_tick_t{
-            .total = 0,
-            .count = 0,
-            .repeat = false,
-        };
-
+        _tick = callback_tick_t{};
         _callback = std::monostate{};
     }
 }

--- a/libraries/Ticker/src/Ticker.cpp
+++ b/libraries/Ticker/src/Ticker.cpp
@@ -43,9 +43,9 @@ void Ticker::_attach(Ticker::Milliseconds milliseconds, bool repeat)
     // whenever duration excedes this limit, make timer repeatable N times
     // in case it is really repeatable, it will reset itself and continue as usual
     _tick = callback_tick_t{};
+    _tick.repeat = repeat;
 
     if (milliseconds > DurationMax) {
-        _tick.repeat = repeat;
         _tick.total += 1;
         while (milliseconds > DurationMax) {
             _tick.total *= 2;
@@ -85,10 +85,6 @@ void Ticker::_static_callback()
         if (_tick.count < _tick.total) {
             return;
         }
-
-        if (_tick.repeat) {
-            _tick.count = 0;
-        }
     }
 
     std::visit([](auto&& callback) {
@@ -100,7 +96,11 @@ void Ticker::_static_callback()
         }
     }, _callback);
 
-    if (_tick.total && _tick.repeat) {
+    if (_tick.total) {
         _tick.count = 0;
+    }
+
+    if (!_tick.repeat) {
+        detach();
     }
 }

--- a/libraries/Ticker/src/Ticker.h
+++ b/libraries/Ticker/src/Ticker.h
@@ -102,9 +102,9 @@ public:
     template <typename TArg, typename Callback = void(*)(TArg)>
     void attach(float seconds, Callback callback, TArg arg)
     {
-        _callback = callback_data_t {
+        _callback = callback_ptr_t{
+            .func = reinterpret_cast<callback_with_arg_t>(callback),
             .arg = reinterpret_cast<void*>(arg),
-            .func = callback,
         };
         _attach(Seconds(seconds), true);
     }
@@ -115,9 +115,9 @@ public:
     template <typename TArg, typename Callback = void(*)(TArg)>
     void attach_ms(uint32_t milliseconds, Callback callback, TArg arg)
     {
-        _callback = callback_data_t {
+        _callback = callback_ptr_t{
+            .func = reinterpret_cast<callback_with_arg_t>(callback),
             .arg = reinterpret_cast<void*>(arg),
-            .func = callback,
         };
         _attach(Milliseconds(milliseconds), true);
     }
@@ -154,9 +154,9 @@ public:
     template <typename TArg, typename Callback = void(*)(TArg)>
     void once(float seconds, Callback callback, TArg arg)
     {
-        _callback = callback_data_t {
+        _callback = callback_ptr_t{
+            .func = reinterpret_cast<callback_with_arg_t>(callback),
             .arg = reinterpret_cast<void*>(arg),
-            .func = callback,
         };
         _attach(Seconds(seconds), false);
     }
@@ -165,9 +165,9 @@ public:
     template <typename TArg, typename Callback = void(*)(TArg)>
     void once_ms(uint32_t milliseconds, Callback callback, TArg arg)
     {
-        _callback = callback_data_t {
+        _callback = callback_ptr_t{
+            .func = reinterpret_cast<callback_with_arg_t>(callback),
             .arg = reinterpret_cast<void*>(arg),
-            .func = callback,
         };
         _attach(Milliseconds(milliseconds), false);
     }
@@ -212,8 +212,8 @@ protected:
 private:
     struct callback_ptr_t
     {
-        void* arg = nullptr;
         callback_with_arg_t func = nullptr;
+        void* arg = nullptr;
     };
 
     using callback_data_t = std::variant<
@@ -221,10 +221,7 @@ private:
         callback_ptr_t,
         callback_function_t>;
 
-    callback_data_t _callback = callback_ptr_t{
-        .arg = nullptr,
-        .func = nullptr,
-    };
+    callback_data_t _callback;
     callback_tick_t _tick;
 
     ETSTimer _timer_internal;

--- a/libraries/Ticker/src/Ticker.h
+++ b/libraries/Ticker/src/Ticker.h
@@ -180,9 +180,8 @@ protected:
     // float -> u32 has some precision issues, though
     using Seconds = std::chrono::duration<float, std::ratio<1>>;
 
-    // NONOS SDK timer object duration value range is 5...6870947 (0x68D7A3)
+    // NONOS SDK timer object duration cannot be longer than 6870947 (0x68D7A3)
     // when that's the case, we split execution into multiple 'ticks'
-    static constexpr auto DurationMin = Milliseconds(5);
     static constexpr auto DurationMax = Milliseconds(6870947);
 
     struct callback_tick_t


### PR DESCRIPTION
resolves #8066

Adds max duration check. In case it is over SDK limit, enable 'repeat'ing timer with a duration proportional to the original one and count until it executes N times, only then run the callback.
Code with durations less than that executes as usual. Original proposal was to not create anything or create some kind of error state... which seems counter-productive to not help out with this pretty solvable use-case.

Three additional updates, while refactoring the class
- Stronger types for internal time management using `std::chrono::duration`. Works the same, `std::chrono::duration` handles seconds <-> milliseconds conversion.
- `::detach()` 'once' timer when it finishes. Fixes (unintentional?) side-effect that we remain `::active()`. Plus, this destroys any lambda-bound variables that will persist with the Ticker object. And, since we can't re-arm with the same function (`Ticker::attach_ms(uint32_t just_the_time)` and etc.)
- `std::variant` aka union for internal callback storage (kind-of similar to #6918). Instead of having two separate code paths, **always** attach our static function and dispatch using type info. Also helps with the issue described above, since it will call `std::function` dtor when ptr + arg is attached instead of doing nothing.

