### PR TITLE
elf2bin.py - Fix syntax warning

### DIFF
--- a/tools/elf2bin.py
+++ b/tools/elf2bin.py
@@ -51,7 +51,7 @@ def get_elf_entry(elf, path):
     lines = io.StringIO(result.stdout)
     for line in lines.readlines():
         if 'Entry point address' in line:
-            words = re.split('\s+', line)
+            words = re.split(r'\s+', line)
             entry_point = words[-2]
             return int(entry_point, 16)
 
@@ -70,7 +70,7 @@ def get_segment_size_addr(elf, segment, path):
     lines = io.StringIO(result.stdout)
     for line in lines.readlines():
         if segment in line:
-            words = re.split('\s+', line)
+            words = re.split(r'\s+', line)
             size = int(words[3], 16)
             addr = int(words[4], 16)
             return [ size, addr ]


### PR DESCRIPTION
Remove warning when building with Python >=3.11:

```
/Users/juherr/.platformio/packages/framework-arduinoespressif8266/tools/elf2bin.py:54: SyntaxWarning: invalid escape sequence '\s'
  words = re.split('\s+', line)
/Users/juherr/.platformio/packages/framework-arduinoespressif8266/tools/elf2bin.py:73: SyntaxWarning: invalid escape sequence '\s'
  words = re.split('\s+', line)
```

See https://adamj.eu/tech/2022/11/04/why-does-python-deprecationwarning-invalid-escape-sequence/ for more details about the warning.