### PR TITLE
Remove stale patch for SDK v1.1 and earlier

### DIFF
--- a/cores/esp8266/core_esp8266_phy.cpp
+++ b/cores/esp8266/core_esp8266_phy.cpp
@@ -360,10 +360,7 @@ void user_rf_pre_init()
 {
     // *((volatile uint32_t*) 0x60000710) = 0;
     spoof_init_data = false;
-    volatile uint32_t* rtc_reg = (volatile uint32_t*) 0x60001000;
-    rtc_reg[30] = 0;
 
-    system_set_os_print(0);
     int rf_mode = __get_rf_mode();
     if (rf_mode >= 0) {
         system_phy_set_rfoption(rf_mode);


### PR DESCRIPTION
The `rts_reg` addresses referenced are not valid for SDK v2.0.0 and up. For `rts_reg[30] = 0;` on SDK v1.1.0, it cleared a checksum. On SDL v2.0.0, it zeros `TestStaFreqCalValInput`.

I don't think this is needed; however, if you have a need to recreate the old behavior for comparison, use `RF_PRE_INIT()` as shown:
```cpp
#include <Esp.h>

RF_PRE_INIT() {
#if 1 && (NONOSDK < (0x30000))
  // Old legacy SDK v1.1 and earlier patch
  // Clear RTC RAM backup area checksum
  volatile uint32_t* rtc_reg = (volatile uint32_t*) 0x60001000;
  rtc_reg[30] = 0;

  // Hide checksum error message
  system_set_os_print(0);
#endif

#if 0 && (NONOSDK >= (0x20000))
  // I don't expect this to be useful; however, this should do what was
  // intended to have been done before.
  //
  // For SDKs 2.0.0 through 3.0.5
  // Clear RTC RAM backup area checksum
  volatile uint32_t* rtc_reg = (volatile uint32_t*) 0x60001000;
  rtc_reg[26] = 0;
#endif
}
```
### Long long ago

In the beginning, before the release of Arduino ESP8266 Core v2.0.0-rc1
We were using SDK `v1.1.0`. This version of the SDK stored the results of a call to `deep_sleep_set_option()` at `rtc_reg[24]`. And kept an RTC memory checksum at `rtc_reg[30]`. 

At the first file commit the patch looked like this:
https://github.com/esp8266/Arduino/blob/dc08418f086bdc6a850582b9ede5e313df4065b4/cores/esp8266/core_esp8266_phy.c#L234-L237

By the time of Core v2.0.0-rc1 we had a more selective patch: 
When this commit was made Aug 5, 2015 the SDK version was around v1.1.0 
https://github.com/esp8266/Arduino/blob/e02932fcddc24740852ec0e39e494e57a8906df2/cores/esp8266/core_esp8266_phy.c#L263-L269

By the time of the release of Core v2.0.0-rc1 (Nov 17, 2015), we were using SDK v1.3.0 which no longer used those offsets in RTC memory. It is not clear to me that the patch was required anymore. And the message that often showed "RTC MEM CHECK FAIL!!!" was no longer in the SDK.

These issues may be entangled with the long version of the patch it is hard to sort out:
* https://github.com/esp8266/Arduino/issues/3408#issuecomment-414159385
* https://github.com/esp8266/Arduino/issues/3408#issuecomment-414477566
* https://github.com/esp8266/Arduino/pull/5056#issuecomment-414586897
