### PR TITLE
add Stream::readStringUntil function that uses string terminator

### DIFF
--- a/cores/esp8266/Stream.cpp
+++ b/cores/esp8266/Stream.cpp
@@ -262,6 +262,32 @@ String Stream::readStringUntil(char terminator) {
     return ret;
 }
 
+String Stream::readStringUntil(const char* terminator, uint32_t count) {
+    String ret;
+    int c;
+    uint32_t termCount = 0;
+    size_t termLen = strlen(terminator);
+    size_t termIndex = 0;
+    size_t index = 0;
+
+    while ((c = timedRead()) > 0) {
+        ret += (char) c;
+        index++;
+
+        if (terminator[termIndex] == c) {
+            if (++termIndex == termLen && ++termCount == count) {
+                // don't include terminator in returned string
+                ret.remove(index - termIndex, termLen);
+                break;
+            }
+        } else {
+            termIndex = 0;
+        }
+    }
+
+    return ret;
+}
+
 // read what can be read, immediate exit on unavailable data
 // prototype similar to Arduino's `int Client::read(buf, len)`
 int Stream::read (uint8_t* buffer, size_t maxLen)

--- a/cores/esp8266/Stream.cpp
+++ b/cores/esp8266/Stream.cpp
@@ -262,10 +262,10 @@ String Stream::readStringUntil(char terminator) {
     return ret;
 }
 
-String Stream::readStringUntil(const char* terminator, uint32_t count) {
+String Stream::readStringUntil(const char* terminator, uint32_t untilTotalNumberOfOccurrences) {
     String ret;
     int c;
-    uint32_t termCount = 0;
+    uint32_t occurrences = 0;
     size_t termLen = strlen(terminator);
     size_t termIndex = 0;
     size_t index = 0;
@@ -275,7 +275,7 @@ String Stream::readStringUntil(const char* terminator, uint32_t count) {
         index++;
 
         if (terminator[termIndex] == c) {
-            if (++termIndex == termLen && ++termCount == count) {
+            if (++termIndex == termLen && ++occurrences == untilTotalNumberOfOccurrences) {
                 // don't include terminator in returned string
                 ret.remove(index - termIndex, termLen);
                 break;

--- a/cores/esp8266/Stream.h
+++ b/cores/esp8266/Stream.h
@@ -115,6 +115,7 @@ class Stream: public Print {
         // Arduino String functions to be added here
         virtual String readString();
         String readStringUntil(char terminator);
+        String readStringUntil(const char* terminator, uint32_t count = 1);
 
         virtual int read (uint8_t* buffer, size_t len);
         int read (char* buffer, size_t len) { return read((uint8_t*)buffer, len); }

--- a/cores/esp8266/Stream.h
+++ b/cores/esp8266/Stream.h
@@ -115,7 +115,7 @@ class Stream: public Print {
         // Arduino String functions to be added here
         virtual String readString();
         String readStringUntil(char terminator);
-        String readStringUntil(const char* terminator, uint32_t count = 1);
+        String readStringUntil(const char* terminator, uint32_t untilTotalNumberOfOccurrences = 1);
 
         virtual int read (uint8_t* buffer, size_t len);
         int read (char* buffer, size_t len) { return read((uint8_t*)buffer, len); }


### PR DESCRIPTION
currently there is a
```c++
String readStringUntil(char terminator)
```
function, but there is no equivalent of it that uses string terminator. this pr implements
```c++
String readStringUntil(const char* terminator, uint32_t count = 1)
```
i found this useful for small html parsing or truncating.