### PR TITLE
Expand access to SDK's struct bss_info

### DIFF
--- a/libraries/ESP8266WiFi/examples/WiFiScan/WiFiScan.ino
+++ b/libraries/ESP8266WiFi/examples/WiFiScan/WiFiScan.ino
@@ -40,7 +40,30 @@ void loop() {
     for (int8_t i = 0; i < scanResult; i++) {
       WiFi.getNetworkInfo(i, ssid, encryptionType, rssi, bssid, channel, hidden);
 
-      Serial.printf(PSTR("  %02d: [CH %02d] [%02X:%02X:%02X:%02X:%02X:%02X] %ddBm %c %c %s\n"), i, channel, bssid[0], bssid[1], bssid[2], bssid[3], bssid[4], bssid[5], rssi, (encryptionType == ENC_TYPE_NONE) ? ' ' : '*', hidden ? 'H' : 'V', ssid.c_str());
+      // get extra info
+      const struct bss_info *bssInfo = WiFi.getNetworkInfo(i);
+      String phyMode;
+      const char *wps = "";
+      if (bssInfo) {
+        phyMode.reserve(12);
+        phyMode = F("802.11");
+        String slash;
+        if (bssInfo->phy_11b) {
+          phyMode += 'b';
+          slash = '/';
+        }
+        if (bssInfo->phy_11g) {
+          phyMode += slash + 'g';
+          slash = '/';
+        }
+        if (bssInfo->phy_11n) {
+          phyMode += slash + 'n';
+        }
+        if (bssInfo->wps) {
+          wps = PSTR("WPS");
+        }
+      }
+      Serial.printf(PSTR("  %02d: [CH %02d] [%02X:%02X:%02X:%02X:%02X:%02X] %ddBm %c %c %-11s %3S %s\n"), i, channel, bssid[0], bssid[1], bssid[2], bssid[3], bssid[4], bssid[5], rssi, (encryptionType == ENC_TYPE_NONE) ? ' ' : '*', hidden ? 'H' : 'V', phyMode.c_str(), wps, ssid.c_str());
       yield();
     }
   } else {

--- a/libraries/ESP8266WiFi/examples/WiFiScan/WiFiScan.ino
+++ b/libraries/ESP8266WiFi/examples/WiFiScan/WiFiScan.ino
@@ -22,7 +22,7 @@ void loop() {
   String ssid;
   int32_t rssi;
   uint8_t encryptionType;
-  uint8_t* bssid;
+  uint8_t *bssid;
   int32_t channel;
   bool hidden;
   int scanResult;

--- a/libraries/ESP8266WiFi/examples/WiFiScan/WiFiScan.ino
+++ b/libraries/ESP8266WiFi/examples/WiFiScan/WiFiScan.ino
@@ -41,7 +41,7 @@ void loop() {
       WiFi.getNetworkInfo(i, ssid, encryptionType, rssi, bssid, channel, hidden);
 
       // get extra info
-      const struct bss_info *bssInfo = WiFi.getNetworkInfo(i);
+      const bss_info *bssInfo = WiFi.getScanInfoByIndex(i);
       String phyMode;
       const char *wps = "";
       if (bssInfo) {

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiScan.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiScan.cpp
@@ -149,12 +149,12 @@ void ESP8266WiFiScanClass::scanDelete() {
 
 /**
  * returns const pointer to the requested scanned wifi entry for furthor parsing.
- * @param networkItem uint8_t
+ * @param networkItem int
  * @return struct bss_info*, may be NULL
  */
-const struct bss_info *ESP8266WiFiScanClass::getNetworkInfo(uint8_t i) {
-    return reinterpret_cast<const struct bss_info*>(_getScanInfoByIndex(i));
-}
+const bss_info *ESP8266WiFiScanClass::getScanInfoByIndex(int i) {
+    return reinterpret_cast<const bss_info*>(_getScanInfoByIndex(i));
+};
 
 /**
  * loads all infos from a scanned wifi in to the ptr parameters

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiScan.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiScan.cpp
@@ -147,6 +147,14 @@ void ESP8266WiFiScanClass::scanDelete() {
     _scanComplete = false;
 }
 
+/**
+ * returns const pointer to the requested scanned wifi entry for furthor parsing.
+ * @param networkItem uint8_t
+ * @return struct bss_info*, may be NULL
+ */
+const struct bss_info *ESP8266WiFiScanClass::getNetworkInfo(uint8_t i) {
+    return reinterpret_cast<const struct bss_info*>(_getScanInfoByIndex(i));
+}
 
 /**
  * loads all infos from a scanned wifi in to the ptr parameters

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiScan.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiScan.h
@@ -41,6 +41,7 @@ class ESP8266WiFiScanClass {
         void scanDelete();
 
         // scan result
+        const struct bss_info *getNetworkInfo(uint8_t i);
         bool getNetworkInfo(uint8_t networkItem, String &ssid, uint8_t &encryptionType, int32_t &RSSI, uint8_t* &BSSID, int32_t &channel, bool &isHidden);
 
         String SSID(uint8_t networkItem);

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiScan.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiScan.h
@@ -41,7 +41,7 @@ class ESP8266WiFiScanClass {
         void scanDelete();
 
         // scan result
-        const struct bss_info *getNetworkInfo(uint8_t i);
+        const bss_info *getScanInfoByIndex(int i);
         bool getNetworkInfo(uint8_t networkItem, String &ssid, uint8_t &encryptionType, int32_t &RSSI, uint8_t* &BSSID, int32_t &channel, bool &isHidden);
 
         String SSID(uint8_t networkItem);


### PR DESCRIPTION
The NONOS SDK's `struct bss_info` in `user_interface.h` has grown since the beginning of this project. The additional elements are not accessible. Add a method for R/O access to full `struct bss_info`.
```cpp
const bss_info *ESP8266WiFiScanClass::getScanInfoByIndex(int i);
```

Update example WiFiScan.ino

Requested here https://github.com/esp8266/Arduino/issues/7965#issuecomment-1266744892. I have also needed this feature.