### PR TITLE
Add creation timestamp to LittleFS directories

### DIFF
--- a/libraries/LittleFS/src/LittleFS.h
+++ b/libraries/LittleFS/src/LittleFS.h
@@ -167,6 +167,14 @@ public:
             return false;
         }
         int rc = lfs_mkdir(&_lfs, path);
+        if ((rc == 0) && _timeCallback) {
+            time_t now = _timeCallback();
+            // Add metadata with creation time to the directory marker
+            int rc = lfs_setattr(&_lfs, path, 'c', (const void *)&now, sizeof(now));
+            if (rc < 0) {
+                DEBUGV("Unable to set last write time on '%s' to %ld\n", path, (long)now);
+            }
+        }
         return (rc==0);
     }
 

--- a/libraries/LittleFS/src/LittleFS.h
+++ b/libraries/LittleFS/src/LittleFS.h
@@ -172,7 +172,7 @@ public:
             // Add metadata with creation time to the directory marker
             int rc = lfs_setattr(&_lfs, path, 'c', (const void *)&now, sizeof(now));
             if (rc < 0) {
-                DEBUGV("Unable to set last write time on '%s' to %ld\n", path, (long)now);
+                DEBUGV("Unable to set creation time on '%s' to %ld\n", path, (long)now);
             }
         }
         return (rc==0);


### PR DESCRIPTION
Partial fix #9120.  This is simple enough to include and does not increase the amount of flash writes on file updates significantly (which a modified-time 't' attribute would).