### PR TITLE
Add pathArgs method in analogy to the args method of ESP8266WebServer

### DIFF
--- a/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
@@ -589,6 +589,13 @@ const String& ESP8266WebServerTemplate<ServerType>::pathArg(unsigned int i) cons
 }
 
 template <typename ServerType>
+const int ESP8266WebServerTemplate<ServerType>::pathArgs() const {
+  if (_currentHandler != nullptr)
+    return _currentHandler->pathArgs();
+  return 0;
+}
+
+template <typename ServerType>
 const String& ESP8266WebServerTemplate<ServerType>::arg(const String& name) const {
   for (int i = 0; i < _currentArgCount + _currentArgsHavePlain; ++i) {
     if ( _currentArgs[i].key == name )

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -58,11 +58,11 @@ enum HTTPAuthMethod { BASIC_AUTH, DIGEST_AUTH };
 #define HTTP_UPLOAD_BUFLEN 2048
 #endif
 
-#define HTTP_MAX_DATA_WAIT 5000 //ms to wait for the client to send the request
-#define HTTP_MAX_DATA_AVAILABLE_WAIT 30 //ms to wait for the client to send the request when there is another client with data available
-#define HTTP_MAX_POST_WAIT 5000 //ms to wait for POST data to arrive
-#define HTTP_MAX_SEND_WAIT 5000 //ms to wait for data chunk to be ACKed
-#define HTTP_MAX_CLOSE_WAIT 2000 //ms to wait for the client to close the connection
+#define HTTP_MAX_DATA_WAIT 5000         // ms to wait for the client to send the request
+#define HTTP_MAX_DATA_AVAILABLE_WAIT 30 // ms to wait for the client to send the request when there is another client with data available
+#define HTTP_MAX_POST_WAIT 5000         // ms to wait for POST data to arrive
+#define HTTP_MAX_SEND_WAIT 5000         // ms to wait for data chunk to be ACKed
+#define HTTP_MAX_CLOSE_WAIT 2000        // ms to wait for the client to close the connection
 
 #define CONTENT_LENGTH_UNKNOWN ((size_t) -1)
 #define CONTENT_LENGTH_NOT_SET ((size_t) -2)
@@ -72,9 +72,9 @@ typedef struct {
   String  filename;
   String  name;
   String  type;
-  size_t  totalSize;    // total size of uploaded file so far
-  size_t  currentSize;  // size of data currently in buf
-  size_t  contentLength; // size of entire post request, file size + headers and other request data.
+  size_t  totalSize;      // total size of uploaded file so far
+  size_t  currentSize;    // size of data currently in buf
+  size_t  contentLength;  // size of entire post request, file size + headers and other request data.
   uint8_t buf[HTTP_UPLOAD_BUFLEN];
 } HTTPUpload;
 
@@ -122,8 +122,8 @@ public:
   void on(const Uri &uri, HTTPMethod method, THandlerFunction fn, THandlerFunction ufn);
   void addHandler(RequestHandlerType* handler);
   void serveStatic(const char* uri, fs::FS& fs, const char* path, const char* cache_header = NULL );
-  void onNotFound(THandlerFunction fn);  //called when handler is not assigned
-  void onFileUpload(THandlerFunction fn); //handle file uploads
+  void onNotFound(THandlerFunction fn);   // called when handler is not assigned
+  void onFileUpload(THandlerFunction fn); // handle file uploads
   void enableCORS(bool enable);
   void enableETag(bool enable, ETagFunction fn = nullptr);
 
@@ -135,21 +135,21 @@ public:
   // Allows setting server options (i.e. SSL keys) by the instantiator
   ServerType &getServer() { return _server; }
 
-  const String& pathArg(unsigned int i) const; // get request path argument by number
+  const String& pathArg(unsigned int i) const;    // get request path argument by number
   const String& arg(const String& name) const;    // get request argument value by name
-  const String& arg(int i) const;          // get request argument value by number
-  const String& argName(int i) const;      // get request argument name by number
-  int args() const;                        // get arguments count
-  bool hasArg(const String& name) const;   // check if argument exists
+  const String& arg(int i) const;                 // get request argument value by number
+  const String& argName(int i) const;             // get request argument name by number
+  int args() const;                               // get arguments count
+  bool hasArg(const String& name) const;          // check if argument exists
   void collectHeaders(const char* headerKeys[], const size_t headerKeysCount); // set the request headers to collect
   template<typename... Args>
-  void collectHeaders(const Args&... args); // set the request headers to collect (variadic template version)
+  void collectHeaders(const Args&... args);       // set the request headers to collect (variadic template version)
   const String& header(const String& name) const; // get request header value by name
-  const String& header(int i) const;       // get request header value by number
-  const String& headerName(int i) const;   // get request header name by number
-  int headers() const;                     // get header count
+  const String& header(int i) const;              // get request header value by number
+  const String& headerName(int i) const;          // get request header name by number
+  int headers() const;                            // get header count
   bool hasHeader(const String& name) const;       // check if header exists
-  const String& hostHeader() const;        // get request host header if available or empty String if not
+  const String& hostHeader() const;               // get request host header if available or empty String if not
 
   // send response to the client
   // code - HTTP response code, can be 200 or 404
@@ -350,4 +350,4 @@ protected:
 using ESP8266WebServer = esp8266webserver::ESP8266WebServerTemplate<WiFiServer>;
 using RequestHandler = esp8266webserver::RequestHandler<WiFiServer>;
 
-#endif //ESP8266WEBSERVER_H
+#endif // ESP8266WEBSERVER_H

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -136,6 +136,7 @@ public:
   ServerType &getServer() { return _server; }
 
   const String& pathArg(unsigned int i) const;    // get request path argument by number
+  const int pathArgs() const;                     // get path arguments count
   const String& arg(const String& name) const;    // get request argument value by name
   const String& arg(int i) const;                 // get request argument value by number
   const String& argName(int i) const;             // get request argument name by number

--- a/libraries/ESP8266WebServer/src/Uri.h
+++ b/libraries/ESP8266WebServer/src/Uri.h
@@ -19,7 +19,7 @@ class Uri {
             return new Uri(_uri);
         };
 
-        virtual bool canHandle(const String &requestUri, __attribute__((unused)) std::vector<String> &pathArgs) {
+        virtual bool canHandle(const String &requestUri, __attribute__((unused)) std::vector<String> &currentPathArgs) {
             return _uri == requestUri;
         }
 };

--- a/libraries/ESP8266WebServer/src/detail/RequestHandler.h
+++ b/libraries/ESP8266WebServer/src/detail/RequestHandler.h
@@ -24,12 +24,15 @@ private:
     RequestHandler<ServerType>* _next = nullptr;
 	
 protected:
-    std::vector<String> pathArgs;
+    std::vector<String> currentPathArgs;
 
 public:
     const String& pathArg(unsigned int i) { 
-        assert(i < pathArgs.size());
-        return pathArgs[i];
+        assert(i < currentPathArgs.size());
+        return currentPathArgs[i];
+    }
+    const int pathArgs() {
+        return currentPathArgs.size();
     }
 };
 

--- a/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
@@ -49,7 +49,7 @@ public:
         if (_method != HTTP_ANY && _method != requestMethod)
             return false;
 
-        return _uri->canHandle(requestUri, RequestHandler<ServerType>::pathArgs);
+        return _uri->canHandle(requestUri, RequestHandler<ServerType>::currentPathArgs);
     }
 
     bool canUpload(const String& requestUri) override  {

--- a/libraries/ESP8266WebServer/src/uri/UriBraces.h
+++ b/libraries/ESP8266WebServer/src/uri/UriBraces.h
@@ -13,11 +13,11 @@ class UriBraces : public Uri {
             return new UriBraces(_uri);
         };
 
-        bool canHandle(const String &requestUri, std::vector<String> &pathArgs) override final {
-            if (Uri::canHandle(requestUri, pathArgs))
+        bool canHandle(const String &requestUri, std::vector<String> &currentPathArgs) override final {
+            if (Uri::canHandle(requestUri, currentPathArgs))
                 return true;
 
-            pathArgs.clear();
+            currentPathArgs.clear();
 
             size_t uriLength = _uri.length();
             unsigned int requestUriIndex = 0;
@@ -33,8 +33,8 @@ class UriBraces : public Uri {
                 i += 2; // index of char after '}'
                 if (i >= uriLength) {
                     // there is no char after '}'
-                    pathArgs.push_back(requestUri.substring(requestUriIndex));
-                    return pathArgs.back().indexOf("/") == -1; // path argument may not contain a '/'
+                    currentPathArgs.push_back(requestUri.substring(requestUriIndex));
+                    return currentPathArgs.back().indexOf("/") == -1; // path argument may not contain a '/'
                 }
                 else
                 {
@@ -42,7 +42,7 @@ class UriBraces : public Uri {
                     int uriIndex = requestUri.indexOf(charEnd, requestUriIndex);
                     if (uriIndex < 0)
                         return false;
-                    pathArgs.push_back(requestUri.substring(requestUriIndex, uriIndex));
+                    currentPathArgs.push_back(requestUri.substring(requestUriIndex, uriIndex));
                     requestUriIndex = (unsigned int) uriIndex;
                 }
             }

--- a/libraries/ESP8266WebServer/src/uri/UriGlob.h
+++ b/libraries/ESP8266WebServer/src/uri/UriGlob.h
@@ -14,7 +14,7 @@ class UriGlob : public Uri {
             return new UriGlob(_uri);
         };
 
-        bool canHandle(const String &requestUri, __attribute__((unused)) std::vector<String> &pathArgs) override final {
+        bool canHandle(const String &requestUri, __attribute__((unused)) std::vector<String> &currentPathArgs) override final {
             return fnmatch(_uri.c_str(), requestUri.c_str(), 0) == 0;
         }
 };

--- a/libraries/ESP8266WebServer/src/uri/UriRegex.h
+++ b/libraries/ESP8266WebServer/src/uri/UriRegex.h
@@ -28,21 +28,21 @@ class UriRegex : public Uri {
             return new UriRegex(_uri);
         };
 
-        bool canHandle(const String &requestUri, std::vector<String> &pathArgs) override final {
-            if (Uri::canHandle(requestUri, pathArgs))
+        bool canHandle(const String &requestUri, std::vector<String> &currentPathArgs) override final {
+            if (Uri::canHandle(requestUri, currentPathArgs))
                 return true;
 
             regmatch_t groupArray[REGEX_MAX_GROUPS];
             if (regexec(&_regexCompiled, requestUri.c_str(), REGEX_MAX_GROUPS, groupArray, 0) == 0) {
                 // matches
-                pathArgs.clear();
+                currentPathArgs.clear();
 
                 unsigned int g = 1; 
                 for (; g < REGEX_MAX_GROUPS; g++) {
                     if (groupArray[g].rm_so == (long int)-1)
                         break;  // No more groups
 
-                    pathArgs.push_back(requestUri.substring(groupArray[g].rm_so, groupArray[g].rm_eo));
+                    currentPathArgs.push_back(requestUri.substring(groupArray[g].rm_so, groupArray[g].rm_eo));
                 }
 
                 return true;


### PR DESCRIPTION
If you want to use path arguments (pathArg) together with UriRegex and optional catch groups in a regular expression you need to know how many path arguments have been found as the number might vary. Otherwise you might access indices that are not available depending on the number of matched optional catch groups.

This pull request implements the method `pathArgs` in analogy to the method `args` for normal server arguments.

Feel free tell me if something should be changed or if something is missing and also feel free to do changes your self to this PR if you want to.

I hope this features helps someone else as well :) - it makes path matching with regular expressions even more powerful. 