### PR TITLE
Tweaked `base64_encode_value` in `cores/esp8266/libb64/cencode.cpp`

### DIFF
--- a/cores/esp8266/libb64/cencode.cpp
+++ b/cores/esp8266/libb64/cencode.cpp
@@ -23,19 +23,12 @@ void base64_init_encodestate_nonewlines(base64_encodestate* state_in){
 }
 
 char base64_encode_value(const char n) {
-  char r;
+  unsigned char r;
 
-  if (n < 26)
-    r = n + 'A';
-  else if (n < 26 + 26)
-    r = n - 26 + 'a';
-  else if (n < 26 + 26 + 10 )
-    r = n - 26 - 26 + '0';
-  else if (n == 62 )
-    r = '+';
-  else
-    r = '/';
-  return r;
+char base64_encode_value(const unsigned char n) {
+  static const char* encoding = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  if (n > 63) return '=';
+  return encoding[n];
 }
 
 int base64_encode_block(const char* plaintext_in, int length_in, char* code_out, base64_encodestate* state_in){

--- a/cores/esp8266/libb64/cencode.cpp
+++ b/cores/esp8266/libb64/cencode.cpp
@@ -22,9 +22,6 @@ void base64_init_encodestate_nonewlines(base64_encodestate* state_in){
   state_in->stepsnewline = -1;
 }
 
-char base64_encode_value(const char n) {
-  unsigned char r;
-
 char base64_encode_value(const unsigned char n) {
   static const char* encoding = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
   if (n > 63) return '=';


### PR DESCRIPTION
Referred to the original libb64 implementation and optimized time complexity of `base64_encode_value` from O(n) to O(1). The existing method, which uses if-else statement, can slow down the execution speed.