### PR TITLE
WiFi.h as alias to ESP8266WiFi.h

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFi.h
+++ b/libraries/ESP8266WiFi/src/WiFi.h
@@ -1,0 +1,2 @@
+
+#include "ESP8266WiFi.h"


### PR DESCRIPTION
Arduino IDE 2 and CLI doesn't bundle the old WiFi library, so WiFi.h works to find the ESP8266WiFi library.

in alternative IDE where libraries are added manually WiFi.h works too

in IDE 1 if the sketch includes ESP8266WiFi.h, other source files including libraries can include WiFi.h and the right WiFi library is used