### PR TITLE
Servo: re-attach to same value (position)

### DIFF
--- a/libraries/Servo/src/Servo.cpp
+++ b/libraries/Servo/src/Servo.cpp
@@ -58,7 +58,7 @@ Servo::~Servo() {
 
 uint8_t Servo::attach(int pin)
 {
-  return attach(pin, DEFAULT_MIN_PULSE_WIDTH, DEFAULT_MAX_PULSE_WIDTH);
+  return attach(pin, _minUs, _maxUs);
 }
 
 uint8_t Servo::attach(int pin, uint16_t minUs, uint16_t maxUs)
@@ -94,7 +94,6 @@ void Servo::detach()
     delay(REFRESH_INTERVAL / 1000); // long enough to complete active period under all circumstances.
     stopWaveform(_pin);
     _attached = false;
-    _valueUs = DEFAULT_NEUTRAL_PULSE_WIDTH;
   }
 }
 

--- a/libraries/Servo/src/Servo.h
+++ b/libraries/Servo/src/Servo.h
@@ -29,7 +29,8 @@
 //
 //   attach(pin)  - Attaches a servo motor to an i/o pin.
 //   attach(pin, min, max) - Attaches to a pin setting min and max values in microseconds
-//   default min is 1000, max is 2000
+//   attach(pin, min, max, value) - Attaches to a pin setting min, max, and current values in microseconds
+//   default min is 1000, max is 2000, and value is 1500.
 //
 //   write()     - Sets the servo angle in degrees.  (invalid angle that is valid as pulse in microseconds is treated as microseconds)
 //   writeMicroseconds() - Sets the servo pulse width in microseconds


### PR DESCRIPTION
The current implementation of the Servo lib always resets the position when `detaching`.
In AVR Servo, this isn't the case, instead, it doesn't move the servo but leaves it as it was before getting detached.
Fixes #8752.
Should obviate #8723