### PR TITLE
WiFiSTA - allow using DHCP again after disconnecting static IP

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
@@ -400,6 +400,8 @@ bool ESP8266WiFiSTAClass::disconnect(bool wifioff, bool eraseCredentials) {
         WiFi.enableSTA(false);
     }
 
+    _useStaticIp = false;
+
     return ret;
 }
 


### PR DESCRIPTION
reset `_useStaticIp` to false in `WiFi.disconnect()`