### PR TITLE
Fix hostname management

### DIFF
--- a/cores/esp8266/LwipIntf.cpp
+++ b/cores/esp8266/LwipIntf.cpp
@@ -16,6 +16,9 @@ extern "C"
 #include "debug.h"
 #include "LwipIntf.h"
 
+extern "C" char* wifi_station_hostname; // sdk's hostname location
+extern "C" char* wifi_station_default_hostname; // sdk's hostname location
+
 // args      | esp order    arduino order
 // ----      + ---------    -------------
 // local_ip  | local_ip     local_ip
@@ -66,7 +69,7 @@ bool LwipIntf::ipAddressReorder(const IPAddress& local_ip, const IPAddress& arg1
 */
 String LwipIntf::hostname(void)
 {
-    return wifi_station_get_hostname();
+    return wifi_station_hostname; //wifi_station_get_hostname();
 }
 
 /**
@@ -75,7 +78,7 @@ String LwipIntf::hostname(void)
 */
 const char* LwipIntf::getHostname(void)
 {
-    return wifi_station_get_hostname();
+    return wifi_station_hostname; //wifi_station_get_hostname();
 }
 
 /**
@@ -136,20 +139,26 @@ bool LwipIntf::hostname(const char* aHostname)
         DEBUGV("hostname '%s' is not compliant with RFC952\n", aHostname);
     }
 
+#if 0
     bool ret = wifi_station_set_hostname(aHostname);
     if (!ret)
     {
         DEBUGV("WiFi.hostname(%s): wifi_station_set_hostname() failed\n", aHostname);
         return false;
     }
+#else
+    bool ret = true;
 
+    strcpy(wifi_station_hostname, aHostname);
+    strcpy(wifi_station_default_hostname, aHostname);
+#endif
     // now we should inform dhcp server for this change, using lwip_renew()
     // looping through all existing interface
     // harmless for AP, also compatible with ethernet adapters (to come)
     for (netif* intf = netif_list; intf; intf = intf->next)
     {
         // unconditionally update all known interfaces
-        intf->hostname = wifi_station_get_hostname();
+        intf->hostname = wifi_station_hostname; //wifi_station_get_hostname();
 
         if (netif_dhcp_data(intf) != nullptr)
         {

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -49,6 +49,9 @@ extern "C" {
 #include "debug.h"
 #include "include/WiFiState.h"
 
+// see comments on wifi_station_hostname in LwipIntf.cpp
+extern "C" char* wifi_station_hostname; // sdk's hostname location
+
 // -----------------------------------------------------------------------------------------------------------------------
 // ------------------------------------------------- Generic WiFi function -----------------------------------------------
 // -----------------------------------------------------------------------------------------------------------------------
@@ -419,7 +422,10 @@ bool ESP8266WiFiGenericClass::mode(WiFiMode_t m) {
         return true;
     }
 
+    char backup_hostname [33] { 0 }; // hostname is 32 chars long (RFC)
+
     if (m != WIFI_OFF && wifi_fpm_get_sleep_type() != NONE_SLEEP_T) {
+        memcpy(backup_hostname, wifi_station_hostname, sizeof(backup_hostname));
         // wifi starts asleep by default
         wifi_fpm_do_wakeup();
         wifi_fpm_close();
@@ -451,6 +457,9 @@ bool ESP8266WiFiGenericClass::mode(WiFiMode_t m) {
             return false; //timeout
         }
     }
+
+    if (backup_hostname[0])
+        memcpy(wifi_station_hostname, backup_hostname, sizeof(backup_hostname));
 
     return ret;
 }


### PR DESCRIPTION
This proposal addresses two issues
- Ethernet hostname change was not working as intended because hostname management relies on wifi_**station**_set_hostname() and STA can be down when ethernet is used,
- Since WiFi is off at boot time, for the same reason, hostname can't be changed until STA is up.

For both issue, solution is to play with hostname location in ram, reserved by SDK, and filled with `ESP-baffed` when WiFi boots but which can be now overwritten back when user had already set it to something.

fixes #8143 
