### PR TITLE
Tools - makecorever.py fixed packaging & avoid needless overwrites

### DIFF
--- a/package/build_boards_manager_package.sh
+++ b/package/build_boards_manager_package.sh
@@ -117,7 +117,7 @@ $SED -E "s/name=([a-zA-Z0-9\ -]+).*/name=\1(${ver})/g"\
 #echo "#define ARDUINO_ESP8266_GIT_DESC `git describe --tags 2>/dev/null`" >>${outdir}/cores/esp8266/core_version.h
 #echo "#define ARDUINO_ESP8266_RELEASE_${ver_define}" >>${outdir}/cores/esp8266/core_version.h
 #echo "#define ARDUINO_ESP8266_RELEASE \"${ver_define}\"" >>${outdir}/cores/esp8266/core_version.h
-python3 ${srcdir}/tools/makecorever.py -b ${outdir} -i cores/esp8266 -p ${srcdir} -v ${plain_ver} -r
+python3 ${srcdir}/tools/makecorever.py --git-root ${srcdir} --version ${plain_ver} --release ${outdir}/cores/esp8266/core_version.h
 
 # Zip the package
 pushd package/versions/${visiblever}

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -312,6 +312,7 @@ function install_core()
         "compiler.c.extra_flags=-Wall -Wextra $debug_flags" \
         "compiler.cpp.extra_flags=-Wall -Wextra $debug_flags" \
         "mkbuildoptglobals.extra_flags=--ci --cache_core" \
+        "recipe.hooks.prebuild.1.pattern=\"{runtime.tools.python3.path}/python3\" -I \"{runtime.tools.makecorever}\" --git-root \"{runtime.platform.path}\" --version \"{version}\" \"{runtime.platform.path}/cores/esp8266/core_version.h\"" \
             > ${core_path}/platform.local.txt
     echo -e "\n----platform.local.txt----"
     cat platform.local.txt

--- a/tests/sanity_check.sh
+++ b/tests/sanity_check.sh
@@ -5,8 +5,9 @@ source "$root/tests/common.sh"
 
 pushd "$root"/tools
 python3 get.py -q
-
+python3 makecorever.py --git-root "$root" "$root/cores/esp8266/core_version.h"
 popd
+
 pushd "$cache_dir"
 
 gcc="$root/tools/xtensa-lx106-elf/bin/xtensa-lx106-elf-gcc"\


### PR DESCRIPTION
amend #9248 

rewrite ci build pattern to only rewrite core_version.h once per job
restore behaviour from #6414 for other cases

update packaging script w/ new arguments