### PR TITLE
decoder.py: allowing to use it live

### DIFF
--- a/tools/decoder.py
+++ b/tools/decoder.py
@@ -126,7 +126,7 @@ def decode_lines(format_addresses, elf, lines):
     def format_address(address):
         return "\n".join(format_addresses(elf, [address]))
 
-    lastepc = 0
+    lastaddr = {}
     for line in lines:
         # ctx could happen multiple times. for the 2nd one, reset list
         # ctx: bearssl *or* ctx: cont *or* ctx: sys *or* ctx: whatever
@@ -146,9 +146,9 @@ def decode_lines(format_addresses, elf, lines):
                 name, addr = pair.split("=")
                 if name in ["epc1", "excvaddr"]:
                     addr = addr.rstrip(',')
-                    if lastepc != addr:
+                    if not name in lastaddr or lastaddr[name] != addr:
                         if addr != '0x00000000':
-                            lastepc = addr
+                            lastaddr[name] = addr
                         output = format_address(addr)
                         if output:
                             print(f"{name}={output}")

--- a/tools/decoder.py
+++ b/tools/decoder.py
@@ -10,6 +10,7 @@ import argparse
 import sys
 import re
 import subprocess
+import shutil
 
 # https://github.com/me-no-dev/EspExceptionDecoder/blob/349d17e4c9896306e2c00b4932be3ba510cad208/src/EspExceptionDecoder.java#L59-L90
 EXCEPTION_CODES = (
@@ -189,9 +190,8 @@ def select_tool(toolchain_path, tool, func):
     path = f"xtensa-lx106-elf-{tool}"
     if toolchain_path:
         path = os.path.join(toolchain_path, path)
-        if not os.path.isfile(path):
-            print(f"error: not existing tool (path -- tool): '{path}'", file=sys.stderr)
-            sys.exit(1)
+        if not shutil.which(path):
+            raise FileNotFoundError(path)
 
     def formatter(func, path):
         def wrapper(elf, addresses):

--- a/tools/decoder.py
+++ b/tools/decoder.py
@@ -189,8 +189,9 @@ def select_tool(toolchain_path, tool, func):
     path = f"xtensa-lx106-elf-{tool}"
     if toolchain_path:
         path = os.path.join(toolchain_path, path)
-        if not shutil.which(path):
-            raise FileNotFoundError(path)
+        
+    if not shutil.which(path):
+        raise FileNotFoundError(path)
 
     def formatter(func, path):
         def wrapper(elf, addresses):

--- a/tools/decoder.py
+++ b/tools/decoder.py
@@ -105,7 +105,7 @@ def decode_lines(format_addresses, elf, lines):
 
     STACK_LINE_RE = re.compile(r"^[0-9a-f]{8}:\s\s+")
 
-    IGNORE_DUP = re.compile(r"^(epc1=0x........,|Fatal exception )")
+    IGNORE_FIRMWARE_RE = re.compile(r"^(epc1=0x........, |Fatal exception )")
 
     CUT_HERE_STRING = "CUT HERE FOR EXCEPTION DECODER"
     DECODE_IT = "DECODE IT"
@@ -136,7 +136,7 @@ def decode_lines(format_addresses, elf, lines):
             stack_addresses = print_all_addresses(stack_addresses)
             last_stack = line.strip()
         # 3fffffb0:  feefeffe feefeffe 3ffe85d8 401004ed
-        elif IGNORE_DUP.match(line):
+        elif IGNORE_FIRMWARE_RE.match(line):
             continue
         elif in_stack and STACK_LINE_RE.match(line):
             _, addrs = line.split(":")


### PR DESCRIPTION
Changes:

- avoid ctx repetition
- hide "DECODE IT"
- immediately print stack at closing marker
- check for executable decoder at startup

live command line example:
```
    pyserial-miniterm /dev/ttyUSB0 115200 | \
        path/to/esp8266/Arduino/tools/decoder.py \
            --tool addr2line \
            --toolchain-path path/to/esp8266/Arduino/tools/xtensa-lx106-elf/bin
            path/to/build.elf
```
