### PR TITLE
add DEBUG payload output

### DIFF
--- a/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.cpp
+++ b/libraries/ESP8266httpUpdate/src/ESP8266httpUpdate.cpp
@@ -208,6 +208,9 @@ HTTPUpdateResult ESP8266HTTPUpdate::handleUpdate(HTTPClient& http, const String&
     DEBUG_HTTP_UPDATE("[httpUpdate] Server header:\n");
     DEBUG_HTTP_UPDATE("[httpUpdate]  - code: %d\n", code);
     DEBUG_HTTP_UPDATE("[httpUpdate]  - len: %d\n", len);
+    if(code != HTTP_CODE_OK) {
+        DEBUG_HTTP_UPDATE("[httpUpdate]  - payload: %s\n", http.getString().c_str());
+    }
 
     String md5;
     if (_md5Sum.length()) {


### PR DESCRIPTION
While my first implementation of an HTTP server update it was useful to see the output of the [PHP script](https://arduino-esp8266.readthedocs.io/en/latest/ota_updates/readme.html#id5) to see what went wrong. 