### PR TITLE
Stack Thunk - check saved a1 before using and zero after using

### DIFF
--- a/cores/esp8266/StackThunk.cpp
+++ b/cores/esp8266/StackThunk.cpp
@@ -179,17 +179,16 @@ asm(
     "movi         a2, stack_thunk_save\n\t"
 /* But, only when inside of bssl stack (saved a1 != 0) */
     "l32i.n       a3, a2, 0\n\t"
-    "beqz         a3, stack_thunk_yield_restore\n\t"
+    "beqz         a3, stack_thunk_yield_do_yield\n\t"
     "l32i.n       a1, a2, 0\n\t"
 /* optimistic_yield(10000) without extra l32r */
+"stack_thunk_yield_do_yield:\n\t"
     "movi         a2, 0x10\n\t"
     "addmi        a2, a2, 0x2700\n\t"
     "call0        optimistic_yield\n\t"
 /* Swap bearssl <-> cont stacks, again */
-"stack_thunk_yield_restore:\n\t"
     "movi         a2, stack_thunk_yield_save\n\t"
     "l32i.n       a1, a2, 0\n\t"
-    "\n"
 /* Restore caller */
     "l32i.n       a0, a1, 12\n\t"
     "addi         a1, a1, 16\n\t"

--- a/cores/esp8266/StackThunk.cpp
+++ b/cores/esp8266/StackThunk.cpp
@@ -73,6 +73,7 @@ void stack_thunk_add_ref()
     }
     stack_thunk_top = stack_thunk_ptr + _stackSize - 1;
     stack_thunk_save = NULL;
+    stack_thunk_yield_save = NULL;
     stack_thunk_repaint();
   }
 }
@@ -90,6 +91,7 @@ void stack_thunk_del_ref()
     stack_thunk_ptr = NULL;
     stack_thunk_top = NULL;
     stack_thunk_save = NULL;
+    stack_thunk_yield_save = NULL;
   }
 }
 
@@ -175,12 +177,16 @@ asm(
     "movi         a2, stack_thunk_yield_save\n\t"
     "s32i.n       a1, a2, 0\n\t"
     "movi         a2, stack_thunk_save\n\t"
+/* But, only when inside of bssl stack (saved a1 != 0) */
+    "l32i.n       a3, a2, 0\n\t"
+    "beqz         a3, stack_thunk_yield_restore\n\t"
     "l32i.n       a1, a2, 0\n\t"
 /* optimistic_yield(10000) without extra l32r */
     "movi         a2, 0x10\n\t"
     "addmi        a2, a2, 0x2700\n\t"
     "call0        optimistic_yield\n\t"
 /* Swap bearssl <-> cont stacks, again */
+"stack_thunk_yield_restore:\n\t"
     "movi         a2, stack_thunk_yield_save\n\t"
     "l32i.n       a1, a2, 0\n\t"
     "\n"

--- a/cores/esp8266/StackThunk.h
+++ b/cores/esp8266/StackThunk.h
@@ -27,6 +27,8 @@
 #ifndef _STACKTHUNK_H
 #define _STACKTHUNK_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -80,9 +82,11 @@ thunk_"#fcnToThunk":\n\
   call0 stack_thunk_fatal_smashing\n\
 .L1"#fcnToThunk":\n\
   movi a15, stack_thunk_save  /* Restore A1(SP) */\n\
-  l32i.n a1, a15, 0\n\
-  l32i.n a15, a1, 8     /* Restore the saved registers */\n\
-  l32i.n a0, a1, 12\n\
+  l32i.n a1, a15, 0/* Restore A1(SP) */\n\
+  movi a0, 0 /* Purge temporary storage */\n\
+  s32i.n a0, a15, 0\n\
+  l32i.n a15, a1, 8/* Restore A15 */\n\
+  l32i.n a0, a1, 12/* Restore A0 */\n\
   addi a1, a1, 16       /* Free up stack and return to caller */\n\
   ret\n\
 .size thunk_"#fcnToThunk", . - thunk_"#fcnToThunk"\n");


### PR DESCRIPTION
Post #9224, allow to call 'stack_thunk_yield()' outside of bssl context
Reset 'stack_thunk_save' before returning from 'thunk_...'ed function