### PR TITLE
Log all exceptions in upload.py

### DIFF
--- a/tools/upload.py
+++ b/tools/upload.py
@@ -65,7 +65,7 @@ if erase_addr:
 
 try:
     esptool.main(cmdline)
-except esptool.FatalError as e:
+except Exception as e:
     sys.stderr.write('\nA fatal esptool.py error occurred: %s' % e)
 finally:
     if erase_file:


### PR DESCRIPTION
Currently some exceptions cause the script to exit with code 2, but without any relevant error message.

As an example, I had an issue with my USB drivers. But the only message I saw using the Arduino IDE was: `uploading error: exit status 2`. With this code change I could see a more specific `Resource busy` error message, which helped me identify the actual problem.