### PR TITLE
fix Stream's parseFloat()

### DIFF
--- a/cores/esp8266/Stream.cpp
+++ b/cores/esp8266/Stream.cpp
@@ -58,16 +58,16 @@ int Stream::timedPeek() {
 
 // returns peek of the next digit in the stream or -1 if timeout
 // discards non-numeric characters
-int Stream::peekNextDigit() {
+int Stream::peekNextDigit(bool detectDecimal) {
     int c;
     while(1) {
         c = timedPeek();
-        if(c < 0)
-            return c;  // timeout
-        if(c == '-')
+        if( c < 0 || // timeout
+            c == '-' ||
+            ( c >= '0' && c <= '9' ) ||
+            ( detectDecimal && c == '.' ) ) {
             return c;
-        if(c >= '0' && c <= '9')
-            return c;
+        }
         read();  // discard non-numeric
     }
 }
@@ -141,7 +141,7 @@ long Stream::parseInt(char skipChar) {
     long value = 0;
     int c;
 
-    c = peekNextDigit();
+    c = peekNextDigit(false);
     // ignore non numeric leading characters
     if(c < 0)
         return 0; // zero returned if timeout
@@ -176,7 +176,7 @@ float Stream::parseFloat(char skipChar) {
     int c;
     float fraction = 1.0f;
 
-    c = peekNextDigit();
+    c = peekNextDigit(true);
     // ignore non numeric leading characters
     if(c < 0)
         return 0; // zero returned if timeout

--- a/cores/esp8266/Stream.h
+++ b/cores/esp8266/Stream.h
@@ -53,7 +53,7 @@ class Stream: public Print {
         unsigned long _startMillis;  // used for timeout measurement
         int timedRead();    // private method to read stream with timeout
         int timedPeek();    // private method to peek stream with timeout
-        int peekNextDigit(); // returns the next numeric digit in the stream or -1 if timeout
+        int peekNextDigit(bool detectDecimal = false); // returns the next numeric digit in the stream or -1 if timeout
 
     public:
         virtual int available() = 0;


### PR DESCRIPTION
cherry-pick updates for `Stream::peekNextDigit()` from AVR implementation: decimal dot is optionally allowed

fixes #8782 