### PR TITLE
delay / esp_delay: transparently manage recurrent scheduled functions

### DIFF
--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -155,6 +155,15 @@ void update_recurrent_grain ()
             // no recurrent function, set grain to max
             recurrent_max_grain_mS = std::numeric_limits<decltype(recurrent_max_grain_mS)>::max();
     }
+
+#if 1
+    static uint32_t last_grain = 0;
+    if (recurrent_max_grain_mS != last_grain)
+    {
+        ::printf("grain4rsf: %u -> %u\n", last_grain, recurrent_max_grain_mS);
+        last_grain = recurrent_max_grain_mS;
+    }
+#endif
 }
 
 void run_scheduled_functions()

--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -151,19 +151,16 @@ void update_recurrent_grain ()
                 // round to the upper millis
                 recurrent_max_grain_mS = recurrent_max_grain_uS <= 1000? 1: (recurrent_max_grain_uS + 999) / 1000;
         }
-        if (recurrent_max_grain_mS == 0)
-            // no recurrent function, set grain to max
-            recurrent_max_grain_mS = std::numeric_limits<decltype(recurrent_max_grain_mS)>::max();
-    }
 
-#if 1
-    static uint32_t last_grain = 0;
-    if (recurrent_max_grain_mS != last_grain)
-    {
-        ::printf("grain4rsf: %u -> %u\n", last_grain, recurrent_max_grain_mS);
-        last_grain = recurrent_max_grain_mS;
-    }
+#ifdef DEBUG_ESP_CORE
+        static uint32_t last_grain = 0;
+        if (recurrent_max_grain_mS != last_grain)
+        {
+            ::printf(":rsf %u->%u\n", last_grain, recurrent_max_grain_mS);
+            last_grain = recurrent_max_grain_mS;
+        }
 #endif
+    }
 }
 
 void run_scheduled_functions()

--- a/cores/esp8266/Schedule.cpp
+++ b/cores/esp8266/Schedule.cpp
@@ -138,7 +138,7 @@ bool schedule_recurrent_function_us(const std::function<bool(void)>& fn,
     return true;
 }
 
