### PR TITLE
Only check the actual used lenght of the hash.

### DIFF
--- a/libraries/ESP8266WiFi/src/BearSSLHelpers.cpp
+++ b/libraries/ESP8266WiFi/src/BearSSLHelpers.cpp
@@ -945,7 +945,7 @@ extern "C" bool SigningVerifier_verify(PublicKey *_pubKey, UpdaterHashClass *has
     }
     br_rsa_pkcs1_vrfy vrfy = br_rsa_pkcs1_vrfy_get_default();
     bool ret = vrfy((const unsigned char *)signature, signatureLen, hash->oid(), hash->len(), _pubKey->getRSA(), vrf);
-    if (!ret || memcmp(vrf, hash->hash(), sizeof(vrf)) ) {
+    if (!ret || memcmp(vrf, hash->hash(), std::min(HashLengthMax, hash->len())) ) {
       return false;
     } else {
       return true;


### PR DESCRIPTION
This fixes the error in #8707 but needs a professional review, since I am no C programmer.

The signature check fails, if the `hash->len()` is only 32 bytes instead of the assumed 64 bytes.
Since the variable `HashLengthMax` has a max in its name, I assume that it is allowed to have shorter hash lengths.
I assume that `memcmp` did an buffer over read here and read stuff after the 32 bytes of hash. But that's my narrow understanding of the internals of C as a non-C developer.