### PR TITLE
ESP8266WebServer - fix possible memory leak in request argument handling

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
@@ -590,10 +590,6 @@ const String& ESP8266WebServerTemplate<ServerType>::pathArg(unsigned int i) cons
 
 template <typename ServerType>
 const String& ESP8266WebServerTemplate<ServerType>::arg(const String& name) const {
-  for (int j = 0; j < _postArgsLen; ++j) {
-    if ( _postArgs[j].key == name )
-      return _postArgs[j].value;
-  }
   for (int i = 0; i < _currentArgCount + _currentArgsHavePlain; ++i) {
     if ( _currentArgs[i].key == name )
       return _currentArgs[i].value;
@@ -622,10 +618,6 @@ int ESP8266WebServerTemplate<ServerType>::args() const {
 
 template <typename ServerType>
 bool ESP8266WebServerTemplate<ServerType>::hasArg(const String& name) const {
-  for (int j = 0; j < _postArgsLen; ++j) {
-    if (_postArgs[j].key == name)
-      return true;
-  }
   for (int i = 0; i < _currentArgCount + _currentArgsHavePlain; ++i) {
     if (_currentArgs[i].key == name)
       return true;

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -323,8 +323,6 @@ protected:
   RequestArgument* _currentArgs = nullptr;
   int              _currentArgsHavePlain = 0;
   std::unique_ptr<HTTPUpload> _currentUpload;
-  int              _postArgsLen = 0;
-  RequestArgument* _postArgs = nullptr;
 
   int              _headerKeysCount = 0;
   RequestArgument* _currentHeaders = nullptr;


### PR DESCRIPTION
* fix possible leak of _postArgs array in case of returning early from _parseForm().
* don't use _postArgs member, but instead use a new local variable postArgs instead.
* same for _postArgsLen member vs.local postArgsLen.
* remove useless NULL pointer check before delete().

fix #9075