### PR TITLE
[String] Fix float assignment using wrong type

### DIFF
--- a/cores/esp8266/WString.cpp
+++ b/cores/esp8266/WString.cpp
@@ -37,7 +37,7 @@
 /*  Conversion helpers                       */
 /*********************************************/
 
-static String toString(unsigned char value, unsigned char base) {
+static String toString(const unsigned char& value, unsigned char base) {
     String out;
 
     char buf[1 + std::numeric_limits<unsigned char>::digits];
@@ -46,7 +46,7 @@ static String toString(unsigned char value, unsigned char base) {
     return out;
 }
 
-static String toString(int value, unsigned char base) {
+static String toString(const int& value, unsigned char base) {
     String out;
 
     char buf[2 + std::numeric_limits<int>::digits];
@@ -55,7 +55,7 @@ static String toString(int value, unsigned char base) {
     return out;
 }
 
-static String toString(unsigned int value, unsigned char base) {
+static String toString(const unsigned int& value, unsigned char base) {
     String out;
 
     char buf[1 + std::numeric_limits<unsigned int>::digits];
@@ -64,7 +64,7 @@ static String toString(unsigned int value, unsigned char base) {
     return out;
 }
 
-static String toString(long value, unsigned char base) {
+static String toString(const long& value, unsigned char base) {
     String out;
 
     char buf[2 + std::numeric_limits<long>::digits];
@@ -73,7 +73,7 @@ static String toString(long value, unsigned char base) {
     return out;
 }
 
-static String toString(unsigned long value, unsigned char base) {
+static String toString(const unsigned long& value, unsigned char base) {
     String out;
 
     char buf[1 + std::numeric_limits<unsigned long>::digits];
@@ -84,7 +84,7 @@ static String toString(unsigned long value, unsigned char base) {
 
 // TODO: {u,}lltoa don't guarantee that the buffer is usable directly, one should always use the returned pointer
 
-static String toString(long long value, unsigned char base) {
+static String toString(const long long& value, unsigned char base) {
     String out;
 
     char buf[2 + std::numeric_limits<long long>::digits];
@@ -93,7 +93,7 @@ static String toString(long long value, unsigned char base) {
     return out;
 }
 
-static String toString(unsigned long long value, unsigned char base) {
+static String toString(const unsigned long long& value, unsigned char base) {
     String out;
 
     char buf[1 + std::numeric_limits<unsigned long long>::digits];
@@ -102,7 +102,7 @@ static String toString(unsigned long long value, unsigned char base) {
     return out;
 }
 
-static String toString(double value, unsigned char decimalPlaces) {
+static String toString(const double& value, unsigned char decimalPlaces) {
     String out;
 
     char buf[33];
@@ -111,7 +111,7 @@ static String toString(double value, unsigned char decimalPlaces) {
     return out;
 }
 
-static String toString(float value, unsigned char decimalPlaces) {
+static String toString(const float& value, unsigned char decimalPlaces) {
     return toString(static_cast<double>(value), decimalPlaces);
 }
 
@@ -140,41 +140,78 @@ String::String(String &&rval) noexcept {
     move(rval);
 }
 
-String::String(unsigned char value, unsigned char base) :
+String::String(const unsigned char& value, unsigned char base) :
     String(toString(value, base))
 {}
 
-String::String(int value, unsigned char base) :
+String::String(unsigned char value) :
+    String(value, 10)
+{}
+
+String::String(const int& value, unsigned char base) :
     String(toString(value, base))
 {}
 
-String::String(unsigned int value, unsigned char base) :
+String::String(int value) :
+    String(value, 10)
+{}
+
+String::String(const unsigned int& value, unsigned char base) :
     String(toString(value, base))
 {}
 
-String::String(long value, unsigned char base) :
+String::String(unsigned int value) :
+    String(value, 10)
+{}
+
+String::String(const long& value, unsigned char base) :
     String(toString(value, base))
 {}
 
-String::String(unsigned long value, unsigned char base) :
+String::String(long value) :
+    String(value, 10)
+{}
+
+String::String(const unsigned long& value, unsigned char base) :
     String(toString(value, base))
 {}
 
-String::String(long long value, unsigned char base) :
+String::String(unsigned long value) :
+    String(value, 10)
+{}
+
+String::String(const long long& value, unsigned char base) :
     String(toString(value, base))
 {}
 
-String::String(unsigned long long value, unsigned char base) :
+String::String(long long value) :
+    String(value, 10)
+{}
+
+String::String(const unsigned long long& value, unsigned char base) :
     String(toString(value, base))
 {}
 
-String::String(float value, unsigned char decimalPlaces) :
+String::String(unsigned long long value) :
+    String(value, 10)
+{}
+
+String::String(const float& value, unsigned char decimalPlaces) :
     String(toString(value, decimalPlaces))
 {}
 
-String::String(double value, unsigned char decimalPlaces) :
+String::String(float value) :
+    String(value, 2)
+{}
+
+String::String(const double& value, unsigned char decimalPlaces) :
     String(toString(value, decimalPlaces))
 {}
+
+String::String(double value) :
+    String(value, 2)
+{}
+
 
 /*********************************************/
 /*  Memory Management                        */
@@ -314,9 +351,54 @@ String &String::operator =(const __FlashStringHelper *pstr) {
     return *this;
 }
 
-String &String::operator =(char c) {
+String &String::operator =(const char& c) {
     char buffer[2] { c, '\0' };
     *this = buffer;
+    return *this;
+}
+
+String &String::operator =(const unsigned char& value) {
+    *this = String(value);
+    return *this;
+}
+
+String &String::operator =(const int& value) {
+    *this = String(value);
+    return *this;
+}
+
+String &String::operator =(const unsigned int& value) {
+    *this = String(value);
+    return *this;
+}
+
+String &String::operator =(const long& value) {
+    *this = String(value);
+    return *this;
+}
+
+String &String::operator =(const unsigned long& value) {
+    *this = String(value);
+    return *this;
+}
+
+String &String::operator =(const long long& value) {
+    *this = String(value);
+    return *this;
+}
+
+String &String::operator =(const unsigned long long& value) {
+    *this = String(value);
+    return *this;
+}
+
+String &String::operator =(const float& value) {
+    *this = String(value);
+    return *this;
+}
+
+String &String::operator =(const double& value) {
+    *this = String(value);
     return *this;
 }
 

--- a/cores/esp8266/WString.h
+++ b/cores/esp8266/WString.h
@@ -66,50 +66,32 @@ class String {
             sso.isHeap  = 0;
         }
 
-        String(unsigned char, unsigned char base);
-        explicit String(unsigned char value) :
-            String(value, 10)
-        {}
+        String(const unsigned char&, unsigned char base);
+        explicit String(unsigned char value);
 
-        String(int, unsigned char base);
-        explicit String(int value) :
-            String(value, 10)
-        {}
+        String(const int&, unsigned char base);
+        explicit String(int value);
 
-        String(unsigned int, unsigned char base);
-        explicit String(unsigned int value) :
-            String(value, 10)
-        {}
+        String(const unsigned int&, unsigned char base);
+        explicit String(unsigned int value);
 
-        String(long, unsigned char base);
-        explicit String(long value) :
-            String(value, 10)
-        {}
+        String(const long&, unsigned char base);
+        explicit String(long value);
 
-        String(unsigned long, unsigned char base);
-        explicit String(unsigned long value) :
-            String(value, 10)
-        {}
+        String(const unsigned long&, unsigned char base);
+        explicit String(unsigned long value);
 
-        String(long long, unsigned char base);
-        explicit String(long long value) :
-            String(value, 10)
-        {}
+        String(const long long&, unsigned char base);
+        explicit String(long long value);
 
-        String(unsigned long long, unsigned char base);
-        explicit String(unsigned long long value) :
-            String(value, 10)
-        {}
+        String(const unsigned long long&, unsigned char base);
+        explicit String(unsigned long long value);
 
-        String(float, unsigned char decimalPlaces);
-        explicit String(float value) :
-            String(value, 2)
-        {}
+        String(const float&, unsigned char decimalPlaces);
+        explicit String(float value);
 
-        String(double, unsigned char decimalPlaces);
-        explicit String(double value) :
-            String(value, 2)
-        {}
+        String(const double&, unsigned char decimalPlaces);
+        explicit String(double value);
 
         ~String() {
             invalidate();
@@ -135,52 +117,17 @@ class String {
         String &operator =(String &&rval) noexcept;
         String &operator =(const char *cstr);
         String &operator =(const __FlashStringHelper *str);
-        String &operator =(char c);
+        String &operator =(const char& c);
 
-        String &operator =(unsigned char value) {
-            *this = String(value);
-            return *this;
-        }
-
-        String &operator =(int value) {
-            *this = String(value);
-            return *this;
-        }
-
-        String &operator =(unsigned int value) {
-            *this = String(value);
-            return *this;
-        }
-
-        String &operator =(long value) {
-            *this = String(value);
-            return *this;
-        }
-
-        String &operator =(unsigned long value) {
-            *this = String(value);
-            return *this;
-        }
-
-        String &operator =(long long value) {
-            *this = String(value);
-            return *this;
-        }
-
-        String &operator =(unsigned long long value) {
-            *this = String(value);
-            return *this;
-        }
-
-        String &operator =(float value) {
-            *this = String(value);
-            return *this;
-        }
-
-        String &operator =(double value) {
-            *this = String(value);
-            return *this;
-        }
+        String &operator =(const unsigned char& value);
+        String &operator =(const int& value);
+        String &operator =(const unsigned int& value);
+        String &operator =(const long& value);
+        String &operator =(const unsigned long& value);
+        String &operator =(const long long& value);
+        String &operator =(const unsigned long long& value);
+        String &operator =(const float& value);
+        String &operator =(const double& value);
 
         // concatenate (works w/ built-in types, same as assignment)
 
@@ -227,11 +174,17 @@ class String {
         bool operator ==(const char *cstr) const {
             return equals(cstr);
         }
+        bool operator ==(const __FlashStringHelper *s) const {
+            return equals(s);
+        }
         bool operator !=(const String &rhs) const {
             return !equals(rhs);
         }
         bool operator !=(const char *cstr) const {
             return !equals(cstr);
+        }
+        bool operator !=(const __FlashStringHelper *s) const {
+            return !equals(s);
         }
         bool operator <(const String &rhs) const;
         bool operator >(const String &rhs) const;


### PR DESCRIPTION
Using 3.0.2 assigning a float to a string resulted in undefined behaviour.

```c++
String str;
float myfloat[12][4];
myfloat[0][0] = 1.0f;
str = myfloat[0][0];
```

`str` does contain a single char.

Not sure if a 2D float array is needed to reproduce it, but that's how it was used in my project.
These were part of a larger struct, so maybe the assignment should be done in a separate function to make sure the compiler is not optimizing the code too much.

Worked fine in 2.7.4
Looks like it might have been introduced here: https://github.com/esp8266/Arduino/pull/8526  @mcspr 

Change is mainly to enforce `explicit` behavior when calling the `toString` static functions by using const reference as their argument.

Also added `bool operator ==(const __FlashStringHelper *s) const` and its counter part, which saved roughly 3k in build size on my project ESPEasy.
