### PR TITLE
Resolve HWDT Reset with core_esp8266_vm

### DIFF
--- a/cores/esp8266/core_esp8266_vm.cpp
+++ b/cores/esp8266/core_esp8266_vm.cpp
@@ -161,14 +161,15 @@ static struct cache_line *__vm_cache; // Always points to MRU (hence the line be
 
 constexpr int addrmask = ~(sizeof(__vm_cache[0].w)-1); // Helper to mask off bits present in cache entry
 
-
 static void spi_init(spi_regs *spi1)
 {
   pinMode(sck, SPECIAL);
   pinMode(miso, SPECIAL);
   pinMode(mosi, SPECIAL);
   pinMode(cs, SPECIAL);
+  // spi_ctrl appears to need setting before other SPI registers
   spi1->spi_ctrl = 0;  // MSB first + plain SPI mode
+  asm("" ::: "memory");
   GPMUX &= ~(1 << 9);
   spi1->spi_clock = spi_clkval;
   spi1->spi_ctrl1 = 0; // undocumented, clear for safety?

--- a/cores/esp8266/core_esp8266_vm.cpp
+++ b/cores/esp8266/core_esp8266_vm.cpp
@@ -168,13 +168,13 @@ static void spi_init(spi_regs *spi1)
   pinMode(miso, SPECIAL);
   pinMode(mosi, SPECIAL);
   pinMode(cs, SPECIAL);
-  spi1->spi_cmd = 0;
+  spi1->spi_ctrl = 0;  // MSB first + plain SPI mode
   GPMUX &= ~(1 << 9);
   spi1->spi_clock = spi_clkval;
-  spi1->spi_ctrl = 0 ; // MSB first + plain SPI mode
   spi1->spi_ctrl1 = 0; // undocumented, clear for safety?
   spi1->spi_ctrl2 = 0; // No add'l delays on signals
   spi1->spi_user2 = 0; // No insn or insn_bits to set
+  spi1->spi_cmd = 0;
 }
 
 // Note: GCC optimization -O2 and -O3 tried and returned *slower* code than the default


### PR DESCRIPTION
With the newer GCC compiler (after tag 3.0.2), example virtualmem was crashing with an HWDT reset. Reordered some SPI register set lines in `spi_init()`. New ordering was based on `SPIClass::begin` in `SPI.cpp`.

Someone with a deeper understanding of these SPI registers should review my changes.

This change may resolve issues described in
* https://github.com/esp8266/Arduino/discussions/9010

Addendum:
I have only tested with the `8M w/256K Heap External 64 MBit PSRAM` build option.