### PR TITLE
Fix typo in section list

### DIFF
--- a/tools/sdk/ld/eagle.app.v6.common.ld.h
+++ b/tools/sdk/ld/eagle.app.v6.common.ld.h
@@ -138,7 +138,7 @@ SECTIONS
 
     *(.text.app_entry*)  /* The main startup code */
 
-    *(.text.gdbstub*, .text.gdb_init)    /* Any GDB hooks */
+    *(.text.gdbstub* .text.gdb_init)    /* Any GDB hooks */
 
     /* all functional callers are placed in IRAM (including SPI/IRQ callbacks/etc) here */
     *(.text._ZNKSt8functionIF*EE*)  /* std::function<any(...)>::operator()() const */
@@ -155,9 +155,9 @@ SECTIONS
     LONG(0x00000000);
 
     *(.ver_number)
-    *.c.o(.literal*, .text*)
-    *.cpp.o(EXCLUDE_FILE (umm_malloc.cpp.o) .literal*, EXCLUDE_FILE (umm_malloc.cpp.o) .text*)
-    *.cc.o(.literal*, .text*)
+    *.c.o(.literal* .text*)
+    *.cpp.o(EXCLUDE_FILE (umm_malloc.cpp.o) .literal* EXCLUDE_FILE (umm_malloc.cpp.o) .text*)
+    *.cc.o(.literal* .text*)
 #ifdef VTABLES_IN_FLASH
     *(.rodata._ZTV*) /* C++ vtables */
 #endif
@@ -220,7 +220,7 @@ SECTIONS
     *(.rodata._ZZ*__func__)
 
     /* std::* exception strings, in their own section to allow string coalescing */
-    *(.irom.exceptiontext, .rodata.exceptiontext)
+    *(.irom.exceptiontext .rodata.exceptiontext)
     *(.rodata.*__exception_what__*) /* G++ seems to throw out templatized section attributes */
 
     /* c++ typeof IDs, etc. */


### PR DESCRIPTION
For GCC LD scripts, using commas in a section expression sometimes cause problems.

With this change,  `.text.gdbstub*` moved from IROM to IRAM where it was intended to be. 
@earlephilhower please correct me or confirm. Thanks!

Resolves issue #8716

I could not find an explanation of how a "," was to be interpreted. It looks like a simple `*(.somthing*, .something2*)` worked; however, a more complex `*(.text.something*, .text.something2*)` did not - _most of the time_.

I don't have much experience with LD scripts. Anyone with more insight please help.