### PR TITLE
ESP8266WebServer - UriRegex runtime logic within assert()

### DIFF
--- a/libraries/ESP8266WebServer/src/uri/UriRegex.h
+++ b/libraries/ESP8266WebServer/src/uri/UriRegex.h
@@ -2,8 +2,9 @@
 #define URI_REGEX_H
 
 #include "Uri.h"
+
+#include <cassert>
 #include <regex.h>
-#include <assert.h>
 
 #ifndef REGEX_MAX_GROUPS
 #define REGEX_MAX_GROUPS 10
@@ -12,13 +13,20 @@
 class UriRegex : public Uri {
 
     private:
-        regex_t _regexCompiled;
+        regex_t _regexCompiled{};
+        int _regexErr{REG_EMPTY};
 
     public:
-        explicit UriRegex(const char *uri) : Uri(uri) {
-            assert(regcomp(&_regexCompiled, uri, REG_EXTENDED) == 0);
-        };
-        explicit UriRegex(const String &uri) : UriRegex(uri.c_str()) {};
+        UriRegex() = delete;
+
+        explicit UriRegex(const char *uri) :
+            Uri(uri),
+            _regexErr(regcomp(&_regexCompiled, uri, REG_EXTENDED))
+        {
+            assert(_regexErr == 0);
+        }
+
+        explicit UriRegex(const String &uri) : UriRegex(uri.c_str()) {}
 
         ~UriRegex() {
             regfree(&_regexCompiled);
@@ -26,15 +34,17 @@ class UriRegex : public Uri {
 
         Uri* clone() const override final {
             return new UriRegex(_uri);
-        };
+        }
 
         bool canHandle(const String &requestUri, std::vector<String> &pathArgs) override final {
             if (Uri::canHandle(requestUri, pathArgs))
                 return true;
 
+            if (_regexErr != 0)
+                return false;
+
             regmatch_t groupArray[REGEX_MAX_GROUPS];
             if (regexec(&_regexCompiled, requestUri.c_str(), REGEX_MAX_GROUPS, groupArray, 0) == 0) {
-                // matches
                 pathArgs.clear();
 
                 unsigned int g = 1; 


### PR DESCRIPTION
move init outside of the body, preseve retval in case we'd want to format some kind of nice error message either through DEBUG_PORT or something else ([regerror](https://linux.die.net/man/3/regerror)?)