### PR TITLE
Nice stack smashing postmortem message

### DIFF
--- a/cores/esp8266/StackThunk.cpp
+++ b/cores/esp8266/StackThunk.cpp
@@ -142,11 +142,12 @@ void stack_thunk_dump_stack()
   ets_printf("<<<stack<<<\n");
 }
 
-/* Called when the stack overflow is detected by a thunk.  Main memory is corrupted at this point.  Do not return. */
-void stack_thunk_fatal_overflow()
+/* Called when the stack overflow is detected by a thunk.  Main memory is corrupted at this point.
+ * Do not return, use libssp-compatible function to notify postmortem and immediately reboot. */
+void stack_thunk_fatal_smashing()
 {
-    ets_printf("FATAL ERROR: BSSL stack overflow\n");
-    abort();
+    ets_printf("FATAL ERROR: BSSL stack smashing detected\n");
+    __stack_chk_fail();
 }
 
-};
+}

--- a/cores/esp8266/StackThunk.h
+++ b/cores/esp8266/StackThunk.h
@@ -41,7 +41,7 @@ extern uint32_t stack_thunk_get_stack_bot();
 extern uint32_t stack_thunk_get_cont_sp();
 extern uint32_t stack_thunk_get_max_usage();
 extern void stack_thunk_dump_stack();
-extern void stack_thunk_fatal_overflow();
+extern void stack_thunk_fatal_smashing();
 
 // Globals required for thunking operation
 extern uint32_t *stack_thunk_ptr;
@@ -75,7 +75,7 @@ thunk_"#fcnToThunk":\n\
   l32i.n a15, a15, 0    /* A15 now has contents of last stack entry */\n\
   l32r a0, .LC_STACK_VALUE"#fcnToThunk" /* A0 now has the check value */\n\
   beq a0, a15, .L1"#fcnToThunk"\n\
-  call0 stack_thunk_fatal_overflow\n\
+  call0 stack_thunk_fatal_smashing\n\
 .L1"#fcnToThunk":\n\
   movi a15, stack_thunk_save  /* Restore A1(SP) */\n\
   l32i.n a1, a15, 0\n\

--- a/cores/esp8266/cont.h
+++ b/cores/esp8266/cont.h
@@ -62,9 +62,8 @@ void cont_run(cont_t*, void (*pfn)(void));
 // execution state (registers and stack)
 void cont_suspend(cont_t*);
 
-// Check guard bytes around the stack. Return 0 in case everything is ok,
-// return 1 if guard bytes were overwritten.
-int cont_check(cont_t* cont);
+// Check guard bytes around the stack. Immediately panics on failure.
+void cont_check(cont_t*);
 
 // Go through stack and check how many bytes are most probably still unchanged
 // and thus weren't used by the user code. i.e. that stack space is free. (high water mark)

--- a/cores/esp8266/cont_util.cpp
+++ b/cores/esp8266/cont_util.cpp
@@ -18,14 +18,18 @@
  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include "cont.h"
+#include <ets_sys.h>
+
 #include <stddef.h>
 #include <string.h>
-#include "ets_sys.h"
 
-extern "C" {
+#include "cont.h"
+#include "debug.h"
 
-#define CONT_STACKGUARD 0xfeefeffe
+extern "C"
+{
+
+static constexpr unsigned int CONT_STACKGUARD { 0xfeefeffe };
 
 void cont_init(cont_t* cont) {
     memset(cont, 0, sizeof(cont_t));
@@ -42,10 +46,15 @@ void cont_init(cont_t* cont) {
     }
 }
 
-int IRAM_ATTR cont_check(cont_t* cont) {
-    if(cont->stack_guard1 != CONT_STACKGUARD || cont->stack_guard2 != CONT_STACKGUARD) return 1;
+void IRAM_ATTR cont_check(cont_t* cont) {
+    if ((cont->stack_guard1 == CONT_STACKGUARD)
+     && (cont->stack_guard2 == CONT_STACKGUARD))
+    {
+        return;
+    }
 
-    return 0;
+    __stack_chk_fail();
+    __builtin_unreachable();
 }
 
 // No need for this to be in IRAM, not expected to be IRQ called

--- a/cores/esp8266/core_esp8266_main.cpp
+++ b/cores/esp8266/core_esp8266_main.cpp
@@ -245,11 +245,14 @@ static void loop_wrapper() {
     }
     loop();
     loop_end();
+    cont_check(g_pcont);
     if (serialEventRun) {
         serialEventRun();
     }
     esp_schedule();
 }
+
+extern "C" void __stack_chk_fail(void);
 
 static void loop_task(os_event_t *events) {
     (void) events;
@@ -257,9 +260,6 @@ static void loop_task(os_event_t *events) {
     ESP.resetHeap();
     cont_run(g_pcont, &loop_wrapper);
     ESP.setDramHeap();
-    if (cont_check(g_pcont) != 0) {
-        panic();
-    }
 }
 
 extern "C" {

--- a/cores/esp8266/debug.h
+++ b/cores/esp8266/debug.h
@@ -26,7 +26,7 @@ void hexdump(const void* mem, uint32_t len, uint8_t cols);
 extern "C"
 {
 #endif
-
+    void __stack_chk_fail(void) __attribute__((noreturn));
     void __unhandled_exception(const char* str) __attribute__((noreturn));
     void __panic_func(const char* file, int line, const char* func) __attribute__((noreturn));
 #define panic() __panic_func(PSTR(__FILE__), __LINE__, __func__)


### PR DESCRIPTION
Wire everything that relies on stack smashing detection to call `__stack_chk_fail()` (aka what libssp / ssp / stack-protector uses) Expose it in our debugging header

Rename overflow -> smashing, as these are different things we are trying to detect (meaning, that we check for things writing there, not some kind of `alloca` issue or the way `-fstack-check` would have worked) ref. #8666

`-fstack-protector` continues to work as it always did CONT replaces `abort()`, also moves its check to the loop wrapper to avoid dumping otherwise useless SYS context memory StackThunk replaces a similar `abort()` call