### PR TITLE
Fix removing first certificate in certs-from-mozilla.py

### DIFF
--- a/libraries/ESP8266WiFi/examples/BearSSL_CertStore/certs-from-mozilla.py
+++ b/libraries/ESP8266WiFi/examples/BearSSL_CertStore/certs-from-mozilla.py
@@ -47,7 +47,6 @@ for row in csvReader:
         if item.startswith("'-----BEGIN CERTIFICATE-----"):
             pems.append(item)
 del names[0] # Remove headers
-del pems[0] # Remove headers
 
 # Try and make ./data, skip if present
 try:


### PR DESCRIPTION
pems has no headers. That operation removes a certificate.