### PR TITLE
WiFiClient - op bool should return false only for empty Client

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -341,7 +341,7 @@ uint8_t WiFiClient::status()
 
 WiFiClient::operator bool()
 {
-    return available() || connected();
+    return (_client != nullptr);
 }
 
 IPAddress WiFiClient::remoteIP()


### PR DESCRIPTION
in 'Arduino language' which doesn't use pointers or references, an empty Client with operator bool returning false is used instead of a NULL pointer. an example is the return value of `server.accept()`.

Implementations of Client operator bool in libraries by Arduino:
the WiFiNINA library
```
WiFiClient::operator bool() {
  return _sock != 255;
}
```
the classic Ethernet library
```
virtual operator bool() { return _sockindex < MAX_SOCK_NUM; }
```
the MbedCore base class for WiFiClient and EthernetClient
```
  operator bool() {
    return sock != nullptr;
  }
```
