### PR TITLE
Add 2 functions to adjust timeout value in WiFiClient.h and WiFiClient.cpp

### DIFF
--- a/libraries/ESP8266WiFi/src/WiFiClient.cpp
+++ b/libraries/ESP8266WiFi/src/WiFiClient.cpp
@@ -387,6 +387,16 @@ void WiFiClient::abort()
 	_client->abort(); // Wich in turn calls tcp_abort which calls tcp_abandon().
 }
 
+// In case you need to increase/decrease timeout current value
+bool WiFiClient::setTimeout( int timeout_ms )
+{
+   if ( timeout_ms <= 0 || timeout_ms > 3600000 ) return(false); // More than 0 and less than 1 hour
+   _timeout = timeout_ms;
+   if (!_client) return(true);
+   else _client->setTimeout(_timeout);
+   return(true);
+}
+
 void WiFiClient::stopAll()
 {
     for (WiFiClient* it = _s_first; it; it = it->_next) {

--- a/libraries/ESP8266WiFi/src/WiFiClient.h
+++ b/libraries/ESP8266WiFi/src/WiFiClient.h
@@ -151,6 +151,12 @@ public:
   // Immediately stops this client instance.
   // Unlike stop(), does not wait to gracefuly shutdown the connection.
   void abort();
+ 
+  // Default timeout is set to 5000 ms. 
+  // setTimeout gives the possibility to adjust this value.
+  // getTimeout return the timeout current value.  
+  bool setTimeout( int );
+  int getTimeout();
 
 protected:
 


### PR DESCRIPTION

Default value of timeout is 5000 ms but currently it can't be changed in case the user think it is inadequate for its application.
For ESP32 we already have the possibility to specifie the timeout value as an argument of the connect function.
The aim of the request is to provide the possibilty to specifie a value for ESP8266 too.

Usage example:
int oldValue = getTimeout();
setTimeout( newValue );
client.connect( args );
setTimeout( oldValue );

WiFiClient.h:
// Default timeout is set to 5000 ms
// setTimeout gives the possibility to adjust this value.
// getTimeout return the timeout current value.
bool setTimeout( int );
int getTimeout();

WiFiClient.cpp:
// In case you need to increase/decrease timeout current value
bool WiFiClient::setTimeout( int timeout_ms )
{
if ( timeout_ms <= 0 || timeout_ms > 3600000 ) return(false); // More than 0 and less than 1 hour
_timeout = timeout_ms;
if (!_client) return(true);
else _client->setTimeout(_timeout);
return(true);
}

int WiFiClient::getTimeout()
{
return( _timeout );
}