### PR TITLE
CI - build with arduino-cli

### DIFF
--- a/.github/workflows/build-ide.yml
+++ b/.github/workflows/build-ide.yml
@@ -52,7 +52,6 @@ jobs:
     - name: Build Sketches
       env:
         ESP8266_ARDUINO_BUILDER: "arduino"
-        ESP8266_ARDUINO_IDE: "${{ runner.temp }}/arduino_ide"
         ESP8266_ARDUINO_LWIP: ${{ matrix.lwip }}
       run: |
         bash ./tests/build.sh 8 ${{ matrix.chunk }}
@@ -75,8 +74,6 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('package/package_esp8266com_index.template.json', 'tests/common.sh', 'tests/build.sh') }}
     - name: Build Sketch
       env:
-        ESP8266_ARDUINO_HARDWARE: "${{ runner.temp }}/hardware"
-        ESP8266_ARDUINO_IDE: "${{ runner.temp }}/arduino_ide"
         ESP8266_ARDUINO_SKETCHES: "libraries/esp8266/examples/Blink/Blink.ino"
       run: |
         bash ./tests/build.sh
@@ -100,8 +97,6 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('package/package_esp8266com_index.template.json', 'tests/common.sh', 'tests/build.sh') }}
     - name: Build Sketch
       env:
-        ESP8266_ARDUINO_HARDWARE: "${{ runner.temp }}/hardware"
-        ESP8266_ARDUINO_IDE: "${{ runner.temp }}/arduino_ide"
         ESP8266_ARDUINO_SKETCHES: "libraries/esp8266/examples/Blink/Blink.ino"
       run: |
         bash ./tests/build.sh

--- a/libraries/esp8266/examples/ConfigFile/ConfigFile.ino
+++ b/libraries/esp8266/examples/ConfigFile/ConfigFile.ino
@@ -12,7 +12,7 @@
 #include <LittleFS.h>
 
 // more and possibly updated information can be found at:
-// https://arduinojson.org/v6/example/config/
+// https://arduinojson.org/v7/example/config/
 
 bool loadConfig() {
   File configFile = LittleFS.open("/config.json", "r");
@@ -21,7 +21,7 @@ bool loadConfig() {
     return false;
   }
 
-  StaticJsonDocument<200> doc;
+  JsonDocument doc;
   auto error = deserializeJson(doc, configFile);
   if (error) {
     Serial.println("Failed to parse config file");
@@ -42,7 +42,7 @@ bool loadConfig() {
 }
 
 bool saveConfig() {
-  StaticJsonDocument<200> doc;
+  JsonDocument doc;
   doc["serverName"] = "api.example.com";
   doc["accessToken"] = "128du9as8du12eoue8da98h123ueh9h98";
 

--- a/tests/build.sh
+++ b/tests/build.sh
@@ -1,19 +1,40 @@
 #!/usr/bin/env bash
 
+# expect to have git available
 root=$(git rev-parse --show-toplevel)
 
+# general configuration related to the builder itself
 ESP8266_ARDUINO_BUILD_DIR=${ESP8266_ARDUINO_BUILD_DIR:-$root}
 ESP8266_ARDUINO_BUILDER=${ESP8266_ARDUINO_BUILDER:-arduino}
 ESP8266_ARDUINO_PRESERVE_CACHE=${ESP8266_ARDUINO_PRESERVE_CACHE:-}
 
-ESP8266_ARDUINO_IDE=${ESP8266_ARDUINO_IDE:-$HOME/arduino_ide}
-ESP8266_ARDUINO_HARDWARE=${ESP8266_ARDUINO_HARDWARE:-$HOME/Arduino/hardware}
-ESP8266_ARDUINO_LIBRARIES=${ESP8266_ARDUINO_LIBRARIES:-$HOME/Arduino/libraries}
-
+# sketch build options
 ESP8266_ARDUINO_DEBUG=${ESP8266_ARDUINO_DEBUG:-nodebug}
 ESP8266_ARDUINO_LWIP=${ESP8266_ARDUINO_LWIP:-default}
 ESP8266_ARDUINO_SKETCHES=${ESP8266_ARDUINO_SKETCHES:-}
 
+ESP8266_ARDUINO_CLI=${ESP8266_ARDUINO_CLI:-$HOME/.local/bin/arduino-cli}
+
+# ref. https://arduino.github.io/arduino-cli/1.2/configuration/#default-directories
+case "${RUNNER_OS:-Linux}" in
+"Linux")
+    ESP8266_ARDUINO_HARDWARE=${ESP8266_ARDUINO_HARDWARE:-$HOME/Arduino/hardware}
+    ESP8266_ARDUINO_LIBRARIES=${ESP8266_ARDUINO_LIBRARIES:-$HOME/Arduino/libraries}
+    ;;
+"macOS")
+    ESP8266_ARDUINO_HARDWARE=${ESP8266_ARDUINO_HARDWARE:-$HOME/Documents/Arduino/hardware}
+    ESP8266_ARDUINO_LIBRARIES=${ESP8266_ARDUINO_LIBRARIES:-$HOME/Documents/Arduino/libraries}
+    ;;
+"Windows")
+    ESP8266_ARDUINO_HARDWARE=${ESP8266_ARDUINO_HARDWARE:-$HOME/Documents/Arduino/hardware}
+    ESP8266_ARDUINO_LIBRARIES=${ESP8266_ARDUINO_LIBRARIES:-$HOME/Documents/Arduino/libraries}
+    ;;
+*)
+    echo 'Unknown ${RUNNER_OS} = "' ${RUNNER_OS} '"'
+    exit 2
+esac
+
+source "$root/tests/lib-skip-ino.sh"
 source "$root/tests/common.sh"
 
 cmd=${0##*/}
@@ -22,8 +43,7 @@ ENVIRONMENT:
   ESP8266_ARDUINO_SKETCHES - list of .ino files; defaults to **all available examples**
   ESP8266_ARDUINO_BUILDER - arduino or platformio
 
-  For Arduino IDE:
-    ESP8266_ARDUINO_IDE - path to the IDE (portable)
+  For Arduino CLI:
     ESP8266_ARDUINO_HARDWARE - path to the hardware directory (usually, containing our repo)
     ESP8266_ARDUINO_LIBRATIES - path to the libraries directory (external dependencies)
     ESP8266_ARDUINO_DEBUG - debug or nodebug
@@ -31,12 +51,14 @@ ENVIRONMENT:
 
 USAGE:
   $cmd <[even | odd]> - build every Nth, when '<N> % 2' is either even or odd
-  $cmd <mod> <rem> - build every Nth, when '<N> % <mod>' is equal to 'rem'
+  $cmd <mod> <rem> <[cnt]> - build every Nth, when '<N> % <mod>' is equal to 'rem'
+                             optionally, set <cnt> to start with the Nth sketch
   $cmd - build every .ino file from ESP8266_ARDUINO_SKETCHES
 "
 
 mod=1
 rem=0
+cnt=0
 
 if [ "$#" -eq 1 ] ; then
     case "$1" in
@@ -60,6 +82,10 @@ if [ "$#" -eq 1 ] ; then
 elif [ "$#" -eq 2 ] ; then
     mod=$1
     rem=$2
+elif [ "$#" -eq 3 ] ; then
+    mod=$1
+    rem=$2
+    cnt=$3
 elif [ "$#" -gt 2 ] ; then
     echo "$usage"
     exit 1
@@ -72,14 +98,17 @@ fi
 case "$ESP8266_ARDUINO_BUILDER" in
 "arduino")
     install_arduino "$ESP8266_ARDUINO_DEBUG"
