### PR TITLE
Add setClientTimeout() to ESP8266HTTPUpdate

### DIFF
--- a/libraries/ESP8266httpUpdate/examples/httpUpdate/httpUpdate.ino
+++ b/libraries/ESP8266httpUpdate/examples/httpUpdate/httpUpdate.ino
@@ -23,17 +23,11 @@ ESP8266WiFiMulti WiFiMulti;
 void setup() {
 
   Serial.begin(115200);
-  // Serial.setDebugOutput(true);
+  // Serial.setDebugOutput(false);
 
   Serial.println();
-  Serial.println();
-  Serial.println();
 
-  for (uint8_t t = 4; t > 0; t--) {
-    Serial.printf("[SETUP] WAIT %d...\n", t);
-    Serial.flush();
-    delay(1000);
-  }
+  ESPhttpUpdate.setClientTimeout(2000);           // default was 8000
 
   WiFi.mode(WIFI_STA);
   WiFiMulti.addAP(APSSID, APPSK);

--- a/libraries/ESP8266httpUpdate/examples/httpUpdate/httpUpdate.ino
+++ b/libraries/ESP8266httpUpdate/examples/httpUpdate/httpUpdate.ino
@@ -27,7 +27,7 @@ void setup() {
 
   Serial.println();
 
-  ESPhttpUpdate.setClientTimeout(2000);           // default was 8000
+  ESPhttpUpdate.setClientTimeout(2000);  // default was 8000
 
   WiFi.mode(WIFI_STA);
   WiFiMulti.addAP(APSSID, APPSK);

--- a/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.cpp
+++ b/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.cpp
@@ -61,6 +61,15 @@ void ESP8266HTTPUpdate::setAuthorization(const String &auth)
     _auth = auth;
 }
 
+/**
+ * set the Timeout for the http request
+ * @param httpClientTimeout const int& millis
+ */
+void ESP8266HTTPUpdate::setClientTimeout(const int &httpClientTimeout)
+{
+    _httpClientTimeout = httpClientTimeout;
+}
+
 HTTPUpdateResult ESP8266HTTPUpdate::update(WiFiClient& client, const String& url, const String& currentVersion)
 {
     HTTPClient http;

--- a/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.cpp
+++ b/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.cpp
@@ -61,15 +61,6 @@ void ESP8266HTTPUpdate::setAuthorization(const String &auth)
     _auth = auth;
 }
 
-/**
- * set the Timeout for the http request
- * @param httpClientTimeout const int& millis
- */
-void ESP8266HTTPUpdate::setClientTimeout(const int &httpClientTimeout)
-{
-    _httpClientTimeout = httpClientTimeout;
-}
-
 HTTPUpdateResult ESP8266HTTPUpdate::update(WiFiClient& client, const String& url, const String& currentVersion)
 {
     HTTPClient http;

--- a/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.h
+++ b/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.h
@@ -130,8 +130,9 @@ public:
     int getLastError(void);
     String getLastErrorString(void);
 
-    void setClientTimeout(const int &);
-
+    void setClientTimeout(int timeout) {
+        _httpClientTimeout = timeout;
+    }
 protected:
     t_httpUpdate_return handleUpdate(HTTPClient& http, const String& currentVersion, bool spiffs = false);
     bool runUpdate(Stream& in, uint32_t size, const String& md5, int command = U_FLASH);

--- a/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.h
+++ b/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.h
@@ -130,6 +130,8 @@ public:
     int getLastError(void);
     String getLastErrorString(void);
 
+    void setClientTimeout(const int &);
+
 protected:
     t_httpUpdate_return handleUpdate(HTTPClient& http, const String& currentVersion, bool spiffs = false);
     bool runUpdate(Stream& in, uint32_t size, const String& md5, int command = U_FLASH);


### PR DESCRIPTION
Shortening up the default hard-coded 8000 ms timeout, will save energy when module can't reach its update server, especially on battery powered projects, and otherwise provide adaptability to the local wlan. The ESPhttpUpdate object is auto-created by #including ESP8266HTTPUpdate. ESP8266HTTPUpdate also provides a constructor with param httpClientTimeout, but to use it required destroying the auto ESPhttpUpdate object, or creating a secondESPhttpUpdate(timeout) object.