### PR TITLE
Soft WDT: detect deliberate infinite loop at Postmortem

### DIFF
--- a/cores/esp8266/core_esp8266_postmortem.cpp
+++ b/cores/esp8266/core_esp8266_postmortem.cpp
@@ -181,7 +181,13 @@ static void postmortem_report(uint32_t sp_dump) {
             exccause, epc1, rst_info.epc2, rst_info.epc3, rst_info.excvaddr, rst_info.depc);
     }
     else if (rst_info.reason == REASON_SOFT_WDT_RST) {
-        ets_printf_P(PSTR("\nSoft WDT reset\n"));
+        ets_printf_P(PSTR("\nSoft WDT reset"));
+        const char infinite_loop[] = { 0x06, 0xff, 0xff };  // loop: j loop
+        if (0 == memcmp_P((void*)rst_info.epc1, infinite_loop, 3u)) {
+            // The SDK is riddled with these. They are usually preceded by an ets_printf.
+            ets_printf_P(PSTR(" - deliberate infinite loop detected"));
+        }
+        ets_putc('\n');
         ets_printf_P(PSTR("\nException (%d):\nepc1=0x%08x epc2=0x%08x epc3=0x%08x excvaddr=0x%08x depc=0x%08x\n"),
             rst_info.exccause, /* Address executing at time of Soft WDT level-1 interrupt */ rst_info.epc1, 0, 0, 0, 0);
     }

--- a/cores/esp8266/core_esp8266_postmortem.cpp
+++ b/cores/esp8266/core_esp8266_postmortem.cpp
@@ -183,7 +183,7 @@ static void postmortem_report(uint32_t sp_dump) {
     else if (rst_info.reason == REASON_SOFT_WDT_RST) {
         ets_printf_P(PSTR("\nSoft WDT reset"));
         const char infinite_loop[] = { 0x06, 0xff, 0xff };  // loop: j loop
-        if (0 == memcmp_P((void*)rst_info.epc1, infinite_loop, 3u)) {
+        if (0 == memcmp_P(infinite_loop, (PGM_VOID_P)rst_info.epc1, 3u)) {
             // The SDK is riddled with these. They are usually preceded by an ets_printf.
             ets_printf_P(PSTR(" - deliberate infinite loop detected"));
         }


### PR DESCRIPTION
A popular method of handling an unrecoverable state is to reboot. The SDK does this in many places by printing a cryptic debug message followed by something equivalent to `while(true){}`, which compiles down to `loop: j loop`, creating a Soft WDT reset. 

This change calls attention to these deliberate WDT resets at Postmortem. In the one case that I examined closer, the SDK responded this way after an OOM event.

For SDK 3.0.5, I found this many "deliberate infinite loops":
| Libary | count |
| ---- | ----:|
| libpp.a |81
| libmain.a |8
| libespnow.a | 6
