### PR TITLE
Add softAPbroadcastIP

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiAP.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiAP.cpp
@@ -323,6 +323,17 @@ IPAddress ESP8266WiFiAPClass::softAPIP() {
     return IPAddress(ip.ip.addr);
 }
 
+/**
+ * Get the softAP broadcast ip address.
+ * @return IPAddress softAP broadcast IP
+ */
+IPAddress ESP8266WiFiAPClass::softAPbroadcastIP()
+{
+    struct ip_info ip;
+    wifi_get_ip_info(SOFTAP_IF, &ip);
+    return IPAddress(ip.ip.addr | ~(ip.netmask.addr));
+}
+
 
 /**
  * Get the softAP interface MAC address.

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiAP.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiAP.h
@@ -45,6 +45,7 @@ class ESP8266WiFiAPClass {
         uint8_t softAPgetStationNum();
 
         IPAddress softAPIP();
+        IPAddress softAPbroadcastIP();
 
         uint8_t* softAPmacAddress(uint8_t* mac);
         String softAPmacAddress(void);


### PR DESCRIPTION
Adding broadcast address retrieval in Access Point mode, example IPAddress broadcast = WiFi.softAPbroadcastIP();