### PR TITLE
Implemented support for filters and removable routes in ESP8266WebServer

### DIFF
--- a/libraries/ESP8266WebServer/README.rst
+++ b/libraries/ESP8266WebServer/README.rst
@@ -54,8 +54,10 @@ Client request handlers
 
 .. code:: cpp
 
-  void on();
+  RequestHandler<ServerType>& on();
+  bool removeRoute();
   void addHandler();
+  bool removeHandler();
   void onNotFound();
   void onFileUpload();	
 
@@ -64,8 +66,25 @@ Client request handlers
 .. code:: cpp
 
   server.on("/", handlerFunction);
+  server.removeRoute("/"); // Removes any route which points to "/" and has HTTP_ANY attribute
+  server.removeRoute("/", HTTP_GET); // Removes any route which points to "/" and has HTTP_GET attribute
   server.onNotFound(handlerFunction); // called when handler is not assigned
   server.onFileUpload(handlerFunction); // handle file uploads
+
+Client request filters
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. code:: cpp
+  
+  RequestHandler<ServerType>& setFilter();
+
+*Example:*
+
+More details about this in `Filters.ino` example.
+
+.. code:: cpp
+
+  server.on("/", handlerFunction).setFilter(ON_AP_STA)
 
 Sending responses to the client
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/libraries/ESP8266WebServer/README.rst
+++ b/libraries/ESP8266WebServer/README.rst
@@ -84,7 +84,7 @@ More details about this in `Filters.ino` example.
 
 .. code:: cpp
 
-  server.on("/", handlerFunction).setFilter(ON_AP_STA)
+  server.on("/", handlerFunction).setFilter(ON_AP_FILTER)
 
 Sending responses to the client
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/libraries/ESP8266WebServer/examples/Filters/Filters.ino
+++ b/libraries/ESP8266WebServer/examples/Filters/Filters.ino
@@ -1,4 +1,4 @@
-#include <WiFi.h>
+#include <ESP8266WiFi.h>
 #include <WiFiClient.h>
 #include <ESP8266WebServer.h>
 #include <ESP8266mDNS.h>

--- a/libraries/ESP8266WebServer/examples/Filters/Filters.ino
+++ b/libraries/ESP8266WebServer/examples/Filters/Filters.ino
@@ -13,18 +13,18 @@ const char *password = "...";
 const char *ap_ssid = "ESP8266_Demo";
 const char *ap_password = "";
 
-WebServer server(80);
+ESP8266WebServer server(80);
 
 const int led = 13;
 
 // ON_STA_FILTER - Only accept requests coming from STA interface
