### PR TITLE
LwipIntfDev - add parameter's missing default value for dnsIP(n)

### DIFF
--- a/cores/esp8266/LwipIntfDev.h
+++ b/cores/esp8266/LwipIntfDev.h
@@ -96,7 +96,7 @@ public:
     {
         return IPAddress(ip4_addr_get_u32(ip_2_ip4(&_netif.gw)));
     }
-    IPAddress dnsIP(int n) const  // WiFi lib way
+    IPAddress dnsIP(int n = 0) const  // WiFi lib way
     {
         return IPAddress(dns_getserver(n));
     }


### PR DESCRIPTION
a little fix in the code from a recent PR https://github.com/esp8266/Arduino/pull/9022