### PR TITLE
hostByName timeout fixes

### DIFF
--- a/cores/esp8266/IPAddress.cpp
+++ b/cores/esp8266/IPAddress.cpp
@@ -27,6 +27,11 @@ IPAddress::IPAddress(const IPAddress& from)
     ip_addr_copy(_ip, from._ip);
 }
 
+IPAddress::IPAddress(IPAddress&& from)
+{
+    ip_addr_copy(_ip, from._ip);
+}
+
 IPAddress::IPAddress() {
     _ip = *IP_ANY_TYPE; // lwIP's v4-or-v6 generic address
 }

--- a/cores/esp8266/IPAddress.h
+++ b/cores/esp8266/IPAddress.h
@@ -66,7 +66,9 @@ class IPAddress: public Printable {
     public:
         // Constructors
         IPAddress();
-        IPAddress(const IPAddress& from);
+        IPAddress(const IPAddress&);
+        IPAddress(IPAddress&&);
+
         IPAddress(uint8_t first_octet, uint8_t second_octet, uint8_t third_octet, uint8_t fourth_octet);
         IPAddress(uint32_t address) { ctor32(address); }
         IPAddress(unsigned long address) { ctor32(address); }

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -667,7 +667,10 @@ static int hostByNameImpl(const char* aHostname, IPAddress& aResult, uint32_t ti
     }
 
     DEBUG_WIFI_GENERIC("[hostByName] Host: %s lookup error: %s (%d)!\n",
-        aHostname, lwip_strerr(err), static_cast<int>(err));
+            aHostname,
+            (err == ERR_TIMEOUT) ? "Timeout" :
+            (err == ERR_INPROGRESS) ? "No response" :
+                "Unknown", static_cast<int>(err));
 
     return 0;
 }