-bool ON_STA_FILTER(WebServer &server) {
-  return WiFi.STA.hasIP() && WiFi.STA.localIP() == server.client().localIP();
+bool ON_STA_FILTER(ESP8266WebServer &server) {
+  return WiFi.localIP() == server.client().localIP();
 }
 
 // ON_AP_FILTER - Only accept requests coming from AP interface
-bool ON_AP_FILTER(WebServer &server) {
-  return WiFi.AP.hasIP() && WiFi.AP.localIP() == server.client().localIP();
+bool ON_AP_FILTER(ESP8266WebServer &server) {
+  return WiFi.softAPIP() == server.client().localIP();
 }
 
 void handleNotFound() {

--- a/libraries/ESP8266WebServer/examples/Filters/Filters.ino
+++ b/libraries/ESP8266WebServer/examples/Filters/Filters.ino
@@ -72,19 +72,19 @@ void setup(void) {
 
   // This route will be accessible by STA clients only
   server.on("/", [&]() {
-    digitalWrite(led, 1);
-    server.send(200, "text/plain", "Hi!, This route is accessible for STA clients only");
-    digitalWrite(led, 0);
-  })
-  .setFilter(ON_STA_FILTER);
+          digitalWrite(led, 1);
+          server.send(200, "text/plain", "Hi!, This route is accessible for STA clients only");
+          digitalWrite(led, 0);
+        })
+    .setFilter(ON_STA_FILTER);
 
   // This route will be accessible by AP clients only
   server.on("/", [&]() {
-    digitalWrite(led, 1);
-    server.send(200, "text/plain", "Hi!, This route is accessible for AP clients only");
-    digitalWrite(led, 0);
-  })
-  .setFilter(ON_AP_FILTER);
+          digitalWrite(led, 1);
+          server.send(200, "text/plain", "Hi!, This route is accessible for AP clients only");
+          digitalWrite(led, 0);
+        })
+    .setFilter(ON_AP_FILTER);
 
   server.on("/inline", []() {
     server.send(200, "text/plain", "this works as well");

--- a/libraries/ESP8266WebServer/examples/Filters/Filters.ino
+++ b/libraries/ESP8266WebServer/examples/Filters/Filters.ino
@@ -1,0 +1,100 @@
+#include <WiFi.h>
+#include <WiFiClient.h>
+#include <ESP8266WebServer.h>
+#include <ESP8266mDNS.h>
+
+// Your STA WiFi Credentials
+// ( This is the AP your ESP will connect to )
+const char *ssid = "...";
+const char *password = "...";
+
+// Your AP WiFi Credentials
+// ( This is the AP your ESP will broadcast )
+const char *ap_ssid = "ESP32_Demo";
+const char *ap_password = "";
+
+WebServer server(80);
+
+const int led = 13;
+
+// ON_STA_FILTER - Only accept requests coming from STA interface
+bool ON_STA_FILTER(WebServer &server) {
+  return WiFi.STA.hasIP() && WiFi.STA.localIP() == server.client().localIP();
+}
+
+// ON_AP_FILTER - Only accept requests coming from AP interface
+bool ON_AP_FILTER(WebServer &server) {
+  return WiFi.AP.hasIP() && WiFi.AP.localIP() == server.client().localIP();
+}
+
+void handleNotFound() {
+  digitalWrite(led, 1);
+  String message = "File Not Found\n\n";
+  message += "URI: ";
+  message += server.uri();
+  message += "\nMethod: ";
+  message += (server.method() == HTTP_GET) ? "GET" : "POST";
+  message += "\nArguments: ";
+  message += server.args();
+  message += "\n";
+  for (uint8_t i = 0; i < server.args(); i++) {
+    message += " " + server.argName(i) + ": " + server.arg(i) + "\n";
+  }
+  server.send(404, "text/plain", message);
+  digitalWrite(led, 0);
+}
+
+void setup(void) {
+  pinMode(led, OUTPUT);
+  digitalWrite(led, 0);
+  Serial.begin(115200);
+  WiFi.mode(WIFI_AP_STA);
+  // Connect to STA
+  WiFi.begin(ssid, password);
+  // Start AP
+  WiFi.softAP(ap_ssid, ap_password);
+  Serial.println("");
+
+  // Wait for connection
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println("");
+  Serial.print("Connected to ");
+  Serial.println(ssid);
+  Serial.print("IP address: ");
+  Serial.println(WiFi.localIP());
+
+  if (MDNS.begin("esp32")) {
+    Serial.println("MDNS responder started");
+  }
+
+  // This route will be accessible by STA clients only
+  server.on("/", [&]() {
+    digitalWrite(led, 1);
+    server.send(200, "text/plain", "Hi!, This route is accessible for STA clients only");
+    digitalWrite(led, 0);
+  }).setFilter(ON_STA_FILTER);
+
+  // This route will be accessible by AP clients only
+  server.on("/", [&]() {
+    digitalWrite(led, 1);
+    server.send(200, "text/plain", "Hi!, This route is accessible for AP clients only");
+    digitalWrite(led, 0);
+  }).setFilter(ON_AP_FILTER);
+
+  server.on("/inline", []() {
+    server.send(200, "text/plain", "this works as well");
+  });
+
+  server.onNotFound(handleNotFound);
+
+  server.begin();
+  Serial.println("HTTP server started");
+}
+
+void loop(void) {
+  server.handleClient();
+  delay(2);  //allow the cpu to switch to other tasks
+}

--- a/libraries/ESP8266WebServer/examples/Filters/Filters.ino
+++ b/libraries/ESP8266WebServer/examples/Filters/Filters.ino
@@ -75,14 +75,16 @@ void setup(void) {
     digitalWrite(led, 1);
     server.send(200, "text/plain", "Hi!, This route is accessible for STA clients only");
     digitalWrite(led, 0);
-  }).setFilter(ON_STA_FILTER);
+  })
+  .setFilter(ON_STA_FILTER);
 
   // This route will be accessible by AP clients only
   server.on("/", [&]() {
     digitalWrite(led, 1);
     server.send(200, "text/plain", "Hi!, This route is accessible for AP clients only");
     digitalWrite(led, 0);
-  }).setFilter(ON_AP_FILTER);
+  })
+  .setFilter(ON_AP_FILTER);
 
   server.on("/inline", []() {
     server.send(200, "text/plain", "this works as well");

--- a/libraries/ESP8266WebServer/examples/WebServer/WebServer.ino
+++ b/libraries/ESP8266WebServer/examples/WebServer/WebServer.ino
@@ -153,7 +153,7 @@ public:
       // Close the file
       if (_fsUploadFile) { _fsUploadFile.close(); }
     }  // if
-  }  // upload()
+  }    // upload()
 
 protected:
   File _fsUploadFile;

