### PR TITLE
mDNS local services publishing

### DIFF
--- a/libraries/ESP8266mDNS/src/LEAmDNS_Control.cpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS_Control.cpp
@@ -234,6 +234,13 @@ namespace MDNSImplementation
                         = (((ProbingStatus_Done == pService->m_ProbeInformation.m_ProbingStatus))
                                ? _replyMaskForService(questionRR.m_Header, *pService, 0)
                                : 0);
+
+                    if (pService->m_ProbeInformation.m_ProbingStatus != ProbingStatus_InProgress)
+                    {
+                        // reply with service description (check MDNSResponder::_announce() comments)
+                        u8ReplyMaskForQuestion |= (ContentFlag_SRV | ContentFlag_TXT | ContentFlag_PTR_NAME | ContentFlag_PTR_TYPE);
+                    }
+
                     u8HostOrServiceReplies |= (pService->m_u8ReplyMask |= u8ReplyMaskForQuestion);
                     DEBUG_EX_INFO(if (u8ReplyMaskForQuestion) {
                         DEBUG_OUTPUT.printf_P(

--- a/tests/host/common/UdpContextSocket.cpp
+++ b/tests/host/common/UdpContextSocket.cpp
@@ -166,14 +166,14 @@ size_t mockUDPFillInBuf(int sock, char* ccinbuf, size_t& ccinbufsize, uint8_t& a
     return ccinbufsize += ret;
 }
 
-size_t mockUDPPeekBytes(int sock, char* dst, size_t usersize, int timeout_ms, char* ccinbuf,
+size_t mockUDPPeekBytes(int sock, char* dst, size_t offset, size_t usersize, int timeout_ms, char* ccinbuf,
                         size_t& ccinbufsize)
 {
     (void)sock;
     (void)timeout_ms;
-    if (usersize > CCBUFSIZE)
+    if (offset + usersize > CCBUFSIZE)
         fprintf(stderr, MOCK "CCBUFSIZE(%d) should be increased by %zd bytes (-> %zd)\n", CCBUFSIZE,
-                usersize - CCBUFSIZE, usersize);
+                offset + usersize - CCBUFSIZE, offset + usersize);
 
     size_t retsize = 0;
     if (ccinbufsize)
@@ -183,10 +183,11 @@ size_t mockUDPPeekBytes(int sock, char* dst, size_t usersize, int timeout_ms, ch
         if (retsize > ccinbufsize)
             retsize = ccinbufsize;
     }
-    memcpy(dst, ccinbuf, retsize);
+    memcpy(dst, ccinbuf + offset, retsize);
     return retsize;
 }
 
+/*
 void mockUDPSwallow(size_t copied, char* ccinbuf, size_t& ccinbufsize)
 {
     // poor man buffer
@@ -201,6 +202,7 @@ size_t mockUDPRead(int sock, char* dst, size_t size, int timeout_ms, char* ccinb
     mockUDPSwallow(copied, ccinbuf, ccinbufsize);
     return copied;
 }
+*/
 
 size_t mockUDPWrite(int sock, const uint8_t* data, size_t size, int timeout_ms, uint32_t ipv4,
                     uint16_t port)

--- a/tests/host/common/UdpContextSocket.cpp
+++ b/tests/host/common/UdpContextSocket.cpp
@@ -187,23 +187,6 @@ size_t mockUDPPeekBytes(int sock, char* dst, size_t offset, size_t usersize, int
     return retsize;
 }
 
-/*
-void mockUDPSwallow(size_t copied, char* ccinbuf, size_t& ccinbufsize)
-{
-    // poor man buffer
-    memmove(ccinbuf, ccinbuf + copied, ccinbufsize - copied);
-    ccinbufsize -= copied;
-}
-
-size_t mockUDPRead(int sock, char* dst, size_t size, int timeout_ms, char* ccinbuf,
-                   size_t& ccinbufsize)
-{
-    size_t copied = mockUDPPeekBytes(sock, dst, size, timeout_ms, ccinbuf, ccinbufsize);
-    mockUDPSwallow(copied, ccinbuf, ccinbufsize);
-    return copied;
-}
-*/
-
 size_t mockUDPWrite(int sock, const uint8_t* data, size_t size, int timeout_ms, uint32_t ipv4,
                     uint16_t port)
 {

--- a/tests/host/common/mock.h
+++ b/tests/host/common/mock.h
@@ -160,13 +160,13 @@ int    mockUDPSocket();
 bool   mockUDPListen(int sock, uint32_t dstaddr, uint16_t port, uint32_t mcast = 0);
 size_t mockUDPFillInBuf(int sock, char* ccinbuf, size_t& ccinbufsize, uint8_t& addrsize,
                         uint8_t addr[16], uint16_t& port);
-size_t mockUDPPeekBytes(int sock, char* dst, size_t usersize, int timeout_ms, char* ccinbuf,
+size_t mockUDPPeekBytes(int sock, char* dst, size_t offset, size_t usersize, int timeout_ms, char* ccinbuf,
                         size_t& ccinbufsize);
-size_t mockUDPRead(int sock, char* dst, size_t size, int timeout_ms, char* ccinbuf,
-                   size_t& ccinbufsize);
+//size_t mockUDPRead(int sock, char* dst, size_t size, int timeout_ms, char* ccinbuf,
+//                   size_t& ccinbufsize);
 size_t mockUDPWrite(int sock, const uint8_t* data, size_t size, int timeout_ms, uint32_t ipv4,
                     uint16_t port);
-void   mockUDPSwallow(size_t copied, char* ccinbuf, size_t& ccinbufsize);
+//void   mockUDPSwallow(size_t copied, char* ccinbuf, size_t& ccinbufsize);
 
 class UdpContext;
 void register_udp(int sock, UdpContext* udp = nullptr);

--- a/tests/host/common/mock.h
+++ b/tests/host/common/mock.h
@@ -162,11 +162,8 @@ size_t mockUDPFillInBuf(int sock, char* ccinbuf, size_t& ccinbufsize, uint8_t& a
                         uint8_t addr[16], uint16_t& port);
 size_t mockUDPPeekBytes(int sock, char* dst, size_t offset, size_t usersize, int timeout_ms, char* ccinbuf,
                         size_t& ccinbufsize);
-//size_t mockUDPRead(int sock, char* dst, size_t size, int timeout_ms, char* ccinbuf,
-//                   size_t& ccinbufsize);
 size_t mockUDPWrite(int sock, const uint8_t* data, size_t size, int timeout_ms, uint32_t ipv4,
                     uint16_t port);
-//void   mockUDPSwallow(size_t copied, char* ccinbuf, size_t& ccinbufsize);
 
 class UdpContext;
 void register_udp(int sock, UdpContext* udp = nullptr);


### PR DESCRIPTION
Force adding local services content in mDNS answers to requests.

Also fix mock Udp `peek()`/`seek()` which helped with mDNS debug.
