### PR TITLE
Test - linkage sanity check

### DIFF
--- a/tests/sanity_check.sh
+++ b/tests/sanity_check.sh
@@ -108,16 +108,10 @@ preprocess=$"$gcc \
 $preprocess \
   "$root/tools/sdk/ld/eagle.app.v6.common.ld.h" \
   -o "local.eagle.app.v6.common.ld"
-step_summary \
-    "Default local.eagle.app.v6.common.ld" \
-    local.eagle.app.v6.common.ld
 
 $preprocess \
   "local.eagle.flash.ld.h" \
   -o "local.eagle.flash.ld"
-step_summary \
-    "Default local.eagle.flash.ld" \
-    local.eagle.flash.ld
 
 libs=$"-lhal -lphy -lpp -lnet80211 -llwip6-1460-feat -lwpa \
 -lcrypto -lmain -lwps -lbearssl -lespnow -lsmartconfig \
@@ -155,7 +149,3 @@ link=$"$root/tools/xtensa-lx106-elf/bin/xtensa-lx106-elf-gcc
 nm=$"$root/tools/xtensa-lx106-elf/bin/xtensa-lx106-elf-nm -C"
 
 $link -o xtensa.elf
-step_summary "CI .elf link map" xtensa.map
-
-$nm xtensa.elf > symbols.txt
-step_summary "CI .elf symbols" symbols.txt

--- a/tests/sanity_check.sh
+++ b/tests/sanity_check.sh
@@ -10,11 +10,25 @@ popd
 
 pushd "$cache_dir"
 
-gcc="$root/tools/xtensa-lx106-elf/bin/xtensa-lx106-elf-gcc"\
-" -I$root/cores/esp8266"\
-" -I$root/tools/sdk/include"\
-" -I$root/variants/generic"\
-" -I$root/tools/sdk/libc/xtensa-lx106-elf"
+cflags=$"
+ -Os
+ -g
+ -free
+ -fipa-pta
+ -Werror=return-type
+ -Wpointer-arith
+ -fno-inline-functions
+ -mtext-section-literals
+ -mlongcalls
+ -falign-functions=4
+ -ffunction-sections
+ -fdata-sections"
+gcc=$"$root/tools/xtensa-lx106-elf/bin/xtensa-lx106-elf-gcc
+ $cflags
+ -I$root/cores/esp8266 \
+ -I$root/tools/sdk/include \
+ -I$root/variants/generic \
+ -I$root/tools/sdk/libc/xtensa-lx106-elf"
 
 $gcc --verbose
 
@@ -43,3 +57,90 @@ cat << EOF > sdk.c
 EOF
 
 $gcc -c sdk.c
+
+cat << EOF > iostream.cpp
+#include <iostream>
+void foo() {
+  std::cout << "hello world";
+}
+EOF
+
+$gcc -c iostream.cpp
+
+cat << EOF > regex.cpp
+#include <string>
+#include <regex>
+
+bool bar(std::string v) {
+  std::regex r("HELLO", std::regex_constants::ECMAScript | std::regex_constants::icase);
+  if (std::regex_search(v, r))
+    return true;
+  return false;
+}
+EOF
+
+$gcc -c regex.cpp
+
+cp "$root/tools/sdk/ld/eagle.flash.1m.ld" "local.eagle.flash.ld.h"
+preprocess=$"$gcc \
+  -DFP_IN_IROM \
+  -DVTABLES_IN_FLASH \
+  -DMMU_IRAM_SIZE=0x8000 \
+  -DMMU_ICACHE_SIZE=0x8000 \
+  -CC -E -P"
+
+$preprocess \
+  "$root/tools/sdk/ld/eagle.app.v6.common.ld.h" \
+  -o "local.eagle.app.v6.common.ld"
+step_summary \
+    "Default local.eagle.app.v6.common.ld" \
+    local.eagle.app.v6.common.ld
+
+$preprocess \
+  "local.eagle.flash.ld.h" \
+  -o "local.eagle.flash.ld"
+cat local.eagle.flash.ld
+step_summary \
+    "Default local.eagle.flash.ld" \
+    local.eagle.flash.ld
+
+libs=$"-lhal -lphy -lpp -lnet80211 -llwip6-1460-feat -lwpa \
+-lcrypto -lmain -lwps -lbearssl -lespnow -lsmartconfig \
+-lairkiss -lwpa2 -lstdc++ -lm -lc -lgcc"
+objects="arduino.o coredecls.o features.o sdk.o iostream.o"
+
+link=$"$root/tools/xtensa-lx106-elf/bin/xtensa-lx106-elf-gcc
+ -nostdlib
+ -u app_entry
+ -mlongcalls
+ -L$cache_dir
+ -L$root/tools/sdk/lib/NONOSDK305
+ -L$root/tools/sdk/lib
+ -L$root/tools/sdk/ld
+ -Wl,-EL
+ -Wl,-T,local.eagle.flash.ld
+ -Wl,--no-check-sections
+ -Wl,-Map,xtensa.map
+ -Wl,--gc-sections
+ -Wl,--defsym,app_entry=0xaaaaaaaa
+ -Wl,--defsym,abort=0xfefefefe
+ -Wl,--defsym,malloc=0xfefefefe
+ -Wl,--defsym,free=0xfefefefe
+ -Wl,--defsym,_read_r=0xfefefefe
+ -Wl,--defsym,_lseek_r=0xfefefefe
+ -Wl,--defsym,_write_r=0xfefefefe
+ -Wl,--defsym,_close_r=0xfefefefe
+ -Wl,--defsym,_free_r=0xfefefefe
+ -Wl,--defsym,_malloc_r=0xfefefefe
+ -Wl,--defsym,_realloc_r=0xfefefefe
+ -Wl,--defsym,_calloc_r=0xfefefefe
+ -Wl,--defsym,_fstat_r=0xfefefefe
+ -Wl,--start-group $objects $libs -Wl,--end-group"
+
+nm=$"$root/tools/xtensa-lx106-elf/bin/xtensa-lx106-elf-nm -C"
+
+$link -o xtensa.elf
+step_summary "CI .elf link map" xtensa.map
+
+$nm xtensa.elf > symbols.txt
+step_summary "CI .elf symbols" symbols.txt


### PR DESCRIPTION
Check GCC building C++ in addition to C code

Check that compiler can build and link .elf using default build flags & defines
Check for known issue w/ newlib-4.5.0 when expecting wide characters support by attempting to link `<iostream>` and `<regex>`

(fixed script from #9259 plus CI summaries)