-    build_sketches_with_arduino "$mod" "$rem" "$ESP8266_ARDUINO_LWIP"
+    build_sketches_with_arduino "$ESP8266_ARDUINO_LWIP" "$mod" "$rem" "$cnt"
     ;;
 "platformio")
     install_platformio nodemcuv2
-    build_sketches_with_platformio "$mod" "$rem"
+    build_sketches_with_platformio "$mod" "$rem" "$cnt"
+    ;;
+"print")
+    print_sketch_info "$mod" "$rem"
     ;;
 *)
-    echo "Unknown builder! Must be either arduino or platformio"
+    echo "Unknown builder! Must be one of - arduino, platformio or print"
     exit 1
     ;;
 esac

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -433,6 +433,8 @@ function install_platformio()
     python3 get.py -q
     popd
 
+    install_libraries "$ESP8266_ARDUINO_BUILD_DIR" "$ESP8266_ARDUINO_LIBRARIES"
+
     # we should reference our up-to-date build tools
     # ref. https://docs.platformio.org/en/latest/core/userguide/pkg/cmd_install.html
     pio pkg install --global --skip-dependencies --platform "https://github.com/platformio/platform-espressif8266.git"
@@ -440,9 +442,11 @@ function install_platformio()
     local framework_symlink="framework-arduinoespressif8266 @ symlink://${ESP8266_ARDUINO_BUILD_DIR}"
     local toolchain_symlink="toolchain-xtensa @ symlink://${ESP8266_ARDUINO_BUILD_DIR}/tools/xtensa-lx106-elf/"
 
-    # pre-generate config; pio-ci with multiple '-O' replace each other instead of appending to the same named list
-    # (and, it is much nicer to write this instead of a multi-line cmdline with several large strings)
+    # pre-generate config; pio-ci with multiple '-O' options replace each other instead of appending to the same named list
     cat <<EOF > $cache_dir/platformio.ini
+[platformio]
+lib_dir =
+    ${ESP8266_ARDUINO_LIBRARIES}
 [env:$board]
 platform = espressif8266
 board = $board
@@ -451,10 +455,6 @@ platform_packages =
     ${framework_symlink}
     ${toolchain_symlink}
 EOF
