### PR TITLE
Tools - upload.py exception handling fixes

### DIFF
--- a/tools/upload.py
+++ b/tools/upload.py
@@ -40,11 +40,11 @@ def make_erase_pair(addr: str, dest_size: int, block_size=2**16):
 
     buffer = bytearray(b"\xff" * block_size)
     while dest_size:
-        unaligned = dest_size % block_size
+        remainder = dest_size % block_size
 
-        if unaligned:
-            src = buffer[unaligned:]
-            src_size = unaligned
+        if remainder:
+            src = buffer[:remainder]
+            src_size = remainder
         else:
             src = buffer
             src_size = block_size

--- a/tools/upload.py
+++ b/tools/upload.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 
 # Wrapper for Arduino core / others that can call esptool.py possibly multiple times
-# Adds pyserial to sys.path automatically based on the path of the current file
-
-# First parameter is pyserial path, second is esptool path, then a series of command arguments
-# i.e. upload.py tools/pyserial tools/esptool write_flash file 0x0
+# Adds pyserial & esptool that are in the same directory as the script to sys.path
 
 import os
 import atexit


### PR DESCRIPTION
don't check exc_info() in `finally`, after `except Exception as e:` block sys module stops tracking it
https://docs.python.org/3/reference/compound_stmts.html#try
https://docs.python.org/3/library/sys.html#sys.exception

#8603 caused error to appear in the log, but build itself was never stopped properly

---

*edit:*

[formatting, strict write_flash opts order, atexit & traceback (fe72928)](https://github.com/esp8266/Arduino/pull/9186/commits/fe729285393716b1b219e64e6ce623efbf277f6d) 


simplify ordering of `write_flash` & `erase_region` arguments
since we always end up in `write_flash`, prefer to think of it as argument pairs 'addr' + 'path'. actual binaries go first, erase temporaries go last. construct write args beforehand and apply when finishing with the command line.

note that this also allows both commands to appear multiple times
(and also to avoid proxying invalid data or possibly misinterpreting everything as write arguments)

it may be reasonable to try to piggyback on esptool parser, but not sure how that would look for upstream

TODO: update to 4.8.1 which has nicer error messaging