### PR TITLE
Fixes exceptions resulting from using SPI0Command

### DIFF
--- a/cores/esp8266/core_esp8266_flash_quirks.cpp
+++ b/cores/esp8266/core_esp8266_flash_quirks.cpp
@@ -66,12 +66,13 @@ void initFlashQuirks() {
             newSR3=SR3;
             if (get_flash_mhz()>26) { // >26Mhz?
                // Set the output drive to 100%
+               // These definitions are for the XM25QH32B part. On a XM25QH32C
+               // part, the XM25QH32B's 100% is C's 25% driver strength.
                newSR3 &= ~(SPI_FLASH_SR3_XMC_DRV_MASK << SPI_FLASH_SR3_XMC_DRV_S);
                newSR3 |= (SPI_FLASH_SR3_XMC_DRV_100 << SPI_FLASH_SR3_XMC_DRV_S);
             }
             if (newSR3 != SR3) { // only write if changed
-               if (SPI0Command(SPI_FLASH_CMD_WEVSR,NULL,0,0)==SPI_RESULT_OK)  // write enable volatile SR
-                  SPI0Command(SPI_FLASH_CMD_WSR3,&newSR3,8,0);  // write to SR3
+               SPI0Command(SPI_FLASH_CMD_WSR3,&newSR3,8,0,SPI_FLASH_CMD_WEVSR);  // write to SR3, use write enable volatile prefix
                SPI0Command(SPI_FLASH_CMD_WRDI,NULL,0,0);        // write disable - probably not needed
             }
          }

--- a/cores/esp8266/esp8266_undocumented.h
+++ b/cores/esp8266/esp8266_undocumented.h
@@ -241,6 +241,17 @@ extern fn_c_exception_handler_t _xtos_c_handler_table[XCHAL_EXCCAUSE_NUM];
 extern fn_c_exception_handler_t _xtos_set_exception_handler(int cause, fn_c_exception_handler_t fn);
 #endif
 
+/*
+  BootROM function that sends the SPI Flash "Write Enable" command, 0x06.
+  The function internally calls Wait_SPI_Idle before enabling.
+  Polls status register forever waiting for WEL bit to set.
+  This function always returns 0; however, most examples test for 0.
+
+  Every function I find that needs WEL set, call this function. I suspect the
+  waiting for the WEL bit to set is a Flash chip anomaly workaround.
+*/
+extern SpiFlashOpResult SPI_write_enable(SpiFlashChip *fc);
+
 extern uint32_t Wait_SPI_Idle(SpiFlashChip *fc);
 extern void Cache_Read_Disable();
 extern int32_t system_func1(uint32_t);

--- a/cores/esp8266/spi_utils.h
+++ b/cores/esp8266/spi_utils.h
@@ -35,7 +35,7 @@ typedef enum {
     SPI_RESULT_TIMEOUT
 } SpiOpResult;
 
-SpiOpResult SPI0Command(uint8_t cmd, uint32_t *data, uint32_t mosi_bits, uint32_t miso_bits);
+SpiOpResult SPI0Command(uint8_t cmd, uint32_t *data, uint32_t mosi_bits, uint32_t miso_bits, uint32_t prefix=0);
 }
 
 #ifdef __cplusplus

--- a/cores/esp8266/spi_utils.h
+++ b/cores/esp8266/spi_utils.h
@@ -35,7 +35,7 @@ typedef enum {
     SPI_RESULT_TIMEOUT
 } SpiOpResult;
 
-SpiOpResult SPI0Command(uint8_t cmd, uint32_t *data, uint32_t mosi_bits, uint32_t miso_bits, uint32_t prefix=0);
+SpiOpResult SPI0Command(uint8_t cmd, uint32_t *data, uint32_t mosi_bits, uint32_t miso_bits, uint32_t pre_cmd=0);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Resolves exceptions occurring when using `experimental::SPI0Command` for flash write operations such as: Write Status Register-1, Sector Eraser, etc.
 * https://github.com/esp8266/Arduino/issues/9139#issue-2299471911

Moved PRECACHE_END to ensure `Wait_SPI_Idlep` and `xt_wsr_ps` are included in the iCache.

Added SPIUCSSETUP to give more settling time for #CS.