### PR TITLE
Fixes to recent changes to Postmortem.

### DIFF
--- a/cores/esp8266/core_esp8266_postmortem.cpp
+++ b/cores/esp8266/core_esp8266_postmortem.cpp
@@ -110,6 +110,10 @@ static void cut_here() {
     ets_putc('\n');
 }
 
+static inline bool is_pc_valid(uint32_t pc) {
+    return pc >= XCHAL_INSTRAM0_VADDR && pc < (XCHAL_INSTROM0_VADDR + XCHAL_INSTROM0_SIZE);
+}
+
 /*
   Add some assembly to grab the stack pointer and pass it as an argument before
   it grows for the target function. Should stabilize the stack offsets, used to
@@ -125,7 +129,7 @@ asm(
     "\n"
 "__wrap_system_restart_local:\n\t"
     "mov          a2,     a1\n\t"
-    "j            postmortem_report\n\t"
+    "j.l          postmortem_report, a3\n\t"
     ".size __wrap_system_restart_local, .-__wrap_system_restart_local\n\t"
 );
 
@@ -183,7 +187,7 @@ static void postmortem_report(uint32_t sp_dump) {
     else if (rst_info.reason == REASON_SOFT_WDT_RST) {
         ets_printf_P(PSTR("\nSoft WDT reset"));
         const char infinite_loop[] = { 0x06, 0xff, 0xff };  // loop: j loop
-        if (0 == memcmp_P(infinite_loop, (PGM_VOID_P)rst_info.epc1, 3u)) {
+        if (is_pc_valid(rst_info.epc1) && 0 == memcmp_P(infinite_loop, (PGM_VOID_P)rst_info.epc1, 3u)) {
             // The SDK is riddled with these. They are usually preceded by an ets_printf.
             ets_printf_P(PSTR(" - deliberate infinite loop detected"));
         }


### PR DESCRIPTION
Fixes to recent changes to Postmortem.

Fix for `dangerous relocation: j: cannot encode`
To cover large jump offsets, use relaxed jump (`J.L`)  in `__wrap_system_restart_local`.

Add check that epc1 is a valid code address before reading.

Should resolve:
* https://github.com/esp8266/Arduino/issues/8923#issue-1708519374