### PR TITLE
Add missing update error codes

### DIFF
--- a/cores/esp8266/Updater.cpp
+++ b/cores/esp8266/Updater.cpp
@@ -70,6 +70,7 @@ bool UpdaterClass::begin(size_t size, int command, int ledPin, uint8_t ledOn) {
 #ifdef DEBUG_UPDATER
     DEBUG_UPDATER.println(F("[begin] already running"));
 #endif
+    _setError(UPDATE_ERROR_RUNNING_ALREADY);
     return false;
   }
 
@@ -86,7 +87,7 @@ bool UpdaterClass::begin(size_t size, int command, int ledPin, uint8_t ledOn) {
     _setError(UPDATE_ERROR_BOOTSTRAP);
     return false;
   }
-  
+
 #ifdef DEBUG_UPDATER
   if (command == U_FS) {
     DEBUG_UPDATER.println(F("[begin] Update Filesystem."));
@@ -133,7 +134,7 @@ bool UpdaterClass::begin(size_t size, int command, int ledPin, uint8_t ledOn) {
 
     //make sure that the size of both sketches is less than the total space (updateEndAddress)
     if(updateStartAddress < currentSketchSize) {
-      _setError(UPDATE_ERROR_SPACE);    
+      _setError(UPDATE_ERROR_SPACE);
       return false;
     }
   }
@@ -162,6 +163,7 @@ bool UpdaterClass::begin(size_t size, int command, int ledPin, uint8_t ledOn) {
 #ifdef DEBUG_UPDATER
     DEBUG_UPDATER.println(F("[begin] Unknown update command."));
 #endif
+    _setError(UPDATE_ERROR_UNKNOWN_COMMAND);
     return false;
   }
 
@@ -404,7 +406,7 @@ bool UpdaterClass::_writeBuffer(){
       modifyFlashMode = true;
     }
   }
-  
+
   if (eraseResult) {
     if(!_async) yield();
     writeResult = ESP.flashWrite(_currentAddress, _buffer, _bufferLen);
@@ -488,7 +490,7 @@ bool UpdaterClass::_verifyEnd() {
         uint8_t buf[4] __attribute__((aligned(4)));
         if(!ESP.flashRead(_startAddress, (uint32_t *) &buf[0], 4)) {
             _currentAddress = (_startAddress);
-            _setError(UPDATE_ERROR_READ);            
+            _setError(UPDATE_ERROR_READ);
             return false;
         }
 
@@ -500,7 +502,7 @@ bool UpdaterClass::_verifyEnd() {
             return true;
         } else if (buf[0] != 0xE9) {
             _currentAddress = (_startAddress);
-            _setError(UPDATE_ERROR_MAGIC_BYTE);            
+            _setError(UPDATE_ERROR_MAGIC_BYTE);
             return false;
         }
 
@@ -512,7 +514,7 @@ bool UpdaterClass::_verifyEnd() {
         // check if new bin fits to SPI flash
         if(bin_flash_size > ESP.getFlashChipRealSize()) {
             _currentAddress = (_startAddress);
-            _setError(UPDATE_ERROR_NEW_FLASH_CONFIG);            
+            _setError(UPDATE_ERROR_NEW_FLASH_CONFIG);
             return false;
         }
 #endif

--- a/cores/esp8266/Updater.cpp
+++ b/cores/esp8266/Updater.cpp
@@ -651,6 +651,12 @@ String UpdaterClass::getErrorString() const {
   case UPDATE_ERROR_OOM:
     out = F("Out of memory");
     break;
+  case UPDATE_ERROR_RUNNING_ALREADY:
+    out = F("Update already running");
+    break;
+  case UPDATE_ERROR_UNKNOWN_COMMAND:
+    out = F("Unknown update command");
+    break;
   default:
     out = F("UNKNOWN");
     break;

--- a/cores/esp8266/Updater.h
+++ b/cores/esp8266/Updater.h
@@ -57,7 +57,7 @@ class UpdaterClass {
     using THandlerFunction_Progress = std::function<void(size_t, size_t)>;
     using THandlerFunction_Error = std::function<void(uint8_t)>;
     using THandlerFunction = std::function<void()>;
-  
+
     UpdaterClass();
     ~UpdaterClass();
 
@@ -71,7 +71,7 @@ class UpdaterClass {
     bool begin(size_t size, int command = U_FLASH, int ledPin = -1, uint8_t ledOn = LOW);
 
     /*
-      Run Updater from asynchronous callbacs
+      Run Updater from asynchronous callbacks
     */
     void runAsync(bool async){ _async = async; }
 
@@ -218,7 +218,7 @@ class UpdaterClass {
     bool _verifyHeader(uint8_t data);
     bool _verifyEnd();
 
-    void _setError(int error);    
+    void _setError(int error);
 
     bool _async = false;
     uint8_t _error = 0;

--- a/cores/esp8266/Updater.h
+++ b/cores/esp8266/Updater.h
@@ -21,6 +21,8 @@
 #define UPDATE_ERROR_SIGN               (12)
 #define UPDATE_ERROR_NO_DATA            (13)
 #define UPDATE_ERROR_OOM                (14)
+#define UPDATE_ERROR_RUNNING_ALREADY    (15)
+#define UPDATE_ERROR_UNKNOWN_COMMAND    (16)
 
 #define U_FLASH   0
 #define U_FS      100


### PR DESCRIPTION
This PR adds the two missing error states when beginning an Update. There were debugging logs for this but the error state was not set which would lead to confusion