### PR TITLE
EthernetCompat - static IP auto gw,mask,dns as in Arduino libraries

### DIFF
--- a/libraries/lwIP_Ethernet/src/EthernetCompat.h
+++ b/libraries/lwIP_Ethernet/src/EthernetCompat.h
@@ -38,10 +38,29 @@ public:
     // Arduino-Ethernet API compatibility, order can be either:
     // mac, ip, gateway, netmask, dns (esp8266 or natural order)
     // mac, ip, dns, gateway, netmask (Arduino legacy)
-    boolean begin(const uint8_t* macAddress, const IPAddress& local_ip = IPADDR_NONE,
-                  const IPAddress& arg1 = IPADDR_NONE, const IPAddress& arg2 = IPADDR_NONE,
-                  const IPAddress& arg3 = IPADDR_NONE)
+    boolean begin(const uint8_t* macAddress, IPAddress local_ip = IPADDR_NONE,
+                  IPAddress arg1 = IPADDR_NONE, IPAddress arg2 = IPADDR_NONE,
+                  IPAddress arg3 = IPADDR_NONE)
     {
+        if (local_ip.isSet() && local_ip.isV4())
+        {
+            // setting auto values using arduino ordering of parameters
+            if (arg1 == IPADDR_NONE)  // else dns or gw
+            {
+                arg1    = local_ip;
+                arg1[3] = 1;
+            }
+            if (arg2 == IPADDR_NONE)  // else gw or mask
+            {
+                arg2    = local_ip;
+                arg2[3] = 1;
+            }
+            // if arg2 is mask (esp ordering), let DNS IP unconfigured
+            if (arg3 == IPADDR_NONE && arg2[0] != 255)  // else mask or dns
+            {
+                arg3 = IPAddress(255, 255, 255, 0);
+            }
+        }
         SPI4EthInit();  // Arduino Ethernet self-initializes SPI
         bool ret = true;
         if (local_ip.isSet())


### PR DESCRIPTION
The parameters of `begin` in EthernetCompat.h are optional but automatic values for gw IP, mask and DNS IP were not calculated.

In the `begin(mac, local_ip, arg1)`, arg1 is assumed to be the DNS IP, because it can be an address outside of the local network. Automatic gw IP based on local_ip with .1 at the end is more likely to be a right auto value than DNS IP. Basically this is the reason for the Arduino ordering of begin parameters.