@@ -702,9 +705,9 @@ int ESP8266WiFiGenericClass::hostByName(const char* aHostname, IPAddress& aResul
  * @param ipaddr
  * @param callback_arg
  */
-static void _dns_found_callback(const char *, const ip_addr_t *ipaddr, void *arg)
+static void _dns_found_callback(const char*, const ip_addr_t* ipaddr, void* arg)
 {
-    auto result = reinterpret_cast<_dns_found_result *>(arg);
+    auto result = reinterpret_cast<_dns_found_result*>(arg);
     if (result->done) {
         delete result;
         return;

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -642,10 +642,11 @@ static int hostByNameImpl(const char* aHostname, IPAddress& aResult, uint32_t ti
     // We need to wait for c/b to fire *or* we exit on our own timeout
     // (which also requires us to notify the c/b that it is supposed to delete the pending obj)
     case ERR_INPROGRESS:
+        // Re-check every 10ms, we expect this to happen fast
         esp_delay(timeout_ms,
             [&]() {
                 return !pending->done;
-            });
+            }, 10);
 
         if (pending->done) {
             if ((pending->addr).isSet()) {

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -653,8 +653,8 @@ static int hostByNameImpl(const char* aHostname, IPAddress& aResult, uint32_t ti
                 err = ERR_OK;
             }
         } else {
-            pending.release();
             pending->done = true;
+            pending.release();
             err = ERR_TIMEOUT;
         }
 

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.h
@@ -24,6 +24,10 @@
 #define ESP8266WIFIGENERIC_H_
 
 #include "ESP8266WiFiType.h"
+
+#include <IPAddress.h>
+#include <lwip/dns.h>
+
 #include <functional>
 #include <memory>
 
@@ -44,11 +48,14 @@ typedef void (*WiFiEventCb)(WiFiEvent_t);
 
 enum class DNSResolveType: uint8_t
 {
-    DNS_AddrType_IPv4 = 0,	// LWIP_DNS_ADDRTYPE_IPV4 = 0
-    DNS_AddrType_IPv6,		// LWIP_DNS_ADDRTYPE_IPV6 = 1
-    DNS_AddrType_IPv4_IPv6,	// LWIP_DNS_ADDRTYPE_IPV4_IPV6 = 2
-    DNS_AddrType_IPv6_IPv4	// LWIP_DNS_ADDRTYPE_IPV6_IPV4 = 3
+    DNS_AddrType_IPv4 = LWIP_DNS_ADDRTYPE_IPV4,
+    DNS_AddrType_IPv6 = LWIP_DNS_ADDRTYPE_IPV6,
+    DNS_AddrType_IPv4_IPv6 = LWIP_DNS_ADDRTYPE_IPV4_IPV6,
+    DNS_AddrType_IPv6_IPv4 = LWIP_DNS_ADDRTYPE_IPV6_IPV4,
 };
+
+inline constexpr auto DNSDefaultTimeoutMs = 10000;
+inline constexpr auto DNSResolveTypeDefault = static_cast<DNSResolveType>(LWIP_DNS_ADDRTYPE_DEFAULT);
 
 struct WiFiState;
 

--- a/tests/host/common/ClientContextTools.cpp
+++ b/tests/host/common/ClientContextTools.cpp
@@ -44,7 +44,7 @@ err_t dns_gethostbyname_addrtype(const char* hostname, ip_addr_t* addr, dns_foun
         return ERR_TIMEOUT;
 
     uint32_t tmp;
-    std::memcpy(&tmp, hbn->h_addr_list, sizeof(tmp));
+    std::memcpy(&tmp, hbn->h_addr_list[0], sizeof(tmp));
     addr->addr = tmp;
 
     return ERR_OK;

--- a/tests/host/common/ClientContextTools.cpp
+++ b/tests/host/common/ClientContextTools.cpp
@@ -37,16 +37,24 @@
 
 #include <netdb.h>  // gethostbyname
 
-err_t dns_gethostbyname(const char* hostname, ip_addr_t* addr, dns_found_callback found,
-                        void* callback_arg)
+err_t dns_gethostbyname_addrtype(const char* hostname, ip_addr_t* addr, dns_found_callback, void*, u8 type)
 {
-    (void)callback_arg;
-    (void)found;
-    struct hostent* hbn = gethostbyname(hostname);
+    auto* hbn = gethostbyname(hostname);
     if (!hbn)
         return ERR_TIMEOUT;
-    addr->addr = *(uint32_t*)hbn->h_addr_list[0];
+
+    uint32_t tmp;
+    std::memcpy(&tmp, hbn->h_addr_list, sizeof(tmp));
+    addr->addr = tmp;
+
     return ERR_OK;
+}
+
+err_t dns_gethostbyname_addrtype(const char* hostname, ip_addr_t* addr, dns_found_callback found,
+                        void* callback_arg)
+{
+    return dns_gethostbyname_addrtype(hostname, addr, found, callback_arg, LWIP_DNS_ADDRTYPE_DEFAULT);
+
 }
 
 static struct tcp_pcb mock_tcp_pcb;

--- a/tests/host/common/ClientContextTools.cpp
+++ b/tests/host/common/ClientContextTools.cpp
@@ -37,7 +37,8 @@
 
 #include <netdb.h>  // gethostbyname
 
-err_t dns_gethostbyname_addrtype(const char* hostname, ip_addr_t* addr, dns_found_callback, void*, u8 type)
+err_t dns_gethostbyname_addrtype(const char* hostname, ip_addr_t* addr, dns_found_callback, void*,
+                                 u8 type)
 {
     auto* hbn = gethostbyname(hostname);
     if (!hbn)
@@ -51,10 +52,10 @@ err_t dns_gethostbyname_addrtype(const char* hostname, ip_addr_t* addr, dns_foun
 }
 
 err_t dns_gethostbyname_addrtype(const char* hostname, ip_addr_t* addr, dns_found_callback found,
-                        void* callback_arg)
+                                 void* callback_arg)
 {
-    return dns_gethostbyname_addrtype(hostname, addr, found, callback_arg, LWIP_DNS_ADDRTYPE_DEFAULT);
-
+    return dns_gethostbyname_addrtype(hostname, addr, found, callback_arg,
+                                      LWIP_DNS_ADDRTYPE_DEFAULT);
 }
 
 static struct tcp_pcb mock_tcp_pcb;


### PR DESCRIPTION
Make a single hostByNameImpl() instead of two implementations
Do not share 'pending' flag between requests, allocate memory per invocation
Translate error message (no string in non-debug lwip) and add TIMEOUT when we exit esp_delay on timeout
Clean-up DNS type case switch and enum, it is already strong enough (and cast is undefined behaviour)

as noticed in #8780