### PR TITLE
Fix C builds

### DIFF
--- a/.github/workflows/build-ide.yml
+++ b/.github/workflows/build-ide.yml
@@ -11,6 +11,22 @@ permissions:
 jobs:
 
   # Examples are built in parallel to avoid CI total job time limitation
+  sanity-check:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: false
+    - uses: actions/cache@v3
+      with:
+        path: ./tools/dist
+        key: ${{ runner.os }}-${{ hashFiles('package/package_esp8266com_index.template.json', 'tests/common.sh', 'tests/build.sh') }}
+    - name: Toolchain sanity checks
+      run: |
+        bash ./tests/sanity_check.sh
 
   build-linux:
     name: Linux - LwIP ${{ matrix.lwip }} (${{ matrix.chunk }})

--- a/cores/esp8266/Esp.cpp
+++ b/cores/esp8266/Esp.cpp
@@ -471,7 +471,7 @@ bool EspClass::checkFlashCRC() {
     uint32_t firstPart = (uintptr_t)&__crc_len - 0x40200000; // How many bytes to check before the 1st CRC val
 
     // Start the checksum
-    uint32_t crc = crc32((const void*)0x40200000, firstPart, 0xffffffff);
+    uint32_t crc = crc32((const void*)0x40200000, firstPart);
     // Pretend the 2 words of crc/len are zero to be idempotent
     crc = crc32(z, 8, crc);
     // Finish the CRC calculation over the rest of flash

--- a/cores/esp8266/core_esp8266_eboot_command.cpp
+++ b/cores/esp8266/core_esp8266_eboot_command.cpp
@@ -29,7 +29,7 @@ extern "C" {
 
 static uint32_t eboot_command_calculate_crc32(const struct eboot_command* cmd)
 {
-    return crc32((const uint8_t*) cmd, offsetof(struct eboot_command, crc32));
+    return crc32((const uint8_t*) cmd, offsetof(struct eboot_command, crc32), 0xffffffff);
 }
 
 int eboot_command_read(struct eboot_command* cmd)

--- a/cores/esp8266/core_esp8266_eboot_command.cpp
+++ b/cores/esp8266/core_esp8266_eboot_command.cpp
@@ -29,7 +29,7 @@ extern "C" {
 
 static uint32_t eboot_command_calculate_crc32(const struct eboot_command* cmd)
 {
-    return crc32((const uint8_t*) cmd, offsetof(struct eboot_command, crc32), 0xffffffff);
+    return crc32((const uint8_t*) cmd, offsetof(struct eboot_command, crc32));
 }
 
 int eboot_command_read(struct eboot_command* cmd)

--- a/cores/esp8266/core_esp8266_features.h
+++ b/cores/esp8266/core_esp8266_features.h
@@ -31,7 +31,7 @@
 #define WIFI_HAS_EVENT_CALLBACK
 #define WIFI_IS_OFF_AT_BOOT
 
-//#include <stdbool.h> // bool
+#include <stdbool.h> // bool
 #include <stddef.h> // size_t
 #include <stdint.h>
 #include <stdlib.h> // malloc()

--- a/cores/esp8266/core_esp8266_features.h
+++ b/cores/esp8266/core_esp8266_features.h
@@ -20,10 +20,8 @@
 
  */
 
-
 #ifndef CORE_ESP8266_FEATURES_H
 #define CORE_ESP8266_FEATURES_H
-
 
 #define CORE_HAS_LIBB64
 #define CORE_HAS_BASE64_CLASS
@@ -130,7 +128,7 @@ void enablePhaseLockedWaveform(void);
 
 // Determine when the sketch runs on ESP8285
 #if !defined(CORE_MOCK)
-bool __attribute__((const, nothrow)) esp_is_8285();
+bool esp_is_8285() __attribute__((const, nothrow));
 #else
 inline bool esp_is_8285()
 {

--- a/cores/esp8266/core_esp8266_features.h
+++ b/cores/esp8266/core_esp8266_features.h
@@ -33,9 +33,10 @@
 #define WIFI_HAS_EVENT_CALLBACK
 #define WIFI_IS_OFF_AT_BOOT
 
-#include <stdlib.h> // malloc()
+#include <stdbool.h> // bool
 #include <stddef.h> // size_t
 #include <stdint.h>
+#include <stdlib.h> // malloc()
 
 #ifndef __STRINGIFY
 #define __STRINGIFY(a) #a

--- a/cores/esp8266/core_esp8266_features.h
+++ b/cores/esp8266/core_esp8266_features.h
@@ -31,7 +31,7 @@
 #define WIFI_HAS_EVENT_CALLBACK
 #define WIFI_IS_OFF_AT_BOOT
 
-#include <stdbool.h> // bool
+//#include <stdbool.h> // bool
 #include <stddef.h> // size_t
 #include <stdint.h>
 #include <stdlib.h> // malloc()
@@ -117,6 +117,7 @@ int esp_get_cpu_freq_mhz()
 #else
 inline int esp_get_cpu_freq_mhz()
 {
+    uint8_t system_get_cpu_freq(void);
     return system_get_cpu_freq();
 }
 #endif

--- a/cores/esp8266/coredecls.h
+++ b/cores/esp8266/coredecls.h
@@ -28,10 +28,11 @@ void __disableWiFiAtBootTime (void) __attribute__((noinline));
 void __real_system_restart_local() __attribute__((noreturn));
 
 uint32_t sqrt32(uint32_t n);
-uint32_t crc32(const void* data, size_t length, uint32_t crc);
 
 #ifdef __cplusplus
 }
+
+uint32_t crc32(const void* data, size_t length, uint32_t crc = 0xffffffff);
 
 #include <functional>
 

--- a/cores/esp8266/coredecls.h
+++ b/cores/esp8266/coredecls.h
@@ -20,14 +20,15 @@ void esp_delay(unsigned long ms);
 void esp_schedule();
 void esp_yield();
 void tune_timeshift64 (uint64_t now_us);
+bool sntp_set_timezone_in_seconds(int32_t timezone);
+
 void disable_extra4k_at_link_time (void) __attribute__((noinline));
 void enable_wifi_enterprise_patch(void) __attribute__((noinline));
-bool sntp_set_timezone_in_seconds(int32_t timezone);
 void __disableWiFiAtBootTime (void) __attribute__((noinline));
 void __real_system_restart_local() __attribute__((noreturn));
 
-uint32_t sqrt32 (uint32_t n);
-uint32_t crc32 (const void* data, size_t length, uint32_t crc = 0xffffffff);
+uint32_t sqrt32(uint32_t n);
+uint32_t crc32(const void* data, size_t length, uint32_t crc);
 
 #ifdef __cplusplus
 }

--- a/cores/esp8266/crc32.cpp
+++ b/cores/esp8266/crc32.cpp
@@ -23,7 +23,7 @@
 #include "pgmspace.h"
 
 // moved from core_esp8266_eboot_command.cpp
-uint32_t crc32 (const void* data, size_t length, uint32_t crc /*= 0xffffffff*/)
+uint32_t crc32 (const void* data, size_t length, uint32_t crc)
 {
     const uint8_t* ldata = (const uint8_t*)data;
     while (length--)

--- a/tests/sanity_check.sh
+++ b/tests/sanity_check.sh
@@ -36,3 +36,9 @@ cat << EOF > features.c
 EOF
 
 $gcc -c features.c
+
+cat << EOF > sdk.c
+#include <version.h>
+EOF
+
+$gcc -c sdk.c

--- a/tests/sanity_check.sh
+++ b/tests/sanity_check.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+root=$(git rev-parse --show-toplevel)
+source "$root/tests/common.sh"
+
+pushd "$root"/tools
+python3 get.py -q
+
+popd
+pushd "$cache_dir"
+
+gcc="$root/tools/xtensa-lx106-elf/bin/xtensa-lx106-elf-gcc"\
+" -I$root/cores/esp8266"\
+" -I$root/tools/sdk/include"\
+" -I$root/variants/generic"\
+" -I$root/tools/sdk/libc/xtensa-lx106-elf"
+
+$gcc --verbose
+
+set -v -x
+
+cat << EOF > arduino.c
+#include <Arduino.h>
+EOF
+
+$gcc -c arduino.c
+
+cat << EOF > coredecls.c
+#include <coredecls.h>
+EOF
+
+$gcc -c coredecls.c
+
+cat << EOF > features.c
+#include <core_esp8266_features.h>
+EOF
+
+$gcc -c features.c


### PR DESCRIPTION
Missing stdbool.h for 'bool' in features .h, at least one user is [arduinoWebSockets](https://github.com/Links2004/arduinoWebSockets/blob/323592f622e0ec8f9ce1f995c5777d9bbaaae1ec/src/libb64/cencode.c#L8-L10)

Also noticed and removed default argument from crc32() in internal .h that *may* be used in .c
(not sure how it worked at all, but at least in our .cpp Gcc somehow figured out it is a no overload solution)

fix #8794 