### PR TITLE
Fix WiFiClientSecure remoteIP(), remotePort(), localIP(), localPort() functions

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClient.h
+++ b/libraries/ESP8266WiFi/src/WiFiClient.h
@@ -91,10 +91,10 @@ public:
   virtual uint8_t connected() override;
   virtual operator bool() override;
 
-  IPAddress remoteIP();
-  uint16_t  remotePort();
-  IPAddress localIP();
-  uint16_t  localPort();
+  virtual IPAddress remoteIP();
+  virtual uint16_t  remotePort();
+  virtual IPAddress localIP();
+  virtual uint16_t  localPort();
 
   static void setLocalPortStart(uint16_t port) { _localPort = port; }
 

--- a/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
+++ b/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.h
@@ -278,6 +278,11 @@ class WiFiClientSecure : public WiFiClient {
     void flush() override { (void)flush(0); }
     void stop() override { (void)stop(0); }
 
+    IPAddress remoteIP() override { return _ctx->remoteIP(); }
+    uint16_t  remotePort() override { return _ctx->remotePort(); }
+    IPAddress localIP() override { return _ctx->localIP(); }
+    uint16_t  localPort() override { return _ctx->localPort(); }
+
     // Allow sessions to be saved/restored automatically to a memory area
     void setSession(Session *session) { _ctx->setSession(session); }
 


### PR DESCRIPTION
Fixes the https://github.com/esp8266/Arduino/issues/8692

Fixes the incorrect behavior of WiFiClientSecure.remoteIP(), .remotePort(), .localIP(), .localPort().