### PR TITLE
fix: Correctly detect Adesto flash size

### DIFF
--- a/cores/esp8266/Esp.cpp
+++ b/cores/esp8266/Esp.cpp
@@ -289,7 +289,12 @@ uint8_t EspClass::getFlashChipVendorId(void)
 
 uint32_t EspClass::getFlashChipRealSize(void)
 {
-    return (1 << ((spi_flash_get_id() >> 16) & 0xFF));
+    uint32_t id = spi_flash_get_id();
+    if ((id & 0xFF) == SPI_FLASH_VENDOR_ATMEL) {
+        return (0x8000 << ((id >> 8) & 0x1F));
+    } else {
+        return (1 << ((id >> 16) & 0xFF));
+    }
 }
 
 uint32_t EspClass::getFlashChipSize(void)


### PR DESCRIPTION
Adesto/Atmel flash chips report their size differently than most. This patch is equivalent to what has previously been applied to esptool with 0b56f85.

https://github.com/espressif/esptool/commit/0b56f85b17cbf5c32ef4cb7c9b4d3430e9b12ea0