--- a/libraries/ESP8266WebServer/examples/WebServer/WebServer.ino
+++ b/libraries/ESP8266WebServer/examples/WebServer/WebServer.ino
@@ -153,7 +153,7 @@ public:
       // Close the file
       if (_fsUploadFile) { _fsUploadFile.close(); }
     }  // if
-  }    // upload()
+  }  // upload()
 
 protected:
   File _fsUploadFile;

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -116,11 +116,17 @@ public:
 
   typedef std::function<void(void)> THandlerFunction;
   typedef std::function<String(FS &fs, const String &fName)> ETagFunction;
+  typedef std::function<bool(ESP8266WebServerTemplate<ServerType> &server)> FilterFunction;
 
-  void on(const Uri &uri, THandlerFunction handler);
-  void on(const Uri &uri, HTTPMethod method, THandlerFunction fn);
-  void on(const Uri &uri, HTTPMethod method, THandlerFunction fn, THandlerFunction ufn);
+  RequestHandler<ServerType>& on(const Uri &uri, THandlerFunction handler);
+  RequestHandler<ServerType>& on(const Uri &uri, HTTPMethod method, THandlerFunction fn);
+  RequestHandler<ServerType>& on(const Uri &uri, HTTPMethod method, THandlerFunction fn, THandlerFunction ufn);
+  bool removeRoute(const char *uri);
+  bool removeRoute(const char *uri, HTTPMethod method);
+  bool removeRoute(const String &uri);
+  bool removeRoute(const String &uri, HTTPMethod method);
   void addHandler(RequestHandlerType* handler);
+  bool removeHandler(RequestHandlerType* handler);
   void serveStatic(const char* uri, fs::FS& fs, const char* path, const char* cache_header = NULL );
   void onNotFound(THandlerFunction fn);  //called when handler is not assigned
   void onFileUpload(THandlerFunction fn); //handle file uploads
@@ -306,6 +312,7 @@ public:
 
 protected:
   void _addRequestHandler(RequestHandlerType* handler);
+  bool _removeRequestHandler(RequestHandlerType *handler);
   void _handleRequest();
   void _finalizeResponse();
   ClientFuture _parseRequest(ClientType& client);

