### PR TITLE
Updater - fixed signature verification for compressed binaries

### DIFF
--- a/cores/esp8266/Updater.cpp
+++ b/cores/esp8266/Updater.cpp
@@ -284,24 +284,8 @@ bool UpdaterClass::end(bool evenIfRemaining){
     _hash->begin();
     for (uint32_t offset = 0; offset < binSize; offset += sizeof(buff)) {
       auto len = std::min(sizeof(buff), binSize - offset);
-
-      if (len % 4 == 0) {
-            ESP.flashRead(_startAddress + offset, reinterpret_cast<uint32_t *>(&buff[0]), len);
-            _hash->add(buff, len);
-        }
-        else {
-            // Calculate padding needed to make len 4-byte aligned
-            uint32_t padLen = (len + 3) & ~3; // Rounds up to nearest multiple of 4
-            
-            // Temporary buffer to satisfy 4-byte alignment requirement
-            uint8_t tempBuff[padLen] = {0};
-            
-            // Read into the temporary buffer
-            ESP.flashRead(_startAddress + offset, reinterpret_cast<uint32_t *>(&tempBuff[0]), padLen); // Note: ESP.flashRead size parameter might be in 4-byte words, not bytes
-            
-            // Process only the relevant portion of the temp buffer
-            _hash->add(tempBuff, len); // Ensure only len bytes are processed, not including the padded bytes
-        }
+      ESP.flashRead(_startAddress + offset, buff, len);
+      _hash->add(buff, len);
     }
     _hash->end();
 

--- a/cores/esp8266/Updater.cpp
+++ b/cores/esp8266/Updater.cpp
@@ -279,7 +279,7 @@ bool UpdaterClass::end(bool evenIfRemaining){
     }
 
     // Calculate hash of the payload, 128 bytes at a time
-    alignas(alignof(uint32_t)) uint8_t buff[128];
+    uint8_t buff[128];
 
     _hash->begin();
     for (uint32_t offset = 0; offset < binSize; offset += sizeof(buff)) {

--- a/cores/esp8266/Updater.cpp
+++ b/cores/esp8266/Updater.cpp
@@ -284,8 +284,24 @@ bool UpdaterClass::end(bool evenIfRemaining){
     _hash->begin();
     for (uint32_t offset = 0; offset < binSize; offset += sizeof(buff)) {
       auto len = std::min(sizeof(buff), binSize - offset);
-      ESP.flashRead(_startAddress + offset, reinterpret_cast<uint32_t *>(&buff[0]), len);
-      _hash->add(buff, len);
+
+      if (len % 4 == 0) {
+            ESP.flashRead(_startAddress + offset, reinterpret_cast<uint32_t *>(&buff[0]), len);
+            _hash->add(buff, len);
+        }
+        else {
+            // Calculate padding needed to make len 4-byte aligned
+            uint32_t padLen = (len + 3) & ~3; // Rounds up to nearest multiple of 4
+            
+            // Temporary buffer to satisfy 4-byte alignment requirement
+            uint8_t tempBuff[padLen] = {0};
+            
+            // Read into the temporary buffer
+            ESP.flashRead(_startAddress + offset, reinterpret_cast<uint32_t *>(&tempBuff[0]), padLen); // Note: ESP.flashRead size parameter might be in 4-byte words, not bytes
+            
+            // Process only the relevant portion of the temp buffer
+            _hash->add(tempBuff, len); // Ensure only len bytes are processed, not including the padded bytes
+        }
     }
     _hash->end();
 

--- a/cores/esp8266/Updater.cpp
+++ b/cores/esp8266/Updater.cpp
@@ -279,7 +279,7 @@ bool UpdaterClass::end(bool evenIfRemaining){
     }
 
     // Calculate hash of the payload, 128 bytes at a time
-    uint8_t buff[128];
+    alignas(alignof(uint32_t)) uint8_t buff[128];
 
     _hash->begin();
     for (uint32_t offset = 0; offset < binSize; offset += sizeof(buff)) {


### PR DESCRIPTION
### Overview

This pull request introduces a fix to the signature verification, ensuring that the hash for compressed signed binaries is correctly calculated.

### Problem Description

Previously, Arduino Core attempted to read from flash memory without proper consideration for the 4-byte alignment requirement when calculating the hash for the signature verification. This did not present an issue when uncompressed binaries are checked as all compiled binaries are 4-aligned _(unconfirmed, just an educated guess)_, and signature verification appears to work well in these cases.
When uploading a compressed binary (based on [this](https://arduino-esp8266.readthedocs.io/en/latest/ota_updates/readme.html#compression)) the gzip algorithm makes no attempt to produce a 4-aligned file. The rest of the signing results in a valid signed binary regardless, however when calculating the hash for the verification process there is a ~75% chance that the hash will include some bytes from the signature, thus compromising the whole signature verification process.

### Solution

* Implementing a conditional check to identify unaligned read requests.
  -   For aligned reads, operations proceed as normal.
  -   For unaligned reads, the read size is adjusted to the nearest 4-byte boundary, ensuring alignment. Only the relevant bytes (excluding the padded ones for alignment) are processed after reading into a temporary buffer.
* These adjustments ensure ESP.flashRead operates within the requirements set by the ESP SDK.
