### PR TITLE
API in WiFiClient to save heap memory

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -313,6 +313,15 @@ bool WiFiClient::flush(unsigned int maxWaitMs)
     return _client->wait_until_acked(maxWaitMs);
 }
 
+// Api for heap saving. Must be call just before WiFiClient::stop().
+void WiFiClient::abortTimeWait() 
+{
+    if (!_client) return;
+    tcp_pcb* p;
+    p = _client->getPCB();
+    if (p) tcp_abort(p);
+}
+
 bool WiFiClient::stop(unsigned int maxWaitMs)
 {
     if (!_client)

--- a/libraries/ESP8266WiFi/src/WiFiClient.h
+++ b/libraries/ESP8266WiFi/src/WiFiClient.h
@@ -103,6 +103,17 @@ public:
   friend class WiFiServer;
 
   using Print::write;
+  
+  // Api for saving precious heap.
+  // When Client class is used by a Server: Client = Server.available(), sockets in TIME_WAIT remain after
+  // issuing Client.stop by the Server application.
+  // This reduce drastically the heap memory in case of multiple client connections to the server ending
+  // with a Server shutdown and an ESP8266 reboot after some hours because of insufficient heap memory.
+  // This API is provided to free heap memory by mean of closing sockets just before issuing a Client.stop
+  // by the Server.
+  // The Server must use this API just before calling Client.stop
+  // Note: none of the proposed methode e.g. tcpCleanup and tcp_kill_timewait works properly.
+  void abortTimeWait(); 
 
   static void stopAll();
   static void stopAllExcept(WiFiClient * c);


### PR DESCRIPTION
When used by a server, heap memory decrease drastically after numerous client acces (Client=Server.available()) because sockets in TIME_WAIT remains too much time after issuing Client.stop by the server in comparison with the ESP8266 memory capacity.
These TIME_WAIT sockets causes a server crash (and random reboot) after some hours or sometimes some minutes running due to lack of available heap memory.
Note that the proposed method tcpCleanup in #1923 does not work because the instruction "extern struct tcp_pcb* tcp_tw_pcbs;" does NOT initialise tcp_tw_pcbs to the one used by the Client. It is only a declaration and because it is only a declaration, tcp_tw_pcbs is set to NULL. Consecuently tcp_abort(tcp_tw_pcbs) is never called.
The proposed request creates an API for an effective call to tcp_abort.
It has to be called before issuing an Client.stop().
With this method heap memory's server does not decrease even in case of frequent clients access an will run hours and days without crashing.
Using this API is of course optional.