-uint32_t compute_recurrent_grain ()
+uint32_t compute_scheduled_recurrent_grain ()
 {
     if (recurrent_max_grain_mS == 0)
     {

--- a/cores/esp8266/Schedule.h
+++ b/cores/esp8266/Schedule.h
@@ -39,6 +39,13 @@
 // scheduled function happen more often: every yield() (vs every loop()),
 // and time resolution is microsecond (vs millisecond). Details are below.
 
+// recurrent_max_grain_mS is used by delay() to let a chance to all
+// recurrent functions to accomplish their duty per their timing
+// requirement.
+// When it is 0, update_recurrent_grain() can be called to recalculate it
+extern uint32_t recurrent_max_grain_mS;
+void update_recurrent_grain ();
+
 // scheduled functions called once:
 //
 // * internal queue is FIFO.

--- a/cores/esp8266/Schedule.h
+++ b/cores/esp8266/Schedule.h
@@ -42,7 +42,7 @@
 // recurrent_max_grain_mS is used by delay() to let a chance to all
 // recurrent functions to accomplish their duty per their timing
 // requirement.
-// When it is 0, update_recurrent_grain() can be called to recalculate it
+// When it is 0, update_recurrent_grain() can be called to recalculate it.
 extern uint32_t recurrent_max_grain_mS;
 void update_recurrent_grain ();
 

--- a/cores/esp8266/Schedule.h
+++ b/cores/esp8266/Schedule.h
@@ -39,12 +39,10 @@
 // scheduled function happen more often: every yield() (vs every loop()),
 // and time resolution is microsecond (vs millisecond). Details are below.
 
-// recurrent_max_grain_mS is used by delay() to let a chance to all
-// recurrent functions to accomplish their duty per their timing
-// requirement.
-// When it is 0, update_recurrent_grain() can be called to recalculate it.
-extern uint32_t recurrent_max_grain_mS;
-void update_recurrent_grain ();
+// compute_recurrent_grain() is used by delay() to give a chance to all
+// recurrent functions to run per their timing requirement.
+
+uint32_t compute_recurrent_grain ();
 
 // scheduled functions called once:
 //

--- a/cores/esp8266/Schedule.h
+++ b/cores/esp8266/Schedule.h
@@ -39,10 +39,10 @@
 // scheduled function happen more often: every yield() (vs every loop()),
 // and time resolution is microsecond (vs millisecond). Details are below.
 
-// compute_recurrent_grain() is used by delay() to give a chance to all
-// recurrent functions to run per their timing requirement.
+// compute_scheduled_recurrent_grain() is used by delay() to give a chance to
+// all recurrent functions to run per their timing requirement.
 
-uint32_t compute_recurrent_grain ();
+uint32_t compute_scheduled_recurrent_grain ();
 
 // scheduled functions called once:
 //

--- a/cores/esp8266/core_esp8266_main.cpp
+++ b/cores/esp8266/core_esp8266_main.cpp
@@ -162,24 +162,22 @@ extern "C" void __esp_delay(unsigned long ms) {
 
 extern "C" void esp_delay(unsigned long ms) __attribute__((weak, alias("__esp_delay")));
 
-bool esp_try_delay(const uint32_t start_ms, const uint32_t timeout_ms, uint32_t intvl_ms) {
+bool esp_try_delay(const uint32_t start_ms, const uint32_t timeout_ms, const uint32_t intvl_ms) {
     uint32_t expired = millis() - start_ms;
     if (expired >= timeout_ms) {
-        return true;
+        return true; // expired
     }
 
-    if (intvl_ms == 0)
-    {
-        // run_recurrent_scheduled_functions() is called from esp_delay()->esp_suspend()
-        // intvl_ms is set according to recurrent schedule functions
-        // intervals based on their respective requirements
-        if (recurrent_max_grain_mS == 0)
-            update_recurrent_grain();
-        intvl_ms = recurrent_max_grain_mS;
-    }
+    // possibly recompute recurrent scheduled function common timing grain
+    update_recurrent_grain();
 
-    esp_delay(std::min((timeout_ms - expired), intvl_ms));
-    return false;
+    // update intvl_ms according to this grain
+    uint32_t ms = compute_gcd(intvl_ms, recurrent_max_grain_mS);
+
+    // recurrent scheduled functions will be called from esp_delay()->esp_suspend()
+    esp_delay(ms? std::min((timeout_ms - expired), ms): (timeout_ms - expired));
+
+    return false; // expiration must be checked again
 }
 
 extern "C" void __yield() {

--- a/cores/esp8266/core_esp8266_main.cpp
+++ b/cores/esp8266/core_esp8266_main.cpp
@@ -168,7 +168,7 @@ bool esp_try_delay(const uint32_t start_ms, const uint32_t timeout_ms, const uin
         return true; // expired
     }
 
-    // possibly recompute recurrent scheduled function common timing grain
+    // possibly recompute recurrent scheduled functions common timing grain
     update_recurrent_grain();
 
     // update intvl_ms according to this grain

--- a/cores/esp8266/core_esp8266_main.cpp
+++ b/cores/esp8266/core_esp8266_main.cpp
@@ -172,7 +172,7 @@ bool esp_try_delay(const uint32_t start_ms, const uint32_t timeout_ms, const uin
     }
 
     // compute greatest chunked delay with respect to scheduled recurrent functions
-    uint32_t grain_ms = std::gcd(intvl_ms, compute_recurrent_grain());
+    uint32_t grain_ms = std::gcd(intvl_ms, compute_scheduled_recurrent_grain());
 
     // recurrent scheduled functions will be called from esp_delay()->esp_suspend()
     esp_delay(grain_ms > 0 ?

--- a/cores/esp8266/core_esp8266_wiring.cpp
+++ b/cores/esp8266/core_esp8266_wiring.cpp
@@ -35,6 +35,7 @@ static uint32_t micros_overflow_count = 0;
 
 void __delay(unsigned long ms) {
     // use API letting recurrent scheduled functions run in background
+    // but stay blocked in delay until ms is expired
     esp_delay(ms, [](){ return true; });
 }
 

--- a/cores/esp8266/core_esp8266_wiring.cpp
+++ b/cores/esp8266/core_esp8266_wiring.cpp
@@ -34,8 +34,8 @@ static uint32_t micros_overflow_count = 0;
 #define REPEAT 1
 
 void __delay(unsigned long ms) {
-    // use API letting recurrent scheduled functions run in background
-    // but stay blocked in delay until ms is expired
+    // Use API letting recurrent scheduled functions run in background
+    // but stay blocked in delay until ms is expired.
     esp_delay(ms, [](){ return true; });
 }
 

--- a/cores/esp8266/core_esp8266_wiring.cpp
+++ b/cores/esp8266/core_esp8266_wiring.cpp
@@ -34,17 +34,8 @@ static uint32_t micros_overflow_count = 0;
 #define REPEAT 1
 
 void __delay(unsigned long ms) {
-
-    // default "userland" delay() will call recurrent scheduled functions
-    // based on best effort according to their respective requirements
-
-    if (recurrent_max_grain_mS == 0)
-        update_recurrent_grain();
-    const auto start_ms = millis();
-    do
-    {
-        run_scheduled_recurrent_functions();
-    } while (!esp_try_delay(start_ms, ms, recurrent_max_grain_mS));
+    // use API letting recurrent scheduled functions run in background
+    esp_delay(ms, [](){ return true; });
 }
 
 void delay(unsigned long ms) __attribute__ ((weak, alias("__delay"))); 

--- a/cores/esp8266/core_esp8266_wiring.cpp
+++ b/cores/esp8266/core_esp8266_wiring.cpp
@@ -34,7 +34,17 @@ static uint32_t micros_overflow_count = 0;
 #define REPEAT 1
 
 void __delay(unsigned long ms) {
-    esp_delay(ms);
+
+    // default "userland" delay() will call recurrent scheduled functions
+    // based on best effort according to their respective requirements
+
+    if (recurrent_max_grain_mS == 0)
+        update_recurrent_grain();
+    const auto start_ms = millis();
+    do
+    {
+        run_scheduled_recurrent_functions();
+    } while (!esp_try_delay(start_ms, ms, recurrent_max_grain_mS));
 }
 
 void delay(unsigned long ms) __attribute__ ((weak, alias("__delay"))); 

--- a/cores/esp8266/coredecls.h
+++ b/cores/esp8266/coredecls.h
@@ -52,15 +52,15 @@ inline void esp_suspend(T&& blocked) {
 // Try to delay until timeout_ms has expired since start_ms.
 // Returns true if timeout_ms has completely expired on entry.
 // Otherwise returns false after delaying for the relative
-// remainder of timeout_ms, or an absolute intvl_ms, whichever is shorter.
+// remainder of timeout_ms, or an absolute intvl_ms, whichever is shorter
+// and possibly amended by recurrent scheduled fuctions timing grain.
 // The delay may be asynchronously cancelled, before that timeout is reached.
-// intvl_ms==0 will adapt to recurrent scheduled functions and run them accordingly
-bool esp_try_delay(const uint32_t start_ms, const uint32_t timeout_ms, uint32_t intvl_ms);
+bool esp_try_delay(const uint32_t start_ms, const uint32_t timeout_ms, const uint32_t intvl_ms);
 
 // This overload of esp_delay() delays for a duration of at most timeout_ms milliseconds.
-// Whenever it is resumed, as well as every intvl_ms millisconds, it performs
-// the blocked callback, and if that returns true, it keeps delaying for the remainder
-// of the original timeout_ms period.
+// Whenever it is resumed, as well as at most every intvl_ms millisconds and depending on
+// recurrent scheduled functions, it performs the blocked callback, and if that returns true,
+// it keeps delaying for the remainder of the original timeout_ms period.
 template <typename T>
 inline void esp_delay(const uint32_t timeout_ms, T&& blocked, const uint32_t intvl_ms) {
     const auto start_ms = millis();
@@ -73,9 +73,11 @@ inline void esp_delay(const uint32_t timeout_ms, T&& blocked, const uint32_t int
 // it keeps delaying for the remainder of the original timeout_ms period.
 template <typename T>
 inline void esp_delay(const uint32_t timeout_ms, T&& blocked) {
-    esp_delay(timeout_ms, std::forward<T>(blocked), 0);
+    esp_delay(timeout_ms, std::forward<T>(blocked), timeout_ms);
 }
 
+// Greatest Common Divisor Euclidian algorithm
+// one entry may be 0, the other is returned
 template <typename T>
 auto compute_gcd (T a, T b)
 {

--- a/cores/esp8266/coredecls.h
+++ b/cores/esp8266/coredecls.h
@@ -1,6 +1,5 @@
 
-#ifndef __COREDECLS_H
-#define __COREDECLS_H
+#pragma once
 
 #include "core_esp8266_features.h"
 
@@ -76,6 +75,16 @@ inline void esp_delay(const uint32_t timeout_ms, T&& blocked) {
     esp_delay(timeout_ms, std::forward<T>(blocked), timeout_ms);
 }
 
-#endif // __cplusplus
+template <typename T>
+auto compute_gcd (T a, T b)
+{
+    while (b)
+    {
+        auto t = b;
+        b = a % b;
+        a = t;
+    }
+    return a;
+}
 
-#endif // __COREDECLS_H
+#endif // __cplusplus

--- a/cores/esp8266/coredecls.h
+++ b/cores/esp8266/coredecls.h
@@ -78,18 +78,4 @@ inline void esp_delay(const uint32_t timeout_ms, T&& blocked) {
     esp_delay(timeout_ms, std::forward<T>(blocked), timeout_ms);
 }
 
-// Greatest Common Divisor Euclidian algorithm
-// one entry may be 0, the other is returned
-template <typename T>
-auto compute_gcd (T a, T b)
-{
-    while (b)
-    {
-        auto t = b;
-        b = a % b;
-        a = t;
-    }
-    return a;
-}
-
 #endif // __cplusplus

--- a/cores/esp8266/coredecls.h
+++ b/cores/esp8266/coredecls.h
@@ -53,7 +53,7 @@ inline void esp_suspend(T&& blocked) {
 // Returns true if timeout_ms has completely expired on entry.
 // Otherwise returns false after delaying for the relative
 // remainder of timeout_ms, or an absolute intvl_ms, whichever is shorter
-// and possibly amended by recurrent scheduled fuctions timing grain.
+// and possibly amended by recurrent scheduled functions timing grain.
 // The delay may be asynchronously cancelled, before that timeout is reached.
 bool esp_try_delay(const uint32_t start_ms, const uint32_t timeout_ms, const uint32_t intvl_ms);
 

--- a/cores/esp8266/coredecls.h
+++ b/cores/esp8266/coredecls.h
@@ -54,7 +54,8 @@ inline void esp_suspend(T&& blocked) {
 // Otherwise returns false after delaying for the relative
 // remainder of timeout_ms, or an absolute intvl_ms, whichever is shorter.
 // The delay may be asynchronously cancelled, before that timeout is reached.
-bool esp_try_delay(const uint32_t start_ms, const uint32_t timeout_ms, const uint32_t intvl_ms);
+// intvl_ms==0 will adapt to recurrent scheduled functions and run them accordingly
+bool esp_try_delay(const uint32_t start_ms, const uint32_t timeout_ms, uint32_t intvl_ms);
 
 // This overload of esp_delay() delays for a duration of at most timeout_ms milliseconds.
 // Whenever it is resumed, as well as every intvl_ms millisconds, it performs
@@ -72,7 +73,7 @@ inline void esp_delay(const uint32_t timeout_ms, T&& blocked, const uint32_t int
 // it keeps delaying for the remainder of the original timeout_ms period.
 template <typename T>
 inline void esp_delay(const uint32_t timeout_ms, T&& blocked) {
-    esp_delay(timeout_ms, std::forward<T>(blocked), timeout_ms);
+    esp_delay(timeout_ms, std::forward<T>(blocked), 0);
 }
 
 template <typename T>

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -451,9 +451,9 @@ bool ESP8266WiFiGenericClass::mode(WiFiMode_t m) {
     //tasks to wait correctly.
     constexpr unsigned int timeoutValue = 1000; //1 second
     if(can_yield()) {
-        // The final argument, intvl_ms, to esp_delay influences how frequently
-        // the scheduled recurrent functions (Schedule.h) are probed.
-        esp_delay(timeoutValue, [m]() { return wifi_get_opmode() != m; }, 5);
+        // The final argument, intvl_ms, to esp_delay determines at least
+        // how frequently wifi_get_opmode() is checked
+        esp_delay(timeoutValue, [m]() { return wifi_get_opmode() != m; }, 100);
 
         //if at this point mode still hasn't been reached, give up
         if(wifi_get_opmode() != (uint8) m) {
@@ -642,11 +642,8 @@ static int hostByNameImpl(const char* aHostname, IPAddress& aResult, uint32_t ti
     // We need to wait for c/b to fire *or* we exit on our own timeout
     // (which also requires us to notify the c/b that it is supposed to delete the pending obj)
     case ERR_INPROGRESS:
-        // Re-check every 10ms, we expect this to happen fast
-        esp_delay(timeout_ms,
-            [&]() {
-                return !pending->done;
-            });
+        // esp_delay will be interrupted by found callback
+        esp_delay(timeout_ms, [&]() { return !pending->done; });
 
         if (pending->done) {
             if ((pending->addr).isSet()) {

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -451,8 +451,7 @@ bool ESP8266WiFiGenericClass::mode(WiFiMode_t m) {
     //tasks to wait correctly.
     constexpr unsigned int timeoutValue = 1000; //1 second
     if(can_yield()) {
-        // The final argument, intvl_ms, to esp_delay determines at least
-        // how frequently wifi_get_opmode() is checked
+        // check opmode every 100ms or give up after timeout
         esp_delay(timeoutValue, [m]() { return wifi_get_opmode() != m; }, 100);
 
         //if at this point mode still hasn't been reached, give up
@@ -642,7 +641,7 @@ static int hostByNameImpl(const char* aHostname, IPAddress& aResult, uint32_t ti
     // We need to wait for c/b to fire *or* we exit on our own timeout
     // (which also requires us to notify the c/b that it is supposed to delete the pending obj)
     case ERR_INPROGRESS:
-        // esp_delay will be interrupted by found callback
+        // sleep until dns_found_callback is called or timeout is reached
         esp_delay(timeout_ms, [&]() { return !pending->done; });
 
         if (pending->done) {

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -646,7 +646,7 @@ static int hostByNameImpl(const char* aHostname, IPAddress& aResult, uint32_t ti
         esp_delay(timeout_ms,
             [&]() {
                 return !pending->done;
-            }, 10);
+            });
 
         if (pending->done) {
             if ((pending->addr).isSet()) {

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp
@@ -84,8 +84,8 @@ static void printWiFiStatus(wl_status_t status)
 static wl_status_t waitWiFiConnect(uint32_t connectTimeoutMs)
 {
     wl_status_t status = WL_CONNECT_FAILED;
-    // The final argument, intvl_ms, to esp_delay influences how frequently
-    // the scheduled recurrent functions (Schedule.h) are probed.
+    // The final argument, intvl_ms, to esp_delay determines
+    // the max ms interval at which status is checked
     esp_delay(connectTimeoutMs,
         [&status]() {
             status = WiFi.status();
@@ -236,8 +236,8 @@ int8_t ESP8266WiFiMulti::startScan()
     WiFi.scanNetworks(true);
 
     // Wait for WiFi scan change or timeout
-    // The final argument, intvl_ms, to esp_delay influences how frequently
-    // the scheduled recurrent functions (Schedule.h) are probed.
+    // The final argument, intvl_ms, to esp_delay determines
+    // the max ms interval at which status is checked
     esp_delay(WIFI_SCAN_TIMEOUT_MS,
         [&scanResult]() {
             scanResult = WiFi.scanComplete();

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp
@@ -90,7 +90,7 @@ static wl_status_t waitWiFiConnect(uint32_t connectTimeoutMs)
         [&status]() {
             status = WiFi.status();
             return status != WL_CONNECTED && status != WL_CONNECT_FAILED;
-        }, 0);
+        }, 100);
 
     // Check status
     if (status == WL_CONNECTED) {
@@ -242,7 +242,7 @@ int8_t ESP8266WiFiMulti::startScan()
         [&scanResult]() {
             scanResult = WiFi.scanComplete();
             return scanResult < 0;
-        }, 0);
+        }, 100);
     // Check for scan timeout which may occur when scan does not report completion
     if (scanResult < 0) {
         DEBUG_WIFI_MULTI("[WIFIM] Scan timeout\n");

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiMulti.cpp
@@ -84,8 +84,8 @@ static void printWiFiStatus(wl_status_t status)
 static wl_status_t waitWiFiConnect(uint32_t connectTimeoutMs)
 {
     wl_status_t status = WL_CONNECT_FAILED;
-    // The final argument, intvl_ms, to esp_delay determines
-    // the max ms interval at which status is checked
+    // Wait for WiFi to connect
+    // stop waiting upon status checked every 100ms or when timeout is reached
     esp_delay(connectTimeoutMs,
         [&status]() {
             status = WiFi.status();
@@ -236,8 +236,7 @@ int8_t ESP8266WiFiMulti::startScan()
     WiFi.scanNetworks(true);
 
     // Wait for WiFi scan change or timeout
-    // The final argument, intvl_ms, to esp_delay determines
-    // the max ms interval at which status is checked
+    // stop waiting upon status checked every 100ms or when timeout is reached
     esp_delay(WIFI_SCAN_TIMEOUT_MS,
         [&scanResult]() {
             scanResult = WiFi.scanComplete();

--- a/libraries/ESP8266WiFi/src/include/ClientContext.h
+++ b/libraries/ESP8266WiFi/src/include/ClientContext.h
@@ -144,8 +144,7 @@ public:
         _connect_pending = true;
         _op_start_time = millis();
         // will resume on timeout or when _connected or _notify_error fires
-        // give scheduled functions a chance to run (e.g. Ethernet uses recurrent)
-        esp_delay(_timeout_ms, [this]() { return this->_connect_pending; }, 1);
+        esp_delay(_timeout_ms, [this]() { return this->_connect_pending; });
         _connect_pending = false;
         if (!_pcb) {
             DEBUGV(":cabrt\r\n");
@@ -485,8 +484,7 @@ protected:
 
             _send_waiting = true;
             // will resume on timeout or when _write_some_from_cb or _notify_error fires
-            // give scheduled functions a chance to run (e.g. Ethernet uses recurrent)
-            esp_delay(_timeout_ms, [this]() { return this->_send_waiting; }, 1);
+            esp_delay(_timeout_ms, [this]() { return this->_send_waiting; });
             _send_waiting = false;
         } while(true);
 


### PR DESCRIPTION
Recurrent scheduled functions will always be running in background.

`esp_delay()`'s interval (`intvl_ms`) is internally kept to its highest  value allowing to honor recurrent scheduled functions requirements.

This allows examples like [`EthClient`](https://github.com/esp8266/Arduino/blob/840ef782371d2c0310aa9cbde8a311fd8b80bf28/libraries/lwIP_Ethernet/examples/EthClient/EthClient.ino#L90) to keep answering to `ping` while "trapped" in a `delay()`.
More generally it transparently allows to keep with the arduino and nonos-sdk trivial programming way and still use background services or drivers running regularly.