-
-    # Install dependencies:
-    # - esp8266/examples/ConfigFile
-    pio pkg install --global --library "ArduinoJson@^6.11.0"
 
     echo $ci_end_group
 }

--- a/tests/dep-arduino-cli.sh
+++ b/tests/dep-arduino-cli.sh
@@ -1,0 +1,27 @@
+case "${RUNNER_OS-}" in
+"Linux")
+    fetch_and_unpack "Linux_64bit.tar.gz" \
+        "d421e2b1cbef59c41e46cf06d077214a1d24cb784030462763781c9d3911cc55257fbcc02a7ee6a2ddda5b459101dc83aeda6b3b5198805bfdce856f82774c93" \
+        "${urlbase}Linux_64bit.tar.gz"
+    ;;
+"Windows")
+    fetch_and_unpack "Windows_64bit.zip" \
+        "05b4eb5820fbaf670de00399d40513ecf2de9d0c2c5593a1227be03b2d11ba53e9d14cf6f934110447d6fd15c6a09769606a34fcab32ec3c2dbaa42f4627b072" \
+        "${urlbase}Windows_64bit.zip"
+    ;;
+"macOS")
+    if [ "${RUNNER_ARCH-}" = "ARM64" ] ; then
+        fetch_and_unpack "macOS_ARM64.tar.gz" \
+            "672693418b730d8ebc57cae2c892553e821706bee06312cc77a598e834afcba7d380df4d337138ecc03a4013a349d89b744b2a3b97fafc214b619856d9162827" \
+            "${urlbase}macOS_ARM64.tar.gz"
+    else
+        fetch_and_unpack "macOS_64bit.tar.gz" \
+            "5659f08d787840aa6689fd063477402b4ed572663fea20de496b249d86a440059e3e6f377bd8020fb6b67202c1bdea6f98a4c4e052c31f01b2c9027ebec10b04" \
+            "${urlbase}macOS_64bit.tar.gz"
+    fi
+    ;;
+*)
+    echo 'Unknown ${RUNNER_OS} = "' ${RUNNER_OS} '"'
+    exit 2
+esac
+

--- a/tests/dep-libraries.sh
+++ b/tests/dep-libraries.sh
@@ -1,0 +1,6 @@
+install_library "$lib_path" \
+    "ArduinoJson" \
+    "ArduinoJson-7.4.1" \
+    "ArduinoJson-v7.4.1.zip" \
+    "1bfbc4aa3e4aa3c8e38f660333b6d5129b0443dbd0fd1eb448d14c7f041ffd2df782951ce622c6da50e2a07dcfcd268727b1f0a000211b9a5a92a806b1645bc0" \
+    "https://github.com/bblanchon/ArduinoJson/archive/refs/tags/v7.4.1.zip"

--- a/tests/lib-skip-ino.sh
+++ b/tests/lib-skip-ino.sh
@@ -1,0 +1,53 @@
+# return 0 if this sketch should not be built in CI (for other archs, not needed, etc.)
+function skip_ino()
+{
+    local ino=$1
+
+    case "$ino" in
+    *"/#attic/"* | \
+    *"/AvrAdcLogger/"* | \
+    *"/RtcTimestampTest/"* | \
+    *"/SoftwareSpi/"* | \
+    *"/TeensyDmaAdcLogger/"* | \
+    *"/TeensyRtcTimestamp/"* | \
+    *"/TeensySdioDemo/"* | \
+    *"/TeensySdioLogger/"* | \
+    *"/UnicodeFilenames/"* | \
+    *"/UserChipSelectFunction/"* | \
+    *"/UserSPIDriver/"* | \
+    *"/debug/"* | \
+    *"/examplesV1/"* | \
+    *"/onewiretest/"*)
+        return 0
+        ;;
+    *"Teensy"*)
+        return 0
+        ;;
+    *)
+        ;;
+    esac
+
+    return 1
+}
+
+# return reason if this sketch is not the main one or it is explicitly disabled with .test.skip in its directory
+function skip_sketch()
+{
+    local sketch=$1
+
+    local sketchdir
+    sketchdir=$(dirname $sketch)
+
+    local sketchdirname
+    sketchdirname=$(basename $sketchdir)
+
+    local sketchname
+    sketchname=$(basename $sketch)
+
+    if [[ "${sketchdirname}.ino" != "$sketchname" ]]; then
+        echo "Skipping $sketch (not the main sketch file)"
+    fi
+    if skip_ino "$sketch" || [[ -f "$sketchdir/.test.skip" ]]; then
+        echo "Skipping $sketch"
+    fi
+}


### PR DESCRIPTION
Sync with GCC14 branch test scripts. macOS & Linux runners expected to work, going to check Windows rn

Remove explicit IDE, HARDWARE & LIBRARIES envirnoment in workflows in favour of script defaults
Remove explicit dependency on IDE & HARDWARE path, assume arduino-cli default paths
Remove dependency on tools/build.py in favour of directly calling arduino-cli
Bump ConfigFile dependencies, set ArduinoJson to v7 & update blob install script