### PR TITLE
Avoid NPE and "multi-deinitialization" of ArduinoOTA

### DIFF
--- a/libraries/ArduinoOTA/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/ArduinoOTA.cpp
@@ -359,9 +359,14 @@ void ArduinoOTAClass::_runUpdate() {
 }
 
 void ArduinoOTAClass::end() {
+    if (!_initialized)
+      return;
+
     _initialized = false;
-    _udp_ota->unref();
-    _udp_ota = 0;
+    if(_udp_ota){
+        _udp_ota->unref();
+        _udp_ota = 0;
+    }
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_MDNS)
     if(_useMDNS){
         MDNS.end();


### PR DESCRIPTION
Avoid a null pointer exception when ArduinoOTA.end() is called more than once and thus the UDP socket is already freed.

Also avoid unnecessary teardown if the class is not initialized yet (for example, begin() wasn't called yet, or end() is called multiple times).