### PR TITLE
WiFi STA encryptionType() getter added

### DIFF
--- a/libraries/ESP8266WiFi/src/ESP8266WiFi.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFi.h
@@ -62,6 +62,7 @@ class ESP8266WiFiClass : public ESP8266WiFiGenericClass, public ESP8266WiFiSTACl
         using ESP8266WiFiGenericClass::channel;
 
         using ESP8266WiFiSTAClass::SSID;
+        using ESP8266WiFiSTAClass::encryptionType;
         using ESP8266WiFiSTAClass::RSSI;
         using ESP8266WiFiSTAClass::BSSID;
         using ESP8266WiFiSTAClass::BSSIDstr;

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiGeneric.cpp
@@ -240,6 +240,7 @@ void ESP8266WiFiGenericClass::_eventCallback(void* arg)
 
     if (event->event == EVENT_STAMODE_AUTHMODE_CHANGE) {
         auto& src = event->event_info.auth_change;
+        WiFi.authMode = src.new_mode;
         if ((src.old_mode != AUTH_OPEN) && (src.new_mode == AUTH_OPEN)) {
             // CVE-2020-12638 workaround.  When we get a change to AUTH_OPEN from any other mode, drop the WiFi link because it's a downgrade attack
             // TODO - When upgrading to 3.x.x with fix, remove this code

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.cpp
@@ -637,6 +637,27 @@ String ESP8266WiFiSTAClass::psk() const {
 }
 
 /**
+ * Return the encryption type of the network
+ * @return  encryption type (enum wl_enc_type)
+ */
+uint8_t ESP8266WiFiSTAClass::encryptionType() {
+  switch(authMode) {
+      case AUTH_OPEN:
+          return ENC_TYPE_NONE;
+      case AUTH_WEP:
+          return ENC_TYPE_WEP;
+      case AUTH_WPA_PSK:
+          return ENC_TYPE_TKIP;
+      case AUTH_WPA2_PSK:
+          return ENC_TYPE_CCMP;
+      case AUTH_WPA_WPA2_PSK:
+          return ENC_TYPE_AUTO;
+      default:
+          return -1;
+  }
+}
+
+/**
  * Return the current bssid / mac associated with the network if configured
  * @return bssid uint8_t *
  */

--- a/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
+++ b/libraries/ESP8266WiFi/src/ESP8266WiFiSTA.h
@@ -84,6 +84,7 @@ class ESP8266WiFiSTAClass: public LwipIntf {
         wl_status_t status();
         String SSID() const;
         String psk() const;
+        uint8_t encryptionType();
 
         uint8_t * BSSID();
         uint8_t * BSSID(uint8_t* bssid);
@@ -94,6 +95,9 @@ class ESP8266WiFiSTAClass: public LwipIntf {
         static void enableInsecureWEP (bool enable = true) { _useInsecureWEP = enable; }
 
     protected:
+        friend class ESP8266WiFiGenericClass;
+
+        uint8_t authMode;
 
         static bool _useStaticIp;
         static bool _useInsecureWEP;


### PR DESCRIPTION
Arduino WiFi API has this function.
in ESP8266WiFi library scan result has  encryptionType() but STA didn't have it.
I found this way to implement it.