--- a/libraries/ESP8266WebServer/src/Parsing-impl.h
+++ b/libraries/ESP8266WebServer/src/Parsing-impl.h
@@ -106,7 +106,7 @@ typename ESP8266WebServerTemplate<ServerType>::ClientFuture ESP8266WebServerTemp
   //attach handler
   RequestHandlerType* handler;
   for (handler = _firstHandler; handler; handler = handler->next()) {
-    if (handler->canHandle(_currentMethod, _currentUri))
+    if (handler->canHandle(*this, _currentMethod, _currentUri))
       break;
   }
   _currentHandler = handler;
@@ -324,7 +324,7 @@ int ESP8266WebServerTemplate<ServerType>::_parseArgumentsPrivate(const String& d
 template <typename ServerType>
 void ESP8266WebServerTemplate<ServerType>::_uploadWriteByte(uint8_t b){
   if (_currentUpload->currentSize == HTTP_UPLOAD_BUFLEN){
-    if(_currentHandler && _currentHandler->canUpload(_currentUri))
+    if(_currentHandler && _currentHandler->canUpload(*this, _currentUri))
       _currentHandler->upload(*this, _currentUri, *_currentUpload);
     _currentUpload->totalSize += _currentUpload->currentSize;
     _currentUpload->currentSize = 0;
@@ -425,7 +425,7 @@ bool ESP8266WebServerTemplate<ServerType>::_parseForm(ClientType& client, const 
             _currentUpload->currentSize = 0;
             _currentUpload->contentLength = len;
             DBGWS("Start File: %s Type: %s\n", _currentUpload->filename.c_str(), _currentUpload->type.c_str());
-            if(_currentHandler && _currentHandler->canUpload(_currentUri))
+            if(_currentHandler && _currentHandler->canUpload(*this, _currentUri))
               _currentHandler->upload(*this, _currentUri, *_currentUpload);
             _currentUpload->status = UPLOAD_FILE_WRITE;
 
@@ -463,11 +463,11 @@ bool ESP8266WebServerTemplate<ServerType>::_parseForm(ClientType& client, const 
                 }
             }
             // Found the boundary string, finish processing this file upload
-            if (_currentHandler && _currentHandler->canUpload(_currentUri))
+            if (_currentHandler && _currentHandler->canUpload(*this, _currentUri))
                 _currentHandler->upload(*this, _currentUri, *_currentUpload);
             _currentUpload->totalSize += _currentUpload->currentSize;
             _currentUpload->status = UPLOAD_FILE_END;
-            if (_currentHandler && _currentHandler->canUpload(_currentUri))
+            if (_currentHandler && _currentHandler->canUpload(*this, _currentUri))
                 _currentHandler->upload(*this, _currentUri, *_currentUpload);
             DBGWS("End File: %s Type: %s Size: %d\n",
                 _currentUpload->filename.c_str(),
@@ -542,7 +542,7 @@ String ESP8266WebServerTemplate<ServerType>::urlDecode(const String& text)
 template <typename ServerType>
 bool ESP8266WebServerTemplate<ServerType>::_parseFormUploadAborted(){
   _currentUpload->status = UPLOAD_FILE_ABORTED;
-  if(_currentHandler && _currentHandler->canUpload(_currentUri))
+  if(_currentHandler && _currentHandler->canUpload(*this, _currentUri))
     _currentHandler->upload(*this, _currentUri, *_currentUpload);
   return false;
 }

--- a/libraries/ESP8266WebServer/src/detail/RequestHandler.h
+++ b/libraries/ESP8266WebServer/src/detail/RequestHandler.h
@@ -12,13 +12,60 @@ class RequestHandler {
     using WebServerType = ESP8266WebServerTemplate<ServerType>;
 public:
     virtual ~RequestHandler() { }
-    virtual bool canHandle(HTTPMethod method, const String& uri) { (void) method; (void) uri; return false; }
-    virtual bool canUpload(const String& uri) { (void) uri; return false; }
-    virtual bool handle(WebServerType& server, HTTPMethod requestMethod, const String& requestUri) { (void) server; (void) requestMethod; (void) requestUri; return false; }
-    virtual void upload(WebServerType& server, const String& requestUri, HTTPUpload& upload) { (void) server; (void) requestUri; (void) upload; }
 
-    RequestHandler<ServerType>* next() { return _next; }
-    void next(RequestHandler<ServerType>* r) { _next = r; }
+    /*
+        note: old handler API for backward compatibility
+    */
+    
+    virtual bool canHandle(HTTPMethod method, const String& uri) {
+        (void) method;
+        (void) uri;
+        return false;
+    }
+    virtual bool canUpload(const String& uri) {
+        (void) uri;
+        return false;
+    }
+
+    /*
+        note: new handler API with support for filters etc.
+    */
+
+    virtual bool canHandle(WebServerType& server, HTTPMethod method, const String& uri) {
+        (void) server;
+        (void) method;
+        (void) uri;
+        return false;
+    }
+    virtual bool canUpload(WebServerType& server, const String& uri) {
+        (void) server;
+        (void) uri;
+        return false;
+    }
+    virtual bool handle(WebServerType& server, HTTPMethod requestMethod, const String& requestUri) {
+        (void) server; 
+        (void) requestMethod;
+        (void) requestUri;
+        return false;
+    }
+    virtual void upload(WebServerType& server, const String& requestUri, HTTPUpload& upload) {
+        (void) server;
+        (void) requestUri;
+        (void) upload;
+    }
+
+    RequestHandler<ServerType>* next() {
+        return _next;
+    }
+
+    void next(RequestHandler<ServerType>* r) {
+        _next = r;
+    }
+
+    virtual RequestHandler<ServerType>& setFilter(std::function<bool(ESP8266WebServerTemplate<ServerType>&)> filter) {
+        (void)filter;
+        return *this;
+    }
 
 private:
     RequestHandler<ServerType>* _next = nullptr;

--- a/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
@@ -74,8 +74,7 @@ public:
     }
 
     bool handle(WebServerType& server, HTTPMethod requestMethod, const String& requestUri) override {
-        (void) server;
-        if (!canHandle(requestMethod, requestUri))
+        if (!canHandle(server, requestMethod, requestUri))
             return false;
 
         _fn();
@@ -83,9 +82,8 @@ public:
     }
 
     void upload(WebServerType& server, const String& requestUri, HTTPUpload& upload) override {
-        (void) server;
         (void) upload;
-        if (canUpload(requestUri))
+        if (canUpload(server, requestUri))
             _ufn();
     }
 
@@ -156,8 +154,7 @@ public:
     }
 
     bool handle(WebServerType& server, HTTPMethod requestMethod, const String& requestUri) override {
-
-        if (!canHandle(requestMethod, requestUri))
+        if (!canHandle(server, requestMethod, requestUri))
             return false;
 
         DEBUGV("DirectoryRequestHandler::handle: request=%s _uri=%s\r\n", requestUri.c_str(), SRH::_uri.c_str());
@@ -264,7 +261,7 @@ public:
     }
 
     bool handle(WebServerType& server, HTTPMethod requestMethod, const String & requestUri) override {
-        if (!canHandle(requestMethod, requestUri))
+        if (!canHandle(server, requestMethod, requestUri))
             return false;
 
         if (server._eTagEnabled) {


### PR DESCRIPTION
This PR implements filters and removable routes in ESP8266 arduino core, making it API compatible with recent changes to ESP32 WebServer API.

Reference (Recent additions to ESP32 WebServer API): 
- https://github.com/espressif/arduino-esp32/pull/9832
- https://github.com/espressif/arduino-esp32/pull/9842
- https://github.com/espressif/arduino-esp32/pull/9851

__Noteable Changes:__
1. Request Filters (`setFilter`)
2. Removable Routes (`removeRoute`, `removeHandler`, `_removeRequestHandler`)
