### PR TITLE
CI - fix pio-ci library dir override

### DIFF
--- a/.github/workflows/build-platformio.yml
+++ b/.github/workflows/build-platformio.yml
@@ -36,4 +36,4 @@ jobs:
         ESP8266_ARDUINO_BUILDER: "platformio"
       run: |
         pip install -U platformio
-        env ESP8266_ARDUINO_SKETCHES="$(find libraries/ -name '*.ino' | shuf -n 10 -)" bash ./tests/build.sh
+        env ESP8266_ARDUINO_SKETCHES="$(find libraries/ -name '*.ino' | grep -e libraries/esp8266/examples -e SoftwareSerial)" bash ./tests/build.sh

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -449,9 +449,6 @@ function install_platformio()
 
     # pre-generate config; pio-ci with multiple '-O' options replace each other instead of appending to the same named list
     cat <<EOF > $cache_dir/platformio.ini
-[platformio]
-lib_dir =
-    ${ESP8266_ARDUINO_LIBRARIES}
 [env:$board]
 platform = espressif8266
 board = $board
@@ -460,6 +457,8 @@ platform_packages =
     ${framework_symlink}
     ${toolchain_symlink}
 EOF
+
+    cat $cache_dir/platformio.ini
 
     echo $ci_end_group
 }
@@ -498,8 +497,8 @@ function build_sketches_with_platformio()
         sketchdir=$(dirname $sketch)
 
         local result
-        time pio ci \
-            --verbose \
+        env PLATFORMIO_LIB_DIR="${ESP8266_ARDUINO_LIBRARIES}" \
+            time pio ci \
             --project-conf $cache_dir/platformio.ini \
             $sketchdir >$cache_dir/build.log 2>&1 \
             && result=0 || result=1


### PR DESCRIPTION
pio-run vs. pio-ci configuration differences
`[platformio]` section is simply ignored
*[(since forever, apparently)](https://github.com/platformio/platformio-core/commit/b165c3f543533094d65544f3bc59d4f4642abc83)*

fixed sketch list for github ci builder
amend #9241 changes