### PR TITLE
Fix Sphinx build warnings

### DIFF
--- a/doc/faq/a06-global-build-options.rst
+++ b/doc/faq/a06-global-build-options.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 How to specify global build defines and options
 ===============================================
 

--- a/doc/faq/readme.rst
+++ b/doc/faq/readme.rst
@@ -187,7 +187,7 @@ regular API.
 
 Read more at `former WiFi persistent mode <../esp8266wifi/generic-class.rst#persistent>`__.
 
-How to resolve "undefined reference to ``flashinit`'" error ?
+How to resolve "undefined reference to ``flashinit``" error ?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Please read `flash layout <../filesystem.rst>`__ documentation entry.


### PR DESCRIPTION
* `doc/faq/a06-global-build-options.rst: WARNING: document isn't included in any toctree`
ref. https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html#special-metadata-fields
same as other a#-... .rst pages
* `doc/faq/readme.rst:190: WARNING: Inline literal start-string without end-string.`
 just a typo