### PR TITLE
Add virtual beginMulticast(...) stub to UDP class

### DIFF
--- a/cores/esp8266/Udp.h
+++ b/cores/esp8266/Udp.h
@@ -43,6 +43,7 @@ class UDP: public Stream {
     public:
         virtual ~UDP() {};
         virtual uint8_t begin(uint16_t) =0;	// initialize, start listening on specified port. Returns 1 if successful, 0 if there are no sockets available to use
+        virtual uint8_t beginMulticast(IPAddress, uint16_t) { return 0; }  // initialize, start listening on specified multicast IP address and port. Returns 1 if successful, 0 on failure
         virtual void stop() =0;  // Finish with the UDP socket
 
         // Sending UDP packets

--- a/doc/esp8266wifi/udp-class.rst
+++ b/doc/esp8266wifi/udp-class.rst
@@ -26,11 +26,11 @@ Multicast UDP
 
 .. code:: cpp
 
-    uint8_t  beginMulticast (IPAddress interfaceAddr, IPAddress multicast, uint16_t port) 
+    uint8_t  beginMulticast (IPAddress multicast, uint16_t port) 
     virtual int  beginPacketMulticast (IPAddress multicastAddress, uint16_t port, IPAddress interfaceAddress, int ttl=1) 
     IPAddress  destinationIP () 
     uint16_t  localPort ()
 
-The ``WiFiUDP`` class supports sending and receiving multicast packets on STA interface. When sending a multicast packet, replace ``udp.beginPacket(addr, port)`` with ``udp.beginPacketMulticast(addr, port, WiFi.localIP())``. When listening to multicast packets, replace ``udp.begin(port)`` with ``udp.beginMulticast(WiFi.localIP(), multicast_ip_addr, port)``. You can use ``udp.destinationIP()`` to tell whether the packet received was sent to the multicast or unicast address.
+The ``WiFiUDP`` class supports sending and receiving multicast packets on STA interface. When sending a multicast packet, replace ``udp.beginPacket(addr, port)`` with ``udp.beginPacketMulticast(addr, port, WiFi.localIP())``. When listening to multicast packets, replace ``udp.begin(port)`` with ``udp.beginMulticast(multicast_ip_addr, port)``. You can use ``udp.destinationIP()`` to tell whether the packet received was sent to the multicast or unicast address.
 
 For code samples please refer to separate section with `examples <udp-examples.rst>`__ dedicated specifically to the UDP Class.

--- a/libraries/ESP8266WiFi/src/WiFiUdp.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiUdp.cpp
@@ -86,16 +86,10 @@ uint8_t WiFiUDP::begin(uint16_t port)
 
 uint8_t WiFiUDP::beginMulticast(IPAddress multicast, uint16_t port)
 {
-    IPAddress local = WiFi.localIP();
-    return _beginMulticast(local, multicast, port);
+    return beginMulticast(IP_ADDR_ANY, multicast, port);
 }
 
 uint8_t WiFiUDP::beginMulticast(IPAddress interfaceAddr, IPAddress multicast, uint16_t port)
-{
-    return _beginMulticast(interfaceAddr, multicast, port);
-}
-
-uint8_t WiFiUDP::_beginMulticast(IPAddress interfaceAddr, IPAddress multicast, uint16_t port)
 {
     if (_ctx) {
         _ctx->unref();

--- a/libraries/ESP8266WiFi/src/WiFiUdp.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiUdp.cpp
@@ -84,7 +84,18 @@ uint8_t WiFiUDP::begin(uint16_t port)
     return (_ctx->listen(IPAddress(), port)) ? 1 : 0;
 }
 
+uint8_t WiFiUDP::beginMulticast(IPAddress multicast, uint16_t port)
+{
+    IPAddress local = WiFi.localIP();
+    return _beginMulticast(local, multicast, port);
+}
+
 uint8_t WiFiUDP::beginMulticast(IPAddress interfaceAddr, IPAddress multicast, uint16_t port)
+{
+    return _beginMulticast(interfaceAddr, multicast, port);
+}
+
+uint8_t WiFiUDP::_beginMulticast(IPAddress interfaceAddr, IPAddress multicast, uint16_t port)
 {
     if (_ctx) {
         _ctx->unref();

--- a/libraries/ESP8266WiFi/src/WiFiUdp.h
+++ b/libraries/ESP8266WiFi/src/WiFiUdp.h
@@ -32,7 +32,6 @@ class UdpContext;
 class WiFiUDP : public UDP, public SList<WiFiUDP> {
 private:
   UdpContext* _ctx;
-  uint8_t _beginMulticast(IPAddress interfaceAddr, IPAddress multicast, uint16_t port);
 
 public:
   WiFiUDP();  // Constructor
@@ -49,7 +48,8 @@ public:
   void stop() override;
   // join a multicast group and listen on the given port
   virtual uint8_t beginMulticast(IPAddress interfaceAddr, uint16_t port);
-  uint8_t beginMulticast(IPAddress interfaceAddr, IPAddress multicast, uint16_t port) __attribute__((deprecated));
+  // join a multicast group and listen on the given port, using a specific interface address
+  uint8_t beginMulticast(IPAddress interfaceAddr, IPAddress multicast, uint16_t port);
 
   // Sending UDP packets
   

--- a/libraries/ESP8266WiFi/src/WiFiUdp.h
+++ b/libraries/ESP8266WiFi/src/WiFiUdp.h
@@ -32,6 +32,7 @@ class UdpContext;
 class WiFiUDP : public UDP, public SList<WiFiUDP> {
 private:
   UdpContext* _ctx;
+  uint8_t _beginMulticast(IPAddress interfaceAddr, IPAddress multicast, uint16_t port);
 
 public:
   WiFiUDP();  // Constructor
@@ -47,7 +48,8 @@ public:
   // Finish with the UDP connection
   void stop() override;
   // join a multicast group and listen on the given port
-  uint8_t beginMulticast(IPAddress interfaceAddr, IPAddress multicast, uint16_t port);
+  virtual uint8_t beginMulticast(IPAddress interfaceAddr, uint16_t port);
+  uint8_t beginMulticast(IPAddress interfaceAddr, IPAddress multicast, uint16_t port) __attribute__((deprecated));
 
   // Sending UDP packets
   


### PR DESCRIPTION
Hi,
It seems that (at least) the Arduino core and the ESP32 core both has the base `beginMulticast` virtual definition in the base `UDP` class:

```cpp
     virtual uint8_t beginMulticast(IPAddress, uint16_t) { return 0; }  // initialize, start listening on specified multicast IP address and port. Returns 1 if successful, 0 on failure
``` 

In order to be compatible with libraries like [arduino-libraries/ArduinoMDNS](https://github.com/arduino-libraries/ArduinoMDNS), I've added the same base virtual function at `UDP` level here too.

With these changes, the above library works on a ESP8266 like a charm.

I'm not sure if the different already existing signature of the `WiFiUDP::beginMulticast` should be left here or not. To be backward compatible, I've added both signatures, but not sure if the one with the different signature should be tagged as deprecated or not.

Thanks!
 L