### PR TITLE
Libraries - fix some warnings with gcc ≥12

### DIFF
--- a/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
@@ -9,25 +9,7 @@
 
 namespace esp8266webserver {
 
-// calculate an ETag for a file in filesystem based on md5 checksum
-// that can be used in the http headers - include quotes.
-static String calcETag(FS &fs, const String &path) {
-    String result;
-
-    // calculate eTag using md5 checksum
-    uint8_t md5_buf[16];
-    File f = fs.open(path, "r");
-    MD5Builder calcMD5;
-    calcMD5.begin();
-    calcMD5.addStream(f, f.size());
-    calcMD5.calculate();
-    calcMD5.getBytes(md5_buf);
-    f.close();
-    // create a minimal-length eTag using base64 byte[]->text encoding.
-    result = "\"" + base64::encode(md5_buf, 16, false) + "\"";
-    return(result);
-} // calcETag
-
+String calcETag(FS &, const String &);
 
 template<typename ServerType>
 class FunctionRequestHandler : public RequestHandler<ServerType> {

--- a/libraries/ESP8266WebServer/src/detail/etag.cpp
+++ b/libraries/ESP8266WebServer/src/detail/etag.cpp
@@ -1,0 +1,24 @@
+#include <ESP8266WebServer.h>
+
+namespace esp8266webserver {
+
+// calculate an ETag for a file in filesystem based on md5 checksum
+// that can be used in the http headers - include quotes.
+String calcETag(FS &fs, const String &path) {
+    String result;
+
+    // calculate eTag using md5 checksum
+    uint8_t md5_buf[16];
+    File f = fs.open(path, "r");
+    MD5Builder calcMD5;
+    calcMD5.begin();
+    calcMD5.addStream(f, f.size());
+    calcMD5.calculate();
+    calcMD5.getBytes(md5_buf);
+    f.close();
+    // create a minimal-length eTag using base64 byte[]->text encoding.
+    result = "\"" + base64::encode(md5_buf, 16, false) + "\"";
+    return(result);
+}
+
+} // namespace esp8266webserver

--- a/libraries/ESP8266WiFiMesh/src/ESP8266WiFiMesh.cpp
+++ b/libraries/ESP8266WiFiMesh/src/ESP8266WiFiMesh.cpp
@@ -535,7 +535,7 @@ void ESP8266WiFiMesh::attemptTransmission(const String &message, bool concluding
   if(WiFi.status() == WL_CONNECTED)
   {
     transmission_status_t transmissionResult = attemptDataTransfer();
-    latestTransmissionOutcomes.push_back(TransmissionResult(connectionQueue.back(), transmissionResult));
+    latestTransmissionOutcomes.emplace_back(connectionQueue.back(), transmissionResult);
   }
   else
   {
@@ -600,7 +600,7 @@ void ESP8266WiFiMesh::attemptTransmission(const String &message, bool concluding
 
       transmission_status_t transmissionResult = connectToNode(currentSSID, currentWiFiChannel, currentBSSID);
 
-      latestTransmissionOutcomes.push_back(TransmissionResult{.origin = currentNetwork, .transmissionStatus = transmissionResult});
+      latestTransmissionOutcomes.emplace_back(currentNetwork, transmissionResult);
     }
   }
 

--- a/libraries/ESP8266WiFiMesh/src/EspnowMeshBackend.cpp
+++ b/libraries/ESP8266WiFiMesh/src/EspnowMeshBackend.cpp
@@ -826,7 +826,7 @@ void EspnowMeshBackend::attemptTransmission(const String &message, const bool sc
     {
       TransmissionStatusType transmissionResult = initiateTransmission(getMessage(), currentNetwork);
   
-      latestTransmissionOutcomes().push_back(TransmissionOutcome{.origin = currentNetwork, .transmissionStatus = transmissionResult});
+      latestTransmissionOutcomes().emplace_back(currentNetwork, transmissionResult);
   
       if(!getTransmissionOutcomesUpdateHook()(*this))
         break;
@@ -897,7 +897,7 @@ void EspnowMeshBackend::attemptAutoEncryptingTransmission(const String &message,
   
       TransmissionStatusType transmissionResult = initiateAutoEncryptingTransmission(getMessage(), currentBSSID, connectionStatus);
   
-      latestTransmissionOutcomes().push_back(TransmissionOutcome{.origin = currentNetwork, .transmissionStatus = transmissionResult});
+      latestTransmissionOutcomes().emplace_back(currentNetwork, transmissionResult);
   
       _encryptionBroker.finalizeAutoEncryptingConnection(currentBSSID, existingEncryptedConnection, requestPermanentConnections);
   

--- a/libraries/ESP8266WiFiMesh/src/TcpIpMeshBackend.cpp
+++ b/libraries/ESP8266WiFiMesh/src/TcpIpMeshBackend.cpp
@@ -451,7 +451,7 @@ void TcpIpMeshBackend::attemptTransmission(const String &message, const bool sca
   if(WiFi.status() == WL_CONNECTED)
   {
     TransmissionStatusType transmissionResult = attemptDataTransfer();
-    latestTransmissionOutcomes().push_back(TransmissionOutcome(constConnectionQueue().back(), transmissionResult));
+    latestTransmissionOutcomes().emplace_back(constConnectionQueue().back(), transmissionResult);
 
     getTransmissionOutcomesUpdateHook()(*this);
   }
@@ -474,7 +474,7 @@ void TcpIpMeshBackend::attemptTransmission(const String &message, const bool sca
       {
         TransmissionStatusType transmissionResult = initiateTransmission(currentNetwork);
               
-        latestTransmissionOutcomes().push_back(TransmissionOutcome{.origin = currentNetwork, .transmissionStatus = transmissionResult});
+        latestTransmissionOutcomes().emplace_back(currentNetwork, transmissionResult);
 
         if(!getTransmissionOutcomesUpdateHook()(*this))
           break;

--- a/libraries/ESP8266mDNS/src/LEAmDNS_Structs.cpp
+++ b/libraries/ESP8266mDNS/src/LEAmDNS_Structs.cpp
@@ -1736,15 +1736,6 @@ namespace MDNSImplementation
     MDNSResponder::stcMDNSServiceQuery::stcAnswer::findIP4Address(
         const IPAddress& p_IPAddress) const
     {
-        return (stcIP4Address*)(((const stcAnswer*)this)->findIP4Address(p_IPAddress));
-    }
-
-    /*
-        MDNSResponder::stcMDNSServiceQuery::stcAnswer::findIP4Address
-    */
-    MDNSResponder::stcMDNSServiceQuery::stcAnswer::stcIP4Address*
-    MDNSResponder::stcMDNSServiceQuery::stcAnswer::findIP4Address(const IPAddress& p_IPAddress)
-    {
         stcIP4Address* pIP4Address = m_pIP4Addresses;
         while (pIP4Address)
         {
@@ -1755,6 +1746,16 @@ namespace MDNSImplementation
             pIP4Address = pIP4Address->m_pNext;
         }
         return pIP4Address;
+    }
+
+    /*
+        MDNSResponder::stcMDNSServiceQuery::stcAnswer::findIP4Address
+    */
+    MDNSResponder::stcMDNSServiceQuery::stcAnswer::stcIP4Address*
+    MDNSResponder::stcMDNSServiceQuery::stcAnswer::findIP4Address(const IPAddress& p_IPAddress)
+    {
+        const auto& cref = static_cast<const decltype(*this)>(*this);
+        return const_cast<stcIP4Address*>(cref.findIP4Address(p_IPAddress));
     }
 
     /*
@@ -2033,7 +2034,8 @@ namespace MDNSImplementation
     MDNSResponder::stcMDNSServiceQuery::stcAnswer*
     MDNSResponder::stcMDNSServiceQuery::answerAtIndex(uint32_t p_u32Index)
     {
-        return (stcAnswer*)(((const stcMDNSServiceQuery*)this)->answerAtIndex(p_u32Index));
+        const auto& cref = static_cast<const decltype(*this)>(*this);
+        return const_cast<stcAnswer*>(cref.answerAtIndex(p_u32Index));
     }
 
     /*


### PR DESCRIPTION
ESP8266WebServer - unused static function / function inside of namespace { ... } would always trigger '-Wunused-function'
```
 ../../libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h:14:15: warning: ‘String esp8266webserver::calcETag(fs::FS&, const String&)’ defined but not used [-Wunused-function]
   14 | static String calcETag(FS &fs, const String &path) {
      |               ^~~~~~~~
```

ESP8266WiFiMesh - class constructors used instead of aggregates. gcc10.3 allows this for some reason, but not later versions
> error: designated initializers cannot be used with a non-aggregate type '...'

LEAmDNS - consistent const <-> non-const accessors for `findIP4Address()` and `answerAtIndex()`
> error: infinite recursion detected [-Werror=infinite-recursion]