### PR TITLE
Force IRAM cache for important SoftwareSerial bits

### DIFF
--- a/tools/sdk/ld/eagle.app.v6.common.ld.h
+++ b/tools/sdk/ld/eagle.app.v6.common.ld.h
@@ -142,6 +142,11 @@ SECTIONS
 
     /* all functional callers are placed in IRAM (including SPI/IRQ callbacks/etc) here */
     *(.text._ZNKSt8functionIF*EE*)  /* std::function<any(...)>::operator()() const */
+    *(.text._ZNK8delegate6detail12DelegateImplIPvvEclEv) /* delegate::detail::DelegateImpl<void*, void>::operator()() const */
+    *(.text._ZNK8delegate6detail12DelegateImplIPvvEcvbEv) /* delegate::detail::DelegateImpl<void*, void>::operator bool() const */
+
+    /* same thing for circular_queue structure methods used in swserial */
+    *(.text._ZNK14circular_queue*E9availableEv) /* circular_queue<any, any>::available() const */
   } >iram1_0_seg :iram1_0_phdr
 
   .irom0.text : ALIGN(4)


### PR DESCRIPTION
see #8830 as to why we might want this

would be pretty annoying to keep in sync
or, reliable regression test would be nice in some form or the other (https://sourceware.org/gdb/current/onlinedocs/gdb#Python-API ?)