### PR TITLE
PHY status API for ethernet drivers

### DIFF
--- a/cores/esp8266/LwipIntfDev.h
+++ b/cores/esp8266/LwipIntfDev.h
@@ -46,6 +46,13 @@
 #define DEFAULT_MTU 1500
 #endif
 
+enum EthernetLinkStatus
+{
+    Unknown,
+    LinkON,
+    LinkOFF
+};
+
 template<class RawDev>
 class LwipIntfDev: public LwipIntf, public RawDev
 {
@@ -105,6 +112,9 @@ public:
 
     // ESP8266WiFi API compatibility
     wl_status_t status();
+
+    // Arduino Ethernet compatibility
+    EthernetLinkStatus linkStatus();
 
 protected:
     err_t netif_init();
@@ -280,6 +290,12 @@ template<class RawDev>
 wl_status_t LwipIntfDev<RawDev>::status()
 {
     return _started ? (connected() ? WL_CONNECTED : WL_DISCONNECTED) : WL_NO_SHIELD;
+}
+
+template<class RawDev>
+EthernetLinkStatus LwipIntfDev<RawDev>::linkStatus()
+{
+    return RawDev::isLinkDetectable() ? _started && RawDev::isLinked() ? LinkON : LinkOFF : Unknown;
 }
 
 template<class RawDev>

--- a/cores/esp8266/LwipIntfDev.h
+++ b/cores/esp8266/LwipIntfDev.h
@@ -100,9 +100,11 @@ public:
     void setDefault(bool deflt = true);
 
     // true if interface has a valid IPv4 address
+    // (and ethernet link status is not detectable or is up)
     bool connected()
     {
-        return !!ip4_addr_get_u32(ip_2_ip4(&_netif.ip_addr));
+        return !!ip4_addr_get_u32(ip_2_ip4(&_netif.ip_addr))
+               && (!RawDev::isLinkDetectable() || RawDev::isLinked());
     }
 
     bool routable()

--- a/libraries/lwIP_Ethernet/examples/EthClient/EthClient.ino
+++ b/libraries/lwIP_Ethernet/examples/EthClient/EthClient.ino
@@ -52,6 +52,8 @@ void loop() {
   Serial.print(':');
   Serial.println(port);
 
+  Serial.printf("Link sense: %d (detectable: %d)\n", eth.isLinked(), eth.isLinkDetectable());
+
   // Use WiFiClient class to create TCP connections
   // (this class could have been named TCPClient)
   WiFiClient client;

--- a/libraries/lwIP_Ethernet/src/EthernetCompat.h
+++ b/libraries/lwIP_Ethernet/src/EthernetCompat.h
@@ -10,13 +10,6 @@ using EthernetUDP    = WiFiUDP;
 using EthernetClient = WiFiClient;
 using EthernetServer = ArduinoWiFiServer;
 
-enum EthernetLinkStatus
-{
-    Unknown,
-    LinkON,
-    LinkOFF
-};
-
 enum
 {
     DHCP_CHECK_NONE        = 0,
@@ -40,7 +33,6 @@ public:
         LwipIntfDev<RawDev>(cs, spi, intr)
     {
         _hardwareStatus = EthernetNoHardware;
-        _linkStatus     = Unknown;
     }
 
     // Arduino-Ethernet API compatibility, order can be either:
@@ -70,7 +62,6 @@ public:
         if (ret)
         {
             _hardwareStatus = EthernetHardwareFound;
-            _linkStatus     = LinkON;
         }
 
         return ret;
@@ -81,19 +72,13 @@ public:
         return _hardwareStatus;
     }
 
-    EthernetLinkStatus linkStatus() const
-    {
-        return _linkStatus;
-    }
-
     int maintain() const
     {
         return DHCP_CHECK_NONE;
     }
 
 protected:
-    HardwareStatus     _hardwareStatus;
-    EthernetLinkStatus _linkStatus;
+    HardwareStatus _hardwareStatus;
 };
 
 using ArduinoWiznet5500lwIP = ArduinoEthernet<Wiznet5500>;

--- a/libraries/lwIP_enc28j60/src/utility/enc28j60.cpp
+++ b/libraries/lwIP_enc28j60/src/utility/enc28j60.cpp
@@ -743,7 +743,8 @@ uint16_t ENC28J60::phyread(uint8_t reg)
     writereg(MIREGADR, reg);
     writereg(MICMD, MICMD_MIIRD);
     // wait until the PHY read completes
-    while(readreg(MISTAT) & MISTAT_BUSY) {
+    while (readreg(MISTAT) & MISTAT_BUSY)
+    {
         delayMicroseconds(15);
     }
     writereg(MICMD, 0);

--- a/libraries/lwIP_enc28j60/src/utility/enc28j60.cpp
+++ b/libraries/lwIP_enc28j60/src/utility/enc28j60.cpp
@@ -106,6 +106,7 @@ void serial_printf(const char* fmt, ...)
 #define MACONX_BANK 0x02
 
 #define MACON1 0x00
+#define MACSTAT1 0x01
 #define MACON3 0x02
 #define MACON4 0x03
 #define MABBIPG 0x04
@@ -113,6 +114,16 @@ void serial_printf(const char* fmt, ...)
 #define MAIPGH 0x07
 #define MAMXFLL 0x0a
 #define MAMXFLH 0x0b
+#define MACON2 0x10
+#define MACSTAT2 0x11
+#define MICMD 0x12
+#define MIREGADR 0x14
+#define MIRDL 0x18
+#define MIRDH 0x19
+
+/* MICMD Register Bit Definitions */
+#define MICMD_MIISCAN 0x02
+#define MICMD_MIIRD 0x01
 
 #define MACON1_TXPAUS 0x08
 #define MACON1_RXPAUS 0x04
@@ -134,6 +145,9 @@ void serial_printf(const char* fmt, ...)
 #define MAADR6 0x01 /* MAADR<7:0> */
 #define MISTAT 0x0a
 #define EREVID 0x12
+
+/* MISTAT Register Bit Definitions */
+#define MISTAT_BUSY 0x01
 
 #define EPKTCNT_BANK 0x01
 #define ERXFCON 0x18
@@ -719,4 +733,26 @@ uint16_t ENC28J60::readFrameData(uint8_t* buffer, uint16_t framesize)
     // PRINTF("enc28j60: received_packets %d\n", received_packets);
 
     return _len;
+}
+
+uint16_t ENC28J60::phyread(uint8_t reg)
+{
+    // ( https://github.com/JAndrassy/EthernetENC/tree/master/src/utility/enc28j60.h )
+
+    setregbank(MACONX_BANK);
+    writereg(MIREGADR, reg);
+    writereg(MICMD, MICMD_MIIRD);
+    // wait until the PHY read completes
+    while(readreg(MISTAT) & MISTAT_BUSY) {
+        delayMicroseconds(15);
+    }
+    writereg(MICMD, 0);
+    return (readreg(MIRDL) | readreg(MIRDH) << 8);
+}
+
+bool ENC28J60::isLinked()
+{
+    // ( https://github.com/JAndrassy/EthernetENC/tree/master/src/utility/enc28j60.h )
+
+    return !!(phyread(MACSTAT2) & 0x400);
 }

--- a/libraries/lwIP_enc28j60/src/utility/enc28j60.h
+++ b/libraries/lwIP_enc28j60/src/utility/enc28j60.h
@@ -79,6 +79,25 @@ public:
     */
     virtual uint16_t readFrame(uint8_t* buffer, uint16_t bufsize);
 
+    /**
+        Check physical link
+        @return true when physical link is up
+    */
+    bool isLinked () const
+    {
+        return true; //XXX TODO
+    }
+
+    /**
+        Report whether ::isLinked() API is implemented
+        @return true when ::isLinked() API is implemented
+    */
+    constexpr bool isLinkDetectable () const
+    {
+        return false;
+    }
+
+
 protected:
     static constexpr bool interruptIsPossible()
     {

--- a/libraries/lwIP_enc28j60/src/utility/enc28j60.h
+++ b/libraries/lwIP_enc28j60/src/utility/enc28j60.h
@@ -83,20 +83,19 @@ public:
         Check physical link
         @return true when physical link is up
     */
-    bool isLinked () const
+    bool isLinked() const
     {
-        return true; //XXX TODO
+        return true;  //XXX TODO
     }
 
     /**
         Report whether ::isLinked() API is implemented
         @return true when ::isLinked() API is implemented
     */
-    constexpr bool isLinkDetectable () const
+    constexpr bool isLinkDetectable() const
     {
         return false;
     }
-
 
 protected:
     static constexpr bool interruptIsPossible()

--- a/libraries/lwIP_enc28j60/src/utility/enc28j60.h
+++ b/libraries/lwIP_enc28j60/src/utility/enc28j60.h
@@ -83,10 +83,7 @@ public:
         Check physical link
         @return true when physical link is up
     */
-    bool isLinked() const
-    {
-        return true;  //XXX TODO
-    }
+    bool isLinked();
 
     /**
         Report whether ::isLinked() API is implemented
@@ -94,7 +91,7 @@ public:
     */
     constexpr bool isLinkDetectable() const
     {
-        return false;
+        return true;
     }
 
 protected:
@@ -150,6 +147,8 @@ private:
 
     // Previously defined in contiki/core/sys/clock.h
     void clock_delay_usec(uint16_t dt);
+
+    uint16_t phyread(uint8_t reg);
 
     uint8_t   _bank;
     int8_t    _cs;

--- a/libraries/lwIP_w5100/src/utility/w5100.h
+++ b/libraries/lwIP_w5100/src/utility/w5100.h
@@ -79,6 +79,24 @@ public:
     */
     uint16_t readFrame(uint8_t* buffer, uint16_t bufsize);
 
+    /**
+        Check physical link
+        @return true when physical link is up
+    */
+    bool isLinked () const
+    {
+        return true; //XXX TODO
+    }
+
+    /**
+        Report whether ::isLinked() API is implemented
+        @return true when ::isLinked() API is implemented
+    */
+    constexpr bool isLinkDetectable () const
+    {
+        return false;
+    }
+
 protected:
     static constexpr bool interruptIsPossible()
     {

--- a/libraries/lwIP_w5100/src/utility/w5100.h
+++ b/libraries/lwIP_w5100/src/utility/w5100.h
@@ -83,16 +83,16 @@ public:
         Check physical link
         @return true when physical link is up
     */
-    bool isLinked () const
+    bool isLinked() const
     {
-        return true; //XXX TODO
+        return true;  //XXX TODO
     }
 
     /**
         Report whether ::isLinked() API is implemented
         @return true when ::isLinked() API is implemented
     */
-    constexpr bool isLinkDetectable () const
+    constexpr bool isLinkDetectable() const
     {
         return false;
     }

--- a/libraries/lwIP_w5500/src/utility/w5500.h
+++ b/libraries/lwIP_w5500/src/utility/w5500.h
@@ -79,6 +79,24 @@ public:
     */
     uint16_t readFrame(uint8_t* buffer, uint16_t bufsize);
 
+    /**
+        Check physical link
+        @return true when physical link is up
+    */
+    bool isLinked ()
+    {
+        return wizphy_getphylink() == PHY_LINK_ON;
+    }
+
+    /**
+        Report whether ::isLinked() API is implemented
+        @return true when ::isLinked() API is implemented
+    */
+    constexpr bool isLinkDetectable () const
+    {
+        return true;
+    }
+
 protected:
     static constexpr bool interruptIsPossible()
     {

--- a/libraries/lwIP_w5500/src/utility/w5500.h
+++ b/libraries/lwIP_w5500/src/utility/w5500.h
@@ -83,7 +83,7 @@ public:
         Check physical link
         @return true when physical link is up
     */
-    bool isLinked ()
+    bool isLinked()
     {
         return wizphy_getphylink() == PHY_LINK_ON;
     }
@@ -92,7 +92,7 @@ public:
         Report whether ::isLinked() API is implemented
         @return true when ::isLinked() API is implemented
     */
-    constexpr bool isLinkDetectable () const
+    constexpr bool isLinkDetectable() const
     {
         return true;
     }


### PR DESCRIPTION
Implementation of `::isLinked()` for ethernet drivers:
This function returns true when the ethernet chip is physically connected.

(*edited*) It currently works and has been tested with W5500 and ENC28J60, and it seems it is not implementable with W5100.
An additional `::isLinkDetectable()` tells when `::isLinked()` is not trivially implemented.

(*edited*)`::connected()` ~is software only and is left unmodified for backward compatibility~ is updated to check link status to [solve compatibility with WiFi API](https://github.com/esp8266/Arduino/pull/6680#pullrequestreview-558672527).

Closes #8099