### PR TITLE
Fix attach servo with initial value

### DIFF
--- a/libraries/Servo/src/Servo.cpp
+++ b/libraries/Servo/src/Servo.cpp
@@ -81,7 +81,7 @@ uint8_t Servo::attach(int pin, uint16_t minUs, uint16_t maxUs)
 
 uint8_t Servo::attach(int pin, uint16_t minUs, uint16_t maxUs, int value)
 {
-  attach(pin, minUs, maxUs, _valueUs);
+  attach(pin, minUs, maxUs);
   write(value);
   return pin;
 }

--- a/libraries/Servo/src/Servo.cpp
+++ b/libraries/Servo/src/Servo.cpp
@@ -63,11 +63,6 @@ uint8_t Servo::attach(int pin)
 
 uint8_t Servo::attach(int pin, uint16_t minUs, uint16_t maxUs)
 {
-  return attach(pin, minUs, maxUs, _valueUs);
-}
-
-uint8_t Servo::attach(int pin, uint16_t minUs, uint16_t maxUs, int value)
-{
   if (!_attached) {
     pinMode(pin, OUTPUT);
     digitalWrite(pin, LOW);
@@ -81,8 +76,13 @@ uint8_t Servo::attach(int pin, uint16_t minUs, uint16_t maxUs, int value)
   _maxUs = max((uint16_t)250, min((uint16_t)3000, maxUs));
   _minUs = max((uint16_t)200, min(_maxUs, minUs));
 
-  write(value);
+  return pin;
+}
 
+uint8_t Servo::attach(int pin, uint16_t minUs, uint16_t maxUs, int value)
+{
+  attach(pin, minUs, maxUs, _valueUs);
+  write(value);
   return pin;
 }
 


### PR DESCRIPTION
functions
```
uint8_t attach(int pin);
uint8_t attach(int pin, uint16_t min, uint16_t max);
```
always sets 0 (zero) as the initial value. This is not obvious. It does not allow to attach servo without movement.

I changed the body of functions, so that the movement was caused only when transmitting the value to the function.
`uint8_t attach(int pin, uint16_t min, uint16_t max, int value);`