### PR TITLE
Add eraseap option to WiFi disconnect method.

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
@@ -357,7 +357,7 @@ bool ESP8266WiFiSTAClass::reconnect() {
  * @param wifioff
  * @return  one value of wl_status_t enum
  */
-bool ESP8266WiFiSTAClass::disconnect(bool wifioff, bool eraseap) {
+bool ESP8266WiFiSTAClass::disconnect(bool wifioff) {
 {
     return disconnect(wifioff, false);
 }

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
@@ -353,28 +353,29 @@ bool ESP8266WiFiSTAClass::reconnect() {
 }
 
 /**
- * Disconnect from the network
- * @param wifioff
+ * Disconnect from the network with clearing saved credentials
+ * @param wifioff Bool indicating whether STA should be disabled.
  * @return  one value of wl_status_t enum
  */
 bool ESP8266WiFiSTAClass::disconnect(bool wifioff) {
-    return disconnect(wifioff, false);
+    // Disconnect with clearing saved credentials.
+    return disconnect(wifioff, true);
 }
 
 /**
  * Disconnect from the network
- * @param wifioff
- * @param eraseap
+ * @param wifioff Bool indicating whether STA should be disabled. 
+ * @param eraseCredentials Bool indicating whether saved credentials should be erased.
  * @return  one value of wl_status_t enum
  */
-bool ESP8266WiFiSTAClass::disconnect(bool wifioff, bool eraseap) {
+bool ESP8266WiFiSTAClass::disconnect(bool wifioff, bool eraseCredentials) {
     bool ret = false;
 
     // Read current config.
     struct station_config conf;
     wifi_station_get_config(&conf);
 
-    if (eraseap) {
+    if (eraseCredentials) {
         memset(&conf.ssid, 0, sizeof(conf.ssid));
         memset(&conf.password, 0, sizeof(conf.password));
     }

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
@@ -357,11 +357,17 @@ bool ESP8266WiFiSTAClass::reconnect() {
  * @param wifioff
  * @return  one value of wl_status_t enum
  */
-bool ESP8266WiFiSTAClass::disconnect(bool wifioff) {
+bool ESP8266WiFiSTAClass::disconnect(bool wifioff, bool eraseap) {
     bool ret = false;
+
+    // Read current config.
     struct station_config conf;
-    *conf.ssid = 0;
-    *conf.password = 0;
+    wifi_station_get_config(&conf);
+
+    if (eraseap) {
+        memset(&conf.ssid, 0, sizeof(conf.ssid));
+        memset(&conf.password, 0, sizeof(conf.password));
+    };
 
     // API Reference: wifi_station_disconnect() need to be called after system initializes and the ESP8266 Station mode is enabled.
     if (WiFi.getMode() & WIFI_STA)

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
@@ -358,7 +358,6 @@ bool ESP8266WiFiSTAClass::reconnect() {
  * @return  one value of wl_status_t enum
  */
 bool ESP8266WiFiSTAClass::disconnect(bool wifioff) {
-{
     return disconnect(wifioff, false);
 }
 

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
@@ -358,6 +358,17 @@ bool ESP8266WiFiSTAClass::reconnect() {
  * @return  one value of wl_status_t enum
  */
 bool ESP8266WiFiSTAClass::disconnect(bool wifioff, bool eraseap) {
+{
+    return disconnect(wifioff, false);
+}
+
+/**
+ * Disconnect from the network
+ * @param wifioff
+ * @param eraseap
+ * @return  one value of wl_status_t enum
+ */
+bool ESP8266WiFiSTAClass::disconnect(bool wifioff, bool eraseap) {
     bool ret = false;
 
     // Read current config.

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
@@ -378,7 +378,7 @@ bool ESP8266WiFiSTAClass::disconnect(bool wifioff, bool eraseap) {
     if (eraseap) {
         memset(&conf.ssid, 0, sizeof(conf.ssid));
         memset(&conf.password, 0, sizeof(conf.password));
-    };
+    }
 
     // API Reference: wifi_station_disconnect() need to be called after system initializes and the ESP8266 Station mode is enabled.
     if (WiFi.getMode() & WIFI_STA)

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
@@ -50,7 +50,7 @@ class ESP8266WiFiSTAClass: public LwipIntf {
         bool reconnect();
 
         bool disconnect(bool wifioff = false);
-        bool disconnect(bool wifioff = false, bool eraseap = false);
+        bool disconnect(bool wifioff, bool eraseap);
 
         bool isConnected();
 

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
@@ -48,7 +48,7 @@ class ESP8266WiFiSTAClass: public LwipIntf {
         bool config(IPAddress local_ip, IPAddress gateway, IPAddress subnet, IPAddress dns1 = (uint32_t)0x00000000, IPAddress dns2 = (uint32_t)0x00000000);
 
         bool reconnect();
-        bool disconnect(bool wifioff = false);
+        bool disconnect(bool wifioff = false, bool eraseap = false);
 
         bool isConnected();
 

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
@@ -50,7 +50,7 @@ class ESP8266WiFiSTAClass: public LwipIntf {
         bool reconnect();
 
         bool disconnect(bool wifioff = false);
-        bool disconnect(bool wifioff, bool eraseap);
+        bool disconnect(bool wifioff, bool eraseCredentials);
 
         bool isConnected();
 

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
@@ -48,6 +48,8 @@ class ESP8266WiFiSTAClass: public LwipIntf {
         bool config(IPAddress local_ip, IPAddress gateway, IPAddress subnet, IPAddress dns1 = (uint32_t)0x00000000, IPAddress dns2 = (uint32_t)0x00000000);
 
         bool reconnect();
+
+        bool disconnect(bool wifioff = false);
         bool disconnect(bool wifioff = false, bool eraseap = false);
 
         bool isConnected();


### PR DESCRIPTION
The problem is that WiFi.disconnect function always set SSID and Password to NULL. On ESP32's version of Arduino, user can define if the config should be ever touched or not. When manually implementing reconnection, current state requires to store credentials externally between disconnect and connect method calls.

This PR aims to fix this problem by introducing second variable (eraseap), which defaults to false to maintain compatibility.