### PR TITLE
Correct class name in readme.rst

### DIFF
--- a/doc/ota_updates/readme.rst
+++ b/doc/ota_updates/readme.rst
@@ -501,7 +501,7 @@ In case OTA update fails dead after entering modifications in your sketch, you c
 HTTP Server
 -----------
 
-``ESPhttpUpdate`` class can check for updates and download a binary file from HTTP web server. It is possible to download updates from every IP or domain address on the network or Internet.
+``ESP8266HTTPUpdate`` class can check for updates and download a binary file from HTTP web server. It is possible to download updates from every IP or domain address on the network or Internet.
 
 Note that by default this class closes all other connections except the one used by the update, this is because the update method blocks. This means that if there's another application receiving data then TCP packets will build up in the buffer leading to out of memory errors causing the OTA update to fail. There's also a limited number of receive buffers available and all may be used up by other applications.
 


### PR DESCRIPTION
Text referred to an object name ESPHTTPUpdate, but context called for class name ESP8266HTTPUpdate