### PR TITLE
LwipIntfDev - config static IP auto gw,mask,dns as in Arduino libraries

### DIFF
--- a/cores/esp8266/LwipIntfDev.h
+++ b/cores/esp8266/LwipIntfDev.h
@@ -63,8 +63,13 @@ public:
         memset(&_netif, 0, sizeof(_netif));
     }
 
+    //The argument order for ESP is not the same as for Arduino. However, there is compatibility code under the hood
+    //to detect Arduino arg order, and handle it correctly.
     boolean config(const IPAddress& local_ip, const IPAddress& arg1, const IPAddress& arg2,
                    const IPAddress& arg3 = IPADDR_NONE, const IPAddress& dns2 = IPADDR_NONE);
+
+    // two and one parameter version. 2nd parameter is DNS like in Arduino. IPv4 only
+    boolean config(IPAddress local_ip, IPAddress dns = INADDR_ANY);
 
     // default mac-address is inferred from esp8266's STA interface
     boolean begin(const uint8_t* macAddress = nullptr, const uint16_t mtu = DEFAULT_MTU);
@@ -210,6 +215,24 @@ boolean LwipIntfDev<RawDev>::config(const IPAddress& localIP, const IPAddress& g
 }
 
 template<class RawDev>
+boolean LwipIntfDev<RawDev>::config(IPAddress local_ip, IPAddress dns)
+{
+    if (!local_ip.isSet())
+        return config(INADDR_ANY, INADDR_ANY, INADDR_ANY);
+
+    if (!local_ip.isV4())
+        return false;
+
+    IPAddress gw(local_ip);
+    gw[3] = 1;
+    if (!dns.isSet())
+    {
+        dns = gw;
+    }
+    return config(local_ip, gw, IPAddress(255, 255, 255, 0), dns);
+}
+
+template<class RawDev>
 boolean LwipIntfDev<RawDev>::begin(const uint8_t* macAddress, const uint16_t mtu)
 {
     if (mtu)
@@ -336,9 +359,6 @@ template<class RawDev>
 void LwipIntfDev<RawDev>::end()
 {
     netif_remove(&_netif);
-    ip_addr_copy(_netif.ip_addr, ip_addr_any);  // to allow DHCP at next begin
-    ip_addr_copy(_netif.netmask, ip_addr_any);
-    ip_addr_copy(_netif.gw, ip_addr_any);
     _started = false;
     RawDev::end();
 }

--- a/libraries/lwIP_Ethernet/src/EthernetCompat.h
+++ b/libraries/lwIP_Ethernet/src/EthernetCompat.h
@@ -86,6 +86,13 @@ public:
         return ret;
     }
 
+    void end()
+    {
+        ip_addr_copy(LwipIntfDev<RawDev>::_netif.ip_addr,
+                     ip_addr_any);  // to allow DHCP at next begin
+        LwipIntfDev<RawDev>::end();
+    }
+
     HardwareStatus hardwareStatus() const
     {
         return _hardwareStatus;


### PR DESCRIPTION
so one more, This one is for 'modern' Ethernet libraries W5100lwIP, W5500lwIP and ENC28J60lwIP used without EthernetCompat.
I wrote [a test](https://github.com/JAndrassy/NetApiHelpers/blob/master/examples/ModernEthernetTest/ModernEthernetTest.ino) for what I consider a modern Ethernet library (one with config for static IP as in WiFi libraries) and to my surprise these libraries matched my idea. Only the automatic dns, gw, subnet values were not supported here again.

So here is the third PR for auto gw,mask,dns as in Arduino libraries. First was in 'begin' for EthernetCompat, second was `config` with two parameters in WiFiSTA.
I had to move the clearing of localIP to `EthernetCompat.end`, because in library with `config`, `disconnect`/`end` should not clear static IP settings. (config(INADDR_NONE) should))