### PR TITLE
Resolve Windows path problems

### DIFF
--- a/tools/mkbuildoptglobals.py
+++ b/tools/mkbuildoptglobals.py
@@ -612,14 +612,13 @@ def parse_args():
     # ref no '--n' parameter, https://stackoverflow.com/a/21998252
 
 
-def get_encoding():
-    try:
-        from locale import getencoding
-    except ImportError:
-        # https://stackoverflow.com/a/23743499
-        return locale.getpreferredencoding(False) or locale.getdefaultlocale()[1]
-
-    return locale.getencoding()
+# retrieve *system* encoding, not the one used by python internally
+if sys.version_info >= (3, 11):
+    def get_encoding():
+        return locale.getencoding()
+else:
+    def get_encoding():
+        return locale.getdefaultlocale()[1]
 
 
 def show_value(desc, value):

--- a/tools/mkbuildoptglobals.py
+++ b/tools/mkbuildoptglobals.py
@@ -187,6 +187,7 @@ from shutil import copyfile
 import glob
 import os
 import platform
+import traceback
 import sys
 import textwrap
 import time
@@ -304,7 +305,6 @@ def add_include_line(build_opt_fqfn, include_fqfn):
         print("add_include_line: Created " + include_fqfn)
     with open(build_opt_fqfn, 'a', encoding="utf-8") as build_opt:
         build_opt.write('-include "' + include_fqfn.replace('\\', '\\\\') + '"\n')
-
 
 def extract_create_build_opt_file(globals_h_fqfn, file_name, build_opt_fqfn):
     """
@@ -655,6 +655,10 @@ def main():
     print_dbg(f"first_time:             {first_time}")
     print_dbg(f"use_aggressive_caching_workaround: {use_aggressive_caching_workaround}")
 
+    if not os.path.exists(build_path_core):
+        os.makedirs(build_path_core)
+        print_msg("Clean build, created dir " + build_path_core)
+
     if first_time or \
     not use_aggressive_caching_workaround or \
     not os.path.exists(commonhfile_fqfn):
@@ -666,10 +670,6 @@ def main():
     if time.time_ns() < os.stat(commonhfile_fqfn).st_mtime_ns:
         touch(commonhfile_fqfn)
         print_err(f"Neutralized future timestamp on build file: {commonhfile_fqfn}")
-
-    if not os.path.exists(build_path_core):
-        os.makedirs(build_path_core)
-        print_msg("Clean build, created dir " + build_path_core)
 
     if os.path.exists(source_globals_h_fqfn):
         print_msg("Using global include from " + source_globals_h_fqfn)
@@ -750,4 +750,10 @@ def main():
     handle_error(0)   # commit print buffer
 
 if __name__ == '__main__':
-    sys.exit(main())
+    rc = 1
+    try:
+        rc = main()
+    except:
+        print_err(traceback.format_exc())
+        handle_error(0)
+    sys.exit(rc)

--- a/tools/mkbuildoptglobals.py
+++ b/tools/mkbuildoptglobals.py
@@ -193,7 +193,6 @@ import textwrap
 import time
 
 import locale
-import codecs
 
 # Need to work on signature line used for match to avoid conflicts with
 # existing embedded documentation methods.

--- a/tools/sizes.py
+++ b/tools/sizes.py
@@ -21,8 +21,19 @@ import argparse
 import os
 import subprocess
 import sys
+import locale
 
 sys.stdout = sys.stderr
+
+
+# retrieve *system* encoding, not the one used by python internally
+if sys.version_info >= (3, 11):
+    def get_encoding():
+        return locale.getencoding()
+else:
+    def get_encoding():
+        return locale.getdefaultlocale()[1]
+
 
 def get_segment_sizes(elf, path, mmu):
     iram_size = 0
@@ -72,10 +83,8 @@ def get_segment_sizes(elf, path, mmu):
         (".bss", "BSS"),
     )
 
-    import locale
-    shell_encoding = locale.getdefaultlocale()[1]
     cmd = [os.path.join(path, "xtensa-lx106-elf-size"), "-A", elf]
-    with subprocess.Popen(cmd, stdout=subprocess.PIPE, universal_newlines=True, encoding=shell_encoding) as proc:
+    with subprocess.Popen(cmd, stdout=subprocess.PIPE, universal_newlines=True, encoding=get_encoding()) as proc:
         lines = proc.stdout.readlines()
         for line in lines:
             words = line.split()

--- a/tools/sizes.py
+++ b/tools/sizes.py
@@ -72,8 +72,10 @@ def get_segment_sizes(elf, path, mmu):
         (".bss", "BSS"),
     )
 
+    import locale
+    shell_encoding = locale.getdefaultlocale()[1]
     cmd = [os.path.join(path, "xtensa-lx106-elf-size"), "-A", elf]
-    with subprocess.Popen(cmd, stdout=subprocess.PIPE, universal_newlines=True) as proc:
+    with subprocess.Popen(cmd, stdout=subprocess.PIPE, universal_newlines=True, encoding=shell_encoding) as proc:
         lines = proc.stdout.readlines()
         for line in lines:
             words = line.split()


### PR DESCRIPTION
Moved up `os.makedirs` for `./core/` directory.
Strange problem creating files with file paths with spaces. 
Strange that "create file" would work when the path did not contain spaces and the last folder of the path hadn't been created.

Added try/except on main to commit print buffer on traceback for context.

Additional issues with diacritics and locale character encoding for shell vs source code.
`build.opt` is written with the same encoding as the shell; however, the data read from the `Sketch.ino.global.h` is `UTF-8`.

should resolve https://github.com/esp8266/Arduino/issues/8856#issue-1582158038