### PR TITLE
emulation on host: fix incorrect lwIP DNS implementation

### DIFF
--- a/tests/host/common/MocklwIP.cpp
+++ b/tests/host/common/MocklwIP.cpp
@@ -3,6 +3,9 @@
 
 #include "MocklwIP.h"
 
+#include <lwip/dns.h>
+#include <arpa/inet.h>
+
 esp8266::AddressListImplementation::AddressList addrList;
 
 extern "C"
@@ -55,6 +58,20 @@ extern "C"
     {
         (void)idx;
         return &netif0;
+    }
+
+    void dns_setserver(u8_t numdns, const ip_addr_t* dnsserver)
+    {
+        (void)numdns;
+        (void)dnsserver;
+    }
+
+    const ip_addr_t* dns_getserver(u8_t numdns)
+    {
+        (void)numdns;
+        static ip_addr_t addr;
+        addr.addr = htonl(0x7f000001);  // 127.0.0.1
+        return &addr;
     }
 
 }  // extern "C"

--- a/tests/host/common/MocklwIP.cpp
+++ b/tests/host/common/MocklwIP.cpp
@@ -4,7 +4,6 @@
 #include "MocklwIP.h"
 
 #include <lwip/dns.h>
-#include <arpa/inet.h>
 
 esp8266::AddressListImplementation::AddressList addrList;
 
@@ -70,7 +69,7 @@ extern "C"
     {
         (void)numdns;
         static ip_addr_t addr;
-        addr.addr = htonl(0x7f000001);  // 127.0.0.1
+        IP4_ADDR(&addr, 127, 0, 0, 1);
         return &addr;
     }
 

--- a/tests/host/common/user_interface.cpp
+++ b/tests/host/common/user_interface.cpp
@@ -136,8 +136,7 @@ extern "C"
         for (ifa = ifAddrStruct; ifa != NULL; ifa = ifa->ifa_next)
         {
             mockverbose("host: interface: %s", ifa->ifa_name);
-            if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET  // ip_info is IPv4 only
-            )
+            if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET)  // ip_info is IPv4 only
             {
                 auto test_ipv4
                     = lwip_ntohl(*(uint32_t*)&((struct sockaddr_in*)ifa->ifa_addr)->sin_addr);
@@ -179,13 +178,13 @@ extern "C"
             info->ip.addr      = ipv4;
             info->netmask.addr = mask;
             info->gw.addr      = ipv4;
-
-            netif0.ip_addr.addr = ipv4;
-            netif0.netmask.addr = mask;
-            netif0.gw.addr      = ipv4;
-            netif0.flags        = NETIF_FLAG_IGMP | NETIF_FLAG_UP | NETIF_FLAG_LINK_UP;
-            netif0.next         = nullptr;
         }
+
+        netif0.ip_addr.addr = ipv4;
+        netif0.netmask.addr = mask;
+        netif0.gw.addr      = ipv4;
+        netif0.flags        = NETIF_FLAG_IGMP | NETIF_FLAG_UP | NETIF_FLAG_LINK_UP;
+        netif0.next         = nullptr;
 
         return true;
     }
@@ -414,19 +413,6 @@ extern "C"
     void ets_isr_unmask(int intr)
     {
         (void)intr;
-    }
-
-    void dns_setserver(u8_t numdns, ip_addr_t* dnsserver)
-    {
-        (void)numdns;
-        (void)dnsserver;
-    }
-
-    ip_addr_t dns_getserver(u8_t numdns)
-    {
-        (void)numdns;
-        ip_addr_t addr = { 0x7f000001 };
-        return addr;
     }
 
 #include <smartconfig.h>


### PR DESCRIPTION
- fix mismatched header of lwIP's `dns_getserver()` implementation
- correctly initialize emulated netif0
- make ipv6 example unfail (even if emulation on host is ipv4 only)
