### PR TITLE
SdFat -> FS HAL mode fixes & test

### DIFF
--- a/libraries/SD/src/SD.cpp
+++ b/libraries/SD/src/SD.cpp
@@ -1,5 +1,14 @@
 #include "SD.h"
 
+static_assert(__builtin_strcmp(SDClassFileMode(FILE_READ), "r") == 0, "");
+static_assert(__builtin_strcmp(SDClassFileMode(FILE_WRITE), "a+") == 0, "");
+
+static_assert(__builtin_strcmp(SDClassFileMode(O_RDONLY), "r") == 0, "");
+static_assert(__builtin_strcmp(SDClassFileMode(O_WRONLY), "w+") == 0, "");
+static_assert(__builtin_strcmp(SDClassFileMode(O_RDWR), "w+") == 0, "");
+static_assert(__builtin_strcmp(SDClassFileMode(O_WRONLY | O_APPEND), "a") == 0, "");
+static_assert(__builtin_strcmp(SDClassFileMode(O_RDWR | O_APPEND), "a+") == 0, "");
+
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SD)
 SDClass SD;
 #endif


### PR DESCRIPTION
* re-use SdFat access mode through static const, no need to hard-code our own value w/ cast in the macro
* separate access-modes from flags
* simple compile-time tests in .cpp

resolve #8831