### PR TITLE
Added support to override host header.

### DIFF
--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.cpp
@@ -119,6 +119,9 @@ bool HTTPClient::begin(WiFiClient &client, const String& host, uint16_t port, co
     return true;
 }
 
+void HTTPClient::setHostHeader(const String& host) {
+    _hostHeader = host;
+}
 
 bool HTTPClient::beginInternal(const String& __url, const char* expectedProtocol)
 {
@@ -840,7 +843,7 @@ bool HTTPClient::sendHeader(const char * type)
     }
 
     header += F("\r\nHost: ");
-    header += _host;
+    header += _hostHeader.isEmpty() ? _host : _hostHeader;
     if (_port != 80 && _port != 443)
     {
         header += ':';

--- a/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.h
+++ b/libraries/ESP8266HTTPClient/src/ESP8266HTTPClient.h
@@ -178,6 +178,7 @@ public:
     void setAuthorization(const char * auth);
     void setAuthorization(String auth);
     void setTimeout(uint16_t timeout);
+    void setHostHeader(const String& host);
 
     // Redirections
     void setFollowRedirects(followRedirects_t follow);
@@ -254,6 +255,7 @@ protected:
 
     /// request handling
     String _host;
+    String _hostHeader;
     uint16_t _port = 0;
     bool _reuse = true;
     uint16_t _tcpTimeout = HTTPCLIENT_DEFAULT_TCP_TIMEOUT;


### PR DESCRIPTION
As [dns is not working](https://github.com/esp8266/Arduino/issues/8780) on my network I decided to workaround the issue for now and figured this might actually be a feature we want here =)