### PR TITLE
WiFiServer - operator bool() and method end()

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiServer.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiServer.cpp
@@ -173,6 +173,14 @@ void WiFiServer::stop() {
     close();
 }
 
+void WiFiServer::end() {
+    close();
+}
+
+WiFiServer::operator bool() {
+  return (status() != CLOSED);
+}
+
 err_t WiFiServer::_accept(tcp_pcb* apcb, err_t err) {
     (void) err;
     DEBUGV("WS:ac\r\n");

--- a/libraries/ESP8266WiFi/src/WiFiServer.h
+++ b/libraries/ESP8266WiFi/src/WiFiServer.h
@@ -100,6 +100,8 @@ public:
   uint16_t port() const;
   void close();
   void stop();
+  void end();
+  explicit operator bool();
 
   using ClientType = WiFiClient;
 


### PR DESCRIPTION
I did a research how different Arduino networking libraries implement the Arduino networking API.
https://github.com/JAndrassy/Arduino-Networking-API/blob/main/ArduinoNetAPILibs.md#server-class

For most libraries it is simpler to implement operator bool() than the method status() with its return value constants. So this PR adds bool operator for WiFiServer in the ESP8266Wifi library.

In the research I find out that end() is the most popular name for the function to stop the server and Arduino now used it too in the new WiFiS3 library.
