### PR TITLE
CI - Python deprecations

### DIFF
--- a/tools/boards.txt.py
+++ b/tools/boards.txt.py
@@ -1877,7 +1877,7 @@ def package ():
     substitution += ',\n'.join(board_items)
     substitution += '\n          ],'
 
-    newfilestr = re.sub(r'"boards":[^\]]*\],', substitution, count=filestr, flags=re.MULTILINE)
+    newfilestr = re.sub(r'"boards":[^\]]*\],', substitution, filestr, flags=re.MULTILINE)
 
     # To get consistent indent/formatting read the JSON and write it out programmatically
     if packagegen:

--- a/tools/boards.txt.py
+++ b/tools/boards.txt.py
@@ -1877,7 +1877,7 @@ def package ():
     substitution += ',\n'.join(board_items)
     substitution += '\n          ],'
 
-    newfilestr = re.sub(r'"boards":[^\]]*\],', substitution, filestr, re.MULTILINE)
+    newfilestr = re.sub(r'"boards":[^\]]*\],', substitution, count=filestr, flags=re.MULTILINE)
 
     # To get consistent indent/formatting read the JSON and write it out programmatically
     if packagegen:

--- a/tools/get.py
+++ b/tools/get.py
@@ -18,11 +18,12 @@ import re
 
 verbose = True
 
-if sys.version_info[0] == 3:
-    from urllib.request import urlretrieve
+from urllib.request import urlretrieve
+
+if sys.version_info >= (3,12):
+    TARFILE_EXTRACT_ARGS = {'filter': 'data'}
 else:
-    # Not Python 3 - today, it is most likely to be Python 2
-    from urllib import urlretrieve
+    TARFILE_EXTRACT_ARGS = {}
 
 dist_dir = 'dist/'
 
@@ -51,9 +52,10 @@ def report_progress(count, blockSize, totalSize):
 def unpack(filename, destination):
     dirname = ''
     print('Extracting {0}'.format(filename))
-    if filename.endswith('tar.gz'):
-        tfile = tarfile.open(filename, 'r:gz')
-        tfile.extractall(destination)
+    extension = filename.split('.')[-1]
+    if filename.endswith((f'.tar.{extension}', f'.t{extension}')):
+        tfile = tarfile.open(filename, f'r:{extension}')
+        tfile.extractall(destination, **TARFILE_EXTRACT_ARGS)
         dirname= tfile.getnames()[0]
     elif filename.endswith('zip'):
         zfile = zipfile.ZipFile(filename)


### PR DESCRIPTION
py3.13 - https://docs.python.org/3/library/re.html#re.sub
> Deprecated since version 3.13: Passing count and flags as positional arguments is deprecated. In future Python versions they will be keyword-only parameters.

py3.12 - https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extraction_filter
> If extraction_filter is None (the default), calling an extraction method without a filter argument will raise a DeprecationWarning, and fall back to the fully_trusted filter, whose dangerous behavior matches previous versions of Python.