### PR TITLE
Pointer<->Int casts are not constexpr

### DIFF
--- a/cores/esp8266/esp_priv.h
+++ b/cores/esp8266/esp_priv.h
@@ -23,9 +23,8 @@
 
 #if defined(CORE_MOCK)
 
-constexpr bool __byteAddressable(const void* addr)
+constexpr bool __byteAddressable(const void*)
 {
-    (void)addr;
     return true;
 }
 
@@ -34,7 +33,7 @@ constexpr bool __byteAddressable(const void* addr)
 #include <sys/config.h>
 
 // returns true when addr can be used without "pgm_" functions or non32xfer service
-constexpr bool __byteAddressable(const void* addr)
+inline bool __byteAddressable(const void* addr)
 {
     return addr < (const void*)(XCHAL_DATARAM0_VADDR + XCHAL_DATARAM0_SIZE);
 }


### PR DESCRIPTION
Gcc is more lenient with this, Clang is not