### PR TITLE
umm_poison false positive from ISR

### DIFF
--- a/cores/esp8266/umm_malloc/umm_local.c
+++ b/cores/esp8266/umm_malloc/umm_local.c
@@ -138,12 +138,16 @@ static void *get_unpoisoned_check_neighbors(void *vptr, const char *file, int li
 void *umm_poison_realloc_fl(void *ptr, size_t size, const char *file, int line) {
     void *ret;
 
+    POISON_CRITICAL_ENTRY();
+
     ptr = get_unpoisoned_check_neighbors(ptr, file, line);
 
     add_poison_size(&size);
     ret = umm_realloc(ptr, size);
 
     ret = get_poisoned(ret, size);
+
+    POISON_CRITICAL_EXIT();
 
     return ret;
 }
@@ -152,7 +156,11 @@ void *umm_poison_realloc_fl(void *ptr, size_t size, const char *file, int line) 
 
 void umm_poison_free_fl(void *ptr, const char *file, int line) {
 
+    POISON_CRITICAL_ENTRY();
+
     ptr = get_unpoisoned_check_neighbors(ptr, file, line);
+
+    POISON_CRITICAL_EXIT();
 
     umm_free(ptr);
 }

--- a/cores/esp8266/umm_malloc/umm_local.h
+++ b/cores/esp8266/umm_malloc/umm_local.h
@@ -48,11 +48,27 @@ static size_t umm_uadd_sat(const size_t a, const size_t b);
 static bool check_poison_neighbors(umm_heap_context_t *_context, uint16_t cur);
 #endif
 
+#if defined(UMM_POISON_CHECK) || defined(UMM_POISON_CHECK_LITE)
+/*
+  The umm_poison logic runs outside the UMM_CRITICAL_* umbrella. When interrupt
+  routines do alloc calls, it is possible to interrupt an in-progress allocation
+  just before the poison is set, with a new alloc request resulting in a false
+  "poison check fail" against the in-progress allocation. The SDK does mallocs
+  from ISRs. SmartConfig can illustrate this issue.
+
+  Add POISON_CRITICAL_* to skip check when not the first.
+*/
+static int volatile umm_poison_critical __attribute__((section(".noinit")));
+
+#define POISON_CRITICAL_ENTRY() (umm_poison_critical++)
+#define POISON_CRITICAL_EXIT() (umm_poison_critical--)
+#define POISON_CRITICAL_GET_LEVEL() (umm_poison_critical)
+#endif
+
 
 #if defined(UMM_STATS) || defined(UMM_STATS_FULL)
 void ICACHE_FLASH_ATTR umm_print_stats(int force);
 #endif
-
 
 
 int ICACHE_FLASH_ATTR umm_info_safe_printf_P(const char *fmt, ...) __attribute__((format(printf, 1, 2)));

--- a/cores/esp8266/umm_malloc/umm_malloc.cpp
+++ b/cores/esp8266/umm_malloc/umm_malloc.cpp
@@ -563,6 +563,9 @@ void ICACHE_MAYBE umm_init(void) {
     // Note, full_init must be true for the primary heap, DRAM.
     umm_init_heap(UMM_HEAP_DRAM, (void *)UMM_MALLOC_CFG_HEAP_ADDR, UMM_MALLOC_CFG_HEAP_SIZE, true);
 
+#if defined(UMM_POISON_CHECK) || defined(UMM_POISON_CHECK_LITE)
+    umm_poison_critical = 0;
+#endif
     // upstream ref:
     //   Initialize the heap from linker supplied values */
     //   umm_init_heap(UMM_MALLOC_CFG_HEAP_ADDR, UMM_MALLOC_CFG_HEAP_SIZE);


### PR DESCRIPTION
The umm_poison logic runs outside the UMM_CRITICAL_* umbrella. When interrupt routines do alloc calls, it is possible to interrupt an in-progress allocation just before the poison is set, with a new alloc request resulting in a false "poison check fail" against the in-progress allocation. The SDK does mallocs from ISRs. SmartConfig can illustrate this issue.

This should resolve https://github.com/esp8266/Arduino/issues/3494#issue-247919259