### PR TITLE
Mock - update func signatures for latest glibc

### DIFF
--- a/cores/esp8266/core_esp8266_noniso.cpp
+++ b/cores/esp8266/core_esp8266_noniso.cpp
@@ -28,19 +28,12 @@
 #include <stdint.h>
 #include <math.h>
 #include <limits>
+
 #include "stdlib_noniso.h"
 
 extern "C" {
 
-char* ltoa(long value, char* result, int base) {
-    return itoa((int)value, result, base);
-}
-
-char* ultoa(unsigned long value, char* result, int base) {
-    return utoa((unsigned int)value, result, base);
-}
-
-char * dtostrf(double number, signed char width, unsigned char prec, char *s) {
+char* dtostrf(double number, signed char width, unsigned char prec, char *s) noexcept {
     bool negative = false;
 
     if (isnan(number)) {
@@ -125,7 +118,7 @@ char * dtostrf(double number, signed char width, unsigned char prec, char *s) {
 
 */
 const char* strrstr(const char*__restrict p_pcString,
-                    const char*__restrict p_pcPattern)
+                    const char*__restrict p_pcPattern) noexcept
 {
     const char* pcResult = 0;
 
@@ -149,4 +142,4 @@ const char* strrstr(const char*__restrict p_pcString,
     return pcResult;
 }
 
-};
+} // extern "C"

--- a/cores/esp8266/stdlib_noniso.cpp
+++ b/cores/esp8266/stdlib_noniso.cpp
@@ -21,11 +21,13 @@
 
 #include "stdlib_noniso.h"
 
+extern "C" {
+
 // ulltoa() is slower than std::to_char() (1.6 times)
 // but is smaller by ~800B/flash and ~250B/rodata
 
 // ulltoa fills str backwards and can return a pointer different from str
-char* ulltoa(unsigned long long val, char* str, int slen, unsigned int radix)
+char* ulltoa(unsigned long long val, char* str, int slen, unsigned int radix) noexcept
 {
     str += --slen;
     *str = 0;
@@ -39,7 +41,7 @@ char* ulltoa(unsigned long long val, char* str, int slen, unsigned int radix)
 }
 
 // lltoa fills str backwards and can return a pointer different from str
-char* lltoa (long long val, char* str, int slen, unsigned int radix)
+char* lltoa(long long val, char* str, int slen, unsigned int radix) noexcept
 {
     bool neg;
     if (val < 0)
@@ -60,3 +62,13 @@ char* lltoa (long long val, char* str, int slen, unsigned int radix)
     }
     return ret;
 }
+
+char* ltoa(long value, char* result, int base) noexcept {
+    return itoa((int)value, result, base);
+}
+
+char* ultoa(unsigned long value, char* result, int base) noexcept {
+    return utoa((unsigned int)value, result, base);
+}
+
+} // extern "C"

--- a/cores/esp8266/stdlib_noniso.h
+++ b/cores/esp8266/stdlib_noniso.h
@@ -22,38 +22,35 @@
 #ifndef STDLIB_NONISO_H
 #define STDLIB_NONISO_H
 
+#include <stdlib.h>
+
 #ifdef __cplusplus
-extern "C"{
+extern "C" {
 #endif
 
-int atoi(const char *s);
+#ifdef __cplusplus
+#define __STDLIB_NONISO_NOEXCEPT noexcept
+#else
+#define __STDLIB_NONISO_NOEXCEPT
+#endif
 
-long atol(const char* s);
+char* ltoa (long val, char *s, int radix) __STDLIB_NONISO_NOEXCEPT;
 
-double atof(const char* s);
+char* lltoa (long long val, char* str, int slen, unsigned int radix) __STDLIB_NONISO_NOEXCEPT;
 
-char* itoa (int val, char *s, int radix);
+char* ultoa (unsigned long val, char *s, int radix) __STDLIB_NONISO_NOEXCEPT;
 
-char* ltoa (long val, char *s, int radix);
+char* ulltoa (unsigned long long val, char* str, int slen, unsigned int radix) __STDLIB_NONISO_NOEXCEPT;
 
-char* lltoa (long long val, char* str, int slen, unsigned int radix);
+char* dtostrf (double val, signed char width, unsigned char prec, char *s) __STDLIB_NONISO_NOEXCEPT;
 
-char* utoa (unsigned int val, char *s, int radix);
+const char* strrstr (const char*__restrict p_pcString,
+                     const char*__restrict p_pcPattern) __STDLIB_NONISO_NOEXCEPT;
 
-char* ultoa (unsigned long val, char *s, int radix);
-
-char* ulltoa (unsigned long long val, char* str, int slen, unsigned int radix);
-
-char* dtostrf (double val, signed char width, unsigned char prec, char *s);
-
-void reverse(char* begin, char* end);
-
-const char* strrstr(const char*__restrict p_pcString,
-                    const char*__restrict p_pcPattern);
+#undef __STDLIB_NONISO_NOEXCEPT
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
-
 
 #endif

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -30,6 +30,7 @@ GENHTML  ?= genhtml
 CXXFLAGS += -std=gnu++17
 CFLAGS += -std=gnu17
 
+# 32-bit mode is prefered, but not required
 ifeq ($(FORCE32),1)
 SIZEOFLONG = $(shell echo 'int main(){return sizeof(long);}'|$(CXX) -m32 -x c++ - -o sizeoflong 2>/dev/null && ./sizeoflong; echo $$?; rm -f sizeoflong;)
 ifneq ($(SIZEOFLONG),4)
@@ -50,6 +51,7 @@ endif
 OUTPUT_BINARY := $(BINDIR)/host_tests
 LCOV_DIRECTORY := $(BINDIR)/../lcov
 
+# Hide full build commands by default
 ifeq ($(V), 0)
 VERBC   = @echo "C   $@";
 VERBCXX = @echo "C++ $@";
@@ -65,6 +67,30 @@ VERBRANLIB =
 endif
 
 $(shell mkdir -p $(BINDIR))
+
+# Core files sometimes override libc functions, check when necessary to hide them
+# TODO proper configure script / other build system?
+ifeq (,$(wildcard $(BINDIR)/.have_strlcpy))
+$(shell echo -e '#include <cstring>\nint main(){char a[4]{}; char b[4]{}; strlcpy(&a[0], &b[0], sizeof(a)); return 0;}' | \
+	$(CXX) -x c++ - -o $(BINDIR)/.have_strlcpy 2>/dev/null || ( echo -e '#!/bin/sh\nexit 1' > $(BINDIR)/.have_strlcpy ; chmod +x $(BINDIR)/.have_strlcpy; ))
+endif
+
+$(shell $(BINDIR)/.have_strlcpy)
+ifeq ($(.SHELLSTATUS), 0)
+FLAGS += -DHAVE_STRLCPY
+endif
+
+ifeq (,$(wildcard $(BINDIR)/.have_strlcat))
+$(shell echo -e '#include <cstring>\nint main(){char a[4]{}; strlcat(&a[0], "test", sizeof(a)); return 0;}' | \
+	$(CXX) -x c++ - -o $(BINDIR)/.have_strlcat 2>/dev/null || ( echo -e '#!/bin/sh\nexit 1' > $(BINDIR)/.have_strlcat ; chmod +x $(BINDIR)/.have_strlcat; ))
+endif
+
+$(shell $(BINDIR)/.have_strlcat)
+ifeq ($(.SHELLSTATUS), 0)
+FLAGS += -DHAVE_STRLCAT
+endif
+
+# Actual build recipes
 
 CORE_CPP_FILES := \
 	$(addprefix $(abspath $(CORE_PATH))/,\

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -76,8 +76,8 @@ $(shell echo -e '#include <cstring>\nint main(){char a[4]{}; char b[4]{}; strlcp
 endif
 
 $(shell $(BINDIR)/.have_strlcpy)
-ifeq ($(.SHELLSTATUS), 0)
-FLAGS += -DHAVE_STRLCPY
+ifneq ($(.SHELLSTATUS), 0)
+FLAGS += -DSTRLCPY_MISSING
 endif
 
 ifeq (,$(wildcard $(BINDIR)/.have_strlcat))
@@ -86,8 +86,8 @@ $(shell echo -e '#include <cstring>\nint main(){char a[4]{}; strlcat(&a[0], "tes
 endif
 
 $(shell $(BINDIR)/.have_strlcat)
-ifeq ($(.SHELLSTATUS), 0)
-FLAGS += -DHAVE_STRLCAT
+ifneq ($(.SHELLSTATUS), 0)
+FLAGS += -DSTRLCAT_MISSING
 endif
 
 # Actual build recipes

--- a/tests/host/common/mock.h
+++ b/tests/host/common/mock.h
@@ -67,10 +67,10 @@ extern "C"
 #endif
     char* utoa(unsigned value, char* result, int base);
     char* itoa(int value, char* result, int base);
-#ifndef HAVE_STRLCAT
+#ifdef STRLCAT_MISSING
     size_t strlcat(char* dst, const char* src, size_t size);
 #endif
-#ifndef HAVE_STRLCPY
+#ifdef STRLCPY_MISSING
     size_t strlcpy(char* dst, const char* src, size_t size);
 #endif
 #ifdef __cplusplus

--- a/tests/host/common/mock.h
+++ b/tests/host/common/mock.h
@@ -56,18 +56,23 @@
 #define D8 8
 
 #include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <stdlib_noniso.h>
 
 #ifdef __cplusplus
 extern "C"
 {
 #endif
-    // TODO: #include <stdlib_noniso.h> ?
-    char* itoa(int val, char* s, int radix);
-    char* ltoa(long val, char* s, int radix);
-
+    char* utoa(unsigned value, char* result, int base);
+    char* itoa(int value, char* result, int base);
+#ifndef HAVE_STRLCAT
     size_t strlcat(char* dst, const char* src, size_t size);
+#endif
+#ifndef HAVE_STRLCPY
     size_t strlcpy(char* dst, const char* src, size_t size);
-
+#endif
 #ifdef __cplusplus
 }
 #endif

--- a/tests/host/common/noniso.c
+++ b/tests/host/common/noniso.c
@@ -18,9 +18,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <math.h>
-#include "stdlib_noniso.h"
 
-void reverse(char* begin, char* end)
+#include <stdlib_noniso.h>
+
+static void reverse(char* begin, char* end)
 {
     char* is = begin;
     char* ie = end - 1;
@@ -83,21 +84,4 @@ char* itoa(int value, char* result, int base)
 
     utoa(uvalue, result, base);
     return out;
-}
-
-int atoi(const char* s)
-{
-    return (int)atol(s);
-}
-
-long atol(const char* s)
-{
-    char* tmp;
-    return strtol(s, &tmp, 10);
-}
-
-double atof(const char* s)
-{
-    char* tmp;
-    return strtod(s, &tmp);
 }

--- a/tests/host/common/strl.cpp
+++ b/tests/host/common/strl.cpp
@@ -6,7 +6,7 @@
 
 extern "C"
 {
-#ifndef HAVE_STRLCAT
+#ifdef STRLCAT_MISSING
     // '_cups_strlcat()' - Safely concatenate two strings.
 
     size_t                   /* O - Length of string */
@@ -43,9 +43,9 @@ extern "C"
 
         return (dstlen + srclen);
     }
-#endif /* !HAVE_STRLCAT */
+#endif /* STRLCAT_MISSING */
 
-#ifndef HAVE_STRLCPY
+#ifdef STRLCPY_MISSING
     // '_cups_strlcpy()' - Safely copy two strings.
 
     size_t                   /* O - Length of string */
@@ -73,6 +73,6 @@ extern "C"
 
         return (srclen);
     }
-#endif /* !HAVE_STRLCPY */
+#endif /* STRLCPY_MISSING */
 
 }  // extern "C"

--- a/tests/host/common/strl.cpp
+++ b/tests/host/common/strl.cpp
@@ -1,84 +1,78 @@
 // https://gist.github.com/Fonger/98cc95ac39fbe1a7e4d9
 
-#ifndef HAVE_STRLCAT
-/*
-    '_cups_strlcat()' - Safely concatenate two strings.
-*/
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
 
-size_t                   /* O - Length of string */
-strlcat(char*       dst, /* O - Destination string */
-        const char* src, /* I - Source string */
-        size_t      size)     /* I - Size of destination string buffer */
+extern "C"
 {
-    size_t srclen; /* Length of source string */
-    size_t dstlen; /* Length of destination string */
+#ifndef HAVE_STRLCAT
+    // '_cups_strlcat()' - Safely concatenate two strings.
 
-    /*
-        Figure out how much room is left...
-    */
-
-    dstlen = strlen(dst);
-    size -= dstlen + 1;
-
-    if (!size)
+    size_t                   /* O - Length of string */
+    strlcat(char*       dst, /* O - Destination string */
+            const char* src, /* I - Source string */
+            size_t      size)     /* I - Size of destination string buffer */
     {
-        return (dstlen); /* No room, return immediately... */
+        size_t srclen; /* Length of source string */
+        size_t dstlen; /* Length of destination string */
+
+        // Figure out how much room is left...
+
+        dstlen = strlen(dst);
+        size -= dstlen + 1;
+
+        if (!size)
+        {
+            return (dstlen); /* No room, return immediately... */
+        }
+
+        // Figure out how much room is needed...
+
+        srclen = strlen(src);
+
+        // Copy the appropriate amount...
+
+        if (srclen > size)
+        {
+            srclen = size;
+        }
+
+        memcpy(dst + dstlen, src, srclen);
+        dst[dstlen + srclen] = '\0';
+
+        return (dstlen + srclen);
     }
-
-    /*
-        Figure out how much room is needed...
-    */
-
-    srclen = strlen(src);
-
-    /*
-        Copy the appropriate amount...
-    */
-
-    if (srclen > size)
-    {
-        srclen = size;
-    }
-
-    memcpy(dst + dstlen, src, srclen);
-    dst[dstlen + srclen] = '\0';
-
-    return (dstlen + srclen);
-}
 #endif /* !HAVE_STRLCAT */
 
 #ifndef HAVE_STRLCPY
-/*
-    '_cups_strlcpy()' - Safely copy two strings.
-*/
+    // '_cups_strlcpy()' - Safely copy two strings.
 
-size_t                   /* O - Length of string */
-strlcpy(char*       dst, /* O - Destination string */
-        const char* src, /* I - Source string */
-        size_t      size)     /* I - Size of destination string buffer */
-{
-    size_t srclen; /* Length of source string */
-
-    /*
-        Figure out how much room is needed...
-    */
-
-    size--;
-
-    srclen = strlen(src);
-
-    /*
-        Copy the appropriate amount...
-    */
-
-    if (srclen > size)
+    size_t                   /* O - Length of string */
+    strlcpy(char*       dst, /* O - Destination string */
+            const char* src, /* I - Source string */
+            size_t      size)     /* I - Size of destination string buffer */
     {
-        srclen = size;
+        size_t srclen; /* Length of source string */
+
+        // Figure out how much room is needed...
+
+        size--;
+
+        srclen = strlen(src);
+
+        // Copy the appropriate amount...
+
+        if (srclen > size)
+        {
+            srclen = size;
+        }
+
+        memcpy(dst, src, srclen);
+        dst[srclen] = '\0';
+
+        return (srclen);
     }
-
-    memcpy(dst, src, srclen);
-    dst[srclen] = '\0';
-
-    return (srclen);
-}
 #endif /* !HAVE_STRLCPY */
+
+}  // extern "C"

--- a/tools/sdk/include/ets_sys.h
+++ b/tools/sdk/include/ets_sys.h
@@ -208,7 +208,6 @@ void *ets_memset(void *s, int c, size_t n);
 void ets_timer_arm_new(ETSTimer *a, int b, int c, int isMstimer);
 void ets_timer_setfn(ETSTimer *t, ETSTimerFunc *fn, void *parg);
 void ets_timer_disarm(ETSTimer *a);
-int atoi(const char *nptr);
 int ets_strncmp(const char *s1, const char *s2, int len);
 int ets_strcmp(const char *s1, const char *s2);
 int ets_strlen(const char *s);


### PR DESCRIPTION
```
/usr/include/stdlib.h:102:15: error: declaration of ‘double atof(const char*) noexcept’ has a different exception specifier
...etc...
```
```
/usr/include/string.h:506:15: error: declaration of ‘size_t strlcpy(char*, const char*, size_t) noexcept’ has a different exception specifier
...etc...
```
```console
> rpm -q -f /usr/include/string.h /usr/include/stdlib.h
glibc-headers-x86-2.38-17.fc39.noarch
glibc-headers-x86-2.38-17.fc39.noarch
```