### PR TITLE
Fix File::readString to work with binary data

### DIFF
--- a/cores/esp8266/FS.cpp
+++ b/cores/esp8266/FS.cpp
@@ -173,18 +173,15 @@ File File::openNextFile() {
     return _fakeDir->openFile("r");
 }
 
-String File::readString()
-{
+String File::readString() {
     String ret;
     ret.reserve(size() - position());
-    char temp[256+1];
-    int countRead = readBytes(temp, sizeof(temp)-1);
-    while (countRead > 0)
-    {
-        temp[countRead] = 0;
-        ret += temp;
-        countRead = readBytes(temp, sizeof(temp)-1);
-    }
+    uint8_t temp[256];
+    int countRead;
+    do {
+        countRead = read(temp, sizeof(temp));
+        ret.concat((const char*)temp, countRead);
+    } while (countRead > 0);
     return ret;
 }
 


### PR DESCRIPTION
Previously, File::readString used a C-style string as an intermediate buffer via the String += operator. This treats a NUL byte as a terminator, making this function work incorrectly if the File contains binary data.

This commit switches the function to use String::concat, which doesn't treat NUL bytes any differently (and is a bit faster, because it doesn't need to use strlen).