### PR TITLE
Move recently added legacy Ethernet API methods from LwipIntfDev to EthernetCompat

### DIFF
--- a/cores/esp8266/LwipIntfDev.h
+++ b/cores/esp8266/LwipIntfDev.h
@@ -83,14 +83,10 @@ public:
         return &_netif;
     }
 
-    uint8_t* macAddress(uint8_t* mac)  // WiFi lib way
+    uint8_t* macAddress(uint8_t* mac)
     {
         memcpy(mac, &_netif.hwaddr, 6);
         return mac;
-    }
-    void MACAddress(uint8_t* mac)  // Ethernet lib way
-    {
-        macAddress(mac);
     }
     IPAddress localIP() const
     {
@@ -104,15 +100,11 @@ public:
     {
         return IPAddress(ip4_addr_get_u32(ip_2_ip4(&_netif.gw)));
     }
-    IPAddress dnsIP(int n = 0) const  // WiFi lib way
+    IPAddress dnsIP(int n = 0) const
     {
         return IPAddress(dns_getserver(n));
     }
-    IPAddress dnsServerIP() const  // Ethernet lib way
-    {
-        return dnsIP(0);
-    }
-    void setDNS(IPAddress dns1, IPAddress dns2 = INADDR_ANY)  // WiFi lib way
+    void setDNS(IPAddress dns1, IPAddress dns2 = INADDR_ANY)
     {
         if (dns1.isSet())
         {
@@ -122,10 +114,6 @@ public:
         {
             dns_setserver(1, dns2);
         }
-    }
-    void setDnsServerIP(const IPAddress dnsIP)  // Ethernet lib way
-    {
-        setDNS(dnsIP);
     }
 
     // 1. Currently when no default is set, esp8266-Arduino uses the first

--- a/libraries/lwIP_Ethernet/src/EthernetCompat.h
+++ b/libraries/lwIP_Ethernet/src/EthernetCompat.h
@@ -103,6 +103,21 @@ public:
         return DHCP_CHECK_NONE;
     }
 
+    void MACAddress(uint8_t* mac)
+    {
+        LwipIntfDev<RawDev>::macAddress(mac);
+    }
+
+    IPAddress dnsServerIP() const
+    {
+        return LwipIntfDev<RawDev>::dnsIP(0);
+    }
+
+    void setDnsServerIP(const IPAddress dnsIP)
+    {
+        LwipIntfDev<RawDev>::setDNS(dnsIP);
+    }
+
 protected:
     HardwareStatus _hardwareStatus;
 };


### PR DESCRIPTION
this PR moves to EthernetCompat the legacy Ethernet API methods added together with other methods to LwipIntfDev in my PR https://github.com/esp8266/Arduino/pull/9022 in November 2023.
I think it is better this way.
the moved methods are MACAddress, dnsServerIP and setDnsServerIP.