### PR TITLE
Add sendJson method for easy JSON responses

### DIFF
--- a/libraries/ESP8266WebServer/examples/JsonServer/JsonServer.ino
+++ b/libraries/ESP8266WebServer/examples/JsonServer/JsonServer.ino
@@ -1,0 +1,51 @@
+#include <ESP8266WiFi.h>
+#include <WiFiClient.h>
+#include <ESP8266WebServer.h>
+#include <ESP8266mDNS.h>
+
+#ifndef STASSID
+#define STASSID "your-ssid"
+#define STAPSK "your-password"
+#endif
+
+const char *ssid = STASSID;
+const char *password = STAPSK;
+
+ESP8266WebServer server(80);
+
+void handleJson() {
+  String json = "{\"message\":\"Hello, from ESP8266!\",\"value\":123}";
+  server.sendJson(json);
+}
+
+void setup(void) {
+  Serial.begin(115200);
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(ssid, password);
+  Serial.println("");
+
+  // Wait for connection
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+
+  Serial.println("");
+  Serial.print("Connected to ");
+  Serial.println(ssid);
+  Serial.print("IP address: ");
+  Serial.println(WiFi.localIP());
+
+  if (MDNS.begin("esp8266")) {
+    Serial.println("MDNS responder started");
+  }
+
+  server.on("/json", HTTP_GET, handleJson);
+  server.begin();
+  Serial.println("HTTP server started");
+}
+
+void loop(void) {
+  server.handleClient();
+  MDNS.update();
+}

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
@@ -560,13 +560,21 @@ void ESP8266WebServerTemplate<ServerType>::send(int code, char* content_type, co
 }
 
 template <typename ServerType>
+void ESP8266WebServerTemplate<ServerType>::send(int code, const String& content_type, const String& content) {
+  send(code, content_type.c_str(), content.c_str(), content.length());
+}
+
+template <typename ServerType>
+void ESP8266WebServerTemplate<ServerType>::sendJson(const String& json, int code) {
+  send(code, "application/json", json);
+}
+
+template <typename ServerType>
 void ESP8266WebServerTemplate<ServerType>::send(int code, const char* content_type, const String& content) {
   return send(code, content_type, content.c_str(), content.length());
 }
 
 template <typename ServerType>
-void ESP8266WebServerTemplate<ServerType>::send(int code, const String& content_type, const String& content) {
-  return send(code, (const char*)content_type.c_str(), content);
 }
 
 template <typename ServerType>

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -164,6 +164,7 @@ public:
   void send(int code, const char* content_type = NULL, const String& content = emptyString);
   void send(int code, char* content_type, const String& content);
   void send(int code, const String& content_type, const String& content);
+  void sendJson(const String& json, int code = 200);
   void send(int code, const char *content_type, const char *content) {
     send_P(code, content_type, content);
   }


### PR DESCRIPTION
I analyzed the ESP8266 Arduino core project and identified an opportunity to improve the ESP8266WebServer library. I implemented a new sendJson method to simplify sending JSON responses, a common requirement for modern IoT applications and REST APIs. This enhancement streamlines development by automatically setting the appropriate Content-Type header and handling the response, which makes the code cleaner and more intuitive. To ensure the new feature is easy to use, I also created a new JsonServer.ino example file to demonstrate its practical application.