### PR TITLE
ESP8266WebServer: Explicitly flush after all responses have been indicated to be sent

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
@@ -743,6 +743,7 @@ void ESP8266WebServerTemplate<ServerType>::_finalizeResponse() {
   if (_chunked) {
     sendContent(emptyString);
   }
+  _currentClient.flush();
 }
 
 template <typename ServerType>


### PR DESCRIPTION
This patch reduces the HTTP connection instability (for example, early-closing of server responses).